### PR TITLE
Fix: resolve d.2 outbound SMS preference override review findings

### DIFF
--- a/_bmad-output/implementation-artifacts/d-2-preference-override-enforcement-for-outbound-sms.md
+++ b/_bmad-output/implementation-artifacts/d-2-preference-override-enforcement-for-outbound-sms.md
@@ -1,6 +1,6 @@
 # Story d.2: Preference Override Enforcement for Outbound SMS
 
-Status: review
+Status: in-progress
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -48,6 +48,12 @@ so that policy exceptions are explicit, justified, and traceable.
   - [x] Contract tests for refusal messaging and no partial writes.
   - [x] Positive-path tests for persisted override + audit linkage.
   - [x] Reopen + override interaction tests for `CLOSED` outbound SMS.
+
+### Review Follow-ups (AI)
+
+- [x] [AI-Review][HIGH] Replaced synthetic `neighbor-${threadId}` fallback with canonical resolver trigger (`neighborId: null` for non-synthetic contexts) so FR-CS-023 enforcement applies to DB-backed threads. [src/src/routes/api/v1/connectshyft.ts:3838]
+- [x] [AI-Review][MEDIUM] Added API coverage for UUID-backed thread/neighbor preference paths validating refusal and success behavior through real `cs_threads -> cs_neighbors` lookup. [tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts:153]
+- [x] [AI-Review][MEDIUM] Added persistence-level override reason canonical-value constraint and upgrade-safe migration coverage. [src/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:36]
 
 ## Dev Notes
 
@@ -157,18 +163,39 @@ GPT-5 Codex
 - Preserved closed-thread reopen behavior for approved outbound SMS and ensured override policy enforcement runs before dispatch.
 - Added migration for durable override records and neighbor `prefers_texting` canonical values.
 - Added automated API and module-level tests covering refusal, success, and CLOSED reopen + override interaction paths.
+- Fixed DB-backed outbound preference enforcement to resolve neighbor preference from canonical thread data for non-synthetic thread contexts.
+- Added upgrade-safe override-reason CHECK constraint enforcement for `connectshyft.cs_sms_preference_overrides`.
+- Added DB-backed UUID thread/neighbor API regression coverage to prevent preference-override enforcement bypass regressions.
 
 ### File List
 
 - _bmad-output/implementation-artifacts/d-2-preference-override-enforcement-for-outbound-sms.md
+- _bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
 - src/src/routes/api/v1/connectshyft.ts
-- src/src/modules/connectshyft/smsPreferenceOverrides.ts
-- src/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts
 - src/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts
+- src/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts
 - tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts
-- tests/support/factories/connectShyftStoryDFactory.ts
+
+## Senior Developer Review (AI)
+
+- 2026-02-27: Completed adversarial code review. Outcome: **Changes Requested** (1 HIGH, 2 MEDIUM).
+- Key findings:
+  - HIGH: SMS preference enforcement can be bypassed for non-synthetic thread detail contexts because outbound policy resolution passes `neighbor-${threadId}` instead of allowing canonical DB neighbor lookup.
+  - MEDIUM: Story d.2 API tests only target seeded synthetic thread IDs and do not cover UUID-backed production lookup paths.
+  - MEDIUM: Override reason canonical values are enforced in service logic but not at DB constraint level.
+- Guardrail blocker: `Critical Capability: yes` with `Real-User Validation Evidence` still pending and `Real-User Validation Result: pending`; closure remains blocked.
+- Verification rerun during review:
+  - `cd src && npm test -- src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts` (pass)
+  - `npm run test:e2e -- tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts` (pass)
+- 2026-02-27: Implemented all review-requested fixes (1 HIGH, 2 MEDIUM) and resolved story/git discrepancy tracking.
+- Verification after fixes:
+  - `cd src && npm test -- src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts` (pass)
+  - `cd src && npm run build` (pass)
+  - `npm run test:e2e -- tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts` (pass)
 
 ## Change Log
 
 - 2026-02-27: Created Story d.2 ready-for-dev context document.
 - 2026-02-27: Implemented outbound SMS `prefers_texting=NO` override enforcement, durable override metadata persistence, refusal no-side-effect semantics, and d.2 API/module automated tests.
+- 2026-02-27: Senior Developer Review (AI) completed; status moved to in-progress with review follow-up tasks added.
+- 2026-02-27: Resolved all AI review findings, added DB-backed regression coverage, and synced story file list with git changes.

--- a/_bmad-output/implementation-artifacts/d-2-preference-override-enforcement-for-outbound-sms.md
+++ b/_bmad-output/implementation-artifacts/d-2-preference-override-enforcement-for-outbound-sms.md
@@ -174,7 +174,10 @@ GPT-5 Codex
 - src/src/routes/api/v1/connectshyft.ts
 - src/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts
 - src/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts
+- src/src/modules/connectshyft/smsPreferenceOverrides.ts
+- src/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts
 - tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts
+- tests/support/factories/connectShyftStoryDFactory.ts
 
 ## Senior Developer Review (AI)
 

--- a/_bmad-output/implementation-artifacts/d-2-preference-override-enforcement-for-outbound-sms.md
+++ b/_bmad-output/implementation-artifacts/d-2-preference-override-enforcement-for-outbound-sms.md
@@ -1,6 +1,6 @@
 # Story d.2: Preference Override Enforcement for Outbound SMS
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -32,22 +32,22 @@ so that policy exceptions are explicit, justified, and traceable.
 
 ## Tasks / Subtasks
 
-- [ ] Add outbound SMS preference policy evaluation (AC: 1, 2)
-  - [ ] Resolve canonical `prefers_texting` value (`UNKNOWN | YES | NO`) for target neighbor/thread context.
-  - [ ] Block outbound SMS for `NO` unless valid override reason is supplied.
-- [ ] Persist override and audit metadata on approved sends (AC: 1)
-  - [ ] Store structured override reason and optional note in durable preference-override records.
-  - [ ] Emit auditable metadata linking actor, thread, reason, and message event.
-- [ ] Enforce no-side-effect refusal semantics (AC: 2)
-  - [ ] Return refusal envelopes for missing/invalid override data.
-  - [ ] Guarantee refusal path does not persist outbound message, audit entry, or lifecycle mutation.
-- [ ] Integrate with closed-thread outbound reopen path (AC: 3)
-  - [ ] Ensure reopen-on-outbound happens before message send attempt.
-  - [ ] Ensure override checks still execute after reopen and before dispatch.
-- [ ] Add test coverage for override and refusal paths (AC: 1, 2, 3)
-  - [ ] Contract tests for refusal messaging and no partial writes.
-  - [ ] Positive-path tests for persisted override + audit linkage.
-  - [ ] Reopen + override interaction tests for `CLOSED` outbound SMS.
+- [x] Add outbound SMS preference policy evaluation (AC: 1, 2)
+  - [x] Resolve canonical `prefers_texting` value (`UNKNOWN | YES | NO`) for target neighbor/thread context.
+  - [x] Block outbound SMS for `NO` unless valid override reason is supplied.
+- [x] Persist override and audit metadata on approved sends (AC: 1)
+  - [x] Store structured override reason and optional note in durable preference-override records.
+  - [x] Emit auditable metadata linking actor, thread, reason, and message event.
+- [x] Enforce no-side-effect refusal semantics (AC: 2)
+  - [x] Return refusal envelopes for missing/invalid override data.
+  - [x] Guarantee refusal path does not persist outbound message, audit entry, or lifecycle mutation.
+- [x] Integrate with closed-thread outbound reopen path (AC: 3)
+  - [x] Ensure reopen-on-outbound happens before message send attempt.
+  - [x] Ensure override checks still execute after reopen and before dispatch.
+- [x] Add test coverage for override and refusal paths (AC: 1, 2, 3)
+  - [x] Contract tests for refusal messaging and no partial writes.
+  - [x] Positive-path tests for persisted override + audit linkage.
+  - [x] Reopen + override interaction tests for `CLOSED` outbound SMS.
 
 ## Dev Notes
 
@@ -143,15 +143,32 @@ GPT-5 Codex
 
 - `rg -n "FR-CS-022|FR-CS-023" _bmad-output/planning-artifacts/prd-ConnectShyft-2026-02-19.md` (pass)
 - `rg -n "prefers_texting|override" _bmad-output/planning-artifacts/ux-design-specification-ConnectShyft-2026-02-19.md` (pass)
+- `npm run branch:ensure-workflow -- --workflow dev-story --story d-2-preference-override-enforcement-for-outbound-sms` (pass)
+- `npm run test:e2e -- tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts` (pass)
+- `npm run test:e2e -- tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts` (pass)
+- `cd src && npm test -- src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts` (pass)
+- `cd src && npm run build` (pass)
 
 ### Completion Notes List
 
-- Created implementation-ready Story d.2 context with required override enforcement, refusal no-side-effect guarantees, and reopen-path integration.
+- Implemented server-authoritative SMS preference enforcement for outbound message actions with canonical `prefers_texting` resolution (`UNKNOWN | YES | NO`).
+- Added required/invalid override refusal envelopes for `prefers_texting=NO` with explicit no-side-effect indicators (`messageDispatched=false`, `lifecycleMutationApplied=false`, `auditPersisted=false`).
+- Added approved override persistence path with structured override reason/note plus audit-linked metadata payloads.
+- Preserved closed-thread reopen behavior for approved outbound SMS and ensured override policy enforcement runs before dispatch.
+- Added migration for durable override records and neighbor `prefers_texting` canonical values.
+- Added automated API and module-level tests covering refusal, success, and CLOSED reopen + override interaction paths.
 
 ### File List
 
 - _bmad-output/implementation-artifacts/d-2-preference-override-enforcement-for-outbound-sms.md
+- src/src/routes/api/v1/connectshyft.ts
+- src/src/modules/connectshyft/smsPreferenceOverrides.ts
+- src/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts
+- src/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts
+- tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts
+- tests/support/factories/connectShyftStoryDFactory.ts
 
 ## Change Log
 
 - 2026-02-27: Created Story d.2 ready-for-dev context document.
+- 2026-02-27: Implemented outbound SMS `prefers_texting=NO` override enforcement, durable override metadata persistence, refusal no-side-effect semantics, and d.2 API/module automated tests.

--- a/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
@@ -65,7 +65,7 @@ development_status:
   epic-c-retrospective: optional
   epic-d: in-progress
   d-1-outbound-sms-call-actions-that-preserve-escalation-semantics: review
-  d-2-preference-override-enforcement-for-outbound-sms: review
+  d-2-preference-override-enforcement-for-outbound-sms: in-progress
   d-3-outbound-audit-outbox-and-refusal-envelope-integration: ready-for-dev
   d-4-operator-interaction-contracts-for-outbound-safety: ready-for-dev
   epic-d-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
@@ -65,7 +65,7 @@ development_status:
   epic-c-retrospective: optional
   epic-d: in-progress
   d-1-outbound-sms-call-actions-that-preserve-escalation-semantics: review
-  d-2-preference-override-enforcement-for-outbound-sms: ready-for-dev
+  d-2-preference-override-enforcement-for-outbound-sms: review
   d-3-outbound-audit-outbox-and-refusal-envelope-integration: ready-for-dev
   d-4-operator-interaction-contracts-for-outbound-safety: ready-for-dev
   epic-d-retrospective: optional

--- a/src/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts
+++ b/src/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts
@@ -6,6 +6,7 @@ const SMS_OVERRIDE_TABLE = 'cs_sms_preference_overrides';
 
 const NEIGHBORS_PREFERS_TEXTING_CHECK = 'cs_neighbors_prefers_texting_canonical_ck';
 const SMS_OVERRIDE_PREFERENCE_CHECK = 'cs_sms_pref_override_pref_value_ck';
+const SMS_OVERRIDE_REASON_CHECK = 'cs_sms_pref_override_reason_ck';
 const SMS_OVERRIDE_SCOPE_INDEX = 'cs_sms_pref_override_scope_idx';
 const SMS_OVERRIDE_REASON_INDEX = 'cs_sms_pref_override_reason_idx';
 
@@ -63,6 +64,29 @@ export async function up(knex: Knex): Promise<void> {
         ALTER TABLE connectshyft.${SMS_OVERRIDE_TABLE}
           ADD CONSTRAINT ${SMS_OVERRIDE_PREFERENCE_CHECK}
           CHECK (preference_value = 'NO');
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${SMS_OVERRIDE_REASON_CHECK}'
+          AND conrelid = 'connectshyft.${SMS_OVERRIDE_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE connectshyft.${SMS_OVERRIDE_TABLE}
+          ADD CONSTRAINT ${SMS_OVERRIDE_REASON_CHECK}
+          CHECK (
+            override_reason IN (
+              'safety-follow-up',
+              'care-plan-exception',
+              'documented-consent',
+              'critical-service-update'
+            )
+          );
       END IF;
     END $$;
   `);

--- a/src/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts
+++ b/src/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts
@@ -1,0 +1,87 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const NEIGHBORS_TABLE = 'cs_neighbors';
+const SMS_OVERRIDE_TABLE = 'cs_sms_preference_overrides';
+
+const NEIGHBORS_PREFERS_TEXTING_CHECK = 'cs_neighbors_prefers_texting_canonical_ck';
+const SMS_OVERRIDE_PREFERENCE_CHECK = 'cs_sms_pref_override_pref_value_ck';
+const SMS_OVERRIDE_SCOPE_INDEX = 'cs_sms_pref_override_scope_idx';
+const SMS_OVERRIDE_REASON_INDEX = 'cs_sms_pref_override_reason_idx';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw('CREATE SCHEMA IF NOT EXISTS connectshyft');
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS connectshyft.${NEIGHBORS_TABLE}
+      ADD COLUMN IF NOT EXISTS prefers_texting TEXT NOT NULL DEFAULT 'UNKNOWN'
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${NEIGHBORS_PREFERS_TEXTING_CHECK}'
+          AND conrelid = 'connectshyft.${NEIGHBORS_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE connectshyft.${NEIGHBORS_TABLE}
+          ADD CONSTRAINT ${NEIGHBORS_PREFERS_TEXTING_CHECK}
+          CHECK (prefers_texting IN ('UNKNOWN', 'YES', 'NO'));
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS connectshyft.${SMS_OVERRIDE_TABLE} (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      neighbor_id TEXT NULL,
+      actor_user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+      preference_value TEXT NOT NULL DEFAULT 'NO',
+      override_reason TEXT NOT NULL,
+      override_note TEXT NULL,
+      message_body TEXT NOT NULL DEFAULT '',
+      message_event_name TEXT NOT NULL DEFAULT 'connectshyft.thread.outbound_message_dispatched',
+      audit_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${SMS_OVERRIDE_PREFERENCE_CHECK}'
+          AND conrelid = 'connectshyft.${SMS_OVERRIDE_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE connectshyft.${SMS_OVERRIDE_TABLE}
+          ADD CONSTRAINT ${SMS_OVERRIDE_PREFERENCE_CHECK}
+          CHECK (preference_value = 'NO');
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${SMS_OVERRIDE_SCOPE_INDEX}
+      ON connectshyft.${SMS_OVERRIDE_TABLE} (tenant_id, org_unit_id, thread_id, created_at_utc)
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${SMS_OVERRIDE_REASON_INDEX}
+      ON connectshyft.${SMS_OVERRIDE_TABLE} (tenant_id, override_reason, created_at_utc)
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(SMS_OVERRIDE_TABLE);
+  await knex.raw(`
+    ALTER TABLE IF EXISTS connectshyft.${NEIGHBORS_TABLE}
+      DROP COLUMN IF EXISTS prefers_texting
+  `);
+}

--- a/src/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts
+++ b/src/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts
@@ -1,0 +1,42 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const SMS_OVERRIDE_TABLE = 'cs_sms_preference_overrides';
+const SMS_OVERRIDE_REASON_CHECK = 'cs_sms_pref_override_reason_ck';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = '${CONNECTSHYFT_SCHEMA}'
+          AND table_name = '${SMS_OVERRIDE_TABLE}'
+      ) AND NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${SMS_OVERRIDE_REASON_CHECK}'
+          AND conrelid = 'connectshyft.${SMS_OVERRIDE_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE connectshyft.${SMS_OVERRIDE_TABLE}
+          ADD CONSTRAINT ${SMS_OVERRIDE_REASON_CHECK}
+          CHECK (
+            override_reason IN (
+              'safety-follow-up',
+              'care-plan-exception',
+              'documented-consent',
+              'critical-service-update'
+            )
+          );
+      END IF;
+    END $$;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE IF EXISTS connectshyft.${SMS_OVERRIDE_TABLE}
+      DROP CONSTRAINT IF EXISTS ${SMS_OVERRIDE_REASON_CHECK}
+  `);
+}

--- a/src/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts
+++ b/src/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts
@@ -1,0 +1,65 @@
+import {
+  AsyncConnectShyftSmsPreferenceOverrideService,
+  validateConnectShyftSmsOverride,
+} from '../smsPreferenceOverrides';
+
+describe('connectshyft sms preference overrides', () => {
+  it('requires override reason when prefers_texting is NO', () => {
+    const result = validateConnectShyftSmsOverride({
+      prefersTexting: 'NO',
+      overrideReason: null,
+      overrideNote: null,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'required',
+    });
+  });
+
+  it('rejects invalid override reason when prefers_texting is NO', () => {
+    const result = validateConnectShyftSmsOverride({
+      prefersTexting: 'NO',
+      overrideReason: 'x',
+      overrideNote: null,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  it('accepts allowed override reason when prefers_texting is NO', () => {
+    const result = validateConnectShyftSmsOverride({
+      prefersTexting: 'NO',
+      overrideReason: 'safety-follow-up',
+      overrideNote: 'Operator documented policy exception.',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      overrideRequired: true,
+      override: {
+        reason: 'safety-follow-up',
+        note: 'Operator documented policy exception.',
+      },
+    });
+  });
+
+  it('resolves synthetic NO preferences without database lookups', async () => {
+    const service = new AsyncConnectShyftSmsPreferenceOverrideService();
+
+    const resolved = await service.resolvePreference({
+      tenantId: 'tenant-connectshyft-c4',
+      orgUnitId: 'org-connectshyft-c4-east',
+      threadId: 'thread-c4-unclaimed-pref-no-1004',
+    });
+
+    expect(resolved).toEqual({
+      prefersTexting: 'NO',
+      neighborId: null,
+      source: 'thread-map',
+    });
+  });
+});

--- a/src/src/modules/connectshyft/smsPreferenceOverrides.ts
+++ b/src/src/modules/connectshyft/smsPreferenceOverrides.ts
@@ -1,0 +1,455 @@
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+
+export type ConnectShyftCanonicalTextingPreference = 'UNKNOWN' | 'YES' | 'NO';
+
+const CONNECTSHYFT_CANONICAL_TEXTING_PREFERENCES = new Set<ConnectShyftCanonicalTextingPreference>([
+  'UNKNOWN',
+  'YES',
+  'NO',
+]);
+
+const CONNECTSHYFT_ALLOWED_SMS_OVERRIDE_REASONS = [
+  'safety-follow-up',
+  'care-plan-exception',
+  'documented-consent',
+  'critical-service-update',
+] as const;
+
+export const CONNECTSHYFT_SMS_OVERRIDE_REASON_OPTIONS: readonly string[] = [
+  ...CONNECTSHYFT_ALLOWED_SMS_OVERRIDE_REASONS,
+];
+
+export type ConnectShyftSmsOverrideReason =
+  (typeof CONNECTSHYFT_ALLOWED_SMS_OVERRIDE_REASONS)[number];
+
+export type ConnectShyftResolvedSmsPreference = {
+  prefersTexting: ConnectShyftCanonicalTextingPreference;
+  neighborId: string | null;
+  source: 'thread-map' | 'neighbor-record' | 'unknown';
+};
+
+export type ConnectShyftValidatedSmsOverride = {
+  reason: ConnectShyftSmsOverrideReason;
+  note: string | null;
+};
+
+export type ConnectShyftValidateSmsOverrideInput = {
+  prefersTexting: ConnectShyftCanonicalTextingPreference;
+  overrideReason: string | null;
+  overrideNote: string | null;
+};
+
+export type ConnectShyftValidateSmsOverrideResult =
+  | {
+    ok: true;
+    overrideRequired: boolean;
+    override: ConnectShyftValidatedSmsOverride | null;
+  }
+  | {
+    ok: false;
+    reason: 'required' | 'invalid';
+    message: string;
+    allowedReasons: readonly string[];
+  };
+
+export type ConnectShyftPersistSmsOverrideInput = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  neighborId: string | null;
+  actorUserId: string | null;
+  preferenceValue: 'NO';
+  override: ConnectShyftValidatedSmsOverride;
+  messageBody: string;
+  messageEventName: string;
+};
+
+export type ConnectShyftPersistedSmsOverride = {
+  overrideId: string;
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  neighborId: string | null;
+  actorUserId: string | null;
+  preferenceValue: 'NO';
+  overrideReason: ConnectShyftSmsOverrideReason;
+  overrideNote: string | null;
+  messageBody: string;
+  messageEventName: string;
+  auditMetadata: Record<string, unknown>;
+  createdAtUtc: string;
+  durability: 'database' | 'in-memory';
+};
+
+const CONNECTSHYFT_SYNTHETIC_THREAD_TEXTING_PREFERENCES: Record<string, ConnectShyftCanonicalTextingPreference> = {
+  'thread-c4-unclaimed-pref-no-1004': 'NO',
+  'thread-c4-closed-pref-no-1005': 'NO',
+};
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const normalizeOptionalString = (value: unknown): string | null => {
+  const normalized = normalizeString(value);
+  return normalized.length > 0 ? normalized : null;
+};
+
+const normalizeOptionalUuid = (value: unknown): string | null => {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized || !UUID_PATTERN.test(normalized)) {
+    return null;
+  }
+
+  return normalized;
+};
+
+const nowIsoUtc = (): string => new Date().toISOString();
+
+const normalizePreference = (value: unknown): ConnectShyftCanonicalTextingPreference => {
+  const normalized = normalizeString(value).toUpperCase();
+  if (CONNECTSHYFT_CANONICAL_TEXTING_PREFERENCES.has(normalized as ConnectShyftCanonicalTextingPreference)) {
+    return normalized as ConnectShyftCanonicalTextingPreference;
+  }
+
+  return 'UNKNOWN';
+};
+
+const normalizeOverrideReason = (value: unknown): ConnectShyftSmsOverrideReason | null => {
+  const normalized = normalizeString(value).toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  return CONNECTSHYFT_ALLOWED_SMS_OVERRIDE_REASONS.includes(
+    normalized as ConnectShyftSmsOverrideReason,
+  )
+    ? (normalized as ConnectShyftSmsOverrideReason)
+    : null;
+};
+
+const isMissingPersistenceError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const candidate = error as { code?: string };
+  return candidate.code === '42P01'
+    || candidate.code === '3F000'
+    || candidate.code === '42703';
+};
+
+export const validateConnectShyftSmsOverride = (
+  input: ConnectShyftValidateSmsOverrideInput,
+): ConnectShyftValidateSmsOverrideResult => {
+  const overrideReason = normalizeOptionalString(input.overrideReason);
+  const normalizedReason = normalizeOverrideReason(overrideReason);
+  const overrideNote = normalizeOptionalString(input.overrideNote);
+
+  if (input.prefersTexting !== 'NO') {
+    return {
+      ok: true,
+      overrideRequired: false,
+      override: normalizedReason
+        ? {
+          reason: normalizedReason,
+          note: overrideNote,
+        }
+        : null,
+    };
+  }
+
+  if (!overrideReason) {
+    return {
+      ok: false,
+      reason: 'required',
+      message: 'Outbound SMS requires an override reason when prefers_texting=NO.',
+      allowedReasons: CONNECTSHYFT_SMS_OVERRIDE_REASON_OPTIONS,
+    };
+  }
+
+  if (!normalizedReason) {
+    return {
+      ok: false,
+      reason: 'invalid',
+      message: 'Override reason is invalid. Use an approved override reason value.',
+      allowedReasons: CONNECTSHYFT_SMS_OVERRIDE_REASON_OPTIONS,
+    };
+  }
+
+  return {
+    ok: true,
+    overrideRequired: true,
+    override: {
+      reason: normalizedReason,
+      note: overrideNote,
+    },
+  };
+};
+
+class InMemoryConnectShyftSmsPreferenceOverrideStore {
+  private readonly preferencesByThreadId = new Map<string, ConnectShyftCanonicalTextingPreference>(
+    Object.entries(CONNECTSHYFT_SYNTHETIC_THREAD_TEXTING_PREFERENCES),
+  );
+
+  private readonly overrides: ConnectShyftPersistedSmsOverride[] = [];
+
+  resolvePreference(input: {
+    threadId: string;
+    neighborId?: string | null;
+  }): ConnectShyftResolvedSmsPreference {
+    const preference = this.preferencesByThreadId.get(input.threadId) || 'UNKNOWN';
+    return {
+      prefersTexting: preference,
+      neighborId: normalizeOptionalString(input.neighborId),
+      source: preference === 'UNKNOWN' ? 'unknown' : 'thread-map',
+    };
+  }
+
+  persistOverride(input: ConnectShyftPersistSmsOverrideInput): ConnectShyftPersistedSmsOverride {
+    const createdAtUtc = nowIsoUtc();
+    const overrideId = randomUUID();
+    const actorUserId = normalizeOptionalUuid(input.actorUserId);
+    const record: ConnectShyftPersistedSmsOverride = {
+      overrideId,
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      threadId: input.threadId,
+      neighborId: normalizeOptionalString(input.neighborId),
+      actorUserId,
+      preferenceValue: 'NO',
+      overrideReason: input.override.reason,
+      overrideNote: input.override.note,
+      messageBody: input.messageBody,
+      messageEventName: input.messageEventName,
+      auditMetadata: {
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        thread_id: input.threadId,
+        neighbor_id: normalizeOptionalString(input.neighborId),
+        actor_user_id: actorUserId,
+        preference_value: 'NO',
+        override_reason: input.override.reason,
+        override_note: input.override.note,
+        message_event_name: input.messageEventName,
+      },
+      createdAtUtc,
+      durability: 'in-memory',
+    };
+
+    this.overrides.push(record);
+    return {
+      ...record,
+      auditMetadata: {
+        ...record.auditMetadata,
+      },
+    };
+  }
+}
+
+class KnexConnectShyftSmsPreferenceOverrideStore {
+  constructor(private readonly knexClient: Knex = db) {}
+
+  async resolvePreference(input: {
+    tenantId: string;
+    orgUnitId: string;
+    threadId: string;
+    neighborId?: string | null;
+  }): Promise<ConnectShyftResolvedSmsPreference> {
+    let neighborId = normalizeOptionalString(input.neighborId);
+
+    if (!neighborId) {
+      const thread = await this.knexClient
+        .withSchema('connectshyft')
+        .table('cs_threads')
+        .where({
+          tenant_id: input.tenantId,
+          org_unit_id: input.orgUnitId,
+          id: input.threadId,
+        })
+        .first<{ neighbor_id?: unknown }>('neighbor_id');
+
+      neighborId = normalizeOptionalString(thread?.neighbor_id);
+    }
+
+    if (!neighborId) {
+      return {
+        prefersTexting: 'UNKNOWN',
+        neighborId: null,
+        source: 'unknown',
+      };
+    }
+
+    if (!UUID_PATTERN.test(neighborId)) {
+      return {
+        prefersTexting: 'UNKNOWN',
+        neighborId,
+        source: 'unknown',
+      };
+    }
+
+    const neighbor = await this.knexClient
+      .withSchema('connectshyft')
+      .table('cs_neighbors')
+      .where({
+        tenant_id: input.tenantId,
+        id: neighborId,
+      })
+      .first<{ prefers_texting?: unknown }>('prefers_texting');
+
+    if (!neighbor) {
+      return {
+        prefersTexting: 'UNKNOWN',
+        neighborId,
+        source: 'unknown',
+      };
+    }
+
+    return {
+      prefersTexting: normalizePreference(neighbor.prefers_texting),
+      neighborId,
+      source: 'neighbor-record',
+    };
+  }
+
+  async persistOverride(input: ConnectShyftPersistSmsOverrideInput): Promise<ConnectShyftPersistedSmsOverride> {
+    const actorUserId = normalizeOptionalUuid(input.actorUserId);
+    const auditMetadata: Record<string, unknown> = {
+      tenant_id: input.tenantId,
+      org_unit_id: input.orgUnitId,
+      thread_id: input.threadId,
+      neighbor_id: normalizeOptionalString(input.neighborId),
+      actor_user_id: actorUserId,
+      preference_value: 'NO',
+      override_reason: input.override.reason,
+      override_note: input.override.note,
+      message_event_name: input.messageEventName,
+    };
+
+    const [row] = await this.knexClient
+      .withSchema('connectshyft')
+      .table('cs_sms_preference_overrides')
+      .insert({
+        id: randomUUID(),
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        thread_id: input.threadId,
+        neighbor_id: normalizeOptionalString(input.neighborId),
+        actor_user_id: actorUserId,
+        preference_value: 'NO',
+        override_reason: input.override.reason,
+        override_note: input.override.note,
+        message_body: input.messageBody,
+        message_event_name: input.messageEventName,
+        audit_metadata: auditMetadata,
+        created_at_utc: this.knexClient.fn.now(),
+      })
+      .returning<
+      Array<{
+        id: string;
+        tenant_id: string;
+        org_unit_id: string;
+        thread_id: string;
+        neighbor_id: string | null;
+        actor_user_id: string | null;
+        preference_value: 'NO';
+        override_reason: ConnectShyftSmsOverrideReason;
+        override_note: string | null;
+        message_body: string;
+        message_event_name: string;
+        audit_metadata: Record<string, unknown>;
+        created_at_utc: string | Date;
+      }>
+      >([
+        'id',
+        'tenant_id',
+        'org_unit_id',
+        'thread_id',
+        'neighbor_id',
+        'actor_user_id',
+        'preference_value',
+        'override_reason',
+        'override_note',
+        'message_body',
+        'message_event_name',
+        'audit_metadata',
+        'created_at_utc',
+      ]);
+
+    return {
+      overrideId: row.id,
+      tenantId: row.tenant_id,
+      orgUnitId: row.org_unit_id,
+      threadId: row.thread_id,
+      neighborId: normalizeOptionalString(row.neighbor_id),
+      actorUserId: normalizeOptionalUuid(row.actor_user_id),
+      preferenceValue: 'NO',
+      overrideReason: row.override_reason,
+      overrideNote: normalizeOptionalString(row.override_note),
+      messageBody: row.message_body,
+      messageEventName: row.message_event_name,
+      auditMetadata: row.audit_metadata || auditMetadata,
+      createdAtUtc: row.created_at_utc instanceof Date
+        ? row.created_at_utc.toISOString()
+        : String(row.created_at_utc),
+      durability: 'database',
+    };
+  }
+}
+
+export class AsyncConnectShyftSmsPreferenceOverrideService {
+  constructor(
+    private readonly store: KnexConnectShyftSmsPreferenceOverrideStore = new KnexConnectShyftSmsPreferenceOverrideStore(),
+    private readonly fallbackStore: InMemoryConnectShyftSmsPreferenceOverrideStore = new InMemoryConnectShyftSmsPreferenceOverrideStore(),
+  ) {}
+
+  async resolvePreference(input: {
+    tenantId: string;
+    orgUnitId: string;
+    threadId: string;
+    neighborId?: string | null;
+  }): Promise<ConnectShyftResolvedSmsPreference> {
+    const fallback = this.fallbackStore.resolvePreference(input);
+    if (fallback.prefersTexting !== 'UNKNOWN') {
+      return fallback;
+    }
+
+    try {
+      return await this.store.resolvePreference(input);
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error;
+      }
+      return fallback;
+    }
+  }
+
+  validateOverride(
+    input: ConnectShyftValidateSmsOverrideInput,
+  ): ConnectShyftValidateSmsOverrideResult {
+    return validateConnectShyftSmsOverride(input);
+  }
+
+  async persistApprovedOverride(
+    input: ConnectShyftPersistSmsOverrideInput,
+  ): Promise<ConnectShyftPersistedSmsOverride> {
+    try {
+      return await this.store.persistOverride(input);
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error;
+      }
+      return this.fallbackStore.persistOverride(input);
+    }
+  }
+}
+
+export const connectShyftSmsPreferenceOverrideServiceAsync =
+  new AsyncConnectShyftSmsPreferenceOverrideService();

--- a/src/src/routes/api/v1/connectshyft.ts
+++ b/src/src/routes/api/v1/connectshyft.ts
@@ -3835,8 +3835,7 @@ const performOutboundAction = async (
   let smsPreferenceDecision: ConnectShyftResolvedSmsPreference | null = null;
   let validatedSmsOverride: ConnectShyftValidatedSmsOverride | null = null;
   if (outboundAction === 'message' && outboundMessagePolicy) {
-    const preferenceNeighborId = lifecycleContext.syntheticThread?.neighborId
-      || (lifecycleContext.detail ? `neighbor-${lifecycleContext.detail.threadId}` : null);
+    const preferenceNeighborId = lifecycleContext.syntheticThread?.neighborId || null;
     smsPreferenceDecision = await connectShyftSmsPreferenceOverrideService.resolvePreference({
       tenantId: context.tenantId,
       orgUnitId: context.orgUnitId,

--- a/src/src/routes/api/v1/connectshyft.ts
+++ b/src/src/routes/api/v1/connectshyft.ts
@@ -40,6 +40,11 @@ import {
   type ConnectShyftLifecycleAction,
   type ConnectShyftThreadState,
 } from '../../../modules/connectshyft/threads';
+import {
+  connectShyftSmsPreferenceOverrideServiceAsync,
+  type ConnectShyftResolvedSmsPreference,
+  type ConnectShyftValidatedSmsOverride,
+} from '../../../modules/connectshyft/smsPreferenceOverrides';
 import { executePlatformMutation } from '../../../platform/mutations/executePlatformMutation';
 import {
   createKnexOrgUnitAccessStore,
@@ -178,6 +183,30 @@ const CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS: Record<string, ConnectShyftSynth
     preferredOutboundCsNumberId: 'cs-number-701',
     summary: 'Unclaimed thread pending deterministic escalation evaluation',
   },
+  'thread-c4-unclaimed-pref-no-1004': {
+    tenantId: 'tenant-connectshyft-c4',
+    orgUnitId: 'org-connectshyft-c4-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 1,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-c4-pref-no-1004',
+    lastInboundCsNumberId: 'cs-number-404',
+    preferredOutboundCsNumberId: 'cs-number-504',
+    summary: 'Unclaimed thread with prefers_texting=NO policy.',
+  },
+  'thread-c4-closed-pref-no-1005': {
+    tenantId: 'tenant-connectshyft-c4',
+    orgUnitId: 'org-connectshyft-c4-east',
+    state: 'CLOSED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-c4-pref-no-1005',
+    lastInboundCsNumberId: 'cs-number-405',
+    preferredOutboundCsNumberId: 'cs-number-505',
+    summary: 'Closed thread with prefers_texting=NO policy.',
+  },
 };
 
 const loadPlatformDb = (): Knex => {
@@ -188,6 +217,7 @@ const loadPlatformDb = (): Knex => {
 const connectShyftEscalationConfigService = new ConnectShyftEscalationConfigService(
   new KnexConnectShyftEscalationConfigStore(loadPlatformDb),
 );
+const connectShyftSmsPreferenceOverrideService = connectShyftSmsPreferenceOverrideServiceAsync;
 
 const actorFromRequest = (req: Request): PlatformAdminActorContext => ({
   userId: req.user?.userId || null,
@@ -1554,6 +1584,26 @@ const parseOutboundCallRequestPolicy = (req: Request): {
     retryCount:
       parseOptionalNonNegativeInteger(resolveField('retryCount'))
       ?? parseOptionalNonNegativeInteger(resolveField('maxRetries')),
+  };
+};
+
+const parseOutboundMessagePolicyRequest = (req: Request): {
+  body: string;
+  overrideReason: string | null;
+  overrideNote: string | null;
+} => {
+  const rawBody = req.body && typeof req.body === 'object'
+    ? req.body as Record<string, unknown>
+    : {};
+
+  const body = normalizeLifecycleString(rawBody.body);
+  const overrideReason = normalizeLifecycleString(rawBody.overrideReason).toLowerCase();
+  const overrideNote = normalizeLifecycleString(rawBody.overrideNote);
+
+  return {
+    body,
+    overrideReason: overrideReason || null,
+    overrideNote: overrideNote || null,
   };
 };
 
@@ -3758,6 +3808,9 @@ const performOutboundAction = async (
 
   const actorRoles = resolveConnectShyftActorRoles(req, context);
   const actorUserId = resolveConnectShyftRequestedActorUserId(req);
+  const outboundMessagePolicy = outboundAction === 'message'
+    ? parseOutboundMessagePolicyRequest(req)
+    : null;
   const lifecycleContext = await resolveLifecycleContext({
     tenantId: context.tenantId,
     orgUnitId: context.orgUnitId,
@@ -3777,6 +3830,57 @@ const performOutboundAction = async (
       },
     });
     return;
+  }
+
+  let smsPreferenceDecision: ConnectShyftResolvedSmsPreference | null = null;
+  let validatedSmsOverride: ConnectShyftValidatedSmsOverride | null = null;
+  if (outboundAction === 'message' && outboundMessagePolicy) {
+    const preferenceNeighborId = lifecycleContext.syntheticThread?.neighborId
+      || (lifecycleContext.detail ? `neighbor-${lifecycleContext.detail.threadId}` : null);
+    smsPreferenceDecision = await connectShyftSmsPreferenceOverrideService.resolvePreference({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      threadId,
+      neighborId: preferenceNeighborId,
+    });
+
+    const overrideValidation = connectShyftSmsPreferenceOverrideService.validateOverride({
+      prefersTexting: smsPreferenceDecision.prefersTexting,
+      overrideReason: outboundMessagePolicy.overrideReason,
+      overrideNote: outboundMessagePolicy.overrideNote,
+    });
+
+    if (!overrideValidation.ok) {
+      refusal(res, {
+        code: overrideValidation.reason === 'required'
+          ? 'CONNECTSHYFT_SMS_OVERRIDE_REASON_REQUIRED'
+          : 'CONNECTSHYFT_SMS_OVERRIDE_REASON_INVALID',
+        message: overrideValidation.message,
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          context,
+          threadId,
+          preferencePolicy: {
+            prefersTexting: smsPreferenceDecision.prefersTexting,
+            source: smsPreferenceDecision.source,
+            overrideRequired: smsPreferenceDecision.prefersTexting === 'NO',
+            overrideAccepted: false,
+            allowedOverrideReasons: overrideValidation.allowedReasons,
+          },
+          sideEffects: {
+            messageDispatched: false,
+            lifecycleMutationApplied: false,
+            auditPersisted: false,
+          },
+        },
+      });
+      return;
+    }
+
+    validatedSmsOverride = overrideValidation.overrideRequired
+      ? overrideValidation.override
+      : null;
   }
 
   let thread: ConnectShyftThread;
@@ -3856,6 +3960,22 @@ const performOutboundAction = async (
     });
   }
 
+  const persistedSmsOverride = outboundAction === 'message'
+    && smsPreferenceDecision?.prefersTexting === 'NO'
+    && validatedSmsOverride
+    ? await connectShyftSmsPreferenceOverrideService.persistApprovedOverride({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      threadId,
+      neighborId: smsPreferenceDecision.neighborId,
+      actorUserId,
+      preferenceValue: 'NO',
+      override: validatedSmsOverride,
+      messageBody: outboundMessagePolicy?.body || '',
+      messageEventName: 'connectshyft.thread.outbound_message_dispatched',
+    })
+    : null;
+
   const operatorFeedback = priorState === 'CLOSED'
     ? 'Conversation reopened on the same thread before outbound dispatch. Escalation and inactivity timers were reset.'
     : priorState === 'UNCLAIMED'
@@ -3887,7 +4007,37 @@ const performOutboundAction = async (
             call: CONNECTSHYFT_OUTBOUND_CALL_POLICY,
             autoClaimPolicy: CONNECTSHYFT_OUTBOUND_CALL_AUTO_CLAIM_POLICY,
           }
-        : {}),
+        : {
+            preferencePolicy: {
+              prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
+              source: smsPreferenceDecision?.source || 'unknown',
+              overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
+              overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
+                || Boolean(validatedSmsOverride),
+              ...(validatedSmsOverride
+                ? {
+                  override: {
+                    reason: validatedSmsOverride.reason,
+                    note: validatedSmsOverride.note,
+                    overrideId: persistedSmsOverride?.overrideId || null,
+                    durability: persistedSmsOverride?.durability || null,
+                    createdAtUtc: persistedSmsOverride?.createdAtUtc || null,
+                    audit: persistedSmsOverride
+                      ? {
+                        eventName: persistedSmsOverride.messageEventName,
+                        metadata: persistedSmsOverride.auditMetadata,
+                      }
+                      : null,
+                  },
+                }
+                : {}),
+            },
+            sideEffects: {
+              messageDispatched: true,
+              lifecycleMutationApplied: priorState === 'CLOSED',
+              auditPersisted: Boolean(persistedSmsOverride),
+            },
+          }),
       ...(sideEffects || {}),
     },
   });

--- a/tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts
+++ b/tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts
@@ -1,0 +1,163 @@
+import { apiRequest } from '../../support/helpers/apiClient';
+import { test, expect } from '../../support/fixtures/connectShyftStoryD.fixture';
+
+test.describe(
+  'Story d.2 preference override enforcement for outbound sms (Automate API Expansion)',
+  () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test(
+      '[P0] refuses outbound sms when prefers_texting=NO and override reason is missing with no partial side effects @P0',
+      async ({ request, storyDContext, storyDMemberHeaders, storyDOutboundMessagePayload }) => {
+        const response = await apiRequest(request, {
+          method: 'POST',
+          path: `${storyDContext.paths.threads}/${storyDContext.threadIds.prefersNoClosed}/messages`,
+          headers: storyDMemberHeaders,
+          data: storyDOutboundMessagePayload,
+        });
+
+        expect(response.status()).toBe(200);
+        const body = await response.json();
+
+        expect(body).toMatchObject({
+          ok: false,
+          code: storyDContext.refusalCodes.smsOverrideRequired,
+          data: {
+            preferencePolicy: {
+              prefersTexting: 'NO',
+              overrideRequired: true,
+              overrideAccepted: false,
+            },
+            sideEffects: {
+              messageDispatched: false,
+              lifecycleMutationApplied: false,
+              auditPersisted: false,
+            },
+          },
+        });
+      },
+    );
+
+    test(
+      '[P0] refuses outbound sms for invalid override reason and preserves refusal-only envelope semantics @P0',
+      async ({
+        request,
+        storyDContext,
+        storyDMemberHeaders,
+        storyDInvalidOverrideMessagePayload,
+      }) => {
+        const response = await apiRequest(request, {
+          method: 'POST',
+          path: `${storyDContext.paths.threads}/${storyDContext.threadIds.prefersNoUnclaimed}/messages`,
+          headers: storyDMemberHeaders,
+          data: storyDInvalidOverrideMessagePayload,
+        });
+
+        expect(response.status()).toBe(200);
+        const body = await response.json();
+
+        expect(body).toMatchObject({
+          ok: false,
+          code: storyDContext.refusalCodes.smsOverrideInvalid,
+          data: {
+            preferencePolicy: {
+              prefersTexting: 'NO',
+              overrideRequired: true,
+              overrideAccepted: false,
+            },
+            sideEffects: {
+              messageDispatched: false,
+              lifecycleMutationApplied: false,
+              auditPersisted: false,
+            },
+          },
+        });
+      },
+    );
+
+    test(
+      '[P0] accepts valid override, persists override+audit metadata, and dispatches outbound sms when prefers_texting=NO @P0',
+      async ({
+        request,
+        storyDContext,
+        storyDMemberHeaders,
+        storyDOverrideMessagePayload,
+      }) => {
+        const response = await apiRequest(request, {
+          method: 'POST',
+          path: `${storyDContext.paths.threads}/${storyDContext.threadIds.prefersNoUnclaimed}/messages`,
+          headers: storyDMemberHeaders,
+          data: storyDOverrideMessagePayload,
+        });
+
+        expect(response.status()).toBe(200);
+        const body = await response.json();
+
+        expect(body).toMatchObject({
+          ok: true,
+          code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+          data: {
+            preferencePolicy: {
+              prefersTexting: 'NO',
+              overrideRequired: true,
+              overrideAccepted: true,
+              override: {
+                reason: storyDOverrideMessagePayload.overrideReason,
+                note: storyDOverrideMessagePayload.overrideNote,
+              },
+            },
+            sideEffects: {
+              messageDispatched: true,
+              auditPersisted: true,
+            },
+          },
+        });
+      },
+    );
+
+    test(
+      '[P1] CLOSED outbound sms with valid override reopens same thread before dispatch and still enforces override policy @P1',
+      async ({
+        request,
+        storyDContext,
+        storyDMemberHeaders,
+        storyDOverrideMessagePayload,
+      }) => {
+        const response = await apiRequest(request, {
+          method: 'POST',
+          path: `${storyDContext.paths.threads}/${storyDContext.threadIds.prefersNoClosed}/messages`,
+          headers: storyDMemberHeaders,
+          data: storyDOverrideMessagePayload,
+        });
+
+        expect(response.status()).toBe(200);
+        const body = await response.json();
+
+        expect(body).toMatchObject({
+          ok: true,
+          code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+          data: {
+            thread: {
+              threadId: storyDContext.threadIds.prefersNoClosed,
+              state: 'UNCLAIMED',
+            },
+            lifecycle: {
+              priorState: 'CLOSED',
+              reopenedFromClosed: true,
+            },
+            lifecycleEvent: storyDContext.eventNames.reopenedByUser,
+            preferencePolicy: {
+              prefersTexting: 'NO',
+              overrideRequired: true,
+              overrideAccepted: true,
+            },
+            sideEffects: {
+              messageDispatched: true,
+              lifecycleMutationApplied: true,
+            },
+          },
+        });
+      },
+    );
+  },
+);

--- a/tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts
+++ b/tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts
@@ -1,10 +1,45 @@
+import { randomUUID } from 'node:crypto';
 import { apiRequest } from '../../support/helpers/apiClient';
 import { test, expect } from '../../support/fixtures/connectShyftStoryD.fixture';
+
+const resolveConnectShyftDbConnection = () => {
+  const databaseUrl =
+    process.env.MONEYSHYFT_TEST_DATABASE_URL
+    || (process.env.CI === 'true' ? process.env.DATABASE_URL : undefined);
+  if (databaseUrl) {
+    return databaseUrl;
+  }
+
+  return {
+    host: process.env.TEST_DB_HOST || '127.0.0.1',
+    port: Number(process.env.TEST_DB_PORT || 5432),
+    database: process.env.TEST_DB_NAME || 'moneyshyft',
+    user: process.env.TEST_DB_USER || 'jeremiahotis',
+    password: process.env.TEST_DB_PASSWORD || 'Oiurueu12',
+  };
+};
+
+const createConnectShyftDbClient = () => {
+  const knexFactory = require('../../../src/node_modules/knex');
+  return knexFactory({
+    client: 'postgresql',
+    connection: resolveConnectShyftDbConnection(),
+    pool: {
+      min: 0,
+      max: 2,
+    },
+  });
+};
+
+const connectShyftDb = createConnectShyftDbClient();
 
 test.describe(
   'Story d.2 preference override enforcement for outbound sms (Automate API Expansion)',
   () => {
     test.describe.configure({ mode: 'serial' });
+    test.afterAll(async () => {
+      await connectShyftDb.destroy();
+    });
 
     test(
       '[P0] refuses outbound sms when prefers_texting=NO and override reason is missing with no partial side effects @P0',
@@ -112,6 +147,150 @@ test.describe(
             },
           },
         });
+      },
+    );
+
+    test(
+      '[P1] db-backed UUID thread+neighbor path enforces override requirements and persists approved override metadata @P1',
+      async ({
+        request,
+        storyDContext,
+        storyDMemberHeaders,
+        storyDOutboundMessagePayload,
+        storyDOverrideMessagePayload,
+      }) => {
+        const neighborId = randomUUID();
+        let threadId = '';
+
+        await connectShyftDb
+          .withSchema('connectshyft')
+          .table('cs_neighbors')
+          .insert({
+            id: neighborId,
+            tenant_id: storyDContext.tenantId,
+            org_unit_id: storyDContext.orgUnitId,
+            first_name: 'StoryD',
+            last_name: 'Neighbor',
+            prefers_texting: 'NO',
+          })
+          .onConflict('id')
+          .merge({
+            tenant_id: storyDContext.tenantId,
+            org_unit_id: storyDContext.orgUnitId,
+            prefers_texting: 'NO',
+          });
+
+        try {
+          const ensureResponse = await apiRequest(request, {
+            method: 'POST',
+            path: storyDContext.paths.threads,
+            headers: storyDMemberHeaders,
+            data: {
+              orgUnitId: storyDContext.orgUnitId,
+              neighborId,
+              source: 'VOICE',
+              lastInboundCsNumberId: 'cs-number-d2-db-1',
+              preferredOutboundCsNumberId: 'cs-number-d2-db-2',
+            },
+          });
+
+          expect(ensureResponse.status()).toBe(201);
+          const ensureBody = await ensureResponse.json();
+          threadId = ensureBody.data.thread.threadId as string;
+          expect(threadId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+          );
+
+          const refusalResponse = await apiRequest(request, {
+            method: 'POST',
+            path: `${storyDContext.paths.threads}/${threadId}/messages`,
+            headers: storyDMemberHeaders,
+            data: storyDOutboundMessagePayload,
+          });
+
+          expect(refusalResponse.status()).toBe(200);
+          const refusalBody = await refusalResponse.json();
+          expect(refusalBody).toMatchObject({
+            ok: false,
+            code: storyDContext.refusalCodes.smsOverrideRequired,
+            data: {
+              preferencePolicy: {
+                prefersTexting: 'NO',
+                source: 'neighbor-record',
+                overrideRequired: true,
+                overrideAccepted: false,
+              },
+            },
+          });
+
+          const successResponse = await apiRequest(request, {
+            method: 'POST',
+            path: `${storyDContext.paths.threads}/${threadId}/messages`,
+            headers: storyDMemberHeaders,
+            data: storyDOverrideMessagePayload,
+          });
+
+          expect(successResponse.status()).toBe(200);
+          const successBody = await successResponse.json();
+          expect(successBody).toMatchObject({
+            ok: true,
+            code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+            data: {
+              preferencePolicy: {
+                prefersTexting: 'NO',
+                source: 'neighbor-record',
+                overrideRequired: true,
+                overrideAccepted: true,
+                override: {
+                  reason: storyDOverrideMessagePayload.overrideReason,
+                  note: storyDOverrideMessagePayload.overrideNote,
+                  durability: 'database',
+                },
+              },
+              sideEffects: {
+                messageDispatched: true,
+                auditPersisted: true,
+              },
+            },
+          });
+
+          const persistedOverride = await connectShyftDb
+            .withSchema('connectshyft')
+            .table('cs_sms_preference_overrides')
+            .where({
+              tenant_id: storyDContext.tenantId,
+              thread_id: threadId,
+            })
+            .orderBy('created_at_utc', 'desc')
+            .first<{
+              preference_value: string;
+              override_reason: string;
+            }>('preference_value', 'override_reason');
+
+          expect(persistedOverride).toMatchObject({
+            preference_value: 'NO',
+            override_reason: storyDOverrideMessagePayload.overrideReason,
+          });
+        } finally {
+          if (threadId) {
+            await connectShyftDb
+              .withSchema('connectshyft')
+              .table('cs_sms_preference_overrides')
+              .where({ thread_id: threadId })
+              .delete();
+            await connectShyftDb
+              .withSchema('connectshyft')
+              .table('cs_threads')
+              .where({ id: threadId })
+              .delete();
+          }
+
+          await connectShyftDb
+            .withSchema('connectshyft')
+            .table('cs_neighbors')
+            .where({ id: neighborId })
+            .delete();
+        }
       },
     );
 

--- a/tests/support/factories/connectShyftStoryDFactory.ts
+++ b/tests/support/factories/connectShyftStoryDFactory.ts
@@ -42,6 +42,8 @@ export type StoryDContext = {
     unclaimed: string;
     claimed: string;
     closed: string;
+    prefersNoUnclaimed: string;
+    prefersNoClosed: string;
   };
   paths: {
     threads: string;
@@ -89,6 +91,8 @@ export function createStoryDContext(
       unclaimed: 'thread-c4-unclaimed-1001',
       claimed: 'thread-c4-claimed-1002',
       closed: 'thread-c4-closed-1003',
+      prefersNoUnclaimed: 'thread-c4-unclaimed-pref-no-1004',
+      prefersNoClosed: 'thread-c4-closed-pref-no-1005',
     },
     paths: {
       threads: '/api/v1/connectshyft/threads',


### PR DESCRIPTION
## Summary
- fix outbound SMS preference enforcement to use canonical DB thread->neighbor lookup for non-synthetic thread contexts
- add canonical override_reason DB CHECK constraint and an upgrade-safe follow-up migration for already-migrated environments
- add DB-backed API regression coverage for UUID thread+neighbor path and sync d.2 story/sprint artifact tracking

## Validation
- cd src && npm test -- src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts
- cd src && npm run build
- npm run test:e2e -- tests/api/platform/d-2-preference-override-enforcement-for-outbound-sms.automate.api.spec.ts