### PR TITLE
Fix: canonical timezone processing across intake and scheduling

### DIFF
--- a/_bmad-output/implementation-artifacts/2-6-canonical-timezone-processing-across-intake-and-scheduling.md
+++ b/_bmad-output/implementation-artifacts/2-6-canonical-timezone-processing-across-intake-and-scheduling.md
@@ -1,6 +1,6 @@
 # Story 2.6: Canonical Timezone Processing Across Intake and Scheduling
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -31,17 +31,17 @@ so that scheduling decisions are accurate and no user sees raw UTC.
 
 ## Tasks / Subtasks
 
-- [ ] Implement canonical timezone resolution strategy (AC: 1)
-  - [ ] Resolve timezone via deterministic fallback (`user -> tenant -> system`).
-  - [ ] Centralize timezone resolver for route intake and scheduling surfaces.
-- [ ] Enforce UTC-at-rest persistence and localized read rendering (AC: 1)
-  - [ ] Validate all persistence paths store UTC timestamps.
-  - [ ] Ensure API serializers/UI adapters convert to resolved local timezone.
-- [ ] Prevent raw UTC leakage on operational surfaces (AC: 2)
-  - [ ] Audit key response payloads and rendered fields for raw UTC strings.
-  - [ ] Add guards against accidental pass-through of UTC formatted timestamps.
-- [ ] Add deterministic cross-timezone tests (AC: 1, 2)
-  - [ ] API and UI contract tests for locale rendering and UTC suppression.
+- [x] Implement canonical timezone resolution strategy (AC: 1)
+  - [x] Resolve timezone via deterministic fallback (`user -> tenant -> system`).
+  - [x] Centralize timezone resolver for route intake and scheduling surfaces.
+- [x] Enforce UTC-at-rest persistence and localized read rendering (AC: 1)
+  - [x] Validate all persistence paths store UTC timestamps.
+  - [x] Ensure API serializers/UI adapters convert to resolved local timezone.
+- [x] Prevent raw UTC leakage on operational surfaces (AC: 2)
+  - [x] Audit key response payloads and rendered fields for raw UTC strings.
+  - [x] Add guards against accidental pass-through of UTC formatted timestamps.
+- [x] Add deterministic cross-timezone tests (AC: 1, 2)
+  - [x] API and UI contract tests for locale rendering and UTC suppression.
 
 ## Dev Notes
 
@@ -101,11 +101,43 @@ GPT-5 Codex
 ### Debug Log References
 
 - Story context prepared from Epic 2 planning artifacts.
+- Added shared route timezone adapter and wired localized serialization in `src/src/routes/api/v1/route.ts`.
+- Added frontend timezone request header and UTC leakage guard in Route lifecycle view adapter.
+- Added cross-timezone API/UI contract coverage for Story 2.6.
+- Hardened route system-timezone fallback to trusted server configuration (`ROUTESHYFT_SYSTEM_TIMEZONE`/`SYSTEM_TIMEZONE`/`TZ`) with UTC default; `x-system-timezone` request overrides are no longer honored in route APIs.
+- Updated lifecycle payload sanitization fallback to render UTC strings using API-resolved timezone context when available.
+- Expanded timezone regression coverage for DST boundary conversion and half-hour offset timezone rendering.
+- Validation commands:
+  - `cd src && npm test -- src/src/routes/api/v1/__tests__/route.timezone.test.ts`
+  - `cd src && npm test -- src/src/routes/api/v1/__tests__/route.test.ts src/src/routes/api/v1/__tests__/route.cashier-intake.test.ts src/src/routes/api/v1/__tests__/route.commitments.test.ts`
+  - `cd src && npm test`
+  - `cd src && npm run build`
+  - `cd frontend && npm run build`
 
 ### Completion Notes List
 
-- Story created and set to `ready-for-dev`.
+- Implemented deterministic timezone context resolution for route intake/scheduling (`user -> tenant -> system`) with safe system default fallback.
+- Enforced localized API presentation adapter for operational route responses; UTC fields are converted to `*Local` and guarded against raw UTC pass-through.
+- Preserved UTC-at-rest persistence paths; added tests that verify stored canonical timestamps remain UTC while read responses are localized.
+- Added API contract coverage for timezone fallback + UTC suppression and UI journey assertions that operational details do not show raw UTC ISO strings.
+- Removed client control of route-level system timezone fallback by sourcing system timezone from trusted server environment defaults.
+- Corrected frontend UTC sanitization fallback to align with API-resolved timezone context instead of browser-local timezone.
+- Added deterministic DST boundary and offset-edge tests (`America/Los_Angeles` DST jump, `Asia/Kolkata` half-hour offset) for localized rendering guarantees.
+- Story status advanced to `review`; sprint status updated to `review`.
 
 ### File List
 
 - _bmad-output/implementation-artifacts/2-6-canonical-timezone-processing-across-intake-and-scheduling.md
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+- src/src/modules/route/api/timezoneAdapter.ts
+- src/src/routes/api/v1/route.ts
+- src/src/routes/api/v1/__tests__/route.timezone.test.ts
+- frontend/src/services/api.ts
+- frontend/src/views/RouteShyft/RouteRequestLifecycleView.vue
+- tests/api/platform/2-4-request-to-commitment-linkage-and-terminal-enforcement.api.spec.ts
+- tests/e2e/platform/2-4-request-to-commitment-linkage-and-terminal-enforcement.spec.ts
+
+## Change Log
+
+- 2026-02-27: Implemented canonical timezone processing across route intake/scheduling serializers and UI adapters; added deterministic timezone fallback + UTC leakage contract tests; updated sprint/story status to `review`.
+- 2026-02-27: Addressed review remediation by removing request-header control of system fallback timezone, aligning UI fallback formatting with API timezone context, and adding DST/offset regression tests.

--- a/_bmad-output/implementation-artifacts/2-6-canonical-timezone-processing-across-intake-and-scheduling.md
+++ b/_bmad-output/implementation-artifacts/2-6-canonical-timezone-processing-across-intake-and-scheduling.md
@@ -1,6 +1,6 @@
 # Story 2.6: Canonical Timezone Processing Across Intake and Scheduling
 
-Status: in-progress
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 

--- a/_bmad-output/implementation-artifacts/2-6-canonical-timezone-processing-across-intake-and-scheduling.md
+++ b/_bmad-output/implementation-artifacts/2-6-canonical-timezone-processing-across-intake-and-scheduling.md
@@ -1,6 +1,6 @@
 # Story 2.6: Canonical Timezone Processing Across Intake and Scheduling
 
-Status: review
+Status: in-progress
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 

--- a/_bmad-output/implementation-artifacts/2-6-canonical-timezone-processing-across-intake-and-scheduling.md
+++ b/_bmad-output/implementation-artifacts/2-6-canonical-timezone-processing-across-intake-and-scheduling.md
@@ -108,11 +108,11 @@ GPT-5 Codex
 - Updated lifecycle payload sanitization fallback to render UTC strings using API-resolved timezone context when available.
 - Expanded timezone regression coverage for DST boundary conversion and half-hour offset timezone rendering.
 - Validation commands:
-  - `cd src && npm test -- src/src/routes/api/v1/__tests__/route.timezone.test.ts`
-  - `cd src && npm test -- src/src/routes/api/v1/__tests__/route.test.ts src/src/routes/api/v1/__tests__/route.cashier-intake.test.ts src/src/routes/api/v1/__tests__/route.commitments.test.ts`
-  - `cd src && npm test`
-  - `cd src && npm run build`
-  - `cd frontend && npm run build`
+  - `cd src && npm test -- src/src/routes/api/v1/__tests__/route.timezone.test.ts` (pass: 6 tests)
+  - `cd src && npm test -- src/src/routes/api/v1/__tests__/route.test.ts src/src/routes/api/v1/__tests__/route.cashier-intake.test.ts src/src/routes/api/v1/__tests__/route.commitments.test.ts` (pass: 22 tests)
+  - `cd src && npm test` (pass: 56 suites, 310 tests)
+  - `cd src && npm run build` (pass)
+  - `cd frontend && npm run build` (pass)
 
 ### Completion Notes List
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -67,7 +67,7 @@ development_status:
   2-3-cashier-assisted-intake-and-voucher-delivery-scheduling: done
   2-4-request-to-commitment-linkage-and-terminal-enforcement: done
   2-5-refusal-outcomes-with-structured-alternatives: in-progress
-  2-6-canonical-timezone-processing-across-intake-and-scheduling: ready-for-dev
+  2-6-canonical-timezone-processing-across-intake-and-scheduling: review
   epic-2-retrospective: optional
   epic-3: backlog
   3-1-unified-dispatcher-queue-and-triage-attributes: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -67,7 +67,7 @@ development_status:
   2-3-cashier-assisted-intake-and-voucher-delivery-scheduling: done
   2-4-request-to-commitment-linkage-and-terminal-enforcement: done
   2-5-refusal-outcomes-with-structured-alternatives: in-progress
-  2-6-canonical-timezone-processing-across-intake-and-scheduling: review
+  2-6-canonical-timezone-processing-across-intake-and-scheduling: in-progress
   epic-2-retrospective: optional
   epic-3: backlog
   3-1-unified-dispatcher-queue-and-triage-attributes: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -67,7 +67,7 @@ development_status:
   2-3-cashier-assisted-intake-and-voucher-delivery-scheduling: done
   2-4-request-to-commitment-linkage-and-terminal-enforcement: done
   2-5-refusal-outcomes-with-structured-alternatives: in-progress
-  2-6-canonical-timezone-processing-across-intake-and-scheduling: in-progress
+  2-6-canonical-timezone-processing-across-intake-and-scheduling: review
   epic-2-retrospective: optional
   epic-3: backlog
   3-1-unified-dispatcher-queue-and-triage-attributes: backlog

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -31,11 +31,19 @@ const getCookieValue = (name: string): string | null => {
 
 api.interceptors.request.use((config) => {
   const method = (config.method || 'get').toLowerCase();
+  config.headers = config.headers || {};
+
+  const existingTimezoneHeader = (config.headers as Record<string, string>)['x-user-timezone'];
+  if (!existingTimezoneHeader && typeof Intl !== 'undefined') {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (timezone) {
+      (config.headers as Record<string, string>)['x-user-timezone'] = timezone;
+    }
+  }
 
   if (!SAFE_METHODS.has(method)) {
     const csrfToken = getCookieValue('csrf_token');
     if (csrfToken) {
-      config.headers = config.headers || {};
       (config.headers as Record<string, string>)['X-CSRF-Token'] = csrfToken;
     }
   }

--- a/frontend/src/views/RouteShyft/RouteRequestLifecycleView.vue
+++ b/frontend/src/views/RouteShyft/RouteRequestLifecycleView.vue
@@ -68,6 +68,8 @@ const reconciliationActions = ref<string[]>([]);
 const refusalBanner = ref('No finalize action submitted yet.');
 const refusalCode = ref('ROUTE_FINALIZE_NOT_SUBMITTED');
 const lifecycleDetails = ref('{}');
+const utcFieldSuffix = /Utc$/;
+const utcIsoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 
 const terminalStatusLabel = computed(() => {
   if (terminalStatus.value === 'unknown') {
@@ -81,8 +83,78 @@ const terminalStatusLabel = computed(() => {
   return terminalStatus.value;
 });
 
+const isValidIanaTimezone = (value: unknown): value is string => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return false;
+  }
+
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: value }).format(new Date());
+    return true;
+  } catch (_error) {
+    return false;
+  }
+};
+
+const resolveDisplayTimezone = (value: unknown): string | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const timezoneCandidate = (value as Record<string, unknown>).timezone;
+  return isValidIanaTimezone(timezoneCandidate) ? timezoneCandidate : null;
+};
+
+const formatUtcForDisplay = (value: string, timezone: string | null): string => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  const formatOptions: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  };
+
+  if (timezone) {
+    formatOptions.timeZone = timezone;
+  }
+
+  return new Intl.DateTimeFormat('en-US', formatOptions).format(parsed);
+};
+
+const sanitizeOperationalPayload = (value: unknown, timezone: string | null): unknown => {
+  if (typeof value === 'string') {
+    return utcIsoPattern.test(value) ? formatUtcForDisplay(value, timezone) : value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeOperationalPayload(entry, timezone));
+  }
+
+  if (value && typeof value === 'object') {
+    const payload = value as Record<string, unknown>;
+    const sanitized: Record<string, unknown> = {};
+
+    for (const [key, entry] of Object.entries(payload)) {
+      const nextKey = utcFieldSuffix.test(key) ? key.replace(utcFieldSuffix, 'Local') : key;
+      sanitized[nextKey] = sanitizeOperationalPayload(entry, timezone);
+    }
+
+    return sanitized;
+  }
+
+  return value;
+};
+
 const setLifecycleDetails = (value: unknown): void => {
-  lifecycleDetails.value = JSON.stringify(value ?? {}, null, 2);
+  const payload = value ?? {};
+  const displayTimezone = resolveDisplayTimezone(payload);
+  lifecycleDetails.value = JSON.stringify(sanitizeOperationalPayload(payload, displayTimezone), null, 2);
 };
 
 const loadReconciliationQueue = async (): Promise<void> => {

--- a/src/src/modules/route/api/timezoneAdapter.ts
+++ b/src/src/modules/route/api/timezoneAdapter.ts
@@ -1,0 +1,112 @@
+import type { Request } from 'express';
+import {
+  formatUtcTimestampForTimezone,
+  isStrictUtcIsoTimestamp,
+  isValidIanaTimezone,
+  resolveTimezoneContext,
+  type TimezoneContext,
+} from '../../../platform/time/timezoneService';
+
+export type RouteTimezoneContext = TimezoneContext;
+
+const DEFAULT_SYSTEM_TIMEZONE = 'UTC';
+const UTC_FIELD_SUFFIX = /Utc$/;
+const UTC_REDACTED_VALUE = '[UTC timestamp withheld]';
+const SYSTEM_TIMEZONE_ENV_KEYS = ['ROUTESHYFT_SYSTEM_TIMEZONE', 'SYSTEM_TIMEZONE', 'TZ'] as const;
+
+const normalizeNonEmptyString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const resolveSystemTimezone = (): string => {
+  for (const envKey of SYSTEM_TIMEZONE_ENV_KEYS) {
+    const candidate = normalizeNonEmptyString(process.env[envKey]);
+    if (candidate && isValidIanaTimezone(candidate)) {
+      return candidate;
+    }
+  }
+
+  return DEFAULT_SYSTEM_TIMEZONE;
+};
+
+const localizeUtcString = (value: string, timezone: string): string => {
+  const localized = formatUtcTimestampForTimezone(value, timezone);
+  return localized || UTC_REDACTED_VALUE;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const localizeValue = (value: unknown, context: RouteTimezoneContext): unknown => {
+  if (typeof value === 'string') {
+    if (isStrictUtcIsoTimestamp(value)) {
+      return localizeUtcString(value, context.timezone);
+    }
+
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => localizeValue(entry, context));
+  }
+
+  if (isPlainObject(value)) {
+    const localized: Record<string, unknown> = {};
+
+    for (const [key, entry] of Object.entries(value)) {
+      const localizedEntry = localizeValue(entry, context);
+      if (UTC_FIELD_SUFFIX.test(key)) {
+        localized[key.replace(UTC_FIELD_SUFFIX, 'Local')] = localizedEntry;
+        continue;
+      }
+
+      localized[key] = localizedEntry;
+    }
+
+    return localized;
+  }
+
+  return value;
+};
+
+export const resolveRouteTimezoneContext = (req: Request): RouteTimezoneContext => {
+  const resolved = resolveTimezoneContext({
+    userTimezone: req.header('x-user-timezone'),
+    tenantTimezone: req.header('x-tenant-timezone'),
+    systemTimezone: resolveSystemTimezone(),
+  });
+
+  if (resolved) {
+    return resolved;
+  }
+
+  return {
+    timezone: DEFAULT_SYSTEM_TIMEZONE,
+    timezoneSource: 'system',
+  };
+};
+
+export const localizeRouteOperationalData = (
+  data: unknown,
+  context: RouteTimezoneContext,
+): Record<string, unknown> => {
+  const localized = localizeValue(data, context);
+  if (!isPlainObject(localized)) {
+    return {
+      value: localized,
+      timezone: context.timezone,
+      timezoneSource: context.timezoneSource,
+    };
+  }
+
+  return {
+    ...localized,
+    timezone: context.timezone,
+    timezoneSource: context.timezoneSource,
+  };
+};

--- a/src/src/modules/route/api/timezoneAdapter.ts
+++ b/src/src/modules/route/api/timezoneAdapter.ts
@@ -12,6 +12,7 @@ export type RouteTimezoneContext = TimezoneContext;
 const DEFAULT_SYSTEM_TIMEZONE = 'UTC';
 const UTC_FIELD_SUFFIX = /Utc$/;
 const UTC_REDACTED_VALUE = '[UTC timestamp withheld]';
+const EMBEDDED_UTC_ISO_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z/g;
 const SYSTEM_TIMEZONE_ENV_KEYS = ['ROUTESHYFT_SYSTEM_TIMEZONE', 'SYSTEM_TIMEZONE', 'TZ'] as const;
 
 const normalizeNonEmptyString = (value: unknown): string => {
@@ -38,6 +39,21 @@ const localizeUtcString = (value: string, timezone: string): string => {
   return localized || UTC_REDACTED_VALUE;
 };
 
+const localizeEmbeddedUtcTokens = (value: string, timezone: string): string => {
+  if (!EMBEDDED_UTC_ISO_PATTERN.test(value)) {
+    return value;
+  }
+
+  EMBEDDED_UTC_ISO_PATTERN.lastIndex = 0;
+  return value.replace(EMBEDDED_UTC_ISO_PATTERN, (candidate) => {
+    if (!isStrictUtcIsoTimestamp(candidate)) {
+      return candidate;
+    }
+
+    return localizeUtcString(candidate, timezone);
+  });
+};
+
 const isPlainObject = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
@@ -48,7 +64,7 @@ const localizeValue = (value: unknown, context: RouteTimezoneContext): unknown =
       return localizeUtcString(value, context.timezone);
     }
 
-    return value;
+    return localizeEmbeddedUtcTokens(value, context.timezone);
   }
 
   if (Array.isArray(value)) {

--- a/src/src/routes/api/v1/__tests__/route.timezone.test.ts
+++ b/src/src/routes/api/v1/__tests__/route.timezone.test.ts
@@ -1,0 +1,239 @@
+import express from 'express';
+import request from 'supertest';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import { CommitmentService } from '../../../../modules/route/application/commitmentService';
+import { IntakeService } from '../../../../modules/route/application/intakeService';
+import {
+  InMemoryCommitmentRepository,
+} from '../../../../modules/route/infrastructure/commitmentRepository';
+import {
+  InMemoryIntakeRequestRepository,
+} from '../../../../modules/route/infrastructure/intakeRequestRepository';
+import { createRouteRouter } from '../route';
+
+jest.mock('../../../../middleware/auth', () => ({
+  authenticateToken: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    const tenantId = 'tenant-route-timezone-1';
+    const orgUnitId = 'org-route-timezone-1';
+
+    req.user = {
+      userId: 'user-route-timezone-1',
+      email: 'dispatcher@example.com',
+      householdId: tenantId,
+      activeTenantId: tenantId,
+      activeOrgUnitId: orgUnitId,
+      role: 'TENANT_STAFF',
+    };
+    req.tenantId = tenantId;
+    req.orgUnitId = orgUnitId;
+    req.scopeMode = 'ORG_UNIT';
+    next();
+  },
+}));
+
+const STRICT_UTC_ISO_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z/;
+
+const basePayload = {
+  tenantId: 'tenant-route-timezone-1',
+  orgUnitId: 'org-route-timezone-1',
+  requestedAtUtc: '2026-02-26T14:00:00.000Z',
+  requestedWindowStartUtc: '2026-02-27T14:00:00.000Z',
+  requestedWindowEndUtc: '2026-02-27T16:00:00.000Z',
+  channel: '2-6-canonical-timezone-processing',
+  notes: 'Route timezone contract coverage',
+  forceRefusal: false,
+  scheduleMode: 'pickup',
+};
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(responseEnvelope);
+
+  const commitmentRepository = new InMemoryCommitmentRepository();
+  const intakeRepository = new InMemoryIntakeRequestRepository();
+  const commitmentService = new CommitmentService(commitmentRepository);
+  const intakeService = new IntakeService(commitmentService, intakeRepository);
+
+  app.use('/api/v1/route', createRouteRouter(commitmentService, intakeService));
+  return { app, intakeRepository };
+};
+
+describe('route timezone presentation contract', () => {
+  it('resolves timezone fallback in strict order user -> tenant -> system for intake responses', async () => {
+    const { app } = buildApp();
+
+    const response = await request(app)
+      .post('/api/v1/route/intake/cashier-requests')
+      .set('x-user-timezone', 'Invalid/Timezone')
+      .set('x-tenant-timezone', 'America/Chicago')
+      .set('x-system-timezone', 'UTC')
+      .send(basePayload);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'ROUTESHYFT_CASHIER_INTAKE_ACCEPTED',
+      data: {
+        timezone: 'America/Chicago',
+        timezoneSource: 'tenant',
+        availableSlots: expect.any(Array),
+      },
+    });
+    expect(JSON.stringify(response.body?.data || {})).not.toMatch(STRICT_UTC_ISO_PATTERN);
+  });
+
+  it('uses system fallback and omits raw utc keys in reconciliation payloads', async () => {
+    const { app } = buildApp();
+
+    const response = await request(app)
+      .get('/api/v1/route/intake/reconciliation/unresolved?staleMinutes=60')
+      .set('x-user-timezone', '')
+      .set('x-tenant-timezone', '')
+      .set('x-system-timezone', 'America/New_York');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'ROUTESHYFT_INTAKE_RECONCILIATION_QUEUE',
+      data: {
+        timezone: 'UTC',
+        timezoneSource: 'system',
+        generatedAtLocal: expect.any(String),
+      },
+    });
+    expect(response.body?.data).not.toHaveProperty('generatedAtUtc');
+    expect(JSON.stringify(response.body?.data || {})).not.toMatch(STRICT_UTC_ISO_PATTERN);
+  });
+
+  it('localizes DST boundary slots without raw UTC leakage', async () => {
+    const { app } = buildApp();
+
+    const response = await request(app)
+      .post('/api/v1/route/intake/requests')
+      .set('x-user-timezone', 'America/Los_Angeles')
+      .send({
+        ...basePayload,
+        requestedAtUtc: '2026-03-08T09:00:00.000Z',
+        requestedWindowStartUtc: '2026-03-08T09:30:00.000Z',
+        requestedWindowEndUtc: '2026-03-08T11:30:00.000Z',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'ROUTESHYFT_DONOR_INTAKE_ACCEPTED',
+      data: {
+        timezone: 'America/Los_Angeles',
+        timezoneSource: 'user',
+      },
+    });
+
+    const slots = response.body?.data?.availableSlots as string[];
+    expect(slots[0]).toMatch(/03\/08\/2026, 01:30 AM/);
+    expect(slots[1]).toMatch(/03\/08\/2026, 04:30 AM/);
+    expect(JSON.stringify(response.body?.data || {})).not.toMatch(STRICT_UTC_ISO_PATTERN);
+  });
+
+  it('localizes half-hour offset timezones deterministically', async () => {
+    const { app } = buildApp();
+
+    const response = await request(app)
+      .post('/api/v1/route/intake/requests')
+      .set('x-user-timezone', 'Asia/Kolkata')
+      .send({
+        ...basePayload,
+        requestedAtUtc: '2026-02-27T13:30:00.000Z',
+        requestedWindowStartUtc: '2026-02-27T14:00:00.000Z',
+        requestedWindowEndUtc: '2026-02-27T16:00:00.000Z',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'ROUTESHYFT_DONOR_INTAKE_ACCEPTED',
+      data: {
+        timezone: 'Asia/Kolkata',
+        timezoneSource: 'user',
+      },
+    });
+
+    const slots = response.body?.data?.availableSlots as string[];
+    expect(slots[0]).toMatch(/02\/27\/2026, 07:30 PM/);
+    expect(slots[1]).toMatch(/02\/27\/2026, 09:30 PM/);
+    expect(JSON.stringify(response.body?.data || {})).not.toMatch(STRICT_UTC_ISO_PATTERN);
+  });
+
+  it('serializes commitment scheduling timestamps as local fields only', async () => {
+    const { app } = buildApp();
+
+    const created = await request(app)
+      .post('/api/v1/route/commitments')
+      .set('x-user-timezone', 'America/Los_Angeles')
+      .send({
+        sourceType: 'route_request',
+        sourceId: 'timezone-commitment-1',
+      });
+
+    expect(created.status).toBe(201);
+    expect(created.body).toMatchObject({
+      ok: true,
+      code: 'ROUTE_COMMITMENT_CREATED',
+      data: {
+        timezone: 'America/Los_Angeles',
+        timezoneSource: 'user',
+        commitment: {
+          createdAtLocal: expect.any(String),
+          updatedAtLocal: expect.any(String),
+        },
+      },
+    });
+    expect(created.body?.data?.commitment).not.toHaveProperty('createdAtUtc');
+    expect(created.body?.data?.commitment).not.toHaveProperty('updatedAtUtc');
+
+    const commitmentId = created.body?.data?.commitment?.commitmentId as string;
+    const transitioned = await request(app)
+      .post(`/api/v1/route/commitments/${commitmentId}/transitions`)
+      .set('x-user-timezone', 'America/Los_Angeles')
+      .send({
+        nextStatus: 'in_progress',
+        reason: 'Timezone serialization coverage',
+      });
+
+    expect(transitioned.status).toBe(200);
+    expect(transitioned.body).toMatchObject({
+      ok: true,
+      code: 'ROUTE_COMMITMENT_TRANSITION_APPLIED',
+      data: {
+        transition: {
+          occurredAtLocal: expect.any(String),
+        },
+      },
+    });
+    expect(transitioned.body?.data?.transition).not.toHaveProperty('occurredAtUtc');
+    expect(JSON.stringify(transitioned.body?.data || {})).not.toMatch(STRICT_UTC_ISO_PATTERN);
+  });
+
+  it('keeps intake persistence timestamps in canonical UTC-at-rest format', async () => {
+    const { app, intakeRepository } = buildApp();
+
+    const createResponse = await request(app)
+      .post('/api/v1/route/intake/requests')
+      .send(basePayload);
+
+    expect(createResponse.status).toBe(200);
+    const requestId = createResponse.body?.data?.requestId as string;
+    const persisted = await intakeRepository.getById(
+      basePayload.tenantId,
+      basePayload.orgUnitId,
+      requestId,
+    );
+
+    expect(persisted).not.toBeNull();
+    expect(persisted?.requestedAtUtc).toBe(basePayload.requestedAtUtc);
+    expect(persisted?.requestedWindowStartUtc).toBe(basePayload.requestedWindowStartUtc);
+    expect(persisted?.requestedWindowEndUtc).toBe(basePayload.requestedWindowEndUtc);
+    expect(persisted?.createdAtUtc).toMatch(STRICT_UTC_ISO_PATTERN);
+    expect(persisted?.updatedAtUtc).toMatch(STRICT_UTC_ISO_PATTERN);
+  });
+});

--- a/src/src/routes/api/v1/__tests__/route.timezone.test.ts
+++ b/src/src/routes/api/v1/__tests__/route.timezone.test.ts
@@ -172,7 +172,7 @@ describe('route timezone presentation contract', () => {
       .set('x-user-timezone', 'America/Los_Angeles')
       .send({
         sourceType: 'route_request',
-        sourceId: 'timezone-commitment-1',
+        sourceId: 'timezone-commitment-1:2026-02-26T14:00:00.000Z',
       });
 
     expect(created.status).toBe(201);

--- a/src/src/routes/api/v1/route.ts
+++ b/src/src/routes/api/v1/route.ts
@@ -11,6 +11,10 @@ import { IntakeService } from '../../../modules/route/application/intakeService'
 import { KnexIntakeRequestRepository } from '../../../modules/route/infrastructure/intakeRequestRepository';
 import { RouteIntakeChannel, RouteIntakePayload } from '../../../modules/route/domain/intakePolicy';
 import { createRouteRouter as createRouteRefusalRouter } from '../../../modules/route/api/router';
+import {
+  localizeRouteOperationalData,
+  resolveRouteTimezoneContext,
+} from '../../../modules/route/api/timezoneAdapter';
 
 const TEST_TENANT_HEADER = 'x-test-route-tenant-id';
 const TEST_ACTOR_HEADER = 'x-test-route-actor-id';
@@ -381,6 +385,11 @@ const applyServiceRefusal = (
   });
 };
 
+const localizeRouteResponseData = (req: Request, data: unknown): Record<string, unknown> => {
+  const timezoneContext = resolveRouteTimezoneContext(req);
+  return localizeRouteOperationalData(data, timezoneContext);
+};
+
 const handleSubmitIntake = (
   intakeService: IntakeService,
   channel: RouteIntakeChannel,
@@ -412,7 +421,7 @@ const handleSubmitIntake = (
     code: result.code,
     message: result.message,
     httpStatus: result.httpStatus,
-    data: result.data,
+    data: localizeRouteResponseData(req, result.data),
   });
 };
 
@@ -464,7 +473,7 @@ const handleResolveIntake = (
     code: result.code,
     message: result.message,
     httpStatus: result.httpStatus,
-    data: result.data,
+    data: localizeRouteResponseData(req, result.data),
   });
 };
 
@@ -505,7 +514,7 @@ const handleSubmitDonorIntake = (
     code: result.code,
     message: result.message,
     httpStatus: result.httpStatus,
-    data: result.data,
+    data: localizeRouteResponseData(req, result.data),
   });
 };
 
@@ -549,7 +558,7 @@ const handleResolveDonorIntake = (
     code: result.code,
     message: result.message,
     httpStatus: result.httpStatus,
-    data: result.data,
+    data: localizeRouteResponseData(req, result.data),
   });
 };
 
@@ -603,7 +612,7 @@ export const createRouteRouter = (
       code: created.code,
       message: created.message,
       httpStatus: created.httpStatus,
-      data: created.data,
+      data: localizeRouteResponseData(req, created.data),
     });
   });
 
@@ -638,7 +647,7 @@ export const createRouteRouter = (
       code: resolved.code,
       message: resolved.message,
       httpStatus: resolved.httpStatus,
-      data: resolved.data,
+      data: localizeRouteResponseData(req, resolved.data),
     });
   });
 
@@ -689,7 +698,7 @@ export const createRouteRouter = (
       code: transitioned.code,
       message: transitioned.message,
       httpStatus: transitioned.httpStatus,
-      data: transitioned.data,
+      data: localizeRouteResponseData(req, transitioned.data),
     });
   });
 
@@ -724,7 +733,7 @@ export const createRouteRouter = (
       code: reconciled.code,
       message: reconciled.message,
       httpStatus: reconciled.httpStatus,
-      data: reconciled.data,
+      data: localizeRouteResponseData(req, reconciled.data),
     });
   });
 

--- a/tests/api/platform/2-4-request-to-commitment-linkage-and-terminal-enforcement.api.spec.ts
+++ b/tests/api/platform/2-4-request-to-commitment-linkage-and-terminal-enforcement.api.spec.ts
@@ -13,6 +13,7 @@ type AuthScope = {
 const INTAKE_COLLECTION_PATH = '/api/v1/route/intake/requests';
 const RECONCILIATION_QUEUE_PATH = '/api/v1/route/intake/reconciliation/unresolved?staleMinutes=60';
 const REQUIRED_ENVELOPE_KEYS = ['ok', 'code', 'message', 'correlationId', 'tenantId'] as const;
+const RAW_UTC_ISO_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z/;
 
 function parseCookieValue(setCookieHeader: string | null, cookieName: string): string {
   if (!setCookieHeader) {
@@ -464,5 +465,79 @@ test.describe('Story 2.4 automate - request-to-commitment linkage API coverage',
         REQUIRED_ENVELOPE_KEYS.every((key) => Object.prototype.hasOwnProperty.call(payload, key)),
       ).toBe(true);
     }
+  });
+
+  test('[P1] localizes intake and scheduling timestamps with no raw UTC leakage in API payloads @P1', async ({ request }) => {
+    const scope = await loginAndResolveScope(request);
+    const scoped = requireScopedContext(scope);
+
+    const timezoneHeaders = {
+      ...scoped.authHeaders,
+      'x-user-timezone': 'America/Los_Angeles',
+      'x-tenant-timezone': 'America/Chicago',
+      'x-system-timezone': 'UTC',
+    };
+
+    const createResponse = await apiRequest(request, {
+      method: 'POST',
+      path: INTAKE_COLLECTION_PATH,
+      headers: timezoneHeaders,
+      data: buildPayload(scoped, false),
+    });
+
+    expect(createResponse.status()).toBe(200);
+    const createBody = await createResponse.json();
+    expect(createBody).toMatchObject({
+      ok: true,
+      code: 'ROUTESHYFT_DONOR_INTAKE_ACCEPTED',
+      data: {
+        timezone: 'America/Los_Angeles',
+        timezoneSource: 'user',
+      },
+    });
+    expect(JSON.stringify(createBody?.data || {})).not.toMatch(RAW_UTC_ISO_PATTERN);
+
+    const commitmentId = createBody?.data?.commitmentId as string;
+    const transitionResponse = await apiRequest(request, {
+      method: 'POST',
+      path: commitmentTransitionPath(commitmentId),
+      headers: timezoneHeaders,
+      data: {
+        nextStatus: 'in_progress',
+        reason: 'story24-timezone-contract',
+      },
+    });
+
+    expect(transitionResponse.status()).toBe(200);
+    const transitionBody = await transitionResponse.json();
+    expect(transitionBody).toMatchObject({
+      ok: true,
+      code: 'ROUTE_COMMITMENT_TRANSITION_APPLIED',
+      data: {
+        timezoneSource: 'user',
+        transition: {
+          occurredAtLocal: expect.any(String),
+        },
+      },
+    });
+    expect(JSON.stringify(transitionBody?.data || {})).not.toMatch(RAW_UTC_ISO_PATTERN);
+
+    const reconciliationResponse = await apiRequest(request, {
+      method: 'GET',
+      path: RECONCILIATION_QUEUE_PATH,
+      headers: timezoneHeaders,
+    });
+
+    expect(reconciliationResponse.status()).toBe(200);
+    const reconciliationBody = await reconciliationResponse.json();
+    expect(reconciliationBody).toMatchObject({
+      ok: true,
+      code: 'ROUTESHYFT_INTAKE_RECONCILIATION_QUEUE',
+      data: {
+        timezoneSource: 'user',
+      },
+    });
+    expect(reconciliationBody).not.toHaveProperty('data.generatedAtUtc');
+    expect(JSON.stringify(reconciliationBody?.data || {})).not.toMatch(RAW_UTC_ISO_PATTERN);
   });
 });

--- a/tests/e2e/platform/2-4-request-to-commitment-linkage-and-terminal-enforcement.spec.ts
+++ b/tests/e2e/platform/2-4-request-to-commitment-linkage-and-terminal-enforcement.spec.ts
@@ -7,6 +7,7 @@ function buildUiPath(tenantId: string, orgUnitId: string): string {
 
 test.describe('Story 2.4 automate - request lifecycle operator journeys', () => {
   test.describe.configure({ mode: 'serial' });
+  const utcIsoPattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z/;
 
   test('[P1] operations lifecycle view shows explicit terminal status and reconciliation actions for unresolved work @P1', async ({ page, story24Context }) => {
     await login(page);
@@ -57,5 +58,32 @@ test.describe('Story 2.4 automate - request lifecycle operator journeys', () => 
     for (const testId of story24Context.requiredTestIds) {
       await expect(page.getByTestId(testId)).toHaveCount(1);
     }
+  });
+
+  test('[P1] lifecycle details do not display raw UTC ISO strings on operational screen @P1', async ({ page, story24Context }) => {
+    await login(page);
+
+    const loadResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/route/intake/reconciliation/unresolved')
+        && response.request().method() === 'GET',
+    );
+
+    await page.goto(buildUiPath(story24Context.tenantId, story24Context.orgUnitId));
+    await loadResponse;
+
+    const details = page.getByTestId('routeshyft-request-lifecycle-details');
+    await expect(details).toBeVisible();
+    await expect(details).not.toContainText(utcIsoPattern);
+
+    const submitResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/route/intake/requests')
+        && response.request().method() === 'POST',
+    );
+    await page.getByTestId('routeshyft-request-finalize-submit').click();
+    await submitResponse;
+
+    await expect(details).not.toContainText(utcIsoPattern);
   });
 });


### PR DESCRIPTION
## Summary
- implement centralized route timezone adapter with deterministic fallback and UTC leakage suppression for route intake/scheduling responses
- add frontend request timezone propagation and lifecycle payload UTC sanitization safeguards
- add API and E2E contract coverage plus route timezone regression tests including DST and offset edge behavior
- update Story 2.6 artifact and sprint status to review

## Validation
- cd src && npm test -- src/src/routes/api/v1/__tests__/route.timezone.test.ts
- cd src && npm test -- src/src/routes/api/v1/__tests__/route.test.ts src/src/routes/api/v1/__tests__/route.cashier-intake.test.ts src/src/routes/api/v1/__tests__/route.commitments.test.ts
- cd src && npm test
- cd src && npm run build
- cd frontend && npm run build