### PR TITLE
Fix: harden d-1 outbound auto-claim transport and lineage guards

### DIFF
--- a/_bmad-output/implementation-artifacts/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.md
+++ b/_bmad-output/implementation-artifacts/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.md
@@ -1,6 +1,6 @@
 # Story d.1: Outbound SMS/Call Actions that Preserve Escalation Semantics
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -150,7 +150,8 @@ GPT-5 Codex
 - `rg -n "^### Story d\\.[1-4]:" _bmad-output/planning-artifacts/epics-ConnectShyft-2026-02-19.md` (pass)
 - `rg -n "^  d-|^  epic-d" _bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml` (pass)
 - `npm run branch:ensure-workflow -- --workflow dev-story --story d-1-outbound-sms-call-actions-that-preserve-escalation-semantics` (pass)
-- `npm run test:e2e -- tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts` (pass; 4 passed)
+- `cd src && npm test -- src/modules/connectshyft/__tests__/providerRegistry.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts` (pass; 32 passed)
+- `npm run test:e2e -- tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts` (pass; 6 passed)
 - `npm run test:e2e -- tests/api/platform/c-4-claim-takeover-and-close-lifecycle-actions.atdd.api.spec.ts tests/api/platform/c-4-claim-takeover-and-close-lifecycle-actions.automate.api.spec.ts tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts` (pass; 18 passed)
 - `cd src && npm run build` (pass)
 - `cd frontend && npm run build` (pass)
@@ -160,22 +161,25 @@ GPT-5 Codex
 
 - Created implementation-ready Story d.1 context with locked outbound/reopen semantics, bridge-call constraints, and escalation guardrails.
 - Implemented outbound response contract enhancements in `src/src/routes/api/v1/connectshyft.ts`: explicit operator feedback, lifecycle metadata, bridge-call-only policy metadata, and CONNECTED auto-claim policy metadata for outbound calls.
+- Tightened CONNECTED auto-claim guardrails in `src/src/routes/api/v1/connectshyft.ts` to require explicit bridge transport evidence and verified provider-leg lineage before claim transition.
+- Enforced bridge/manual-retry outbound call policy at provider-adapter dispatch boundary in `src/src/modules/connectshyft/providerRegistry.ts` and covered with unit tests in `src/src/modules/connectshyft/__tests__/providerRegistry.test.ts`.
 - Preserved CLOSED outbound reopen semantics on same thread id with `thread_reopened_by_user` and deterministic escalation reset metadata in response envelope.
-- Updated thread-detail UX action feedback path in `frontend/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue` to prioritize API-supplied `operatorFeedback` language.
-- Activated and completed d.1 API contract coverage in `tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts` (all 4 tests passing).
+- Added regression API coverage in `tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts` for missing transport evidence and metadata-only/no-lineage CONNECTED events (all 6 tests passing).
+- Resolved Playwright preflight tenancy contract drift by updating `scripts/run-playwright-with-preflight.sh` tenant probe JWT secret precedence to honor runtime `JWT_SECRET`.
 - Full backend Jest run currently reports unrelated failures outside ConnectShyft d.1 scope; story-targeted API suites and compile/build checks pass.
 
 ### File List
 
 - _bmad-output/implementation-artifacts/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.md
-- src/src/routes/api/v1/connectshyft.ts
-- frontend/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
-- tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts
-- tests/support/factories/connectShyftStoryDFactory.ts
-- tests/support/fixtures/connectShyftStoryD.fixture.ts
 - _bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+- scripts/run-playwright-with-preflight.sh
+- src/src/modules/connectshyft/providerRegistry.ts
+- src/src/modules/connectshyft/__tests__/providerRegistry.test.ts
+- src/src/routes/api/v1/connectshyft.ts
+- tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts
 
 ## Change Log
 
 - 2026-02-27: Created Story d.1 ready-for-dev context document.
 - 2026-02-27: Implemented d.1 outbound lifecycle/call policy contract updates; activated and passed d.1 automate API coverage; updated story status to review.
+- 2026-03-02: Hardened CONNECTED auto-claim lineage/transport gates, enforced adapter-boundary bridge/manual retry policy, added two regression API tests, resolved preflight tenancy contract probe mismatch, and moved story status to done.

--- a/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
@@ -64,7 +64,7 @@ development_status:
   c-5-deterministic-escalation-scheduler-with-claim-only-reset: done
   epic-c-retrospective: optional
   epic-d: in-progress
-  d-1-outbound-sms-call-actions-that-preserve-escalation-semantics: review
+  d-1-outbound-sms-call-actions-that-preserve-escalation-semantics: done
   d-2-preference-override-enforcement-for-outbound-sms: in-progress
   d-3-outbound-audit-outbox-and-refusal-envelope-integration: review
   d-4-operator-interaction-contracts-for-outbound-safety: review

--- a/scripts/run-playwright-with-preflight.sh
+++ b/scripts/run-playwright-with-preflight.sh
@@ -222,13 +222,16 @@ const fs = require('fs');
 const path = require('path');
 
 const backendEnvPath = path.resolve(process.cwd(), 'src/.env');
-let jwtSecret = 'your_jwt_secret_change_in_production';
-if (fs.existsSync(backendEnvPath)) {
-  for (const rawLine of fs.readFileSync(backendEnvPath, 'utf8').split('\n')) {
-    const line = rawLine.trim();
-    if (line.startsWith('JWT_SECRET=')) {
-      jwtSecret = line.slice('JWT_SECRET='.length).trim();
-      break;
+let jwtSecret = (process.env.JWT_SECRET || '').trim();
+if (!jwtSecret) {
+  jwtSecret = 'your_jwt_secret_change_in_production';
+  if (fs.existsSync(backendEnvPath)) {
+    for (const rawLine of fs.readFileSync(backendEnvPath, 'utf8').split('\n')) {
+      const line = rawLine.trim();
+      if (line.startsWith('JWT_SECRET=')) {
+        jwtSecret = line.slice('JWT_SECRET='.length).trim();
+        break;
+      }
     }
   }
 }

--- a/src/src/modules/connectshyft/__tests__/providerRegistry.test.ts
+++ b/src/src/modules/connectshyft/__tests__/providerRegistry.test.ts
@@ -1,5 +1,6 @@
 import { generateKeyPairSync, sign as signPayload } from 'node:crypto';
 import {
+  ConnectShyftProviderDispatchPolicyError,
   resolveConnectShyftProviderAdapter,
   resolveConnectShyftRequestedProviderKey,
 } from '../providerRegistry';
@@ -406,6 +407,50 @@ describe('connectshyft provider registry', () => {
       providerSpecificFieldsStripped: true,
       providerBranchingInDomain: false,
     });
+  });
+
+  it('enforces bridge-only/manual retry policy at the adapter dispatch boundary', async () => {
+    const result = resolveConnectShyftProviderAdapter({
+      req: buildRequest({
+        body: {
+          providerKey: 'telnyx',
+        },
+      }),
+      operation: 'call',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error('Expected adapter resolution to succeed');
+    }
+
+    await expect(
+      result.adapter.dispatchOutboundCall({
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        callPolicy: {
+          transport: 'sip',
+          autoRetry: false,
+          redialPolicy: 'manual_only',
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED',
+    });
+
+    await expect(
+      result.adapter.dispatchOutboundCall({
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        callPolicy: {
+          transport: 'bridge',
+          autoRetry: true,
+          redialPolicy: 'manual_only',
+        },
+      }),
+    ).rejects.toBeInstanceOf(ConnectShyftProviderDispatchPolicyError);
   });
 
   it('prefers body providerKey over test header provider request override', () => {

--- a/src/src/modules/connectshyft/providerRegistry.ts
+++ b/src/src/modules/connectshyft/providerRegistry.ts
@@ -15,6 +15,8 @@ const TELNYX_TIMESTAMP_HEADER = 'telnyx-timestamp';
 const TELNYX_PUBLIC_KEY_ENV = 'TELNYX_PUBLIC_KEY';
 const CONNECTSHYFT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS_ENV = 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS';
 const DEFAULT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS = 300;
+const CONNECTSHYFT_REQUIRED_CALL_TRANSPORT = 'bridge';
+const CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY = 'manual_only';
 
 export type ConnectShyftProviderOperation = 'call' | 'message' | 'webhook';
 export type ConnectShyftProviderResolutionReason =
@@ -38,6 +40,32 @@ export type ConnectShyftProviderDispatchResult = {
   adapterInvoked: true;
   providerBranchingInDomain: false;
 };
+
+export type ConnectShyftOutboundCallDispatchPolicy = {
+  transport: string;
+  autoRetry: boolean;
+  redialPolicy: string;
+};
+
+export class ConnectShyftProviderDispatchPolicyError extends Error {
+  readonly code:
+    | 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED'
+    | 'CONNECTSHYFT_OUTBOUND_CALL_RETRY_FORBIDDEN';
+  readonly data: Record<string, unknown>;
+
+  constructor(input: {
+    code:
+      | 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED'
+      | 'CONNECTSHYFT_OUTBOUND_CALL_RETRY_FORBIDDEN';
+    message: string;
+    data: Record<string, unknown>;
+  }) {
+    super(input.message);
+    this.name = 'ConnectShyftProviderDispatchPolicyError';
+    this.code = input.code;
+    this.data = input.data;
+  }
+}
 
 export type ConnectShyftProviderCanonicalEvent = {
   eventType: string;
@@ -123,6 +151,7 @@ export interface ConnectShyftProviderAdapter {
     tenantId: string;
     orgUnitId: string;
     threadId: string;
+    callPolicy?: ConnectShyftOutboundCallDispatchPolicy;
   }): Promise<ConnectShyftProviderDispatchResult>;
   dispatchOutboundMessage(input: {
     tenantId: string;
@@ -738,6 +767,41 @@ const createAdapter = (input: {
   providerKey: input.providerKey,
   adapterInterfaceVersion: 'v1',
   async dispatchOutboundCall(dispatchInput) {
+    const requestedTransport = normalizeString(dispatchInput.callPolicy?.transport).toLowerCase();
+    if (
+      requestedTransport.length > 0
+      && requestedTransport !== CONNECTSHYFT_REQUIRED_CALL_TRANSPORT
+    ) {
+      throw new ConnectShyftProviderDispatchPolicyError({
+        code: 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED',
+        message: 'Outbound calls require bridge transport only.',
+        data: {
+          requestedTransport,
+          allowedTransport: CONNECTSHYFT_REQUIRED_CALL_TRANSPORT,
+        },
+      });
+    }
+
+    const requestedRedialPolicy = normalizeString(dispatchInput.callPolicy?.redialPolicy).toLowerCase();
+    const requestedAutoRetry = dispatchInput.callPolicy?.autoRetry === true;
+    if (
+      requestedAutoRetry
+      || (
+        requestedRedialPolicy.length > 0
+        && requestedRedialPolicy !== CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY
+      )
+    ) {
+      throw new ConnectShyftProviderDispatchPolicyError({
+        code: 'CONNECTSHYFT_OUTBOUND_CALL_RETRY_FORBIDDEN',
+        message: 'Automatic redial/retry is disabled. Operators must re-initiate calls manually.',
+        data: {
+          requestedAutoRetry,
+          requestedRedialPolicy: requestedRedialPolicy || null,
+          allowedRedialPolicy: CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY,
+        },
+      });
+    }
+
     return buildDispatchResult({
       providerKey: input.providerKey,
       channel: 'call',

--- a/src/src/routes/api/v1/connectshyft.ts
+++ b/src/src/routes/api/v1/connectshyft.ts
@@ -45,8 +45,10 @@ import {
   type ConnectShyftValidatedSmsOverride,
 } from '../../../modules/connectshyft/smsPreferenceOverrides';
 import {
+  ConnectShyftProviderDispatchPolicyError,
   resolveConnectShyftProviderAdapter,
   resolveConnectShyftRequestedProviderKey,
+  type ConnectShyftOutboundCallDispatchPolicy,
   type ConnectShyftProviderDispatchResult,
 } from '../../../modules/connectshyft/providerRegistry';
 import { executePlatformMutation } from '../../../platform/mutations/executePlatformMutation';
@@ -889,6 +891,32 @@ const resolveInboundWebhookCorrelation = async (input: {
     providerMessageId: providerIdentifiers.providerMessageId,
     providerEventId: providerIdentifiers.providerEventId,
   };
+};
+
+const verifyConnectedCallLineage = async (input: {
+  correlation: Extract<ConnectShyftResolvedWebhookCorrelation, { ok: true }>;
+  providerName: string;
+}): Promise<boolean> => {
+  const providerLegId = normalizeLifecycleString(input.correlation.providerLegId);
+  if (!providerLegId) {
+    return false;
+  }
+
+  const lookup = await resolveConnectShyftProviderCorrelationByIdentifiers({
+    providerName: input.providerName,
+    providerLegId,
+    tenantId: input.correlation.tenantId,
+    db: loadPlatformDb(),
+  });
+  if (!lookup.ok) {
+    return false;
+  }
+
+  return (
+    lookup.correlation.tenantId === input.correlation.tenantId
+    && lookup.correlation.orgUnitId === input.correlation.orgUnitId
+    && lookup.correlation.threadId === input.correlation.threadId
+  );
 };
 
 const nowIsoUtc = (): string => new Date().toISOString();
@@ -2452,8 +2480,12 @@ const parseOutboundMessagePolicyRequest = (req: Request): {
   };
 };
 
-const enforceOutboundCallPolicyRequest = (req: Request, res: Response): boolean => {
-  const callPolicy = parseOutboundCallRequestPolicy(req);
+const enforceOutboundCallPolicyRequest = (
+  req: Request,
+  res: Response,
+  parsedCallPolicy: ReturnType<typeof parseOutboundCallRequestPolicy> = parseOutboundCallRequestPolicy(req),
+): boolean => {
+  const callPolicy = parsedCallPolicy;
 
   if (
     callPolicy.transport
@@ -4702,7 +4734,14 @@ const performOutboundAction = async (
     return;
   }
 
-  if (outboundAction === 'call' && !enforceOutboundCallPolicyRequest(req, res)) {
+  const outboundCallPolicyRequest = outboundAction === 'call'
+    ? parseOutboundCallRequestPolicy(req)
+    : null;
+  if (
+    outboundAction === 'call'
+    && outboundCallPolicyRequest
+    && !enforceOutboundCallPolicyRequest(req, res, outboundCallPolicyRequest)
+  ) {
     return;
   }
 
@@ -4895,6 +4934,14 @@ const performOutboundAction = async (
     });
   }
 
+  const outboundCallDispatchPolicy: ConnectShyftOutboundCallDispatchPolicy | null = outboundAction === 'call'
+    ? {
+      transport: outboundCallPolicyRequest?.transport || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT,
+      autoRetry: outboundCallPolicyRequest?.autoRetry === true,
+      redialPolicy: outboundCallPolicyRequest?.redialPolicy || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY,
+    }
+    : null;
+
   let providerDispatch: ConnectShyftProviderDispatchResult;
   try {
     providerDispatch = outboundAction === 'call'
@@ -4902,6 +4949,7 @@ const performOutboundAction = async (
         tenantId: context.tenantId,
         orgUnitId: context.orgUnitId,
         threadId,
+        callPolicy: outboundCallDispatchPolicy || undefined,
       })
       : await providerSelection.adapter.dispatchOutboundMessage({
         tenantId: context.tenantId,
@@ -4909,6 +4957,29 @@ const performOutboundAction = async (
         threadId,
       });
   } catch (error) {
+    if (error instanceof ConnectShyftProviderDispatchPolicyError) {
+      respondConnectShyftBusinessRefusal(res, {
+        code: error.code,
+        message: error.message,
+        data: {
+          context,
+          threadId,
+          providerResolution: {
+            ...providerSelection.providerResolution,
+            adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+            providerBranchingInDomain: false,
+          },
+          sideEffects: {
+            dispatchAttempted: false,
+            lifecycleMutationApplied: priorState === 'CLOSED',
+            auditPersisted: sideEffectsPersisted,
+          },
+          providerCallPolicy: error.data,
+        },
+      });
+      return;
+    }
+
     respondConnectShyftBusinessRefusal(res, {
       code: 'CONNECTSHYFT_PROVIDER_DISPATCH_FAILED',
       message: 'Provider dispatch failed before persistence.',
@@ -5358,8 +5429,14 @@ const handleInboundWebhook = async (
 
   const isVoiceEvent = normalizedEventType.startsWith('voice') || normalizedEventType.includes('call');
   const callPolicy = parseOutboundCallRequestPolicy(req);
-  const callTransport = callPolicy.transport || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT;
+  const callTransport = callPolicy.transport || null;
   const canApplyAutoClaimForTransport = callTransport === CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT;
+  const hasVerifiedConnectedCallLineage = isConnectedCallEvent
+    ? await verifyConnectedCallLineage({
+      correlation,
+      providerName: providerSelection.providerResolution.resolvedProvider,
+    })
+    : false;
   let threadState: ConnectShyftThreadState | null = null;
   let lifecycleContext: ResolvedLifecycleContext | null = null;
   let thread: ConnectShyftThread | null = null;
@@ -5395,7 +5472,9 @@ const handleInboundWebhook = async (
     } else if (lifecycleContext.currentState !== 'UNCLAIMED') {
       autoClaim.reason = `state_${lifecycleContext.currentState.toLowerCase()}`;
     } else if (!canApplyAutoClaimForTransport) {
-      autoClaim.reason = 'unsupported_transport';
+      autoClaim.reason = callTransport ? 'unsupported_transport' : 'transport_required';
+    } else if (!hasVerifiedConnectedCallLineage) {
+      autoClaim.reason = 'unverified_call_lineage';
     } else {
       const actorUserId = resolveWebhookActorUserId(req);
       const metadata = buildLifecycleMetadata({

--- a/tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts
+++ b/tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts
@@ -138,6 +138,9 @@ test.describe(
 
         expect(response.status()).toBe(200);
         const body = await response.json();
+        const providerLegId = body?.data?.dispatch?.providerLegId as string;
+        expect(typeof providerLegId).toBe('string');
+        expect(providerLegId.length).toBeGreaterThan(0);
         expect(body).toMatchObject({
           ok: true,
           code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED',
@@ -204,6 +207,7 @@ test.describe(
             tenantId: storyDContext.tenantId,
             actorUserId: '00000000-0000-4000-8000-000000000042',
             transport: 'bridge',
+            providerLegId,
           },
         });
         expect(connectedResponse.status()).toBe(200);
@@ -288,6 +292,106 @@ test.describe(
         expect(fallbackBody?.data?.lifecycle?.reopenedByInbound).toBe(false);
         expect(voiceBody?.data?.timeline?.eventName).toBe(storyDContext.eventNames.inboundVoiceFallback);
         expect(fallbackBody?.data?.timeline?.eventName).toBe(storyDContext.eventNames.inboundVoiceFallback);
+      },
+    );
+
+    test(
+      '[P1] CONNECTED webhook without explicit transport does not auto-claim even when provider leg mapping exists @P1',
+      async ({
+        request,
+        storyDContext,
+        storyDMemberHeaders,
+        storyDAdminHeaders,
+        storyDCallPayload,
+      }) => {
+        const regressionThreadId = storyDContext.threadIds.prefersNoUnclaimed;
+        const callResponse = await apiRequest(request, {
+          method: 'POST',
+          path: `${storyDContext.paths.threads}/${regressionThreadId}/call`,
+          headers: storyDMemberHeaders,
+          data: storyDCallPayload,
+        });
+        expect(callResponse.status()).toBe(200);
+        const callBody = await callResponse.json();
+        const providerLegId = callBody?.data?.dispatch?.providerLegId as string;
+        expect(typeof providerLegId).toBe('string');
+        expect(providerLegId.length).toBeGreaterThan(0);
+
+        const connectedWithoutTransportResponse = await apiRequest(request, {
+          method: 'POST',
+          path: storyDContext.paths.inboundWebhook,
+          headers: storyDAdminHeaders,
+          data: {
+            eventType: 'voice.connected',
+            threadId: regressionThreadId,
+            orgUnitId: storyDContext.orgUnitId,
+            tenantId: storyDContext.tenantId,
+            providerLegId,
+          },
+        });
+        expect(connectedWithoutTransportResponse.status()).toBe(200);
+        const connectedWithoutTransportBody = await connectedWithoutTransportResponse.json();
+        expect(connectedWithoutTransportBody).toMatchObject({
+          ok: true,
+          data: {
+            lifecycle: {
+              autoClaimedByConnectedEvent: false,
+            },
+            autoClaim: {
+              attempted: true,
+              applied: false,
+              reason: 'transport_required',
+            },
+          },
+        });
+      },
+    );
+
+    test(
+      '[P1] CONNECTED webhook with metadata-only bridge transport does not auto-claim without mapped outbound lineage @P1',
+      async ({
+        request,
+        storyDContext,
+        storyDAdminHeaders,
+        storyDMemberHeaders,
+      }) => {
+        const regressionThreadId = storyDContext.threadIds.prefersNoUnclaimed;
+        const metadataOnlyConnectedResponse = await apiRequest(request, {
+          method: 'POST',
+          path: storyDContext.paths.inboundWebhook,
+          headers: storyDAdminHeaders,
+          data: {
+            eventType: 'voice.connected',
+            threadId: regressionThreadId,
+            orgUnitId: storyDContext.orgUnitId,
+            tenantId: storyDContext.tenantId,
+            transport: 'bridge',
+          },
+        });
+        expect(metadataOnlyConnectedResponse.status()).toBe(200);
+        const metadataOnlyConnectedBody = await metadataOnlyConnectedResponse.json();
+        expect(metadataOnlyConnectedBody).toMatchObject({
+          ok: true,
+          data: {
+            lifecycle: {
+              autoClaimedByConnectedEvent: false,
+            },
+            autoClaim: {
+              attempted: true,
+              applied: false,
+              reason: 'unverified_call_lineage',
+            },
+          },
+        });
+
+        const detailResponse = await apiRequest(request, {
+          method: 'GET',
+          path: `${storyDContext.paths.threads}/${regressionThreadId}`,
+          headers: storyDMemberHeaders,
+        });
+        expect(detailResponse.status()).toBe(200);
+        const detailBody = await detailResponse.json();
+        expect(detailBody?.data?.thread?.state).toBe('UNCLAIMED');
       },
     );
   },


### PR DESCRIPTION
## Summary
- enforce bridge/manual-retry call policy at provider adapter dispatch boundary
- require explicit bridge transport and verified provider-leg lineage before CONNECTED auto-claim
- add regression API tests for missing transport and metadata-only/no-lineage connected events
- fix Playwright preflight tenant probe JWT secret precedence so managed runtime contract checks are reliable
- sync story and sprint status artifacts to done

## Validation
- npm run policy:check
- cd src && npm test -- src/modules/connectshyft/__tests__/providerRegistry.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts
- npm run test:e2e -- tests/api/platform/d-1-outbound-sms-call-actions-that-preserve-escalation-semantics.automate.api.spec.ts
- cd src && npm run build