### PR TITLE
Fix: finalize c.2 thread ensure conflict-safe idempotency

### DIFF
--- a/_bmad-output/implementation-artifacts/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.md
+++ b/_bmad-output/implementation-artifacts/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.md
@@ -1,6 +1,6 @@
 # Story c.2: Thread Ensure Endpoint with Conflict-Safe Idempotency
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -23,8 +23,8 @@ so that duplicate active threads are never created for the same neighbor context
 - Backend/API Implies Human Operability: yes
 - Frontend/Operator Usability Criteria Included: yes
 - Operability Pairing Notes: Existing-thread reuse must be deterministic and non-disruptive so operators do not see duplicate conversations.
-- Real-User Validation Evidence: Pending critical-capability validation run. Record concrete UI/API operator evidence before closeout.
-- Real-User Validation Result: pending
+- Real-User Validation Evidence: 2026-03-02 manual operator validation by Jeremiah in local runtime. Concurrent ensure flow validated for tenant `tenant-connectshyft-c1` and orgUnit `org-connectshyft-c1-east` with inbound/outbound markers `cs-inbound-c2-real-001` / `cs-outbound-c2-real-001`; resolved thread id `155cb908-612d-4470-a34f-059cb730d240`. Inbox screenshot shows exactly one matching thread card and no duplicate conversation card. Thread-detail screenshot confirms same thread id (`155cb908-612d-4470-a34f-059cb730d240`) after opening from inbox. Automated runtime validation also passed with managed stack (`bash scripts/ci-run-playwright-stack.sh ...` => 5/5 c.2 specs passed).
+- Real-User Validation Result: pass
 - Role-Admin UI Path: N/A
 - Role-Admin UI Path Verified: n/a
 - Access-Control Exemption Rationale: Endpoint uses existing context/auth patterns; no new role-administration workflow.
@@ -129,6 +129,8 @@ GPT-5 Codex
 - `npx playwright test tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts tests/e2e/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.spec.ts --project=chromium`
 - `cd src && MONEYSHYFT_TEST_DATABASE_URL='postgresql://jeremiahotis:Oiruueu12@127.0.0.1:5432/moneyshyft' npm test -- src/src/modules/connectshyft/__tests__/threads.test.ts src/src/modules/connectshyft/__tests__/threads.contract.test.ts`
 - `npx playwright test --list tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts tests/e2e/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.spec.ts` (pass)
+- `cd src && npm run build` (pass)
+- `bash scripts/ci-run-playwright-stack.sh npx playwright test tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts tests/e2e/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.spec.ts --project=chromium` (pass; 5/5)
 
 ### Completion Notes List
 
@@ -136,21 +138,25 @@ GPT-5 Codex
 - Expanded story c.2 API coverage for malformed-neighbor refusal and cross-tenant no-leak refusal semantics while retaining concurrent idempotency verification.
 - Added c.2 E2E operator journey proving concurrent ensure requests converge to one thread identity and one inbox card, with navigation into the same thread detail context.
 - Verified related thread module behavior with Jest unit + Postgres contract test suites.
+- Canonicalized `neighborId` casing for UUID/slug inputs before ensure persistence to close case-variant duplicate-thread risk under the active-thread uniqueness constraint.
+- Upgraded c.2 contention coverage from two parallel callers to a 12-request burst and added stable-thread-contract assertions across all responses.
+- Added API coverage proving uppercase/lowercase `neighborId` variants converge to one canonical active thread identity and one active row.
+- Added deterministic E2E cleanup for ensured test threads so c.2 UI automation does not leave persistent `cs_threads` residue.
+- Reconciled Dev Agent Record file inventory with story-specific git history (removed unrelated c.3/c.4 files; restored sprint-status entry from c.2 implementation commit).
+- Executed c.2 API + E2E runtime validation under managed backend/frontend stack startup; all five c.2 specs passed.
+- Recorded manual real-user validation evidence from operator-run inbox/detail flow screenshots and verified single-thread continuity.
 
 ### File List
 
 - _bmad-output/implementation-artifacts/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.md
+- _bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
 - src/src/routes/api/v1/connectshyft.ts
-- src/src/modules/connectshyft/readContracts.ts
-- src/src/modules/connectshyft/__tests__/readContracts.test.ts
-- frontend/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
 - tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
-- tests/api/platform/c-3-inbox-and-thread-detail-read-contracts.atdd.api.spec.ts
 - tests/e2e/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.spec.ts
-- tests/e2e/platform/c-3-inbox-and-thread-detail-read-contracts.atdd.spec.ts
-- tests/e2e/platform/c-4-claim-takeover-and-close-lifecycle-actions.automate.spec.ts
 
 ## Change Log
 
 - 2026-02-24: Created Story c.2 ready-for-dev context document.
 - 2026-03-02: Implemented c.2 conflict-safe ensure validation and expanded API/E2E coverage; status moved to review.
+- 2026-03-02: Hardened c.2 case-safe neighbor idempotency, expanded high-contention/contract checks, added E2E thread cleanup, and reconciled story file inventory with git history.
+- 2026-03-02: Completed real-user validation evidence capture and moved story status to done.

--- a/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
@@ -58,7 +58,7 @@ development_status:
   epic-b-retrospective: optional
   epic-c: in-progress
   c-1-core-connectshyft-thread-schema-and-lifecycle-constraints: done
-  c-2-thread-ensure-endpoint-with-conflict-safe-idempotency: review
+  c-2-thread-ensure-endpoint-with-conflict-safe-idempotency: done
   c-3-inbox-and-thread-detail-read-contracts: done
   c-4-claim-takeover-and-close-lifecycle-actions: done
   c-5-deterministic-escalation-scheduler-with-claim-only-reset: done

--- a/src/src/routes/api/v1/connectshyft.ts
+++ b/src/src/routes/api/v1/connectshyft.ts
@@ -80,7 +80,7 @@ import { isStrictUtcIsoTimestamp } from '../../../platform/time/timezoneService'
 
 const router = Router();
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const CONNECTSHYFT_NEIGHBOR_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/i;
+const CONNECTSHYFT_NEIGHBOR_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const TEST_ACTIVE_THREAD_NEIGHBOR_IDS_HEADER = 'x-test-connectshyft-active-thread-neighbor-ids';
 const TEST_USER_ID_HEADER = 'x-test-connectshyft-user-id';
 const CONNECTSHYFT_SYSTEM_ACTOR_USER_ID = '00000000-0000-4000-8000-000000000001';
@@ -2522,9 +2522,29 @@ const resolveWebhookActorUserId = (req: Request): string => {
   return CONNECTSHYFT_SYSTEM_ACTOR_USER_ID;
 };
 
+const normalizeConnectShyftNeighborIdentifier = (neighborId: string): string => {
+  const normalized = neighborId.trim();
+  if (!normalized) {
+    return '';
+  }
+
+  if (UUID_PATTERN.test(normalized)) {
+    return normalized.toLowerCase();
+  }
+
+  const normalizedSlugCandidate = normalized.toLowerCase();
+  if (CONNECTSHYFT_NEIGHBOR_SLUG_PATTERN.test(normalizedSlugCandidate)) {
+    return normalizedSlugCandidate;
+  }
+
+  return normalized;
+};
+
 const parseThreadEnsureBody = (req: Request) => ({
   orgUnitId: parseOrgUnitIdFromBody(req),
-  neighborId: typeof req.body?.neighborId === 'string' ? req.body.neighborId.trim() : '',
+  neighborId: typeof req.body?.neighborId === 'string'
+    ? normalizeConnectShyftNeighborIdentifier(req.body.neighborId)
+    : '',
   source: typeof req.body?.source === 'string' ? req.body.source : 'VOICE',
   forcedState: typeof req.body?.forcedState === 'string' ? req.body.forcedState : undefined,
   lastInboundCsNumberId: typeof req.body?.lastInboundCsNumberId === 'string'

--- a/tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
+++ b/tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts
@@ -2,6 +2,8 @@ import { apiRequest } from '../../support/helpers/apiClient';
 import { test, expect } from '../../support/fixtures/connectShyftStoryC1.fixture';
 import { createStoryC1Headers } from '../../support/factories/connectShyftStoryC1Factory';
 
+const CONNECTSHYFT_ENSURE_HIGH_CONTENTION_REQUESTS = 12;
+
 const resolveConnectShyftDbConnection = () => {
   const databaseUrl =
     process.env.MONEYSHYFT_TEST_DATABASE_URL
@@ -32,6 +34,32 @@ const createConnectShyftDbClient = () => {
 };
 
 const connectShyftDb = createConnectShyftDbClient();
+
+const readStableThreadContract = (thread: {
+  threadId: string;
+  tenantId: string;
+  orgUnitId: string;
+  neighborId: string;
+  source: string;
+  state: string;
+  lastInboundCsNumberId: string;
+  preferredOutboundCsNumberId: string;
+  escalation: {
+    stage: number;
+    nextEvaluationAtUtc: string | null;
+  };
+}) => ({
+  threadId: thread.threadId,
+  tenantId: thread.tenantId,
+  orgUnitId: thread.orgUnitId,
+  neighborId: thread.neighborId,
+  source: thread.source,
+  state: thread.state,
+  lastInboundCsNumberId: thread.lastInboundCsNumberId,
+  preferredOutboundCsNumberId: thread.preferredOutboundCsNumberId,
+  escalationStage: thread.escalation.stage,
+  escalationNextEvaluationAtUtc: thread.escalation.nextEvaluationAtUtc,
+});
 
 const countActiveThreadsForIdentity = async ({
   tenantId,
@@ -74,28 +102,46 @@ test.describe(
           neighborId: uniqueNeighborId,
         };
 
-        const [firstResponse, secondResponse] = await Promise.all([
-          apiRequest(request, {
-            method: 'POST',
-            path: storyC1Context.paths.threadsCollection,
-            headers: storyC1OperatorHeaders,
-            data: ensurePayload,
-          }),
-          apiRequest(request, {
-            method: 'POST',
-            path: storyC1Context.paths.threadsCollection,
-            headers: storyC1OperatorHeaders,
-            data: ensurePayload,
-          }),
-        ]);
+        const responses = await Promise.all(
+          Array.from({ length: CONNECTSHYFT_ENSURE_HIGH_CONTENTION_REQUESTS }, () =>
+            apiRequest(request, {
+              method: 'POST',
+              path: storyC1Context.paths.threadsCollection,
+              headers: storyC1OperatorHeaders,
+              data: ensurePayload,
+            })),
+        );
 
-        expect(firstResponse.status()).toBe(201);
-        expect(secondResponse.status()).toBe(201);
+        responses.forEach((response) => {
+          expect(response.status()).toBe(201);
+        });
 
-        const firstBody = await firstResponse.json();
-        const secondBody = await secondResponse.json();
+        const bodies = await Promise.all(responses.map((response) => response.json()));
+        const resolvedThreadIds = bodies.map((body) => body.data.thread.threadId);
+        const uniqueThreadIds = new Set(resolvedThreadIds);
+        expect(uniqueThreadIds.size).toBe(1);
 
-        expect(firstBody.data.thread.threadId).toBe(secondBody.data.thread.threadId);
+        const expectedThreadId = resolvedThreadIds[0];
+        const expectedContract = readStableThreadContract(bodies[0].data.thread);
+        bodies.forEach((body) => {
+          expect(body).toMatchObject({
+            ok: true,
+            code: 'CONNECTSHYFT_THREAD_ENSURED',
+            data: {
+              thread: {
+                threadId: expectedThreadId,
+                tenantId: storyC1Context.tenantId,
+                orgUnitId: storyC1Context.orgUnitId,
+                neighborId: uniqueNeighborId,
+                state: 'UNCLAIMED',
+              },
+            },
+          });
+          expect(readStableThreadContract(body.data.thread)).toEqual(expectedContract);
+          expect(Date.parse(body.data.thread.updatedAtUtc)).toBeGreaterThanOrEqual(
+            Date.parse(body.data.thread.createdAtUtc),
+          );
+        });
 
         const activeThreadCount = await countActiveThreadsForIdentity({
           tenantId: storyC1Context.tenantId,
@@ -112,6 +158,72 @@ test.describe(
             org_unit_id: storyC1Context.orgUnitId,
             neighbor_id: uniqueNeighborId,
           })
+          .del();
+      },
+    );
+
+    test(
+      '[P1] ensure normalizes neighborId case variants to one active thread identity @P1',
+      async ({ request, storyC1Context, storyC1OperatorHeaders, storyC1CreatePayload }) => {
+        const canonicalNeighborId = `${storyC1CreatePayload.neighborId}-case-${Date.now().toString(36)}`;
+        const upperCaseNeighborId = canonicalNeighborId.toUpperCase();
+
+        const createResponse = await apiRequest(request, {
+          method: 'POST',
+          path: storyC1Context.paths.threadsCollection,
+          headers: storyC1OperatorHeaders,
+          data: {
+            ...storyC1CreatePayload,
+            neighborId: upperCaseNeighborId,
+          },
+        });
+        const reuseResponse = await apiRequest(request, {
+          method: 'POST',
+          path: storyC1Context.paths.threadsCollection,
+          headers: storyC1OperatorHeaders,
+          data: {
+            ...storyC1CreatePayload,
+            neighborId: canonicalNeighborId,
+          },
+        });
+
+        expect(createResponse.status()).toBe(201);
+        expect(reuseResponse.status()).toBe(201);
+
+        const createBody = await createResponse.json();
+        const reuseBody = await reuseResponse.json();
+        expect(createBody.data.thread.threadId).toBe(reuseBody.data.thread.threadId);
+        expect(createBody.data.thread.neighborId).toBe(canonicalNeighborId);
+        expect(reuseBody.data.thread.neighborId).toBe(canonicalNeighborId);
+
+        const activeThreadCount = await countActiveThreadsForIdentity({
+          tenantId: storyC1Context.tenantId,
+          orgUnitId: storyC1Context.orgUnitId,
+          neighborId: canonicalNeighborId,
+        });
+        expect(activeThreadCount).toBe(1);
+
+        const caseInsensitiveCount = await connectShyftDb
+          .withSchema('connectshyft')
+          .table('cs_threads')
+          .where({
+            tenant_id: storyC1Context.tenantId,
+            org_unit_id: storyC1Context.orgUnitId,
+          })
+          .whereRaw('LOWER(neighbor_id) = LOWER(?)', [canonicalNeighborId])
+          .andWhere('state', '<>', 'CLOSED')
+          .count<{ count: string | number }>({ count: '*' })
+          .first();
+        expect(Number(caseInsensitiveCount?.count ?? 0)).toBe(1);
+
+        await connectShyftDb
+          .withSchema('connectshyft')
+          .table('cs_threads')
+          .where({
+            tenant_id: storyC1Context.tenantId,
+            org_unit_id: storyC1Context.orgUnitId,
+          })
+          .whereRaw('LOWER(neighbor_id) = LOWER(?)', [canonicalNeighborId])
           .del();
       },
     );

--- a/tests/e2e/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.spec.ts
+++ b/tests/e2e/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.spec.ts
@@ -8,6 +8,53 @@ import {
   type StoryC1Context,
 } from '../../support/factories/connectShyftStoryC1Factory';
 
+const resolveConnectShyftDbConnection = () => {
+  const databaseUrl =
+    process.env.MONEYSHYFT_TEST_DATABASE_URL
+    || (process.env.CI === 'true' ? process.env.DATABASE_URL : undefined);
+  if (databaseUrl) {
+    return databaseUrl;
+  }
+
+  return {
+    host: process.env.TEST_DB_HOST || '127.0.0.1',
+    port: Number(process.env.TEST_DB_PORT || 5432),
+    database: process.env.TEST_DB_NAME || 'moneyshyft',
+    user: process.env.TEST_DB_USER || 'jeremiahotis',
+    password: process.env.TEST_DB_PASSWORD || 'Oiurueu12',
+  };
+};
+
+const createConnectShyftDbClient = () => {
+  const knexFactory = require('../../../src/node_modules/knex');
+  return knexFactory({
+    client: 'postgresql',
+    connection: resolveConnectShyftDbConnection(),
+    pool: {
+      min: 0,
+      max: 2,
+    },
+  });
+};
+
+const connectShyftDb = createConnectShyftDbClient();
+
+const cleanupEnsuredThread = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  neighborId: string;
+}) => {
+  await connectShyftDb
+    .withSchema('connectshyft')
+    .table('cs_threads')
+    .where({
+      tenant_id: input.tenantId,
+      org_unit_id: input.orgUnitId,
+      neighbor_id: input.neighborId,
+    })
+    .del();
+};
+
 const buildInboxUrl = (
   context: StoryC1Context,
   actorUserId: string,
@@ -36,6 +83,9 @@ test.describe(
   'Story c.2 automate - thread ensure endpoint conflict-safe idempotency operator journey',
   () => {
     test.describe.configure({ mode: 'serial' });
+    test.afterAll(async () => {
+      await connectShyftDb.destroy();
+    });
 
     test(
       '[P0] operator sees one card and enters the same ensured thread context after concurrent ensure calls @P0',
@@ -55,43 +105,51 @@ test.describe(
           preferredOutboundCsNumberId: `cs-outbound-c2-${suffix}`,
         };
 
-        const [firstResponse, secondResponse] = await Promise.all([
-          apiRequest(request, {
-            method: 'POST',
-            path: context.paths.threadsCollection,
-            headers: operatorHeaders,
-            data: ensurePayload,
-          }),
-          apiRequest(request, {
-            method: 'POST',
-            path: context.paths.threadsCollection,
-            headers: operatorHeaders,
-            data: ensurePayload,
-          }),
-        ]);
+        try {
+          const [firstResponse, secondResponse] = await Promise.all([
+            apiRequest(request, {
+              method: 'POST',
+              path: context.paths.threadsCollection,
+              headers: operatorHeaders,
+              data: ensurePayload,
+            }),
+            apiRequest(request, {
+              method: 'POST',
+              path: context.paths.threadsCollection,
+              headers: operatorHeaders,
+              data: ensurePayload,
+            }),
+          ]);
 
-        expect(firstResponse.status()).toBe(201);
-        expect(secondResponse.status()).toBe(201);
+          expect(firstResponse.status()).toBe(201);
+          expect(secondResponse.status()).toBe(201);
 
-        const firstBody = await firstResponse.json();
-        const secondBody = await secondResponse.json();
-        const threadId = firstBody?.data?.thread?.threadId as string;
-        expect(threadId).toBeTruthy();
-        expect(secondBody?.data?.thread?.threadId).toBe(threadId);
+          const firstBody = await firstResponse.json();
+          const secondBody = await secondResponse.json();
+          const threadId = firstBody?.data?.thread?.threadId as string;
+          expect(threadId).toBeTruthy();
+          expect(secondBody?.data?.thread?.threadId).toBe(threadId);
 
-        await login(page);
-        await page.goto(buildInboxUrl(context, context.userId, ensurePayload));
+          await login(page);
+          await page.goto(buildInboxUrl(context, context.userId, ensurePayload));
 
-        await expect(page.getByRole('heading', { name: 'ConnectShyft Inbox' })).toBeVisible();
+          await expect(page.getByRole('heading', { name: 'ConnectShyft Inbox' })).toBeVisible();
 
-        const targetCard = page
-          .getByTestId('connectshyft-thread-card')
-          .filter({ hasText: ensurePayload.lastInboundCsNumberId });
-        await expect(targetCard).toHaveCount(1);
+          const targetCard = page
+            .getByTestId('connectshyft-thread-card')
+            .filter({ hasText: ensurePayload.lastInboundCsNumberId });
+          await expect(targetCard).toHaveCount(1);
 
-        await targetCard.getByTestId('connectshyft-thread-card-primary-action').click();
-        await expect(page).toHaveURL(new RegExp(`/app/connectshyft/threads/${threadId}`));
-        await expect(page.getByTestId('connectshyft-thread-id-chip')).toContainText(threadId);
+          await targetCard.getByTestId('connectshyft-thread-card-primary-action').click();
+          await expect(page).toHaveURL(new RegExp(`/app/connectshyft/threads/${threadId}`));
+          await expect(page.getByTestId('connectshyft-thread-id-chip')).toContainText(threadId);
+        } finally {
+          await cleanupEnsuredThread({
+            tenantId: context.tenantId,
+            orgUnitId: context.orgUnitId,
+            neighborId: ensurePayload.neighborId,
+          });
+        }
       },
     );
   },


### PR DESCRIPTION
## Summary
- canonicalize ConnectShyft neighborId inputs (UUID/slug) before ensure persistence to prevent case-variant duplicate active threads
- strengthen c.2 API validation with 12-request contention burst, stable response contract checks, and case-variant identity convergence assertions
- add deterministic cleanup to c.2 E2E ensure flow and close out c.2 story/sprint status with manual real-user evidence

## Validation
- bash scripts/ci-run-playwright-stack.sh npx playwright test tests/api/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.api.spec.ts tests/e2e/platform/c-2-thread-ensure-endpoint-with-conflict-safe-idempotency.spec.ts --project=chromium
- cd src && npm run build
