### PR TITLE
Fix: implement f-3 provider correlation fallback mapping

### DIFF
--- a/_bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
+++ b/_bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
@@ -1,6 +1,6 @@
 # Story f.3: Provider Leg and Message Correlation Fallback Mapping
 
-Status: ready-for-dev
+Status: review
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -33,22 +33,22 @@ so that webhook handling remains deterministic even if metadata is incomplete.
 
 ## Tasks / Subtasks
 
-- [ ] Implement provider leg/message mapping persistence (AC: 1, 3)
-  - [ ] Persist provider call leg IDs with provider name and internal call attempt linkage.
-  - [ ] Persist provider message IDs with provider name and internal message linkage.
-- [ ] Implement fallback correlation resolution path (AC: 2)
-  - [ ] Attempt metadata-first correlation, then provider identifier fallback lookup.
-  - [ ] Return deterministic refusal when correlation cannot be resolved safely.
-- [ ] Preserve operator-visible deterministic outcomes on fallback paths (AC: 4)
-  - [ ] Ensure unresolved correlation emits auditable deterministic refusal outcomes surfaced through existing ConnectShyft contracts.
-  - [ ] Ensure resolved fallback emits exactly one canonical domain mutation per provider event.
-- [ ] Integrate replay-safe uniqueness controls (AC: 3)
-  - [ ] Enforce unique constraints for provider ID mappings.
-  - [ ] Ensure duplicate callbacks do not create duplicate message/voicemail/thread events.
-- [ ] Add correlation and replay test coverage (AC: 1, 2, 3, 4)
-  - [ ] Unit tests for metadata-present and metadata-missing paths.
-  - [ ] Integration tests for duplicate callbacks and deterministic refusal outcomes.
-  - [ ] Contract tests for deterministic operator-visible timeline/state outcomes after fallback resolution/refusal.
+- [x] Implement provider leg/message mapping persistence (AC: 1, 3)
+  - [x] Persist provider call leg IDs with provider name and internal call attempt linkage.
+  - [x] Persist provider message IDs with provider name and internal message linkage.
+- [x] Implement fallback correlation resolution path (AC: 2)
+  - [x] Attempt metadata-first correlation, then provider identifier fallback lookup.
+  - [x] Return deterministic refusal when correlation cannot be resolved safely.
+- [x] Preserve operator-visible deterministic outcomes on fallback paths (AC: 4)
+  - [x] Ensure unresolved correlation emits auditable deterministic refusal outcomes surfaced through existing ConnectShyft contracts.
+  - [x] Ensure resolved fallback emits exactly one canonical domain mutation per provider event.
+- [x] Integrate replay-safe uniqueness controls (AC: 3)
+  - [x] Enforce unique constraints for provider ID mappings.
+  - [x] Ensure duplicate callbacks do not create duplicate message/voicemail/thread events.
+- [x] Add correlation and replay test coverage (AC: 1, 2, 3, 4)
+  - [x] Unit tests for metadata-present and metadata-missing paths.
+  - [x] Integration tests for duplicate callbacks and deterministic refusal outcomes.
+  - [x] Contract tests for deterministic operator-visible timeline/state outcomes after fallback resolution/refusal.
 
 ## Dev Notes
 
@@ -99,16 +99,37 @@ GPT-5 Codex
 
 ### Debug Log References
 
-- Story context generation only (no implementation commands executed).
+- `npm run branch:ensure-workflow -- --workflow dev-story --story f-3-provider-leg-message-correlation-fallback-mapping` (fail: lane mismatch on `codex/dev`)
+- `npm run branch:ensure-workflow -- --lane connectshyft --workflow dev-story --story f-3-provider-leg-message-correlation-fallback-mapping` (pass after branch change)
+- `cd src && npm test -- src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts src/modules/connectshyft/__tests__/providerRegistry.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts` (pass)
+- `cd src && npm run build` (pass)
+- `cd src && npm test` (pass: 61 passed, 2 skipped)
 
 ### Completion Notes List
 
-- Created implementation-ready Story f.3 context for provider ID fallback correlation and replay-safe mapping behavior.
+- Added `src/src/modules/connectshyft/providerCorrelationMappings.ts` with provider leg/message correlation mapping persistence, metadata-fallback lookup resolution, and replay-safe webhook receipt dedupe primitives.
+- Extended provider dispatch contracts in `src/src/modules/connectshyft/providerRegistry.ts` to return deterministic `providerLegId`/`providerMessageId` values used by fallback mapping.
+- Updated `src/src/routes/api/v1/connectshyft.ts` to:
+  - persist provider identifier mappings after outbound dispatch canonical events,
+  - apply metadata-first correlation with provider-identifier fallback on inbound webhooks,
+  - emit deterministic business refusals for unresolved/ambiguous/conflicting correlation,
+  - suppress duplicate callbacks before lifecycle/canonical mutation writes via receipt dedupe.
+- Added migration `20260228103000_create_connectshyft_provider_correlation_mappings.ts` for provider-scoped uniqueness and webhook dedupe constraints (`cs_provider_identifier_mappings`, `cs_webhook_receipts`).
+- Added test coverage for mapping persistence, fallback correlation, duplicate suppression, and deterministic refusal/timeline contracts.
 
 ### File List
 
 - _bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
+- src/src/modules/connectshyft/providerCorrelationMappings.ts
+- src/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+- src/src/modules/connectshyft/providerRegistry.ts
+- src/src/modules/connectshyft/__tests__/providerRegistry.test.ts
+- src/src/routes/api/v1/connectshyft.ts
+- src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts
+- src/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts
+- src/src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts
 
 ## Change Log
 
 - 2026-02-27: Created Story f.3 ready-for-dev context document.
+- 2026-02-28: Implemented provider correlation fallback mapping persistence, deterministic unresolved-correlation refusal contracts, replay-safe callback dedupe, and corresponding module/route/migration test coverage.

--- a/_bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
+++ b/_bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
@@ -146,6 +146,7 @@ GPT-5 Codex
 - src/src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts
 - src/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts
 - src/src/migrations/__tests__/scopeProviderCorrelationUniquenessToTenantMigration.test.ts
+- tests/api/platform/a-1-connectshyft-feature-flag-and-availability-guardrails.api.spec.ts
 
 ## Senior Developer Review (AI)
 

--- a/_bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
+++ b/_bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
@@ -1,6 +1,6 @@
 # Story f.3: Provider Leg and Message Correlation Fallback Mapping
 
-Status: review
+Status: in-progress
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -49,6 +49,14 @@ so that webhook handling remains deterministic even if metadata is incomplete.
   - [x] Unit tests for metadata-present and metadata-missing paths.
   - [x] Integration tests for duplicate callbacks and deterministic refusal outcomes.
   - [x] Contract tests for deterministic operator-visible timeline/state outcomes after fallback resolution/refusal.
+
+### Review Follow-ups (AI)
+
+- [x] [AI-Review][HIGH] Scope provider identifier mapping uniqueness and lookup by `tenant_id` to prevent cross-tenant correlation collisions (`src/src/modules/connectshyft/providerCorrelationMappings.ts`, `src/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts`).
+- [x] [AI-Review][HIGH] Scope webhook dedupe uniqueness by tenant to prevent cross-tenant duplicate suppression (`src/src/modules/connectshyft/providerCorrelationMappings.ts`, `src/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts`).
+- [x] [AI-Review][HIGH] Remove silent DB-error fallback to in-memory correlation/dedupe and return explicit refusal telemetry (`src/src/modules/connectshyft/providerCorrelationMappings.ts`, `src/src/routes/api/v1/connectshyft.ts`).
+- [x] [AI-Review][MEDIUM] Add integration coverage for `CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT` and partial-metadata conflict paths (`src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts`).
+- [x] [AI-Review][MEDIUM] Add contract assertions for refusal/duplicate timeline outcomes to fully cover AC4 deterministic operator-visible behavior (`src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts`).
 
 ## Dev Notes
 
@@ -104,6 +112,8 @@ GPT-5 Codex
 - `cd src && npm test -- src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts src/modules/connectshyft/__tests__/providerRegistry.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts` (pass)
 - `cd src && npm run build` (pass)
 - `cd src && npm test` (pass: 61 passed, 2 skipped)
+- `cd src && npm test -- src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts src/modules/connectshyft/__tests__/providerRegistry.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts src/migrations/__tests__/scopeProviderCorrelationUniquenessToTenantMigration.test.ts` (pass)
+- `cd src && npm run build` (pass)
 
 ### Completion Notes List
 
@@ -116,20 +126,90 @@ GPT-5 Codex
   - suppress duplicate callbacks before lifecycle/canonical mutation writes via receipt dedupe.
 - Added migration `20260228103000_create_connectshyft_provider_correlation_mappings.ts` for provider-scoped uniqueness and webhook dedupe constraints (`cs_provider_identifier_mappings`, `cs_webhook_receipts`).
 - Added test coverage for mapping persistence, fallback correlation, duplicate suppression, and deterministic refusal/timeline contracts.
+- Added tenant-scoped uniqueness remediation migration `20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts` to enforce tenant isolation on provider correlation and webhook dedupe constraints.
+- Updated correlation/dedupe persistence paths to fail closed with explicit error contracts when DB-backed writes/reads are unavailable.
+- Added conflict-path and timeline-contract assertions for webhook refusal/suppression behavior, including metadata-vs-fallback conflict scenarios.
 
 ### File List
 
 - _bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
+- _bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
 - src/src/modules/connectshyft/providerCorrelationMappings.ts
 - src/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
-- src/src/modules/connectshyft/providerRegistry.ts
-- src/src/modules/connectshyft/__tests__/providerRegistry.test.ts
 - src/src/routes/api/v1/connectshyft.ts
 - src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts
-- src/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts
-- src/src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts
+- src/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts
+- src/src/migrations/__tests__/scopeProviderCorrelationUniquenessToTenantMigration.test.ts
+
+## Senior Developer Review (AI)
+
+### Reviewer
+
+- Reviewer: Jeremiah
+- Date: 2026-03-01
+- Outcome: Changes Requested
+
+### Findings
+
+1. **[HIGH] Tenant scope missing from provider identifier mapping uniqueness + lookup**
+   - Current mapping uniqueness and lookup are keyed only by `provider_name + identifier_kind + provider_identifier`, which permits cross-tenant collisions and wrong-thread fallback resolution if provider IDs are reused across tenants.
+   - Evidence:
+     - `src/src/modules/connectshyft/providerCorrelationMappings.ts:225` (`onConflict(['provider_name', 'identifier_kind', 'provider_identifier'])`)
+     - `src/src/modules/connectshyft/providerCorrelationMappings.ts:290` (`where({ provider_name, identifier_kind, provider_identifier })`)
+     - `src/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:60` (`UNIQUE (provider_name, identifier_kind, provider_identifier)`)
+   - Contract mismatch:
+     - `_bmad-output/planning-artifacts/architecture-ConnectShyft-2026-02-19.md:64` (hard isolation boundary is `tenant_id`)
+     - `_bmad-output/planning-artifacts/architecture.md:427` (repository query always includes `where tenant_id = ?`)
+
+2. **[HIGH] Webhook dedupe uniqueness is not tenant-scoped**
+   - Replay dedupe is currently global per provider + dedupe key, so one tenant can suppress valid webhook writes for another tenant when event IDs or identifiers collide.
+   - Evidence:
+     - `src/src/modules/connectshyft/providerCorrelationMappings.ts:618` (`onConflict(['provider_name', 'dedupe_key'])`)
+     - `src/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:141` (`UNIQUE (provider_name, dedupe_key)`)
+   - Contract mismatch:
+     - `_bmad-output/planning-artifacts/architecture-ConnectShyft-2026-02-19.md:351` (`cs_webhook_receipts` unique key includes `tenant_id`)
+
+3. **[HIGH] DB write/read failures silently downgrade to process-local in-memory state**
+   - On DB failure, correlation mapping and webhook dedupe switch to in-memory stores without surfacing a refusal/error contract. In multi-instance or restart scenarios, replay safety and deterministic correlation are no longer guaranteed.
+   - Evidence:
+     - `src/src/modules/connectshyft/providerCorrelationMappings.ts:435` (mapping DB catch -> in-memory fallback)
+     - `src/src/modules/connectshyft/providerCorrelationMappings.ts:635` (receipt DB catch -> in-memory fallback)
+
+4. **[MEDIUM] Conflict refusal paths are implemented but not covered by tests**
+   - `CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT` logic exists, but no route/module tests assert these branches, leaving regression risk for metadata-vs-fallback mismatch handling.
+   - Evidence:
+     - `src/src/routes/api/v1/connectshyft.ts:815`
+     - `src/src/routes/api/v1/connectshyft.ts:862`
+     - No matching assertions in `src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts` or `src/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+
+5. **[MEDIUM] AC4 contract coverage is partial for refusal/duplicate timeline outcomes**
+   - Current tests validate refusal codes and duplicate suppression flags, but do not fully assert deterministic operator-visible timeline/refusal contract fields (for example `timelineOutcome` on refusal and stable timeline assertions for refused callbacks).
+   - Evidence:
+     - Response fields produced in `src/src/routes/api/v1/connectshyft.ts:5088`
+     - Refusal assertions stop short of timeline contract in `src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts:587`
+   - Duplicate suppression assertions do not validate timeline determinism in `src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts:616`
+
+### Remediation Status (2026-03-01)
+
+- All five findings above have been remediated in this story branch and validated by targeted test and build runs.
+
+### Validation Evidence
+
+- `cd src && npm test -- src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts src/modules/connectshyft/__tests__/providerRegistry.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts` (pass: 30 passed, 0 failed)
+- `cd src && npm test -- src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts src/modules/connectshyft/__tests__/providerRegistry.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts src/migrations/__tests__/scopeProviderCorrelationUniquenessToTenantMigration.test.ts` (pass: 37 passed, 0 failed)
+- `cd src && npm run build` (pass)
+
+### Guardrail Review
+
+- Guardrail Classification Reviewed: yes
+- Critical Capability: yes
+- Real-User Validation Evidence: pending
+- Real-User Validation Result: pending
+- Guardrail blocker present: yes (critical capability cannot be closed with pending real-user validation evidence)
 
 ## Change Log
 
 - 2026-02-27: Created Story f.3 ready-for-dev context document.
 - 2026-02-28: Implemented provider correlation fallback mapping persistence, deterministic unresolved-correlation refusal contracts, replay-safe callback dedupe, and corresponding module/route/migration test coverage.
+- 2026-03-01: Senior Developer Review (AI) completed; 3 high and 2 medium issues documented, review follow-up tasks created, status moved to in-progress.
+- 2026-03-01: Addressed all 5 AI review findings with tenant-scoped uniqueness hardening, explicit DB-unavailable refusal telemetry, conflict/timeline contract tests, and story/git file-list reconciliation.

--- a/_bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
+++ b/_bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
@@ -134,10 +134,16 @@ GPT-5 Codex
 
 - _bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md
 - _bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+- src/jest.config.js
+- src/src/__tests__/jest.setup.ts
 - src/src/modules/connectshyft/providerCorrelationMappings.ts
 - src/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+- src/src/modules/connectshyft/providerRegistry.ts
+- src/src/modules/connectshyft/__tests__/providerRegistry.test.ts
 - src/src/routes/api/v1/connectshyft.ts
 - src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts
+- src/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts
+- src/src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts
 - src/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts
 - src/src/migrations/__tests__/scopeProviderCorrelationUniquenessToTenantMigration.test.ts
 

--- a/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
@@ -80,7 +80,7 @@ development_status:
   epic-f: in-progress
   f-1-provider-adapter-interface-and-provider-registry: review
   f-2-canonical-comms-event-model-and-event-store: in-progress
-  f-3-provider-leg-message-correlation-fallback-mapping: ready-for-dev
+  f-3-provider-leg-message-correlation-fallback-mapping: review
   f-4-telnyx-adapter-implementation-and-cutover-guardrails: ready-for-dev
   epic-f-retrospective: optional
   epic-ux-remediation: in-progress

--- a/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
@@ -80,7 +80,7 @@ development_status:
   epic-f: in-progress
   f-1-provider-adapter-interface-and-provider-registry: review
   f-2-canonical-comms-event-model-and-event-store: in-progress
-  f-3-provider-leg-message-correlation-fallback-mapping: review
+  f-3-provider-leg-message-correlation-fallback-mapping: in-progress
   f-4-telnyx-adapter-implementation-and-cutover-guardrails: ready-for-dev
   epic-f-retrospective: optional
   epic-ux-remediation: in-progress

--- a/src/jest.config.js
+++ b/src/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
   moduleFileExtensions: ['ts', 'js', 'json'],
   clearMocks: true,
+  setupFilesAfterEnv: ['<rootDir>/src/__tests__/jest.setup.ts'],
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
   },

--- a/src/src/__tests__/jest.setup.ts
+++ b/src/src/__tests__/jest.setup.ts
@@ -1,0 +1,25 @@
+const closeCachedModuleMethod = async (
+  modulePath: string,
+  methodName: 'destroy' | 'end',
+): Promise<void> => {
+  try {
+    const resolvedPath = require.resolve(modulePath);
+    const cachedModule = require.cache[resolvedPath];
+    if (!cachedModule) {
+      return;
+    }
+
+    const exportedModule = cachedModule.exports?.default ?? cachedModule.exports;
+    const cleanupMethod = exportedModule?.[methodName];
+    if (typeof cleanupMethod === 'function') {
+      await cleanupMethod.call(exportedModule);
+    }
+  } catch (_error) {
+    // Best-effort cleanup: no-op when the module is not loaded or already closed.
+  }
+};
+
+afterAll(async () => {
+  await closeCachedModuleMethod('../config/knex', 'destroy');
+  await closeCachedModuleMethod('../config/database', 'end');
+});

--- a/src/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts
+++ b/src/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts
@@ -1,0 +1,161 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const PROVIDER_IDENTIFIER_MAPPINGS_TABLE = 'cs_provider_identifier_mappings';
+const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+
+const PROVIDER_IDENTIFIER_KIND_CHECK = 'cs_provider_identifier_mappings_kind_ck';
+const PROVIDER_IDENTIFIER_UNIQUE = 'cs_provider_identifier_mappings_provider_identifier_uq';
+const PROVIDER_IDENTIFIER_SCOPE_INDEX = 'connectshyft_cs_provider_identifier_mappings_scope_idx';
+
+const WEBHOOK_RECEIPT_IDENTIFIER_KIND_CHECK = 'cs_webhook_receipts_identifier_kind_ck';
+const WEBHOOK_RECEIPT_IDENTIFIER_PRESENCE_CHECK = 'cs_webhook_receipts_identifier_presence_ck';
+const WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE = 'cs_webhook_receipts_provider_dedupe_uq';
+const WEBHOOK_RECEIPT_SCOPE_INDEX = 'connectshyft_cs_webhook_receipts_scope_idx';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}`);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE} (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      provider_name TEXT NOT NULL,
+      identifier_kind TEXT NOT NULL,
+      provider_identifier TEXT NOT NULL,
+      internal_reference_id TEXT NOT NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${PROVIDER_IDENTIFIER_KIND_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+          ADD CONSTRAINT ${PROVIDER_IDENTIFIER_KIND_CHECK}
+          CHECK (identifier_kind IN ('call_leg', 'message'));
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${PROVIDER_IDENTIFIER_UNIQUE}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+          ADD CONSTRAINT ${PROVIDER_IDENTIFIER_UNIQUE}
+          UNIQUE (provider_name, identifier_kind, provider_identifier);
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${PROVIDER_IDENTIFIER_SCOPE_INDEX}
+      ON ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE} (
+        tenant_id,
+        org_unit_id,
+        thread_id,
+        created_at_utc,
+        id
+      )
+  `);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE} (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      provider_name TEXT NOT NULL,
+      provider_event_id TEXT NULL,
+      provider_identifier_kind TEXT NULL,
+      provider_identifier TEXT NULL,
+      canonical_event_type TEXT NOT NULL,
+      dedupe_key TEXT NOT NULL,
+      processed_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${WEBHOOK_RECEIPT_IDENTIFIER_KIND_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+          ADD CONSTRAINT ${WEBHOOK_RECEIPT_IDENTIFIER_KIND_CHECK}
+          CHECK (
+            provider_identifier_kind IS NULL
+            OR provider_identifier_kind IN ('call_leg', 'message')
+          );
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${WEBHOOK_RECEIPT_IDENTIFIER_PRESENCE_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+          ADD CONSTRAINT ${WEBHOOK_RECEIPT_IDENTIFIER_PRESENCE_CHECK}
+          CHECK (
+            provider_event_id IS NOT NULL
+            OR provider_identifier IS NOT NULL
+          );
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+          ADD CONSTRAINT ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE}
+          UNIQUE (provider_name, dedupe_key);
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${WEBHOOK_RECEIPT_SCOPE_INDEX}
+      ON ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE} (
+        tenant_id,
+        org_unit_id,
+        thread_id,
+        processed_at_utc,
+        id
+      )
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(WEBHOOK_RECEIPTS_TABLE);
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(PROVIDER_IDENTIFIER_MAPPINGS_TABLE);
+}

--- a/src/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts
+++ b/src/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts
@@ -1,0 +1,64 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const PROVIDER_IDENTIFIER_MAPPINGS_TABLE = 'cs_provider_identifier_mappings';
+const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+
+const PROVIDER_IDENTIFIER_UNIQUE = 'cs_provider_identifier_mappings_provider_identifier_uq';
+const WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE = 'cs_webhook_receipts_provider_dedupe_uq';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}') IS NOT NULL THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+          DROP CONSTRAINT IF EXISTS ${PROVIDER_IDENTIFIER_UNIQUE};
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+          ADD CONSTRAINT ${PROVIDER_IDENTIFIER_UNIQUE}
+          UNIQUE (tenant_id, provider_name, identifier_kind, provider_identifier);
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+          DROP CONSTRAINT IF EXISTS ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE};
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+          ADD CONSTRAINT ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE}
+          UNIQUE (tenant_id, provider_name, dedupe_key);
+      END IF;
+    END $$;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}') IS NOT NULL THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+          DROP CONSTRAINT IF EXISTS ${PROVIDER_IDENTIFIER_UNIQUE};
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+          ADD CONSTRAINT ${PROVIDER_IDENTIFIER_UNIQUE}
+          UNIQUE (provider_name, identifier_kind, provider_identifier);
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+          DROP CONSTRAINT IF EXISTS ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE};
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+          ADD CONSTRAINT ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE}
+          UNIQUE (provider_name, dedupe_key);
+      END IF;
+    END $$;
+  `);
+}

--- a/src/src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts
+++ b/src/src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts
@@ -1,0 +1,63 @@
+import { down, up } from '../20260228103000_create_connectshyft_provider_correlation_mappings';
+
+function buildKnexMock() {
+  const dropped: string[] = [];
+
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+    schema: {
+      withSchema: (schema: string) => ({
+        dropTableIfExists: async (tableName: string) => {
+          dropped.push(`${schema}.${tableName}`);
+        },
+      }),
+    },
+  };
+
+  return {
+    knex,
+    dropped,
+  };
+}
+
+describe('20260228103000_create_connectshyft_provider_correlation_mappings migration', () => {
+  it('creates provider identifier mappings and webhook receipt dedupe schema idempotently', async () => {
+    const { knex } = buildKnexMock();
+
+    await up(knex);
+
+    const rawCalls = knex.raw.mock.calls.map((call: [string]) => call[0]);
+
+    expect(rawCalls).toEqual(expect.arrayContaining([
+      'CREATE SCHEMA IF NOT EXISTS connectshyft',
+    ]));
+
+    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_provider_identifier_mappings'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('identifier_kind TEXT NOT NULL'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('internal_reference_id TEXT NOT NULL'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('cs_provider_identifier_mappings_kind_ck'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('cs_provider_identifier_mappings_provider_identifier_uq'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('UNIQUE (provider_name, identifier_kind, provider_identifier)'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_provider_identifier_mappings_scope_idx'))).toBe(true);
+
+    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_webhook_receipts'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('provider_event_id TEXT NULL'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('dedupe_key TEXT NOT NULL'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('cs_webhook_receipts_identifier_kind_ck'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('cs_webhook_receipts_identifier_presence_ck'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('cs_webhook_receipts_provider_dedupe_uq'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('UNIQUE (provider_name, dedupe_key)'))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_webhook_receipts_scope_idx'))).toBe(true);
+  });
+
+  it('drops webhook receipt and provider identifier mapping tables in down migration', async () => {
+    const { knex, dropped } = buildKnexMock();
+
+    await down(knex);
+
+    expect(dropped).toEqual([
+      'connectshyft.cs_webhook_receipts',
+      'connectshyft.cs_provider_identifier_mappings',
+    ]);
+  });
+});

--- a/src/src/migrations/__tests__/scopeProviderCorrelationUniquenessToTenantMigration.test.ts
+++ b/src/src/migrations/__tests__/scopeProviderCorrelationUniquenessToTenantMigration.test.ts
@@ -1,0 +1,53 @@
+import {
+  down,
+  up,
+} from '../20260301113000_scope_provider_correlation_uniqueness_to_tenant';
+
+function buildKnexMock() {
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+  };
+
+  return {
+    knex,
+  };
+}
+
+describe('20260301113000_scope_provider_correlation_uniqueness_to_tenant migration', () => {
+  it('updates provider correlation uniqueness constraints to include tenant scope', async () => {
+    const { knex } = buildKnexMock();
+
+    await up(knex);
+
+    const rawCalls = knex.raw.mock.calls.map((call: [string]) => call[0]);
+
+    expect(rawCalls.some((sql: string) => sql.includes(
+      'DROP CONSTRAINT IF EXISTS cs_provider_identifier_mappings_provider_identifier_uq',
+    ))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes(
+      'UNIQUE (tenant_id, provider_name, identifier_kind, provider_identifier)',
+    ))).toBe(true);
+
+    expect(rawCalls.some((sql: string) => sql.includes(
+      'DROP CONSTRAINT IF EXISTS cs_webhook_receipts_provider_dedupe_uq',
+    ))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes(
+      'UNIQUE (tenant_id, provider_name, dedupe_key)',
+    ))).toBe(true);
+  });
+
+  it('restores pre-tenant uniqueness constraints in down migration', async () => {
+    const { knex } = buildKnexMock();
+
+    await down(knex);
+
+    const rawCalls = knex.raw.mock.calls.map((call: [string]) => call[0]);
+
+    expect(rawCalls.some((sql: string) => sql.includes(
+      'UNIQUE (provider_name, identifier_kind, provider_identifier)',
+    ))).toBe(true);
+    expect(rawCalls.some((sql: string) => sql.includes(
+      'UNIQUE (provider_name, dedupe_key)',
+    ))).toBe(true);
+  });
+});

--- a/src/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+++ b/src/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
@@ -1,0 +1,203 @@
+import {
+  recordConnectShyftWebhookReceipt,
+  recordConnectShyftProviderIdentifierMapping,
+  resetConnectShyftProviderCorrelationStateForTests,
+  resolveConnectShyftProviderCorrelationByIdentifiers,
+} from '../providerCorrelationMappings';
+
+describe('connectshyft provider correlation mappings', () => {
+  beforeEach(() => {
+    resetConnectShyftProviderCorrelationStateForTests();
+  });
+
+  it('records provider call/message mappings with provider-scoped uniqueness', async () => {
+    const callRecord = await recordConnectShyftProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      identifierKind: 'call_leg',
+      providerIdentifier: 'telnyx-leg-f3-1001',
+      internalReferenceId: 'canonical-call-f3-1001',
+    });
+
+    expect(callRecord.status).toBe('created');
+    expect(callRecord.mapping).toMatchObject({
+      providerName: 'telnyx',
+      identifierKind: 'call_leg',
+      providerIdentifier: 'telnyx-leg-f3-1001',
+      threadId: 'thread-f3-unclaimed-1001',
+      internalReferenceId: 'canonical-call-f3-1001',
+    });
+
+    const duplicateCallRecord = await recordConnectShyftProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      identifierKind: 'call_leg',
+      providerIdentifier: 'telnyx-leg-f3-1001',
+      internalReferenceId: 'canonical-call-f3-duplicate',
+    });
+
+    expect(duplicateCallRecord.status).toBe('duplicate');
+    expect(duplicateCallRecord.mapping?.internalReferenceId).toBe('canonical-call-f3-1001');
+
+    const messageRecord = await recordConnectShyftProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      identifierKind: 'message',
+      providerIdentifier: 'telnyx-msg-f3-1001',
+      internalReferenceId: 'canonical-message-f3-1001',
+    });
+
+    expect(messageRecord.status).toBe('created');
+    expect(messageRecord.mapping).toMatchObject({
+      providerName: 'telnyx',
+      identifierKind: 'message',
+      providerIdentifier: 'telnyx-msg-f3-1001',
+      threadId: 'thread-f3-unclaimed-1001',
+      internalReferenceId: 'canonical-message-f3-1001',
+    });
+  });
+
+  it('resolves metadata fallback via provider leg/message identifiers', async () => {
+    await recordConnectShyftProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      identifierKind: 'call_leg',
+      providerIdentifier: 'telnyx-leg-f3-1001',
+      internalReferenceId: 'canonical-call-f3-1001',
+    });
+
+    const resolvedByCallLeg = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: 'telnyx',
+      providerLegId: 'telnyx-leg-f3-1001',
+    });
+
+    expect(resolvedByCallLeg).toMatchObject({
+      ok: true,
+      source: 'provider_leg_id',
+      correlation: {
+        tenantId: 'tenant-connectshyft-f3',
+        orgUnitId: 'org-connectshyft-f3-east',
+        threadId: 'thread-f3-unclaimed-1001',
+      },
+    });
+
+    await recordConnectShyftProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      identifierKind: 'message',
+      providerIdentifier: 'telnyx-msg-f3-1001',
+      internalReferenceId: 'canonical-message-f3-1001',
+    });
+
+    const resolvedByMessage = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: 'telnyx',
+      providerMessageId: 'telnyx-msg-f3-1001',
+    });
+
+    expect(resolvedByMessage).toMatchObject({
+      ok: true,
+      source: 'provider_message_id',
+      correlation: {
+        tenantId: 'tenant-connectshyft-f3',
+        orgUnitId: 'org-connectshyft-f3-east',
+        threadId: 'thread-f3-unclaimed-1001',
+      },
+    });
+  });
+
+  it('returns deterministic ambiguous result when both identifiers map to different internal records', async () => {
+    await recordConnectShyftProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      identifierKind: 'call_leg',
+      providerIdentifier: 'telnyx-leg-f3-1001',
+      internalReferenceId: 'canonical-call-f3-1001',
+    });
+
+    await recordConnectShyftProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-claimed-1002',
+      providerName: 'telnyx',
+      identifierKind: 'message',
+      providerIdentifier: 'telnyx-msg-f3-1002',
+      internalReferenceId: 'canonical-message-f3-1002',
+    });
+
+    const resolution = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: 'telnyx',
+      providerLegId: 'telnyx-leg-f3-1001',
+      providerMessageId: 'telnyx-msg-f3-1002',
+    });
+
+    expect(resolution).toEqual({
+      ok: false,
+      reason: 'ambiguous',
+    });
+  });
+
+  it('returns deterministic refusal reasons when fallback cannot resolve', async () => {
+    const missingIdentifiers = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: 'telnyx',
+    });
+    expect(missingIdentifiers).toEqual({
+      ok: false,
+      reason: 'missing-identifiers',
+    });
+
+    const notFound = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: 'telnyx',
+      providerLegId: 'telnyx-leg-f3-unknown',
+    });
+    expect(notFound).toEqual({
+      ok: false,
+      reason: 'not-found',
+    });
+  });
+
+  it('suppresses duplicate webhook receipts using provider-scoped deterministic dedupe keys', async () => {
+    const first = await recordConnectShyftWebhookReceipt({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      canonicalEventType: 'CallConnected',
+      providerEventId: 'provider-event-f3-1001',
+      providerLegId: 'telnyx-leg-f3-1001',
+    });
+
+    expect(first).toEqual({
+      deterministic: true,
+      duplicate: false,
+      dedupeKey: 'provider-event:provider-event-f3-1001',
+    });
+
+    const duplicate = await recordConnectShyftWebhookReceipt({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      canonicalEventType: 'CallConnected',
+      providerEventId: 'provider-event-f3-1001',
+      providerLegId: 'telnyx-leg-f3-1001',
+    });
+
+    expect(duplicate).toEqual({
+      deterministic: true,
+      duplicate: true,
+      dedupeKey: 'provider-event:provider-event-f3-1001',
+    });
+  });
+});

--- a/src/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+++ b/src/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
@@ -200,4 +200,139 @@ describe('connectshyft provider correlation mappings', () => {
       dedupeKey: 'provider-event:provider-event-f3-1001',
     });
   });
+
+  it('allows duplicate provider identifiers across tenants and marks tenant-unspecified lookup as ambiguous', async () => {
+    await recordConnectShyftProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3-a',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      identifierKind: 'call_leg',
+      providerIdentifier: 'telnyx-leg-f3-shared',
+      internalReferenceId: 'canonical-call-f3-tenant-a',
+    });
+
+    const otherTenantRecord = await recordConnectShyftProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3-b',
+      orgUnitId: 'org-connectshyft-f3-west',
+      threadId: 'thread-f3-claimed-1002',
+      providerName: 'telnyx',
+      identifierKind: 'call_leg',
+      providerIdentifier: 'telnyx-leg-f3-shared',
+      internalReferenceId: 'canonical-call-f3-tenant-b',
+    });
+
+    expect(otherTenantRecord.status).toBe('created');
+
+    const ambiguousLookup = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: 'telnyx',
+      providerLegId: 'telnyx-leg-f3-shared',
+    });
+
+    expect(ambiguousLookup).toEqual({
+      ok: false,
+      reason: 'ambiguous',
+    });
+
+    const tenantScopedLookup = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: 'telnyx',
+      providerLegId: 'telnyx-leg-f3-shared',
+      tenantId: 'tenant-connectshyft-f3-a',
+    });
+
+    expect(tenantScopedLookup).toMatchObject({
+      ok: true,
+      source: 'provider_leg_id',
+      correlation: {
+        tenantId: 'tenant-connectshyft-f3-a',
+        threadId: 'thread-f3-unclaimed-1001',
+      },
+    });
+  });
+
+  it('does not suppress duplicate receipts across tenants for the same provider event key', async () => {
+    const tenantAFirst = await recordConnectShyftWebhookReceipt({
+      tenantId: 'tenant-connectshyft-f3-a',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      canonicalEventType: 'MessageDelivered',
+      providerEventId: 'provider-event-f3-shared-2001',
+      providerMessageId: 'telnyx-msg-f3-shared-2001',
+    });
+    expect(tenantAFirst.duplicate).toBe(false);
+
+    const tenantBFirst = await recordConnectShyftWebhookReceipt({
+      tenantId: 'tenant-connectshyft-f3-b',
+      orgUnitId: 'org-connectshyft-f3-west',
+      threadId: 'thread-f3-unclaimed-9001',
+      providerName: 'telnyx',
+      canonicalEventType: 'MessageDelivered',
+      providerEventId: 'provider-event-f3-shared-2001',
+      providerMessageId: 'telnyx-msg-f3-shared-2001',
+    });
+    expect(tenantBFirst.duplicate).toBe(false);
+
+    const tenantASecond = await recordConnectShyftWebhookReceipt({
+      tenantId: 'tenant-connectshyft-f3-a',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      canonicalEventType: 'MessageDelivered',
+      providerEventId: 'provider-event-f3-shared-2001',
+      providerMessageId: 'telnyx-msg-f3-shared-2001',
+    });
+    expect(tenantASecond.duplicate).toBe(true);
+  });
+
+  it('returns explicit persistence errors on db-backed mapping or receipt writes instead of silent in-memory fallback', async () => {
+    const failingDbChain: any = {
+      insert: jest.fn().mockReturnThis(),
+      onConflict: jest.fn().mockReturnThis(),
+      ignore: jest.fn().mockReturnThis(),
+      returning: jest.fn(async () => {
+        throw new Error('db-unavailable');
+      }),
+    };
+
+    const failingDb: any = {
+      withSchema: jest.fn(() => ({
+        table: jest.fn(() => failingDbChain),
+      })),
+    };
+
+    const mappingResult = await recordConnectShyftProviderIdentifierMapping({
+      tenantId: '11111111-1111-4111-8111-111111111111',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: '22222222-2222-4222-8222-222222222222',
+      providerName: 'telnyx',
+      identifierKind: 'call_leg',
+      providerIdentifier: 'telnyx-leg-f3-db-failure',
+      internalReferenceId: 'canonical-call-f3-db-failure',
+      db: failingDb,
+    });
+
+    expect(mappingResult.status).toBe('error');
+    expect(mappingResult.errorCode).toBe('CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE');
+
+    const receiptResult = await recordConnectShyftWebhookReceipt({
+      tenantId: '11111111-1111-4111-8111-111111111111',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: '22222222-2222-4222-8222-222222222222',
+      providerName: 'telnyx',
+      canonicalEventType: 'CallConnected',
+      providerEventId: 'provider-event-f3-db-failure',
+      providerLegId: 'telnyx-leg-f3-db-failure',
+      db: failingDb,
+    });
+
+    expect(receiptResult).toMatchObject({
+      deterministic: true,
+      duplicate: false,
+      dedupeKey: 'provider-event:provider-event-f3-db-failure',
+      error: {
+        code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+      },
+    });
+  });
 });

--- a/src/src/modules/connectshyft/__tests__/providerRegistry.test.ts
+++ b/src/src/modules/connectshyft/__tests__/providerRegistry.test.ts
@@ -181,6 +181,8 @@ describe('connectshyft provider registry', () => {
     expect(callDispatch).toMatchObject({
       providerKey: 'telnyx',
       channel: 'call',
+      providerLegId: 'telnyx-call-leg-thread-f1-unclaimed-1001',
+      providerMessageId: null,
       adapterInvoked: true,
       providerBranchingInDomain: false,
     });
@@ -193,6 +195,8 @@ describe('connectshyft provider registry', () => {
     expect(messageDispatch).toMatchObject({
       providerKey: 'telnyx',
       channel: 'message',
+      providerLegId: null,
+      providerMessageId: 'telnyx-message-thread-f1-unclaimed-1001',
       adapterInvoked: true,
       providerBranchingInDomain: false,
     });

--- a/src/src/modules/connectshyft/providerCorrelationMappings.ts
+++ b/src/src/modules/connectshyft/providerCorrelationMappings.ts
@@ -8,7 +8,8 @@ export type ConnectShyftProviderIdentifierKind = 'call_leg' | 'message';
 export type ConnectShyftProviderCorrelationRefusalReason =
   | 'missing-identifiers'
   | 'not-found'
-  | 'ambiguous';
+  | 'ambiguous'
+  | 'unavailable';
 
 export type ConnectShyftProviderIdentifierMapping = {
   tenantId: string;
@@ -92,6 +93,15 @@ const normalizeIdentifierKind = (value: unknown): ConnectShyftProviderIdentifier
 };
 
 const buildMappingKey = (
+  tenantId: string,
+  providerName: string,
+  identifierKind: ConnectShyftProviderIdentifierKind,
+  providerIdentifier: string,
+): string => {
+  return `${tenantId}|${providerName}|${identifierKind}|${providerIdentifier}`;
+};
+
+const buildMappingLookupKey = (
   providerName: string,
   identifierKind: ConnectShyftProviderIdentifierKind,
   providerIdentifier: string,
@@ -173,20 +183,47 @@ const mapDbRowToRecord = (
   };
 };
 
-const findInMemoryMapping = (input: {
+const findInMemoryMappings = (input: {
+  tenantId?: string | null;
   providerName: string;
   identifierKind: ConnectShyftProviderIdentifierKind;
   providerIdentifier: string;
-}): ConnectShyftProviderIdentifierMappingRecord | null => {
-  const key = buildMappingKey(input.providerName, input.identifierKind, input.providerIdentifier);
-  return inMemoryProviderIdentifierMappings.get(key) || null;
+}): ConnectShyftProviderIdentifierMappingRecord[] => {
+  const tenantId = normalizeString(input.tenantId || null);
+  const lookupKey = buildMappingLookupKey(
+    input.providerName,
+    input.identifierKind,
+    input.providerIdentifier,
+  );
+  const matches: ConnectShyftProviderIdentifierMappingRecord[] = [];
+  for (const record of inMemoryProviderIdentifierMappings.values()) {
+    if (
+      record.providerName === input.providerName
+      && record.identifierKind === input.identifierKind
+      && record.providerIdentifier === input.providerIdentifier
+      && (!tenantId || record.tenantId === tenantId)
+      && buildMappingLookupKey(
+        record.providerName,
+        record.identifierKind,
+        record.providerIdentifier,
+      ) === lookupKey
+    ) {
+      matches.push(record);
+    }
+  }
+  return matches;
 };
 
 const saveInMemoryMapping = (record: ConnectShyftProviderIdentifierMappingRecord): {
   status: 'created' | 'duplicate';
   mapping: ConnectShyftProviderIdentifierMapping;
 } => {
-  const key = buildMappingKey(record.providerName, record.identifierKind, record.providerIdentifier);
+  const key = buildMappingKey(
+    record.tenantId,
+    record.providerName,
+    record.identifierKind,
+    record.providerIdentifier,
+  );
   const existing = inMemoryProviderIdentifierMappings.get(key);
   if (existing) {
     return {
@@ -222,7 +259,7 @@ const saveDbMapping = async (input: {
       internal_reference_id: input.record.internalReferenceId,
       created_at_utc: input.record.createdAtUtc,
     })
-    .onConflict(['provider_name', 'identifier_kind', 'provider_identifier'])
+    .onConflict(['tenant_id', 'provider_name', 'identifier_kind', 'provider_identifier'])
     .ignore()
     .returning([
       'tenant_id',
@@ -247,6 +284,7 @@ const saveDbMapping = async (input: {
     .withSchema('connectshyft')
     .table(PROVIDER_IDENTIFIER_MAPPINGS_TABLE)
     .where({
+      tenant_id: input.record.tenantId,
       provider_name: input.record.providerName,
       identifier_kind: input.record.identifierKind,
       provider_identifier: input.record.providerIdentifier,
@@ -278,32 +316,41 @@ const saveDbMapping = async (input: {
   };
 };
 
-const findDbMapping = async (input: {
+const findDbMappings = async (input: {
   db: Knex;
+  tenantId?: string | null;
   providerName: string;
   identifierKind: ConnectShyftProviderIdentifierKind;
   providerIdentifier: string;
-}): Promise<ConnectShyftProviderIdentifierMappingRecord | null> => {
-  const row = await input.db
+}): Promise<ConnectShyftProviderIdentifierMappingRecord[]> => {
+  const query = input.db
     .withSchema('connectshyft')
     .table(PROVIDER_IDENTIFIER_MAPPINGS_TABLE)
     .where({
       provider_name: input.providerName,
       identifier_kind: input.identifierKind,
       provider_identifier: input.providerIdentifier,
-    })
-    .first([
-      'tenant_id',
-      'org_unit_id',
-      'thread_id',
-      'provider_name',
-      'identifier_kind',
-      'provider_identifier',
-      'internal_reference_id',
-      'created_at_utc',
-    ]);
+    });
 
-  return mapDbRowToRecord(row as ConnectShyftProviderMappingRow | null);
+  const tenantId = normalizeString(input.tenantId || null);
+  if (tenantId) {
+    query.andWhere('tenant_id', tenantId);
+  }
+
+  const rows = await query.select([
+    'tenant_id',
+    'org_unit_id',
+    'thread_id',
+    'provider_name',
+    'identifier_kind',
+    'provider_identifier',
+    'internal_reference_id',
+    'created_at_utc',
+  ]);
+
+  return rows
+    .map((row) => mapDbRowToRecord(row as ConnectShyftProviderMappingRow))
+    .filter((record): record is ConnectShyftProviderIdentifierMappingRecord => record !== null);
 };
 
 const toCorrelationResolution = (input: {
@@ -378,8 +425,10 @@ export const recordConnectShyftProviderIdentifierMapping = async (input: {
   createdAtUtc?: string;
   db?: Knex;
 }): Promise<{
-  status: 'created' | 'duplicate' | 'ignored';
+  status: 'created' | 'duplicate' | 'ignored' | 'error';
   mapping: ConnectShyftProviderIdentifierMapping | null;
+  errorCode?: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE';
+  errorMessage?: string;
 }> => {
   const providerName = normalizeProviderName(input.providerName);
   const providerIdentifier = normalizeString(input.providerIdentifier);
@@ -432,11 +481,14 @@ export const recordConnectShyftProviderIdentifierMapping = async (input: {
       status: saved.status,
       mapping: saved.mapping,
     };
-  } catch (_error) {
-    const saved = saveInMemoryMapping(record);
+  } catch (error) {
     return {
-      status: saved.status,
-      mapping: saved.mapping,
+      status: 'error',
+      mapping: null,
+      errorCode: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE',
+      errorMessage: error instanceof Error
+        ? error.message
+        : 'Provider correlation mapping persistence unavailable.',
     };
   }
 };
@@ -445,11 +497,13 @@ export const resolveConnectShyftProviderCorrelationByIdentifiers = async (input:
   providerName: string;
   providerLegId?: string | null;
   providerMessageId?: string | null;
+  tenantId?: string | null;
   db?: Knex;
 }): Promise<ConnectShyftProviderCorrelationLookupResult> => {
   const providerName = normalizeProviderName(input.providerName);
   const providerLegId = normalizeString(input.providerLegId || null);
   const providerMessageId = normalizeString(input.providerMessageId || null);
+  const tenantId = normalizeString(input.tenantId || null);
 
   if (!providerName || (!providerLegId && !providerMessageId)) {
     return {
@@ -458,11 +512,16 @@ export const resolveConnectShyftProviderCorrelationByIdentifiers = async (input:
     };
   }
 
-  let callLegMapping: ConnectShyftProviderIdentifierMappingRecord | null = null;
-  let messageMapping: ConnectShyftProviderIdentifierMappingRecord | null = null;
+  let callLegMappings: ConnectShyftProviderIdentifierMappingRecord[] = [];
+  let messageMappings: ConnectShyftProviderIdentifierMappingRecord[] = [];
+  const dbScopeTenantId = tenantId && UUID_PATTERN.test(tenantId)
+    ? tenantId
+    : null;
+  const canQueryDb = Boolean(input.db && (!tenantId || dbScopeTenantId));
 
   if (providerLegId) {
-    callLegMapping = findInMemoryMapping({
+    callLegMappings = findInMemoryMappings({
+      tenantId,
       providerName,
       identifierKind: 'call_leg',
       providerIdentifier: providerLegId,
@@ -470,68 +529,163 @@ export const resolveConnectShyftProviderCorrelationByIdentifiers = async (input:
   }
 
   if (providerMessageId) {
-    messageMapping = findInMemoryMapping({
+    messageMappings = findInMemoryMappings({
+      tenantId,
       providerName,
       identifierKind: 'message',
       providerIdentifier: providerMessageId,
     });
   }
 
-  if (input.db && providerLegId && !callLegMapping) {
+  if (canQueryDb && providerLegId && callLegMappings.length === 0) {
     try {
-      callLegMapping = await findDbMapping({
-        db: input.db,
+      callLegMappings = await findDbMappings({
+        db: input.db as Knex,
+        tenantId: dbScopeTenantId,
         providerName,
         identifierKind: 'call_leg',
         providerIdentifier: providerLegId,
       });
     } catch (_error) {
-      callLegMapping = callLegMapping || null;
+      return {
+        ok: false,
+        reason: 'unavailable',
+      };
     }
   }
 
-  if (input.db && providerMessageId && !messageMapping) {
+  if (canQueryDb && providerMessageId && messageMappings.length === 0) {
     try {
-      messageMapping = await findDbMapping({
-        db: input.db,
+      messageMappings = await findDbMappings({
+        db: input.db as Knex,
+        tenantId: dbScopeTenantId,
         providerName,
         identifierKind: 'message',
         providerIdentifier: providerMessageId,
       });
     } catch (_error) {
-      messageMapping = messageMapping || null;
+      return {
+        ok: false,
+        reason: 'unavailable',
+      };
     }
   }
 
-  if (callLegMapping && messageMapping && mappingsConflict(callLegMapping, messageMapping)) {
+  const contextKey = (mapping: ConnectShyftProviderIdentifierMappingRecord): string => {
+    return `${mapping.tenantId}|${mapping.orgUnitId}|${mapping.threadId}`;
+  };
+
+  const dedupeMappingsByContext = (
+    mappings: ConnectShyftProviderIdentifierMappingRecord[],
+  ): Map<string, ConnectShyftProviderIdentifierMappingRecord> => {
+    const deduped = new Map<string, ConnectShyftProviderIdentifierMappingRecord>();
+    mappings.forEach((mapping) => {
+      const key = contextKey(mapping);
+      if (!deduped.has(key)) {
+        deduped.set(key, mapping);
+      }
+    });
+    return deduped;
+  };
+
+  const callLegByContext = dedupeMappingsByContext(callLegMappings);
+  const messageByContext = dedupeMappingsByContext(messageMappings);
+  const callLegContextKeys = Array.from(callLegByContext.keys());
+  const messageContextKeys = Array.from(messageByContext.keys());
+  const hasCallLegInput = Boolean(providerLegId);
+  const hasMessageInput = Boolean(providerMessageId);
+
+  if (hasCallLegInput && hasMessageInput) {
+    const consensusContexts = callLegContextKeys.filter((key) => messageByContext.has(key));
+
+    if (consensusContexts.length === 1) {
+      const consensusKey = consensusContexts[0];
+      return toCorrelationResolution({
+        callLegMapping: callLegByContext.get(consensusKey) || null,
+        messageMapping: messageByContext.get(consensusKey) || null,
+        source: 'provider_consensus',
+      });
+    }
+
+    if (consensusContexts.length > 1) {
+      return {
+        ok: false,
+        reason: 'ambiguous',
+      };
+    }
+
+    if (callLegByContext.size > 0 && messageByContext.size > 0) {
+      const [callLegCandidate] = Array.from(callLegByContext.values());
+      const [messageCandidate] = Array.from(messageByContext.values());
+      if (callLegCandidate && messageCandidate && mappingsConflict(callLegCandidate, messageCandidate)) {
+        return {
+          ok: false,
+          reason: 'ambiguous',
+        };
+      }
+    }
+
+    if (callLegByContext.size > 1 || messageByContext.size > 1) {
+      return {
+        ok: false,
+        reason: 'ambiguous',
+      };
+    }
+
+    if (callLegByContext.size === 1 && messageByContext.size === 0) {
+      return toCorrelationResolution({
+        callLegMapping: Array.from(callLegByContext.values())[0],
+        messageMapping: null,
+        source: 'provider_leg_id',
+      });
+    }
+
+    if (messageByContext.size === 1 && callLegByContext.size === 0) {
+      return toCorrelationResolution({
+        callLegMapping: null,
+        messageMapping: Array.from(messageByContext.values())[0],
+        source: 'provider_message_id',
+      });
+    }
+
     return {
       ok: false,
-      reason: 'ambiguous',
+      reason: 'not-found',
     };
   }
 
-  if (callLegMapping && messageMapping) {
-    return toCorrelationResolution({
-      callLegMapping,
-      messageMapping,
-      source: 'provider_consensus',
-    });
+  if (hasCallLegInput) {
+    if (callLegByContext.size > 1) {
+      return {
+        ok: false,
+        reason: 'ambiguous',
+      };
+    }
+
+    if (callLegByContext.size === 1) {
+      return toCorrelationResolution({
+        callLegMapping: Array.from(callLegByContext.values())[0],
+        messageMapping: null,
+        source: 'provider_leg_id',
+      });
+    }
   }
 
-  if (callLegMapping) {
-    return toCorrelationResolution({
-      callLegMapping,
-      messageMapping: null,
-      source: 'provider_leg_id',
-    });
-  }
+  if (hasMessageInput) {
+    if (messageByContext.size > 1) {
+      return {
+        ok: false,
+        reason: 'ambiguous',
+      };
+    }
 
-  if (messageMapping) {
-    return toCorrelationResolution({
-      callLegMapping: null,
-      messageMapping,
-      source: 'provider_message_id',
-    });
+    if (messageByContext.size === 1) {
+      return toCorrelationResolution({
+        callLegMapping: null,
+        messageMapping: Array.from(messageByContext.values())[0],
+        source: 'provider_message_id',
+      });
+    }
   }
 
   return {
@@ -554,6 +708,10 @@ export const recordConnectShyftWebhookReceipt = async (input: {
   deterministic: true;
   duplicate: boolean;
   dedupeKey: string | null;
+  error?: {
+    code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE';
+    message: string;
+  };
 }> => {
   const providerName = normalizeProviderName(input.providerName);
   const tenantId = normalizeString(input.tenantId);
@@ -578,7 +736,7 @@ export const recordConnectShyftWebhookReceipt = async (input: {
     };
   }
 
-  const inMemoryReceiptKey = `${providerName}|${dedupeKey}`;
+  const inMemoryReceiptKey = `${tenantId}|${providerName}|${dedupeKey}`;
   if (!shouldUseDbForWebhookReceipt({ tenantId, threadId }, input.db)) {
     if (inMemoryWebhookReceiptKeys.has(inMemoryReceiptKey)) {
       return {
@@ -615,7 +773,7 @@ export const recordConnectShyftWebhookReceipt = async (input: {
         canonical_event_type: canonicalEventType,
         dedupe_key: dedupeKey,
       })
-      .onConflict(['provider_name', 'dedupe_key'])
+      .onConflict(['tenant_id', 'provider_name', 'dedupe_key'])
       .ignore()
       .returning(['id']);
 
@@ -632,19 +790,17 @@ export const recordConnectShyftWebhookReceipt = async (input: {
       duplicate: true,
       dedupeKey,
     };
-  } catch (_error) {
-    if (inMemoryWebhookReceiptKeys.has(inMemoryReceiptKey)) {
-      return {
-        deterministic: true,
-        duplicate: true,
-        dedupeKey,
-      };
-    }
-    inMemoryWebhookReceiptKeys.add(inMemoryReceiptKey);
+  } catch (error) {
     return {
       deterministic: true,
       duplicate: false,
       dedupeKey,
+      error: {
+        code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+        message: error instanceof Error
+          ? error.message
+          : 'Webhook receipt persistence unavailable.',
+      },
     };
   }
 };

--- a/src/src/modules/connectshyft/providerCorrelationMappings.ts
+++ b/src/src/modules/connectshyft/providerCorrelationMappings.ts
@@ -1,0 +1,655 @@
+import type { Knex } from 'knex';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PROVIDER_IDENTIFIER_MAPPINGS_TABLE = 'cs_provider_identifier_mappings';
+const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+
+export type ConnectShyftProviderIdentifierKind = 'call_leg' | 'message';
+export type ConnectShyftProviderCorrelationRefusalReason =
+  | 'missing-identifiers'
+  | 'not-found'
+  | 'ambiguous';
+
+export type ConnectShyftProviderIdentifierMapping = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  identifierKind: ConnectShyftProviderIdentifierKind;
+  providerIdentifier: string;
+  internalReferenceId: string;
+  createdAtUtc: string;
+};
+
+export type ConnectShyftProviderCorrelationResolution = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  providerLegId: string | null;
+  providerMessageId: string | null;
+  internalCallReferenceId: string | null;
+  internalMessageReferenceId: string | null;
+};
+
+export type ConnectShyftProviderCorrelationLookupResult =
+  | {
+    ok: true;
+    source: 'provider_leg_id' | 'provider_message_id' | 'provider_consensus';
+    correlation: ConnectShyftProviderCorrelationResolution;
+  }
+  | {
+    ok: false;
+    reason: ConnectShyftProviderCorrelationRefusalReason;
+  };
+
+type ConnectShyftProviderIdentifierMappingRecord = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  identifierKind: ConnectShyftProviderIdentifierKind;
+  providerIdentifier: string;
+  internalReferenceId: string;
+  createdAtUtc: string;
+};
+
+type ConnectShyftProviderMappingRow = {
+  tenant_id?: unknown;
+  org_unit_id?: unknown;
+  thread_id?: unknown;
+  provider_name?: unknown;
+  identifier_kind?: unknown;
+  provider_identifier?: unknown;
+  internal_reference_id?: unknown;
+  created_at_utc?: unknown;
+};
+
+const inMemoryProviderIdentifierMappings =
+  new Map<string, ConnectShyftProviderIdentifierMappingRecord>();
+const inMemoryWebhookReceiptKeys = new Set<string>();
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+};
+
+const normalizeProviderName = (value: unknown): string => {
+  return normalizeString(value).toLowerCase();
+};
+
+const normalizeIdentifierKind = (value: unknown): ConnectShyftProviderIdentifierKind | null => {
+  const normalized = normalizeString(value).toLowerCase();
+  if (normalized === 'call_leg') {
+    return 'call_leg';
+  }
+  if (normalized === 'message') {
+    return 'message';
+  }
+  return null;
+};
+
+const buildMappingKey = (
+  providerName: string,
+  identifierKind: ConnectShyftProviderIdentifierKind,
+  providerIdentifier: string,
+): string => {
+  return `${providerName}|${identifierKind}|${providerIdentifier}`;
+};
+
+const shouldUseDb = (
+  input: {
+    tenantId: string;
+    threadId: string;
+  },
+  db?: Knex,
+): boolean => {
+  return Boolean(
+    db
+    && UUID_PATTERN.test(input.tenantId)
+    && UUID_PATTERN.test(input.threadId),
+  );
+};
+
+const shouldUseDbForWebhookReceipt = (
+  input: {
+    tenantId: string;
+    threadId: string;
+  },
+  db?: Knex,
+): boolean => {
+  return Boolean(
+    db
+    && UUID_PATTERN.test(input.tenantId)
+    && UUID_PATTERN.test(input.threadId),
+  );
+};
+
+const mapDbRowToRecord = (
+  row: ConnectShyftProviderMappingRow | null,
+): ConnectShyftProviderIdentifierMappingRecord | null => {
+  if (!row) {
+    return null;
+  }
+
+  const identifierKind = normalizeIdentifierKind(row.identifier_kind);
+  if (!identifierKind) {
+    return null;
+  }
+
+  const providerName = normalizeProviderName(row.provider_name);
+  const providerIdentifier = normalizeString(row.provider_identifier);
+  const tenantId = normalizeString(row.tenant_id);
+  const orgUnitId = normalizeString(row.org_unit_id);
+  const threadId = normalizeString(row.thread_id);
+  const internalReferenceId = normalizeString(row.internal_reference_id);
+  const createdAtUtc = row.created_at_utc instanceof Date
+    ? row.created_at_utc.toISOString()
+    : normalizeString(row.created_at_utc);
+
+  if (
+    !providerName
+    || !providerIdentifier
+    || !tenantId
+    || !orgUnitId
+    || !threadId
+    || !internalReferenceId
+    || !createdAtUtc
+  ) {
+    return null;
+  }
+
+  return {
+    tenantId,
+    orgUnitId,
+    threadId,
+    providerName,
+    identifierKind,
+    providerIdentifier,
+    internalReferenceId,
+    createdAtUtc,
+  };
+};
+
+const findInMemoryMapping = (input: {
+  providerName: string;
+  identifierKind: ConnectShyftProviderIdentifierKind;
+  providerIdentifier: string;
+}): ConnectShyftProviderIdentifierMappingRecord | null => {
+  const key = buildMappingKey(input.providerName, input.identifierKind, input.providerIdentifier);
+  return inMemoryProviderIdentifierMappings.get(key) || null;
+};
+
+const saveInMemoryMapping = (record: ConnectShyftProviderIdentifierMappingRecord): {
+  status: 'created' | 'duplicate';
+  mapping: ConnectShyftProviderIdentifierMapping;
+} => {
+  const key = buildMappingKey(record.providerName, record.identifierKind, record.providerIdentifier);
+  const existing = inMemoryProviderIdentifierMappings.get(key);
+  if (existing) {
+    return {
+      status: 'duplicate',
+      mapping: { ...existing },
+    };
+  }
+
+  inMemoryProviderIdentifierMappings.set(key, record);
+  return {
+    status: 'created',
+    mapping: { ...record },
+  };
+};
+
+const saveDbMapping = async (input: {
+  db: Knex;
+  record: ConnectShyftProviderIdentifierMappingRecord;
+}): Promise<{
+  status: 'created' | 'duplicate';
+  mapping: ConnectShyftProviderIdentifierMapping;
+}> => {
+  const insertedRows = await input.db
+    .withSchema('connectshyft')
+    .table(PROVIDER_IDENTIFIER_MAPPINGS_TABLE)
+    .insert({
+      tenant_id: input.record.tenantId,
+      org_unit_id: input.record.orgUnitId,
+      thread_id: input.record.threadId,
+      provider_name: input.record.providerName,
+      identifier_kind: input.record.identifierKind,
+      provider_identifier: input.record.providerIdentifier,
+      internal_reference_id: input.record.internalReferenceId,
+      created_at_utc: input.record.createdAtUtc,
+    })
+    .onConflict(['provider_name', 'identifier_kind', 'provider_identifier'])
+    .ignore()
+    .returning([
+      'tenant_id',
+      'org_unit_id',
+      'thread_id',
+      'provider_name',
+      'identifier_kind',
+      'provider_identifier',
+      'internal_reference_id',
+      'created_at_utc',
+    ]);
+
+  const inserted = mapDbRowToRecord(insertedRows[0] as ConnectShyftProviderMappingRow | undefined || null);
+  if (inserted) {
+    return {
+      status: 'created',
+      mapping: { ...inserted },
+    };
+  }
+
+  const existingRow = await input.db
+    .withSchema('connectshyft')
+    .table(PROVIDER_IDENTIFIER_MAPPINGS_TABLE)
+    .where({
+      provider_name: input.record.providerName,
+      identifier_kind: input.record.identifierKind,
+      provider_identifier: input.record.providerIdentifier,
+    })
+    .first([
+      'tenant_id',
+      'org_unit_id',
+      'thread_id',
+      'provider_name',
+      'identifier_kind',
+      'provider_identifier',
+      'internal_reference_id',
+      'created_at_utc',
+    ]);
+
+  const existing = mapDbRowToRecord(existingRow as ConnectShyftProviderMappingRow | null);
+  if (!existing) {
+    return {
+      status: 'duplicate',
+      mapping: {
+        ...input.record,
+      },
+    };
+  }
+
+  return {
+    status: 'duplicate',
+    mapping: { ...existing },
+  };
+};
+
+const findDbMapping = async (input: {
+  db: Knex;
+  providerName: string;
+  identifierKind: ConnectShyftProviderIdentifierKind;
+  providerIdentifier: string;
+}): Promise<ConnectShyftProviderIdentifierMappingRecord | null> => {
+  const row = await input.db
+    .withSchema('connectshyft')
+    .table(PROVIDER_IDENTIFIER_MAPPINGS_TABLE)
+    .where({
+      provider_name: input.providerName,
+      identifier_kind: input.identifierKind,
+      provider_identifier: input.providerIdentifier,
+    })
+    .first([
+      'tenant_id',
+      'org_unit_id',
+      'thread_id',
+      'provider_name',
+      'identifier_kind',
+      'provider_identifier',
+      'internal_reference_id',
+      'created_at_utc',
+    ]);
+
+  return mapDbRowToRecord(row as ConnectShyftProviderMappingRow | null);
+};
+
+const toCorrelationResolution = (input: {
+  callLegMapping: ConnectShyftProviderIdentifierMappingRecord | null;
+  messageMapping: ConnectShyftProviderIdentifierMappingRecord | null;
+  source: 'provider_leg_id' | 'provider_message_id' | 'provider_consensus';
+}): ConnectShyftProviderCorrelationLookupResult => {
+  const resolvedBase = input.callLegMapping || input.messageMapping;
+  if (!resolvedBase) {
+    return {
+      ok: false,
+      reason: 'not-found',
+    };
+  }
+
+  return {
+    ok: true,
+    source: input.source,
+    correlation: {
+      tenantId: resolvedBase.tenantId,
+      orgUnitId: resolvedBase.orgUnitId,
+      threadId: resolvedBase.threadId,
+      providerName: resolvedBase.providerName,
+      providerLegId: input.callLegMapping?.providerIdentifier || null,
+      providerMessageId: input.messageMapping?.providerIdentifier || null,
+      internalCallReferenceId: input.callLegMapping?.internalReferenceId || null,
+      internalMessageReferenceId: input.messageMapping?.internalReferenceId || null,
+    },
+  };
+};
+
+const mappingsConflict = (
+  left: ConnectShyftProviderIdentifierMappingRecord,
+  right: ConnectShyftProviderIdentifierMappingRecord,
+): boolean => {
+  return left.tenantId !== right.tenantId
+    || left.orgUnitId !== right.orgUnitId
+    || left.threadId !== right.threadId;
+};
+
+const buildWebhookDedupeKey = (input: {
+  canonicalEventType: string;
+  providerEventId?: string | null;
+  providerLegId?: string | null;
+  providerMessageId?: string | null;
+}): string | null => {
+  const canonicalEventType = normalizeString(input.canonicalEventType).toLowerCase();
+  const providerEventId = normalizeString(input.providerEventId || null).toLowerCase();
+  const providerLegId = normalizeString(input.providerLegId || null).toLowerCase();
+  const providerMessageId = normalizeString(input.providerMessageId || null).toLowerCase();
+
+  if (providerEventId) {
+    return `provider-event:${providerEventId}`;
+  }
+  if (providerLegId && canonicalEventType) {
+    return `call-leg:${providerLegId}|event:${canonicalEventType}`;
+  }
+  if (providerMessageId && canonicalEventType) {
+    return `message:${providerMessageId}|event:${canonicalEventType}`;
+  }
+  return null;
+};
+
+export const recordConnectShyftProviderIdentifierMapping = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  identifierKind: ConnectShyftProviderIdentifierKind;
+  providerIdentifier: string;
+  internalReferenceId: string;
+  createdAtUtc?: string;
+  db?: Knex;
+}): Promise<{
+  status: 'created' | 'duplicate' | 'ignored';
+  mapping: ConnectShyftProviderIdentifierMapping | null;
+}> => {
+  const providerName = normalizeProviderName(input.providerName);
+  const providerIdentifier = normalizeString(input.providerIdentifier);
+  const tenantId = normalizeString(input.tenantId);
+  const orgUnitId = normalizeString(input.orgUnitId);
+  const threadId = normalizeString(input.threadId);
+  const internalReferenceId = normalizeString(input.internalReferenceId);
+  const createdAtUtc = normalizeString(input.createdAtUtc) || new Date().toISOString();
+
+  if (
+    !providerName
+    || !providerIdentifier
+    || !tenantId
+    || !orgUnitId
+    || !threadId
+    || !internalReferenceId
+  ) {
+    return {
+      status: 'ignored',
+      mapping: null,
+    };
+  }
+
+  const record: ConnectShyftProviderIdentifierMappingRecord = {
+    tenantId,
+    orgUnitId,
+    threadId,
+    providerName,
+    identifierKind: input.identifierKind,
+    providerIdentifier,
+    internalReferenceId,
+    createdAtUtc,
+  };
+
+  if (!shouldUseDb({ tenantId, threadId }, input.db)) {
+    const saved = saveInMemoryMapping(record);
+    return {
+      status: saved.status,
+      mapping: saved.mapping,
+    };
+  }
+
+  try {
+    const saved = await saveDbMapping({
+      db: input.db as Knex,
+      record,
+    });
+
+    return {
+      status: saved.status,
+      mapping: saved.mapping,
+    };
+  } catch (_error) {
+    const saved = saveInMemoryMapping(record);
+    return {
+      status: saved.status,
+      mapping: saved.mapping,
+    };
+  }
+};
+
+export const resolveConnectShyftProviderCorrelationByIdentifiers = async (input: {
+  providerName: string;
+  providerLegId?: string | null;
+  providerMessageId?: string | null;
+  db?: Knex;
+}): Promise<ConnectShyftProviderCorrelationLookupResult> => {
+  const providerName = normalizeProviderName(input.providerName);
+  const providerLegId = normalizeString(input.providerLegId || null);
+  const providerMessageId = normalizeString(input.providerMessageId || null);
+
+  if (!providerName || (!providerLegId && !providerMessageId)) {
+    return {
+      ok: false,
+      reason: 'missing-identifiers',
+    };
+  }
+
+  let callLegMapping: ConnectShyftProviderIdentifierMappingRecord | null = null;
+  let messageMapping: ConnectShyftProviderIdentifierMappingRecord | null = null;
+
+  if (providerLegId) {
+    callLegMapping = findInMemoryMapping({
+      providerName,
+      identifierKind: 'call_leg',
+      providerIdentifier: providerLegId,
+    });
+  }
+
+  if (providerMessageId) {
+    messageMapping = findInMemoryMapping({
+      providerName,
+      identifierKind: 'message',
+      providerIdentifier: providerMessageId,
+    });
+  }
+
+  if (input.db && providerLegId && !callLegMapping) {
+    try {
+      callLegMapping = await findDbMapping({
+        db: input.db,
+        providerName,
+        identifierKind: 'call_leg',
+        providerIdentifier: providerLegId,
+      });
+    } catch (_error) {
+      callLegMapping = callLegMapping || null;
+    }
+  }
+
+  if (input.db && providerMessageId && !messageMapping) {
+    try {
+      messageMapping = await findDbMapping({
+        db: input.db,
+        providerName,
+        identifierKind: 'message',
+        providerIdentifier: providerMessageId,
+      });
+    } catch (_error) {
+      messageMapping = messageMapping || null;
+    }
+  }
+
+  if (callLegMapping && messageMapping && mappingsConflict(callLegMapping, messageMapping)) {
+    return {
+      ok: false,
+      reason: 'ambiguous',
+    };
+  }
+
+  if (callLegMapping && messageMapping) {
+    return toCorrelationResolution({
+      callLegMapping,
+      messageMapping,
+      source: 'provider_consensus',
+    });
+  }
+
+  if (callLegMapping) {
+    return toCorrelationResolution({
+      callLegMapping,
+      messageMapping: null,
+      source: 'provider_leg_id',
+    });
+  }
+
+  if (messageMapping) {
+    return toCorrelationResolution({
+      callLegMapping: null,
+      messageMapping,
+      source: 'provider_message_id',
+    });
+  }
+
+  return {
+    ok: false,
+    reason: 'not-found',
+  };
+};
+
+export const recordConnectShyftWebhookReceipt = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  canonicalEventType: string;
+  providerEventId?: string | null;
+  providerLegId?: string | null;
+  providerMessageId?: string | null;
+  db?: Knex;
+}): Promise<{
+  deterministic: true;
+  duplicate: boolean;
+  dedupeKey: string | null;
+}> => {
+  const providerName = normalizeProviderName(input.providerName);
+  const tenantId = normalizeString(input.tenantId);
+  const orgUnitId = normalizeString(input.orgUnitId);
+  const threadId = normalizeString(input.threadId);
+  const canonicalEventType = normalizeString(input.canonicalEventType);
+  const providerEventId = normalizeString(input.providerEventId || null);
+  const providerLegId = normalizeString(input.providerLegId || null);
+  const providerMessageId = normalizeString(input.providerMessageId || null);
+  const dedupeKey = buildWebhookDedupeKey({
+    canonicalEventType,
+    providerEventId,
+    providerLegId,
+    providerMessageId,
+  });
+
+  if (!providerName || !dedupeKey || !tenantId || !orgUnitId || !threadId || !canonicalEventType) {
+    return {
+      deterministic: true,
+      duplicate: false,
+      dedupeKey,
+    };
+  }
+
+  const inMemoryReceiptKey = `${providerName}|${dedupeKey}`;
+  if (!shouldUseDbForWebhookReceipt({ tenantId, threadId }, input.db)) {
+    if (inMemoryWebhookReceiptKeys.has(inMemoryReceiptKey)) {
+      return {
+        deterministic: true,
+        duplicate: true,
+        dedupeKey,
+      };
+    }
+    inMemoryWebhookReceiptKeys.add(inMemoryReceiptKey);
+    return {
+      deterministic: true,
+      duplicate: false,
+      dedupeKey,
+    };
+  }
+
+  try {
+    const db = input.db as Knex;
+    const inserted = await db
+      .withSchema('connectshyft')
+      .table(WEBHOOK_RECEIPTS_TABLE)
+      .insert({
+        tenant_id: tenantId,
+        org_unit_id: orgUnitId,
+        thread_id: threadId,
+        provider_name: providerName,
+        provider_event_id: providerEventId || null,
+        provider_identifier_kind: providerLegId
+          ? 'call_leg'
+          : providerMessageId
+            ? 'message'
+            : null,
+        provider_identifier: providerLegId || providerMessageId || null,
+        canonical_event_type: canonicalEventType,
+        dedupe_key: dedupeKey,
+      })
+      .onConflict(['provider_name', 'dedupe_key'])
+      .ignore()
+      .returning(['id']);
+
+    if (inserted.length > 0) {
+      return {
+        deterministic: true,
+        duplicate: false,
+        dedupeKey,
+      };
+    }
+
+    return {
+      deterministic: true,
+      duplicate: true,
+      dedupeKey,
+    };
+  } catch (_error) {
+    if (inMemoryWebhookReceiptKeys.has(inMemoryReceiptKey)) {
+      return {
+        deterministic: true,
+        duplicate: true,
+        dedupeKey,
+      };
+    }
+    inMemoryWebhookReceiptKeys.add(inMemoryReceiptKey);
+    return {
+      deterministic: true,
+      duplicate: false,
+      dedupeKey,
+    };
+  }
+};
+
+export const resetConnectShyftProviderCorrelationStateForTests = (): void => {
+  inMemoryProviderIdentifierMappings.clear();
+  inMemoryWebhookReceiptKeys.clear();
+};

--- a/src/src/modules/connectshyft/providerRegistry.ts
+++ b/src/src/modules/connectshyft/providerRegistry.ts
@@ -30,6 +30,8 @@ export type ConnectShyftProviderResolution = {
 export type ConnectShyftProviderDispatchResult = {
   providerKey: string;
   channel: 'call' | 'message';
+  providerLegId: string | null;
+  providerMessageId: string | null;
   adapterInvoked: true;
   providerBranchingInDomain: false;
 };
@@ -528,11 +530,20 @@ const toCanonicalEventType = (rawEventType: string): string => {
 };
 
 const buildDispatchResult = (
-  providerKey: string,
-  channel: 'call' | 'message',
+  input: {
+    providerKey: string;
+    channel: 'call' | 'message';
+    threadId: string;
+  },
 ): ConnectShyftProviderDispatchResult => ({
-  providerKey,
-  channel,
+  providerKey: input.providerKey,
+  channel: input.channel,
+  providerLegId: input.channel === 'call'
+    ? `${input.providerKey}-call-leg-${input.threadId}`
+    : null,
+  providerMessageId: input.channel === 'message'
+    ? `${input.providerKey}-message-${input.threadId}`
+    : null,
   adapterInvoked: true,
   providerBranchingInDomain: false,
 });
@@ -543,11 +554,19 @@ const createAdapter = (input: {
 }): ConnectShyftProviderAdapter => ({
   providerKey: input.providerKey,
   adapterInterfaceVersion: 'v1',
-  async dispatchOutboundCall(_dispatchInput) {
-    return buildDispatchResult(input.providerKey, 'call');
+  async dispatchOutboundCall(dispatchInput) {
+    return buildDispatchResult({
+      providerKey: input.providerKey,
+      channel: 'call',
+      threadId: dispatchInput.threadId,
+    });
   },
-  async dispatchOutboundMessage(_dispatchInput) {
-    return buildDispatchResult(input.providerKey, 'message');
+  async dispatchOutboundMessage(dispatchInput) {
+    return buildDispatchResult({
+      providerKey: input.providerKey,
+      channel: 'message',
+      threadId: dispatchInput.threadId,
+    });
   },
   validateInboundWebhookSignature({ req }) {
     if (input.validateInboundWebhookSignature) {

--- a/src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts
+++ b/src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts
@@ -3,6 +3,7 @@ import { generateKeyPairSync, sign as signPayload } from 'node:crypto';
 import request from 'supertest';
 import * as PlatformAdminService from '../../../../services/PlatformAdminService';
 import * as ProviderRegistry from '../../../../modules/connectshyft/providerRegistry';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
 import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
 import connectShyftRouter from '../connectshyft';
 
@@ -95,6 +96,10 @@ describe('connectshyft provider adapter registry route integration', () => {
   const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
   const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
   let entitlementSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetConnectShyftProviderCorrelationStateForTests();
+  });
 
   beforeAll(() => {
     process.env.NODE_ENV = 'test';
@@ -536,6 +541,141 @@ describe('connectshyft provider adapter registry route integration', () => {
     });
   });
 
+  it('resolves webhook correlation by provider identifiers when metadata is missing', async () => {
+    const app = buildApp();
+    const callResponse = await request(app)
+      .post('/api/v1/connectshyft/threads/thread-f1-unclaimed-1001/call')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: 'org-connectshyft-f1-east',
+        providerKey: 'telnyx',
+      });
+
+    expect(callResponse.status).toBe(200);
+    const providerLegId = callResponse.body?.data?.dispatch?.providerLegId as string;
+    expect(typeof providerLegId).toBe('string');
+    expect(providerLegId.length).toBeGreaterThan(0);
+
+    const webhookResponse = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildHeaders())
+      .send({
+        eventType: 'voice.connected',
+        providerKey: 'telnyx',
+        providerLegId,
+      });
+
+    expect(webhookResponse.status).toBe(200);
+    expect(webhookResponse.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        threadId: 'thread-f1-unclaimed-1001',
+        correlation: {
+          source: 'provider_fallback',
+          deterministic: true,
+          providerLegId,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+        },
+      },
+    });
+  });
+
+  it('returns deterministic refusal when correlation metadata and fallback identifiers are missing', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildHeaders())
+      .send({
+        eventType: 'voice.connected',
+        providerKey: 'telnyx',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED',
+      refusalType: 'business',
+      data: {
+        correlation: {
+          deterministic: true,
+          reason: 'missing-identifiers',
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+      },
+    });
+  });
+
+  it('suppresses duplicate webhook callbacks and prevents duplicate domain writes', async () => {
+    const app = buildApp();
+    const messageResponse = await request(app)
+      .post('/api/v1/connectshyft/threads/thread-f1-unclaimed-1001/messages')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: 'org-connectshyft-f1-east',
+        providerKey: 'telnyx',
+        channel: 'sms',
+        body: 'Story f3 duplicate callback suppression test',
+      });
+
+    expect(messageResponse.status).toBe(200);
+    const providerMessageId = messageResponse.body?.data?.dispatch?.providerMessageId as string;
+    expect(typeof providerMessageId).toBe('string');
+    expect(providerMessageId.length).toBeGreaterThan(0);
+
+    const webhookPayload = {
+      eventType: 'sms.delivered',
+      providerKey: 'telnyx',
+      providerEventId: 'provider-event-f3-duplicate-1001',
+      providerMessageId,
+    };
+
+    const first = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildHeaders())
+      .send(webhookPayload);
+    expect(first.status).toBe(200);
+    expect(first.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+        },
+      },
+    });
+
+    const duplicate = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildHeaders())
+      .send(webhookPayload);
+    expect(duplicate.status).toBe(200);
+    expect(duplicate.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        replaySafe: {
+          duplicate: true,
+          suppressedDomainWrites: true,
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+      },
+    });
+    expect(duplicate.body.data).not.toHaveProperty('canonicalEvent');
+  });
+
   it('returns deterministic refusal when provider dispatch fails before side-effect persistence', async () => {
     const dispatchFailureSpy = jest.spyOn(ProviderRegistry, 'resolveConnectShyftProviderAdapter').mockReturnValue({
       ok: true,
@@ -553,6 +693,8 @@ describe('connectshyft provider adapter registry route integration', () => {
         dispatchOutboundMessage: async () => ({
           providerKey: 'telnyx',
           channel: 'message',
+          providerLegId: null,
+          providerMessageId: 'telnyx-message-thread-f1-unclaimed-1001',
           adapterInvoked: true,
           providerBranchingInDomain: false,
         }),

--- a/src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts
+++ b/src/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts
@@ -3,6 +3,7 @@ import { generateKeyPairSync, sign as signPayload } from 'node:crypto';
 import request from 'supertest';
 import * as PlatformAdminService from '../../../../services/PlatformAdminService';
 import * as ProviderRegistry from '../../../../modules/connectshyft/providerRegistry';
+import db from '../../../../config/knex';
 import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
 import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
 import connectShyftRouter from '../connectshyft';
@@ -118,7 +119,7 @@ describe('connectshyft provider adapter registry route integration', () => {
     });
   });
 
-  afterAll(() => {
+  afterAll(async () => {
     entitlementSpy.mockRestore();
     process.env.NODE_ENV = previousNodeEnv;
     process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
@@ -127,6 +128,11 @@ describe('connectshyft provider adapter registry route integration', () => {
     process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
     process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
     process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+    try {
+      await db.destroy();
+    } catch (_error) {
+      // ignore teardown close errors in test cleanup
+    }
   });
 
   it('dispatches outbound call through deterministic provider adapter resolution metadata', async () => {
@@ -580,6 +586,107 @@ describe('connectshyft provider adapter registry route integration', () => {
           duplicate: false,
           suppressedDomainWrites: false,
         },
+        timeline: {
+          routingDecision: 'accepted',
+        },
+      },
+    });
+  });
+
+  it('returns deterministic conflict refusal when full metadata disagrees with provider fallback mapping', async () => {
+    const app = buildApp();
+    const callResponse = await request(app)
+      .post('/api/v1/connectshyft/threads/thread-f1-unclaimed-1001/call')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: 'org-connectshyft-f1-east',
+        providerKey: 'telnyx',
+      });
+
+    expect(callResponse.status).toBe(200);
+    const providerLegId = callResponse.body?.data?.dispatch?.providerLegId as string;
+    expect(typeof providerLegId).toBe('string');
+
+    const webhookResponse = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildHeaders())
+      .send({
+        eventType: 'voice.connected',
+        providerKey: 'telnyx',
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-claimed-1002',
+        providerLegId,
+      });
+
+    expect(webhookResponse.status).toBe(200);
+    expect(webhookResponse.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
+      refusalType: 'business',
+      data: {
+        correlation: {
+          deterministic: true,
+          reason: 'conflict',
+          providerLegId,
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
+        },
+      },
+    });
+  });
+
+  it('returns deterministic conflict refusal when partial metadata disagrees with provider fallback mapping', async () => {
+    const app = buildApp();
+    const callResponse = await request(app)
+      .post('/api/v1/connectshyft/threads/thread-f1-unclaimed-1001/call')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: 'org-connectshyft-f1-east',
+        providerKey: 'telnyx',
+      });
+
+    expect(callResponse.status).toBe(200);
+    const providerLegId = callResponse.body?.data?.dispatch?.providerLegId as string;
+    expect(typeof providerLegId).toBe('string');
+
+    const webhookResponse = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildHeaders())
+      .send({
+        eventType: 'voice.connected',
+        providerKey: 'telnyx',
+        threadId: 'thread-f1-closed-1003',
+        providerLegId,
+      });
+
+    expect(webhookResponse.status).toBe(200);
+    expect(webhookResponse.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
+      refusalType: 'business',
+      data: {
+        correlation: {
+          deterministic: true,
+          reason: 'conflict',
+          providerLegId,
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
+        },
       },
     });
   });
@@ -608,6 +715,10 @@ describe('connectshyft provider adapter registry route integration', () => {
           lifecycleMutationApplied: false,
           canonicalEventPersisted: false,
           outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
         },
       },
     });
@@ -674,6 +785,10 @@ describe('connectshyft provider adapter registry route integration', () => {
       },
     });
     expect(duplicate.body.data).not.toHaveProperty('canonicalEvent');
+    expect(duplicate.body.data).not.toHaveProperty('timeline');
+    expect(duplicate.body.data).not.toHaveProperty('audit');
+    expect(duplicate.body.data).not.toHaveProperty('outbox');
+    expect(duplicate.body.data).not.toHaveProperty('lifecycle');
   });
 
   it('returns deterministic refusal when provider dispatch fails before side-effect persistence', async () => {

--- a/src/src/routes/api/v1/connectshyft.ts
+++ b/src/src/routes/api/v1/connectshyft.ts
@@ -686,9 +686,10 @@ type ConnectShyftResolvedWebhookCorrelation =
       | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
       | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
       | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS'
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE'
       | 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT';
     message: string;
-    reason: 'missing-identifiers' | 'not-found' | 'ambiguous' | 'conflict';
+    reason: 'missing-identifiers' | 'not-found' | 'ambiguous' | 'unavailable' | 'conflict';
     providerLegId: string | null;
     providerMessageId: string | null;
     providerEventId: string | null;
@@ -757,12 +758,13 @@ const extractWebhookProviderIdentifiers = (body: unknown): {
 };
 
 const resolveWebhookCorrelationFailure = (
-  reason: 'missing-identifiers' | 'not-found' | 'ambiguous',
+  reason: 'missing-identifiers' | 'not-found' | 'ambiguous' | 'unavailable',
 ): {
   code:
     | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
     | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
-    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS';
+    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS'
+    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE';
   message: string;
 } => {
   if (reason === 'missing-identifiers') {
@@ -775,6 +777,12 @@ const resolveWebhookCorrelationFailure = (
     return {
       code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS',
       message: 'Inbound webhook correlation is ambiguous across provider identifiers.',
+    };
+  }
+  if (reason === 'unavailable') {
+    return {
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE',
+      message: 'Inbound webhook correlation lookup is temporarily unavailable.',
     };
   }
   return {
@@ -799,6 +807,7 @@ const resolveInboundWebhookCorrelation = async (input: {
       providerName: input.providerName,
       providerLegId: providerIdentifiers.providerLegId,
       providerMessageId: providerIdentifiers.providerMessageId,
+      tenantId,
       db: loadPlatformDb(),
     });
 
@@ -837,6 +846,7 @@ const resolveInboundWebhookCorrelation = async (input: {
     providerName: input.providerName,
     providerLegId: providerIdentifiers.providerLegId,
     providerMessageId: providerIdentifiers.providerMessageId,
+    tenantId: tenantId || null,
     db: loadPlatformDb(),
   });
   if (!fallback.ok) {
@@ -2135,8 +2145,12 @@ const persistOutboundProviderIdentifierMappings = async (input: {
   canonicalEventId: string;
 }): Promise<{
   deterministic: true;
-  callLegMapping: 'created' | 'duplicate' | 'ignored';
-  messageMapping: 'created' | 'duplicate' | 'ignored';
+  callLegMapping: 'created' | 'duplicate' | 'ignored' | 'error';
+  messageMapping: 'created' | 'duplicate' | 'ignored' | 'error';
+  error: {
+    code: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE';
+    message: string;
+  } | null;
 }> => {
   const callLegMappingResult = input.dispatch.providerLegId
     ? await recordConnectShyftProviderIdentifierMapping({
@@ -2168,6 +2182,17 @@ const persistOutboundProviderIdentifierMappings = async (input: {
     deterministic: true,
     callLegMapping: callLegMappingResult.status,
     messageMapping: messageMappingResult.status,
+    error: callLegMappingResult.status === 'error'
+      ? {
+        code: callLegMappingResult.errorCode || 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE',
+        message: callLegMappingResult.errorMessage || 'Provider correlation mapping persistence unavailable.',
+      }
+      : messageMappingResult.status === 'error'
+        ? {
+          code: messageMappingResult.errorCode || 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE',
+          message: messageMappingResult.errorMessage || 'Provider correlation mapping persistence unavailable.',
+        }
+        : null,
   };
 };
 
@@ -4904,6 +4929,34 @@ const performOutboundAction = async (
     dispatch: providerDispatch,
     canonicalEventId: canonicalEvent.eventId,
   });
+  if (correlationMapping.error) {
+    respondConnectShyftBusinessRefusal(res, {
+      code: correlationMapping.error.code,
+      message: 'Provider dispatch completed but correlation mapping persistence is unavailable.',
+      data: {
+        context,
+        threadId,
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+          providerBranchingInDomain: false,
+        },
+        correlationMapping: {
+          deterministic: true,
+          callLegMapping: correlationMapping.callLegMapping,
+          messageMapping: correlationMapping.messageMapping,
+        },
+        sideEffects: {
+          dispatchAttempted: true,
+          lifecycleMutationApplied: priorState === 'CLOSED',
+          auditPersisted: sideEffectsPersisted,
+          canonicalEventPersisted: true,
+          correlationMappingPersisted: false,
+        },
+      },
+    });
+    return;
+  }
 
   const operatorFeedback = priorState === 'CLOSED'
     ? 'Conversation reopened on the same thread before outbound dispatch. Escalation and inactivity timers were reset.'
@@ -5109,6 +5162,45 @@ const handleInboundWebhook = async (
     providerMessageId: correlation.providerMessageId,
     db: loadPlatformDb(),
   });
+  if (webhookReceipt.error) {
+    refusal(res, {
+      code: webhookReceipt.error.code,
+      message: 'Inbound webhook correlation resolved but receipt persistence is unavailable.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: correlation.source,
+          deterministic: true,
+          threadId,
+          tenantId,
+          orgUnitId,
+          providerLegId: correlation.providerLegId,
+          providerMessageId: correlation.providerMessageId,
+          providerEventId: correlation.providerEventId,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: webhookReceipt.dedupeKey,
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
+        },
+      },
+    });
+    return;
+  }
   if (webhookReceipt.duplicate) {
     success(res, {
       code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',

--- a/src/src/routes/api/v1/connectshyft.ts
+++ b/src/src/routes/api/v1/connectshyft.ts
@@ -71,6 +71,11 @@ import {
   recordConnectShyftCanonicalEvent,
   type ConnectShyftCanonicalEventRecord,
 } from '../../../modules/connectshyft/canonicalEvents';
+import {
+  recordConnectShyftProviderIdentifierMapping,
+  recordConnectShyftWebhookReceipt,
+  resolveConnectShyftProviderCorrelationByIdentifiers,
+} from '../../../modules/connectshyft/providerCorrelationMappings';
 import { isStrictUtcIsoTimestamp } from '../../../platform/time/timezoneService';
 
 const router = Router();
@@ -660,6 +665,219 @@ const normalizeLifecycleString = (value: unknown): string => {
   }
 
   return value.trim();
+};
+
+type ConnectShyftWebhookCorrelationSource = 'metadata' | 'provider_fallback';
+
+type ConnectShyftResolvedWebhookCorrelation =
+  | {
+    ok: true;
+    source: ConnectShyftWebhookCorrelationSource;
+    tenantId: string;
+    orgUnitId: string;
+    threadId: string;
+    providerLegId: string | null;
+    providerMessageId: string | null;
+    providerEventId: string | null;
+  }
+  | {
+    ok: false;
+    code:
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS'
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT';
+    message: string;
+    reason: 'missing-identifiers' | 'not-found' | 'ambiguous' | 'conflict';
+    providerLegId: string | null;
+    providerMessageId: string | null;
+    providerEventId: string | null;
+  };
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+};
+
+const readWebhookIdentifierFromSources = (
+  sources: Array<Record<string, unknown> | null>,
+  candidates: string[],
+): string | null => {
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+    for (const candidate of candidates) {
+      const value = normalizeLifecycleString(source[candidate]);
+      if (value) {
+        return value;
+      }
+    }
+  }
+  return null;
+};
+
+const extractWebhookProviderIdentifiers = (body: unknown): {
+  providerLegId: string | null;
+  providerMessageId: string | null;
+  providerEventId: string | null;
+} => {
+  const payload = asRecord(body);
+  const providerPayload = asRecord(payload?.providerPayload);
+  const data = asRecord(payload?.data);
+  const dataPayload = asRecord(data?.payload);
+  const sources = [payload, providerPayload, dataPayload, data];
+
+  return {
+    providerLegId: readWebhookIdentifierFromSources(sources, [
+      'providerLegId',
+      'provider_leg_id',
+      'callControlId',
+      'call_control_id',
+      'telnyxCallControlId',
+    ]),
+    providerMessageId: readWebhookIdentifierFromSources(sources, [
+      'providerMessageId',
+      'provider_message_id',
+      'messageUuid',
+      'message_uuid',
+      'telnyxMessageId',
+      'telnyx_message_id',
+    ]),
+    providerEventId: readWebhookIdentifierFromSources(sources, [
+      'providerEventId',
+      'provider_event_id',
+      'eventId',
+      'event_id',
+      'id',
+    ]),
+  };
+};
+
+const resolveWebhookCorrelationFailure = (
+  reason: 'missing-identifiers' | 'not-found' | 'ambiguous',
+): {
+  code:
+    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
+    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
+    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS';
+  message: string;
+} => {
+  if (reason === 'missing-identifiers') {
+    return {
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED',
+      message: 'Inbound webhook requires correlation metadata or provider identifiers.',
+    };
+  }
+  if (reason === 'ambiguous') {
+    return {
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS',
+      message: 'Inbound webhook correlation is ambiguous across provider identifiers.',
+    };
+  }
+  return {
+    code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND',
+    message: 'Inbound webhook correlation mapping not found for provider identifiers.',
+  };
+};
+
+const resolveInboundWebhookCorrelation = async (input: {
+  body: unknown;
+  providerName: string;
+}): Promise<ConnectShyftResolvedWebhookCorrelation> => {
+  const payload = asRecord(input.body);
+  const tenantId = normalizeLifecycleString(payload?.tenantId);
+  const orgUnitId = normalizeLifecycleString(payload?.orgUnitId);
+  const threadId = normalizeLifecycleString(payload?.threadId);
+  const providerIdentifiers = extractWebhookProviderIdentifiers(input.body);
+  const hasCompleteMetadata = Boolean(tenantId && orgUnitId && threadId);
+
+  if (hasCompleteMetadata) {
+    const fallbackProbe = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: input.providerName,
+      providerLegId: providerIdentifiers.providerLegId,
+      providerMessageId: providerIdentifiers.providerMessageId,
+      db: loadPlatformDb(),
+    });
+
+    if (
+      fallbackProbe.ok
+      && (
+        fallbackProbe.correlation.tenantId !== tenantId
+        || fallbackProbe.correlation.orgUnitId !== orgUnitId
+        || fallbackProbe.correlation.threadId !== threadId
+      )
+    ) {
+      return {
+        ok: false,
+        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
+        message: 'Inbound webhook correlation metadata conflicts with provider identifier mapping.',
+        reason: 'conflict',
+        providerLegId: providerIdentifiers.providerLegId,
+        providerMessageId: providerIdentifiers.providerMessageId,
+        providerEventId: providerIdentifiers.providerEventId,
+      };
+    }
+
+    return {
+      ok: true,
+      source: 'metadata',
+      tenantId,
+      orgUnitId,
+      threadId,
+      providerLegId: providerIdentifiers.providerLegId,
+      providerMessageId: providerIdentifiers.providerMessageId,
+      providerEventId: providerIdentifiers.providerEventId,
+    };
+  }
+
+  const fallback = await resolveConnectShyftProviderCorrelationByIdentifiers({
+    providerName: input.providerName,
+    providerLegId: providerIdentifiers.providerLegId,
+    providerMessageId: providerIdentifiers.providerMessageId,
+    db: loadPlatformDb(),
+  });
+  if (!fallback.ok) {
+    const failure = resolveWebhookCorrelationFailure(fallback.reason);
+    return {
+      ok: false,
+      code: failure.code,
+      message: failure.message,
+      reason: fallback.reason,
+      providerLegId: providerIdentifiers.providerLegId,
+      providerMessageId: providerIdentifiers.providerMessageId,
+      providerEventId: providerIdentifiers.providerEventId,
+    };
+  }
+
+  if (
+    (tenantId && tenantId !== fallback.correlation.tenantId)
+    || (orgUnitId && orgUnitId !== fallback.correlation.orgUnitId)
+    || (threadId && threadId !== fallback.correlation.threadId)
+  ) {
+    return {
+      ok: false,
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
+      message: 'Inbound webhook partial metadata conflicts with provider identifier mapping.',
+      reason: 'conflict',
+      providerLegId: providerIdentifiers.providerLegId,
+      providerMessageId: providerIdentifiers.providerMessageId,
+      providerEventId: providerIdentifiers.providerEventId,
+    };
+  }
+
+  return {
+    ok: true,
+    source: 'provider_fallback',
+    tenantId: fallback.correlation.tenantId,
+    orgUnitId: fallback.correlation.orgUnitId,
+    threadId: fallback.correlation.threadId,
+    providerLegId: providerIdentifiers.providerLegId,
+    providerMessageId: providerIdentifiers.providerMessageId,
+    providerEventId: providerIdentifiers.providerEventId,
+  };
 };
 
 const nowIsoUtc = (): string => new Date().toISOString();
@@ -1906,6 +2124,51 @@ const recordCanonicalThreadEvent = async (input: {
     actorUserId: input.actorUserId,
     db: loadPlatformDb(),
   });
+};
+
+const persistOutboundProviderIdentifierMappings = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  dispatch: ConnectShyftProviderDispatchResult;
+  canonicalEventId: string;
+}): Promise<{
+  deterministic: true;
+  callLegMapping: 'created' | 'duplicate' | 'ignored';
+  messageMapping: 'created' | 'duplicate' | 'ignored';
+}> => {
+  const callLegMappingResult = input.dispatch.providerLegId
+    ? await recordConnectShyftProviderIdentifierMapping({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      threadId: input.threadId,
+      providerName: input.providerName,
+      identifierKind: 'call_leg',
+      providerIdentifier: input.dispatch.providerLegId,
+      internalReferenceId: input.canonicalEventId,
+      db: loadPlatformDb(),
+    })
+    : { status: 'ignored' as const };
+
+  const messageMappingResult = input.dispatch.providerMessageId
+    ? await recordConnectShyftProviderIdentifierMapping({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      threadId: input.threadId,
+      providerName: input.providerName,
+      identifierKind: 'message',
+      providerIdentifier: input.dispatch.providerMessageId,
+      internalReferenceId: input.canonicalEventId,
+      db: loadPlatformDb(),
+    })
+    : { status: 'ignored' as const };
+
+  return {
+    deterministic: true,
+    callLegMapping: callLegMappingResult.status,
+    messageMapping: messageMappingResult.status,
+  };
 };
 
 const listCanonicalThreadEvents = async (input: {
@@ -4633,6 +4896,15 @@ const performOutboundAction = async (
     actorUserId,
   });
 
+  const correlationMapping = await persistOutboundProviderIdentifierMappings({
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    threadId,
+    providerName: providerDispatch.providerKey,
+    dispatch: providerDispatch,
+    canonicalEventId: canonicalEvent.eventId,
+  });
+
   const operatorFeedback = priorState === 'CLOSED'
     ? 'Conversation reopened on the same thread before outbound dispatch. Escalation and inactivity timers were reset.'
     : priorState === 'UNCLAIMED'
@@ -4692,6 +4964,7 @@ const performOutboundAction = async (
       },
       canonicalEvent,
       dispatch: providerDispatch,
+      correlationMapping,
       ...(outboundAction === 'call'
         ? {
             call: CONNECTSHYFT_OUTBOUND_CALL_POLICY,
@@ -4777,9 +5050,103 @@ const handleInboundWebhook = async (
   const eventType = canonicalTranslation.eventType;
   const normalizedEventType = eventType.toLowerCase();
   const isConnectedCallEvent = CONNECTSHYFT_CONNECTED_CALL_EVENT_TYPES.has(normalizedEventType);
-  const threadId = normalizeLifecycleString(req.body?.threadId) || null;
-  const tenantId = normalizeLifecycleString(req.body?.tenantId) || null;
-  const orgUnitId = normalizeLifecycleString(req.body?.orgUnitId) || null;
+  const correlation = await resolveInboundWebhookCorrelation({
+    body: req.body,
+    providerName: providerSelection.providerResolution.resolvedProvider,
+  });
+  if (!correlation.ok) {
+    refusal(res, {
+      code: correlation.code,
+      message: correlation.message,
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        correlation: {
+          deterministic: true,
+          metadataFirstAttempted: true,
+          fallbackLookupAttempted: true,
+          reason: correlation.reason,
+          providerLegId: correlation.providerLegId,
+          providerMessageId: correlation.providerMessageId,
+          providerEventId: correlation.providerEventId,
+        },
+        operatorFeedbackMeta: {
+          actionable: true,
+          hiddenTransition: false,
+          messageKey: 'connectshyft.webhook.correlation.unresolved',
+          remediation: 'Retry with thread metadata or provider identifiers that map to a prior outbound dispatch.',
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
+        },
+      },
+    });
+    return;
+  }
+
+  const tenantId = correlation.tenantId;
+  const orgUnitId = correlation.orgUnitId;
+  const threadId = correlation.threadId;
+
+  const webhookReceipt = await recordConnectShyftWebhookReceipt({
+    tenantId,
+    orgUnitId,
+    threadId,
+    providerName: providerSelection.providerResolution.resolvedProvider,
+    canonicalEventType: eventType,
+    providerEventId: correlation.providerEventId,
+    providerLegId: correlation.providerLegId,
+    providerMessageId: correlation.providerMessageId,
+    db: loadPlatformDb(),
+  });
+  if (webhookReceipt.duplicate) {
+    success(res, {
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      message: 'Inbound webhook accepted (duplicate suppressed)',
+      data: {
+        sid: typeof req.body?.sid === 'string' ? req.body.sid : null,
+        from: typeof req.body?.from === 'string' ? req.body.from : null,
+        to: typeof req.body?.to === 'string' ? req.body.to : null,
+        eventType,
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: correlation.source,
+          deterministic: true,
+          threadId,
+          tenantId,
+          orgUnitId,
+          providerLegId: correlation.providerLegId,
+          providerMessageId: correlation.providerMessageId,
+          providerEventId: correlation.providerEventId,
+        },
+        replaySafe: {
+          duplicate: true,
+          suppressedDomainWrites: true,
+          dedupeKey: webhookReceipt.dedupeKey,
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+      },
+    });
+    return;
+  }
+
   const isVoiceEvent = normalizedEventType.startsWith('voice') || normalizedEventType.includes('call');
   const callPolicy = parseOutboundCallRequestPolicy(req);
   const callTransport = callPolicy.transport || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT;
@@ -4797,15 +5164,13 @@ const handleInboundWebhook = async (
       sideEffectsPersisted: boolean;
     } = null;
 
-  if (tenantId && orgUnitId && threadId) {
-    lifecycleContext = await resolveLifecycleContext({
-      tenantId,
-      orgUnitId,
-      threadId,
-      actorUserId: null,
-    });
-    threadState = lifecycleContext.currentState;
-  }
+  lifecycleContext = await resolveLifecycleContext({
+    tenantId,
+    orgUnitId,
+    threadId,
+    actorUserId: null,
+  });
+  threadState = lifecycleContext.currentState;
 
   if (isConnectedCallEvent) {
     autoClaim = {
@@ -4895,21 +5260,19 @@ const handleInboundWebhook = async (
     }
   }
 
-  const canonicalEvent = tenantId && orgUnitId && threadId
-    ? await recordCanonicalThreadEvent({
-      tenantId,
-      orgUnitId,
-      threadId,
+  const canonicalEvent = await recordCanonicalThreadEvent({
+    tenantId,
+    orgUnitId,
+    threadId,
+    eventType,
+    payload: buildCanonicalPayloadForInboundWebhook({
       eventType,
-      payload: buildCanonicalPayloadForInboundWebhook({
-        eventType,
-        routingDecision,
-        threadState,
-        autoClaimApplied: autoClaim?.applied === true,
-      }),
-      actorUserId: resolveWebhookActorUserId(req),
-    })
-    : null;
+      routingDecision,
+      threadState,
+      autoClaimApplied: autoClaim?.applied === true,
+    }),
+    actorUserId: resolveWebhookActorUserId(req),
+  });
 
   success(res, {
     code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
@@ -4922,6 +5285,21 @@ const handleInboundWebhook = async (
       providerResolution: {
         ...providerSelection.providerResolution,
         adapterInvoked: true,
+      },
+      correlation: {
+        source: correlation.source,
+        deterministic: true,
+        threadId,
+        tenantId,
+        orgUnitId,
+        providerLegId: correlation.providerLegId,
+        providerMessageId: correlation.providerMessageId,
+        providerEventId: correlation.providerEventId,
+      },
+      replaySafe: {
+        duplicate: false,
+        suppressedDomainWrites: false,
+        dedupeKey: webhookReceipt.dedupeKey,
       },
       canonicalTranslation,
       domainHandlers: {

--- a/tests/api/platform/a-1-connectshyft-feature-flag-and-availability-guardrails.api.spec.ts
+++ b/tests/api/platform/a-1-connectshyft-feature-flag-and-availability-guardrails.api.spec.ts
@@ -182,6 +182,9 @@ test.describe(
         path: storyA1Context.paths.webhookSms,
         headers: storyA1AllEnabledHeaders,
         data: {
+          tenantId: storyA1Context.tenantId,
+          orgUnitId: storyA1Context.orgUnitId,
+          threadId: ensuredThreadId,
           sid: 'SM1234567890-ALLOW',
           from: '+12605550123',
           to: '+12605550999',


### PR DESCRIPTION
## Summary
- implement story `f-3-provider-leg-message-correlation-fallback-mapping` with provider ID persistence and metadata-first + fallback correlation resolution
- enforce tenant-scoped uniqueness/dedupe and deterministic refusal outcomes for unresolved or conflicting callbacks
- add/extend migration, module, and route tests for replay safety and operator-visible deterministic behavior
- add Jest global teardown (`src/src/__tests__/jest.setup.ts`) and wire it in `src/jest.config.js` to close shared DB handles cleanly after test runs

## Validation
- `npm run branch:ensure-workflow -- --workflow ta --story _bmad-output/implementation-artifacts/f-3-provider-leg-message-correlation-fallback-mapping.md`
- `cd src && npm test -- src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts src/modules/connectshyft/__tests__/providerRegistry.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts src/migrations/__tests__/connectShyftProviderCorrelationMappingsMigration.test.ts src/migrations/__tests__/scopeProviderCorrelationUniquenessToTenantMigration.test.ts`
- `cd src && npm run build`
