### PR TITLE
Docs: SignShyft planning chain and Story 1.1 closeout

### DIFF
--- a/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
+++ b/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
@@ -1,6 +1,6 @@
 # Story 1.1: Establish signshyft lane scaffolding and policy wiring
 
-Status: ready-for-dev
+Status: in-progress
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
+++ b/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
@@ -15,6 +15,20 @@ so that SignShyft delivery cannot interfere with RouteShyft or ConnectShyft lane
 3. Lane enforcement and policy checks pass with SignShyft artifacts present.
 4. Existing non-SignShyft lane artifacts are unchanged by this story.
 
+## Operability Guardrails
+
+- Guardrail Classification Reviewed: yes
+- Critical Capability: no
+- Access-Control Story: no
+- Backend/API Implies Human Operability: no
+- Frontend/Operator Usability Criteria Included: n/a
+- Operability Pairing Notes: N/A
+- Real-User Validation Evidence: N/A
+- Real-User Validation Result: n/a
+- Role-Admin UI Path: N/A
+- Role-Admin UI Path Verified: n/a
+- Access-Control Exemption Rationale: N/A
+
 ## Tasks / Subtasks
 
 - [ ] Generate lane-tagged SignShyft planning artifacts.

--- a/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
+++ b/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
@@ -1,6 +1,6 @@
 # Story 1.1: Establish signshyft lane scaffolding and policy wiring
 
-Status: in-progress
+Status: review
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
+++ b/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
@@ -1,0 +1,28 @@
+# Story 1.1: Establish signshyft lane scaffolding and policy wiring
+
+Status: ready-for-dev
+
+## Story
+
+As a platform operator,
+I want SignShyft planning and sprint artifacts to be isolated to the `signshyft` lane,
+so that SignShyft delivery cannot interfere with RouteShyft or ConnectShyft lanes.
+
+## Acceptance Criteria
+
+1. SignShyft planning artifacts use lane-tagged filenames and `project_lane: signshyft` metadata.
+2. SignShyft sprint status file is generated and contains `project_lane: signshyft`.
+3. Lane enforcement and policy checks pass with SignShyft artifacts present.
+4. Existing non-SignShyft lane artifacts are unchanged by this story.
+
+## Tasks / Subtasks
+
+- [ ] Generate lane-tagged SignShyft planning artifacts.
+- [ ] Generate SignShyft sprint status keys from epics.
+- [ ] Validate `enforce-project-lane` and `policy:check` with `PROJECT_LANE=signshyft`.
+- [ ] Capture final readiness and lane validation evidence.
+
+## Dev Notes
+
+- Keep all SignShyft planning docs under `_bmad-output/planning-artifacts/*signshyft*.md`.
+- Keep SignShyft story artifacts under `_bmad-output/implementation-artifacts/` with epic.story key naming.

--- a/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
+++ b/_bmad-output/implementation-artifacts/1-1-establish-signshyft-lane-scaffolding-and-policy-wiring.md
@@ -1,6 +1,6 @@
 # Story 1.1: Establish signshyft lane scaffolding and policy wiring
 
-Status: review
+Status: done
 
 ## Story
 

--- a/_bmad-output/implementation-artifacts/s-1-lane-bootstrap-and-governance.md
+++ b/_bmad-output/implementation-artifacts/s-1-lane-bootstrap-and-governance.md
@@ -1,0 +1,29 @@
+# Story s-1: Lane Bootstrap and Governance
+
+Status: ready-for-dev
+
+## Story
+
+As a platform operator,
+I want a dedicated SignShyft lane with strict guardrails,
+so that SignShyft work cannot interfere with RouteShyft or ConnectShyft.
+
+## Acceptance Criteria
+
+1. `signshyft` is registered in lane policy with branch/file token enforcement.
+2. A dedicated sprint status file exists with `project_lane: signshyft`.
+3. Lane context and lane guard commands resolve and validate against SignShyft successfully.
+4. Planning and naming conventions include SignShyft stream guidance.
+
+## Tasks / Subtasks
+
+- [ ] Register SignShyft lane in lane policy.
+- [ ] Create SignShyft sprint status file.
+- [ ] Validate lane context and lane guard scripts.
+- [ ] Update naming/policy docs to include SignShyft stream mapping.
+
+## Dev Notes
+
+- Keep SignShyft planning/status files isolated from existing lanes.
+- Future SignShyft stories should use story keys prefixed with `s-`.
+

--- a/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
@@ -43,7 +43,7 @@ story_location: _bmad-output/implementation-artifacts
 
 development_status:
   epic-1: backlog
-  1-1-establish-signshyft-lane-scaffolding-and-policy-wiring: in-progress
+  1-1-establish-signshyft-lane-scaffolding-and-policy-wiring: review
   1-2-create-signshyft-api-skeleton-with-required-plugins: backlog
   1-3-create-signshyft-web-shell-for-staff-and-signer-route-groups: backlog
   1-4-implement-canonical-refusal-reasons-and-api-contract-fixtures: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
@@ -1,6 +1,7 @@
 # generated: 2026-03-03
 # project: SignShyft
 # project_key: NOKEY
+# project_lane: signshyft
 # tracking_system: file-system
 # story_location: _bmad-output/implementation-artifacts
 #
@@ -41,12 +42,56 @@ tracking_system: file-system
 story_location: _bmad-output/implementation-artifacts
 
 development_status:
-  epic-s1: backlog
-  s-1-lane-bootstrap-and-governance: ready-for-dev
-  s-2-template-and-version-management: backlog
-  s-3-render-engine-determinism-and-preview-parity: backlog
-  s-4-envelopes-signer-otp-and-completion-flow: backlog
-  s-5-finalization-audit-and-document-hash-chain: backlog
-  s-6-webhooks-and-wordpress-phase-a-integration: backlog
-  s-7-deployment-observability-and-backup-restore: backlog
-  epic-s1-retrospective: optional
+  epic-1: backlog
+  1-1-establish-signshyft-lane-scaffolding-and-policy-wiring: ready-for-dev
+  1-2-create-signshyft-api-skeleton-with-required-plugins: backlog
+  1-3-create-signshyft-web-shell-for-staff-and-signer-route-groups: backlog
+  1-4-implement-canonical-refusal-reasons-and-api-contract-fixtures: backlog
+  epic-1-retrospective: optional
+
+  epic-2: backlog
+  2-1-implement-template-crud-endpoints-and-list-ui: backlog
+  2-2-implement-template-version-read-and-draft-patch-workflow: backlog
+  2-3-add-draft-pdf-upload-and-hash-capture: backlog
+  2-4-add-layout-validation-endpoint-and-blocking-publish-guard: backlog
+  2-5-implement-publish-immutability-and-clone-new-draft-workflow: backlog
+  epic-2-retrospective: optional
+
+  epic-3: backlog
+  3-1-define-renderengine-interface-and-enforce-import-boundary: backlog
+  3-2-implement-shared-layout-ts-used-by-preview-and-final: backlog
+  3-3-implement-deterministic-signature-and-initials-rasterization-pipeline: backlog
+  3-4-implement-render-semaphore-and-busy-refusal-behavior: backlog
+  3-5-add-golden-render-drift-tests: backlog
+  epic-3-retrospective: optional
+
+  epic-4: backlog
+  4-1-implement-envelope-create-list-get-with-recipient-signer-links: backlog
+  4-2-implement-recipient-signing-mode-and-turn-enforcement: backlog
+  4-3-implement-signer-token-lifecycle-and-resend-rotation: backlog
+  4-4-implement-otp-challenge-and-verify-flow: backlog
+  4-5-implement-signer-submit-endpoint-and-persistence-model: backlog
+  epic-4-retrospective: optional
+
+  epic-5: backlog
+  5-1-implement-signer-complete-endpoint-and-finalization-orchestration: backlog
+  5-2-implement-final-pdf-flattening-certificate-page-and-hash-persistence: backlog
+  5-3-implement-staff-download-and-audit-timeline-surfaces: backlog
+  5-4-implement-retention-workers-for-draft-token-otp-and-finalized-artifacts: backlog
+  5-5-implement-document-hash-chain-persistence-integrity-checks: backlog
+  epic-5-retrospective: optional
+
+  epic-6: backlog
+  6-1-implement-webhook-endpoint-management-apis-and-staff-ui: backlog
+  6-2-implement-webhook-worker-queue-with-retry-backoff-and-idempotent-delivery-ids: backlog
+  6-3-implement-webhook-hmac-signing-spec-v1: backlog
+  6-4-implement-webhook-payload-contract-for-wp-consumption: backlog
+  6-5-publish-wp-integration-hardening-guide-and-receiver-checklist: backlog
+  epic-6-retrospective: optional
+
+  epic-7: backlog
+  7-1-implement-infra-artifacts-for-docker-nginx-and-systemd: backlog
+  7-2-implement-minimum-monitoring-stack-and-memwatch-automation: backlog
+  7-3-implement-backup-and-restore-automation-scripts: backlog
+  7-4-resolve-policy-constants-and-lock-final-operational-defaults: backlog
+  epic-7-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
@@ -43,7 +43,7 @@ story_location: _bmad-output/implementation-artifacts
 
 development_status:
   epic-1: backlog
-  1-1-establish-signshyft-lane-scaffolding-and-policy-wiring: review
+  1-1-establish-signshyft-lane-scaffolding-and-policy-wiring: done
   1-2-create-signshyft-api-skeleton-with-required-plugins: backlog
   1-3-create-signshyft-web-shell-for-staff-and-signer-route-groups: backlog
   1-4-implement-canonical-refusal-reasons-and-api-contract-fixtures: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
@@ -43,7 +43,7 @@ story_location: _bmad-output/implementation-artifacts
 
 development_status:
   epic-1: backlog
-  1-1-establish-signshyft-lane-scaffolding-and-policy-wiring: ready-for-dev
+  1-1-establish-signshyft-lane-scaffolding-and-policy-wiring: in-progress
   1-2-create-signshyft-api-skeleton-with-required-plugins: backlog
   1-3-create-signshyft-web-shell-for-staff-and-signer-route-groups: backlog
   1-4-implement-canonical-refusal-reasons-and-api-contract-fixtures: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml
@@ -1,0 +1,52 @@
+# generated: 2026-03-03
+# project: SignShyft
+# project_key: NOKEY
+# tracking_system: file-system
+# story_location: _bmad-output/implementation-artifacts
+#
+# STATUS DEFINITIONS:
+# ==================
+# Epic Status:
+#   - backlog: Epic not yet started
+#   - in-progress: Epic actively being worked on
+#   - done: All stories in epic completed
+#
+# Epic Status Transitions:
+#   - backlog -> in-progress: Automatically when first story is created (via create-story)
+#   - in-progress -> done: Manually when all stories reach 'done' status
+#
+# Story Status:
+#   - backlog: Story only exists in epic file
+#   - ready-for-dev: Story file created in stories folder
+#   - in-progress: Developer actively working on implementation
+#   - review: Ready for code review (via Dev's code-review workflow)
+#   - done: Story completed
+#
+# Retrospective Status:
+#   - optional: Can be completed but not required
+#   - done: Retrospective has been completed
+#
+# WORKFLOW NOTES:
+# ===============
+# - Epic transitions to 'in-progress' automatically when first story is created
+# - Stories can be worked in parallel if team capacity allows
+# - SM typically creates next story after previous one is 'done' to incorporate learnings
+# - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
+
+generated: 2026-03-03
+project: SignShyft
+project_key: NOKEY
+project_lane: signshyft
+tracking_system: file-system
+story_location: _bmad-output/implementation-artifacts
+
+development_status:
+  epic-s1: backlog
+  s-1-lane-bootstrap-and-governance: ready-for-dev
+  s-2-template-and-version-management: backlog
+  s-3-render-engine-determinism-and-preview-parity: backlog
+  s-4-envelopes-signer-otp-and-completion-flow: backlog
+  s-5-finalization-audit-and-document-hash-chain: backlog
+  s-6-webhooks-and-wordpress-phase-a-integration: backlog
+  s-7-deployment-observability-and-backup-restore: backlog
+  epic-s1-retrospective: optional

--- a/_bmad-output/planning-artifacts/architecture-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/architecture-signshyft-2026-03-03.md
@@ -1,0 +1,294 @@
+---
+stepsCompleted: [1, 2, 3, 4, 5, 6, 7, 8]
+workflowType: architecture
+project: SignShyft
+project_lane: signshyft
+author: Jeremiah
+date: 2026-03-03
+status: complete
+inputDocuments:
+  - /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/prd-signshyft-2026-03-03.md
+  - /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/ux-design-specification-signshyft-2026-03-03.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/01_SignShyft_Constitution.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/02_Concrete_Folder_Structure.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/03_RenderEngine_Interface_and_Contract.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/12_Rendering_Determinism_Spec.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/13_OpenAPI.yaml
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/20_DB_DDL_and_RLS.sql
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/30_Deployment_Runbook.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/SignShyft_Webhook_Signing_Spec.md
+---
+
+# Architecture Decision Document - SignShyft
+
+**Author:** Jeremiah  
+**Date:** 2026-03-03  
+**Status:** Complete
+
+## 1. Context and Scope
+
+SignShyft is a bounded e-signature module that must run in parallel with existing Shyft lanes without interference. The architecture is optimized for deterministic document rendering, legal artifact custody, and safe operation on a single 1GB droplet.
+
+In scope:
+
+1. Staff template/version lifecycle.
+2. Signer workflows with token and OTP policy.
+3. Deterministic preview/final rendering and finalization.
+4. Canonical finalized PDF + audit/hash chain storage.
+5. Signed outbound webhook integration (WordPress Phase A).
+
+Out of scope:
+
+1. Multi-node distributed processing.
+2. Public template authoring.
+3. Alternate storage backends in v1.
+
+## 2. Fixed Constraints (Binding)
+
+1. Tenant identity from Host header + JWT claim; never from body/query.
+2. Business refusals use HTTP 200 + canonical refusal payload.
+3. Published template versions are immutable.
+4. PDF engine imports are restricted to `apps/signshyft-api/src/render/engines/*`.
+5. Preview and final rendering share the same `layout.ts` logic.
+6. Render concurrency fixed at 1.
+7. Canonical finalized artifacts stored in SignShyft local storage.
+8. V1 storage root is `/var/lib/signshyft` and not web-accessible.
+
+## 3. High-Level Architecture
+
+### 3.1 Runtime Components
+
+1. `signshyft-api` (Fastify/TypeScript): HTTP API for staff and signer routes.
+2. `signshyft-webhooks` worker: outbound webhook queue processing and retries.
+3. Postgres schema `signshyft`: tenant-scoped persistence with RLS.
+4. Local disk storage: templates, temp files, and finalized PDFs.
+5. Nginx reverse proxy: TLS termination and `/api` proxy to API container.
+
+### 3.2 Module Structure
+
+Code placement follows the defined folder standard:
+
+1. `apps/signshyft-api/src/plugins` for tenant/auth/refusal/rls/rate-limit/storage/webhook plugins.
+2. `apps/signshyft-api/src/routes` for `public`, `staff`, and `signer` surfaces.
+3. `apps/signshyft-api/src/services` for business orchestration.
+4. `apps/signshyft-api/src/render` with strict engine boundary.
+5. `apps/signshyft-api/src/workers/webhooks.ts` for queue execution.
+6. `apps/signshyft-web` for SPA staff/signer frontends.
+
+## 4. Canonical Architecture Decisions
+
+### AD-SS-01: Bounded SignShyft Lane Isolation
+
+Decision:
+
+1. All planning artifacts and implementation outputs must declare `project_lane: signshyft`.
+2. Artifact filenames must include `signshyft` token.
+3. SignShyft has dedicated sprint status file and lane policy checks.
+
+Rationale:
+
+Prevents accidental planning or workflow collisions with RouteShyft and ConnectShyft lanes.
+
+### AD-SS-02: Tenant Isolation via Context + RLS
+
+Decision:
+
+1. API sets `SET LOCAL app.tenant_id`, `app.actor_role`, and `app.actor_id` per request.
+2. Database access relies on RLS policies scoped to current tenant and staff roles.
+
+Rationale:
+
+Creates defense-in-depth between API enforcement and data-layer enforcement.
+
+### AD-SS-03: Refusal Envelope Contract
+
+Decision:
+
+1. Business-rule failures return HTTP 200 with `{success:false,reason,...}`.
+2. Transport/auth/system failures remain non-200 as appropriate.
+
+Rationale:
+
+Stabilizes client integration semantics across staff UI and WordPress workflows.
+
+### AD-SS-04: Template Version Immutability
+
+Decision:
+
+1. `PUBLISHED` versions are immutable.
+2. Any change requires cloning to a new `DRAFT` version.
+
+Rationale:
+
+Preserves legal integrity and repeatability of historical final documents.
+
+### AD-SS-05: RenderEngine Hard Boundary
+
+Decision:
+
+1. Only files under `render/engines/*` may import pdf engine implementation.
+2. API/service layers consume only `RenderEngine` interface contract.
+
+Rationale:
+
+Prevents engine leakage and future-proofs adapter substitution.
+
+### AD-SS-06: Preview/Final Parity via Shared Layout
+
+Decision:
+
+1. `renderPreview` and `renderFinal` both call shared `layout.ts` logic.
+2. Duplicate line-break/measurement logic outside `layout.ts` is prohibited.
+
+Rationale:
+
+Eliminates drift between what users preview and what becomes legal final output.
+
+### AD-SS-07: Deterministic Signature/Initials Rasterization
+
+Decision:
+
+1. Capture signature/initials as vector stroke data.
+2. Rasterize deterministically at 300 DPI equivalent before embedding.
+3. Same pipeline for signatures and initials.
+
+Rationale:
+
+Ensures reproducible outputs and stable legal rendering behavior.
+
+### AD-SS-08: Finalization Invariants
+
+Decision:
+
+1. Finalization appends certificate page, flattens fields, computes sha256.
+2. Canonical field payload hash is stored for provenance.
+3. Hash chain entries include `prev_sha256` linkages.
+
+Rationale:
+
+Maintains provable artifact lineage and tamper-evident progression.
+
+### AD-SS-09: Single-Worker Render Concurrency
+
+Decision:
+
+1. Render semaphore concurrency = 1.
+2. Busy state returns `RENDER_BUSY` refusal.
+3. Busy and failure outcomes must be audited.
+
+Rationale:
+
+Protects stability on 1GB host and prevents memory collapse.
+
+### AD-SS-10: Signed Webhook Contract
+
+Decision:
+
+1. Outbound webhooks use required SignShyft headers and HMAC-SHA256 `v1` signature.
+2. String-to-sign includes version/timestamp/deliveryId/rawBodySha256.
+3. Retries preserve same `deliveryId`.
+
+Rationale:
+
+Provides deterministic verification and replay-safe behavior for WordPress receivers.
+
+### AD-SS-11: Secret Rotation Strategy
+
+Decision:
+
+1. Endpoint secret storage uses base64 encoded values.
+2. Dual-secret rotation supports overlap grace window.
+
+Rationale:
+
+Enables zero-downtime key rotation for active integrations.
+
+### AD-SS-12: Storage Ownership and Retention
+
+Decision:
+
+1. SignShyft remains canonical store for finalized docs and audits.
+2. Integrations store references/status only.
+3. Retention defaults: finalized 7 years, drafts/tokens/otp 30 days.
+
+Rationale:
+
+Keeps legal artifact custody centralized and compliant.
+
+## 5. Data Architecture
+
+### 5.1 Core Tables
+
+1. `templates`, `template_versions`
+2. `envelopes`, `recipients`
+3. `signer_tokens`, `otp_challenges`
+4. `field_values`, `signature_strokes`
+5. `audit_events`, `document_hashes`
+6. `webhook_endpoints`, `webhook_deliveries`
+
+### 5.2 Status Models
+
+1. Envelope: `DRAFT|SENT|IN_PROGRESS|COMPLETED|VOIDED|EXPIRED|DECLINED|ERROR`
+2. Recipient: `PENDING|VIEWED|OTP_VERIFIED|COMPLETED|DECLINED`
+3. Template version: `DRAFT|PUBLISHED|DEPRECATED|ARCHIVED`
+
+### 5.3 RLS Model
+
+1. Every tenant-scoped table has RLS enabled.
+2. Staff policies enforce tenant match + role membership.
+
+## 6. API Architecture
+
+### 6.1 Route Surfaces
+
+1. Public: `/public/health`
+2. Staff: `/staff/templates`, `/staff/template-versions/*`, `/staff/envelopes/*`, `/staff/webhooks/*`
+3. Signer: `/signer/access/{token}`, `/signer/envelopes/{token}/*`
+
+### 6.2 Contract Rules
+
+1. Refusal payload schema is shared across staff/signer endpoints.
+2. Envelope creation returns per-recipient signer links.
+3. Resend endpoint rotates token and invalidates prior token.
+4. Download endpoint is staff-authenticated canonical retrieval path.
+
+## 7. Deployment Architecture (1GB Droplet)
+
+1. API container memory cap: 256MB, memswap 768MB.
+2. Webhook worker container memory cap: 256MB, memswap 768MB.
+3. Local storage mounted at `/var/lib/signshyft`.
+4. Nginx proxies `/api` to `127.0.0.1:4010` with 180s read timeout.
+5. Swap configured at 2GB.
+6. Systemd service manages compose lifecycle.
+
+## 8. Operational Architecture
+
+1. Monitoring baseline: `docker stats`, `free -h`, `df -h /var/lib/signshyft`, `sysstat`, memwatch cron.
+2. Backup baseline: nightly `pg_dump` + filesystem archive, 14-day rotation.
+3. Quarterly restore drills are mandatory in staging.
+
+## 9. Testing and Quality Gates
+
+1. Golden render hash tests detect output drift.
+2. Contract tests for refusal payload and webhook headers.
+3. RLS tenant isolation tests on all critical tables.
+4. Lane policy checks run for planning and implementation artifacts.
+5. Parity tests enforce preview/final shared layout path.
+
+## 10. Implementation Sequence Alignment
+
+Architecture follows the phased build sequence:
+
+1. Skeleton and plugins.
+2. Templates/versioning.
+3. Rendering engine and determinism tests.
+4. Envelopes/signer flow.
+5. Finalization and custody.
+6. Webhooks and retries.
+7. WordPress Phase A integration.
+
+## 11. Known Decisions to Confirm Before Build Lock
+
+1. Resolve token TTL policy conflict (OpenAPI 48h vs env sample 7 days) in final implementation constants.
+2. Lock webhook retry max attempts/backoff values and surface in ops docs.
+3. Confirm whether admin “last backup timestamp” widget is mandatory for MVP or optional.

--- a/_bmad-output/planning-artifacts/architecture-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/architecture-signshyft-2026-03-03.md
@@ -287,8 +287,16 @@ Architecture follows the phased build sequence:
 6. Webhooks and retries.
 7. WordPress Phase A integration.
 
-## 11. Known Decisions to Confirm Before Build Lock
+## 11. Locked V1 Operational Decisions
 
-1. Resolve token TTL policy conflict (OpenAPI 48h vs env sample 7 days) in final implementation constants.
-2. Lock webhook retry max attempts/backoff values and surface in ops docs.
-3. Confirm whether admin “last backup timestamp” widget is mandatory for MVP or optional.
+1. Signer token TTL is locked at 48 hours (`172800` seconds) and must use explicit signer token config naming (`SIGNER_TOKEN_TTL_SECONDS`).
+2. Webhook retry behavior is locked:
+   - total attempts: 10 (attempt 1 initial + attempts 2..10 retries)
+   - `exp = attempt - 2`
+   - `baseDelaySeconds = 10 * (2 ** exp)`
+   - `cappedDelaySeconds = min(baseDelaySeconds, 900)`
+   - `sleepSeconds = random_uniform(0, cappedDelaySeconds)` (full jitter)
+3. Admin backup observability is required for MVP:
+   - display last successful backup timestamp
+   - display last backup status (`SUCCESS` or `FAIL`)
+4. Backup telemetry persistence is required (e.g., `backup_runs` table or equivalent metrics store with `started_at`, `completed_at`, `status`, and artifact reference).

--- a/_bmad-output/planning-artifacts/epics-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/epics-signshyft-2026-03-03.md
@@ -1,0 +1,466 @@
+---
+stepsCompleted: [1, 2, 3, 4]
+workflowType: epics-and-stories
+project: SignShyft
+project_lane: signshyft
+author: Jeremiah
+date: 2026-03-03
+inputDocuments:
+  - /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/prd-signshyft-2026-03-03.md
+  - /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/architecture-signshyft-2026-03-03.md
+  - /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/ux-design-specification-signshyft-2026-03-03.md
+---
+
+# SignShyft - Epics and Stories
+
+## Overview
+
+This document decomposes SignShyft requirements into implementation-ready epics and stories for the `signshyft` lane. Scope is locked to v1 constraints from constitution, OpenAPI, schema, and ops specs.
+
+## Requirement Traceability Summary
+
+### Functional Requirement Inventory (PRD Reference)
+
+FR-SS-001 through FR-SS-053 from `/Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/prd-signshyft-2026-03-03.md`.
+
+### Non-Functional Requirement Inventory
+
+NFR-SS-001 through NFR-SS-012 from the same PRD.
+
+## Epic List
+
+1. Epic 1: Lane Governance and Platform Skeleton
+2. Epic 2: Template and Version Authoring
+3. Epic 3: Deterministic Rendering Engine
+4. Epic 4: Envelope and Signer Flow
+5. Epic 5: Finalization, Audit, and Document Custody
+6. Epic 6: Webhooks and WordPress Integration
+7. Epic 7: Deployment, Monitoring, and Operational Resilience
+
+---
+
+## Epic 1: Lane Governance and Platform Skeleton
+
+Goal: establish SignShyft lane-safe foundation, API/web shells, plugin chain, and refusal contract consistency.
+
+### Story 1.1: Establish signshyft lane scaffolding and policy wiring
+
+Acceptance Criteria:
+
+1. Planning artifacts and lane config include `signshyft` mappings and metadata.
+2. Sprint status file exists for SignShyft lane.
+3. Lane enforcement passes for SignShyft artifacts.
+4. No RouteShyft/ConnectShyft lane artifacts are modified by this story.
+
+FR Coverage: FR-SS-050, FR-SS-051, FR-SS-052, FR-SS-053
+
+### Story 1.2: Create signshyft-api skeleton with required plugins
+
+Acceptance Criteria:
+
+1. Fastify TypeScript API boots with health route.
+2. Plugin chain includes tenant/auth/refusal/rls/rate-limit/storage/webhooks.
+3. Refusal plugin exposes canonical HTTP 200 refusal helper.
+4. Request lifecycle includes DB session context initialization contract.
+
+FR Coverage: FR-SS-001, FR-SS-002, FR-SS-003, FR-SS-005
+NFR Coverage: NFR-SS-001, NFR-SS-002
+
+### Story 1.3: Create signshyft-web shell for staff and signer route groups
+
+Acceptance Criteria:
+
+1. `signshyft-web` app builds and serves route shells for staff and signer pages.
+2. Route guards separate staff-auth and signer-token contexts.
+3. Placeholder refusal renderer supports canonical reason display.
+
+FR Coverage: FR-SS-003
+
+### Story 1.4: Implement canonical refusal reasons and API contract fixtures
+
+Acceptance Criteria:
+
+1. Refusal reason enumeration matches locked list in spec.
+2. API tests verify business refusals are HTTP 200 payloads.
+3. Client helpers normalize refusal rendering.
+
+FR Coverage: FR-SS-003, FR-SS-004
+
+---
+
+## Epic 2: Template and Version Authoring
+
+Goal: deliver staff-facing template and version lifecycle with immutable publish rules.
+
+### Story 2.1: Implement template CRUD endpoints and list UI
+
+Acceptance Criteria:
+
+1. `GET/POST /staff/templates` contract implemented.
+2. Staff templates list supports search and archive filtering.
+3. Tenant RLS enforced on template data.
+
+FR Coverage: FR-SS-007
+NFR Coverage: NFR-SS-001
+
+### Story 2.2: Implement template version read and draft patch workflow
+
+Acceptance Criteria:
+
+1. `GET/PATCH /staff/template-versions/{id}` implemented.
+2. Non-draft patch attempts return refusal.
+3. Version editor screen allows schema/render config updates in draft only.
+
+FR Coverage: FR-SS-008, FR-SS-009
+
+### Story 2.3: Add draft PDF upload and hash capture
+
+Acceptance Criteria:
+
+1. Multipart upload endpoint stores PDF in configured storage path.
+2. SHA-256 hash captured and persisted.
+3. Invalid/oversized files return canonical refusal reasons.
+
+FR Coverage: FR-SS-010, FR-SS-011
+
+### Story 2.4: Add layout validation endpoint and blocking publish guard
+
+Acceptance Criteria:
+
+1. `POST /staff/template-versions/{id}/validate` returns diagnostics.
+2. Publish flow blocked on `blockingErrors`.
+3. Validation results visible in staff editor UI.
+
+FR Coverage: FR-SS-012, FR-SS-013
+
+### Story 2.5: Implement publish immutability and clone-new-draft workflow
+
+Acceptance Criteria:
+
+1. Publish sets version immutable and records publish metadata.
+2. Post-publish edits refuse with immutable reason.
+3. Clone-from-published creates new draft with copied schema/render config.
+
+FR Coverage: FR-SS-014, FR-SS-015
+
+---
+
+## Epic 3: Deterministic Rendering Engine
+
+Goal: enforce deterministic render behavior and strong engine boundaries.
+
+### Story 3.1: Define RenderEngine interface and enforce import boundary
+
+Acceptance Criteria:
+
+1. Canonical `RenderEngine` interface implemented.
+2. ESLint no-restricted-imports rule blocks out-of-bound pdf-lib imports.
+3. Build fails when boundary is violated.
+
+FR Coverage: FR-SS-016, FR-SS-017
+NFR Coverage: NFR-SS-003
+
+### Story 3.2: Implement shared layout.ts used by preview and final
+
+Acceptance Criteria:
+
+1. Single layout module handles wrapping and measurement.
+2. Preview and final paths both call shared layout functions.
+3. No duplicate layout logic exists outside engine layout module.
+
+FR Coverage: FR-SS-016
+
+### Story 3.3: Implement deterministic signature and initials rasterization pipeline
+
+Acceptance Criteria:
+
+1. Stroke data persisted as vectors.
+2. Rasterization uses deterministic policy at 300 DPI equivalent.
+3. Same raster path used for signature and initials.
+
+FR Coverage: FR-SS-018
+
+### Story 3.4: Implement render semaphore and busy refusal behavior
+
+Acceptance Criteria:
+
+1. Render concurrency fixed to 1.
+2. Busy requests return `RENDER_BUSY` refusal payload.
+3. Busy and failure outcomes create audit events.
+
+FR Coverage: FR-SS-022, FR-SS-023
+NFR Coverage: NFR-SS-004, NFR-SS-005
+
+### Story 3.5: Add golden render drift tests
+
+Acceptance Criteria:
+
+1. Given fixed template/values, final hash matches golden baseline.
+2. CI fails when hash drifts unexpectedly.
+3. Test fixtures include multiline text, checkbox/radio, signature, initials cases.
+
+FR Coverage: FR-SS-016, FR-SS-018, FR-SS-020
+NFR Coverage: NFR-SS-003
+
+---
+
+## Epic 4: Envelope and Signer Flow
+
+Goal: deliver secure recipient workflow from envelope creation through signer completion.
+
+### Story 4.1: Implement envelope create/list/get with recipient signer links
+
+Acceptance Criteria:
+
+1. `GET/POST /staff/envelopes` and `GET /staff/envelopes/{id}` implemented per OpenAPI.
+2. Create requires `expiresAt` and recipients.
+3. Response includes signer URLs and token expiry metadata per recipient.
+
+FR Coverage: FR-SS-024, FR-SS-025
+
+### Story 4.2: Implement recipient signing mode and turn enforcement
+
+Acceptance Criteria:
+
+1. `ORDERED` and `PARALLEL` modes persisted.
+2. Ordered flow enforces turn checks.
+3. Wrong-turn attempts return `NOT_YOUR_TURN` refusal.
+
+FR Coverage: FR-SS-026, FR-SS-027
+
+### Story 4.3: Implement signer token lifecycle and resend rotation
+
+Acceptance Criteria:
+
+1. Tokens are single-recipient scoped and expiring.
+2. Resend endpoint rotates token and invalidates prior token.
+3. Access endpoint is rate-limited and audited.
+
+FR Coverage: FR-SS-028, FR-SS-029, FR-SS-006
+
+### Story 4.4: Implement OTP challenge and verify flow
+
+Acceptance Criteria:
+
+1. OTP policies (`EMAIL|SMS|NONE`) enforced per recipient.
+2. OTP records hash code, attempts, expiry, verified timestamp.
+3. Invalid and expired attempts return canonical refusal reasons.
+
+FR Coverage: FR-SS-033, FR-SS-034, FR-SS-035
+
+### Story 4.5: Implement signer submit endpoint and persistence model
+
+Acceptance Criteria:
+
+1. `POST /signer/envelopes/{token}/submit` stores field values and strokes by binding key.
+2. Required-field validation errors return refusal responses.
+3. Signer UI supports save/submit feedback for large forms.
+
+FR Coverage: FR-SS-030
+
+---
+
+## Epic 5: Finalization, Audit, and Document Custody
+
+Goal: enforce legal-grade completion path, custody, and retrieval with retention controls.
+
+### Story 5.1: Implement signer complete endpoint and finalization orchestration
+
+Acceptance Criteria:
+
+1. `POST /signer/envelopes/{token}/complete` enforces envelope/signer state checks.
+2. Completion triggers renderFinal pipeline and status transitions.
+3. Failure modes map to canonical refusal reasons.
+
+FR Coverage: FR-SS-031
+
+### Story 5.2: Implement final PDF flattening, certificate page, and hash persistence
+
+Acceptance Criteria:
+
+1. Finalized PDF flattened and certificate page appended.
+2. Final bytes hashed with sha256 and stored on envelope.
+3. Canonical payload hash stored in audit metadata chain.
+
+FR Coverage: FR-SS-019, FR-SS-020, FR-SS-021
+
+### Story 5.3: Implement staff download and audit timeline surfaces
+
+Acceptance Criteria:
+
+1. Staff-only download endpoint returns finalized artifact.
+2. Envelope details show key audit events.
+3. Unauthorized download attempts are rejected and audited.
+
+FR Coverage: FR-SS-032, FR-SS-048
+
+### Story 5.4: Implement retention workers for draft/token/otp and finalized artifacts
+
+Acceptance Criteria:
+
+1. 30-day purge for draft/incomplete/tokens/otp artifacts.
+2. 7-year retention policy metadata for finalized artifacts.
+3. Purge actions are audit-logged.
+
+FR Coverage: FR-SS-046, FR-SS-047
+
+### Story 5.5: Implement document hash chain persistence integrity checks
+
+Acceptance Criteria:
+
+1. Hash chain writes include `prev_sha256` references.
+2. Per-envelope chain integrity verifier exists for ops audits.
+3. Integrity failures are surfaced in ops logs.
+
+FR Coverage: FR-SS-049
+
+---
+
+## Epic 6: Webhooks and WordPress Integration
+
+Goal: deliver secure, signed, retry-safe outbound event delivery and WP wiring.
+
+### Story 6.1: Implement webhook endpoint management APIs and staff UI
+
+Acceptance Criteria:
+
+1. Staff can list/create/update webhook endpoints.
+2. Endpoint model includes `targetApp`, URL, enabled state.
+3. Test endpoint queues test delivery.
+
+FR Coverage: FR-SS-036, FR-SS-037
+
+### Story 6.2: Implement webhook worker queue with retry/backoff and idempotent delivery IDs
+
+Acceptance Criteria:
+
+1. Delivery queue tracks attempts, next attempt, last status/error.
+2. Retry policy applies to retryable failure classes only.
+3. Retries reuse same delivery ID for attempt chain.
+
+FR Coverage: FR-SS-038, FR-SS-041
+
+### Story 6.3: Implement webhook HMAC signing spec v1
+
+Acceptance Criteria:
+
+1. Required headers are emitted on all deliveries.
+2. String-to-sign and signature output match signing spec.
+3. Signature test vectors verify cross-language deterministic results.
+
+FR Coverage: FR-SS-039, FR-SS-040
+NFR Coverage: NFR-SS-006, NFR-SS-008
+
+### Story 6.4: Implement webhook payload contract for WP consumption
+
+Acceptance Criteria:
+
+1. Payload includes required WP fields and document identifier.
+2. Event types include completed/voided/expired/status-changed variants.
+3. Contract tests validate schema and field presence.
+
+FR Coverage: FR-SS-042
+
+### Story 6.5: Publish WP integration hardening guide and receiver checklist
+
+Acceptance Criteria:
+
+1. Guide includes no-token/no-signer-url logging/storage constraints.
+2. Receiver checklist includes raw body verification and timestamp window enforcement.
+3. Integration examples cover idempotency and secret rotation.
+
+FR Coverage: FR-SS-043
+NFR Coverage: NFR-SS-007, NFR-SS-009
+
+---
+
+## Epic 7: Deployment, Monitoring, and Operational Resilience
+
+Goal: make v1 deployable and supportable on constrained infrastructure.
+
+### Story 7.1: Implement infra artifacts for Docker, Nginx, and systemd
+
+Acceptance Criteria:
+
+1. Compose file deploys API and webhook worker with memory limits.
+2. Nginx config supports TLS and `/api` proxy with required timeouts.
+3. systemd compose unit supports boot persistence.
+
+FR Coverage: FR-SS-044, FR-SS-045
+NFR Coverage: NFR-SS-004
+
+### Story 7.2: Implement minimum monitoring stack and memwatch automation
+
+Acceptance Criteria:
+
+1. Ops commands and docs provided for memory/disk/container observability.
+2. `sysstat` and memwatch cron setup documented and script-verified.
+3. Render busy/failure events are visible in logs and audit streams.
+
+FR Coverage: FR-SS-023, FR-SS-048
+NFR Coverage: NFR-SS-004
+
+### Story 7.3: Implement backup and restore automation scripts
+
+Acceptance Criteria:
+
+1. Nightly DB dump and filesystem archive commands implemented.
+2. 14-day retention rotation applied.
+3. Restore procedure script verifies health + preview/finalize smoke checks.
+
+FR Coverage: FR-SS-044, FR-SS-046, FR-SS-047
+NFR Coverage: NFR-SS-010, NFR-SS-011
+
+### Story 7.4: Resolve policy constants and lock final operational defaults
+
+Acceptance Criteria:
+
+1. Token TTL conflict is resolved and documented in code + API docs.
+2. Webhook retry limits/backoff values are locked and documented.
+3. Optional admin backup timestamp requirement finalized for MVP scope.
+
+FR Coverage: FR-SS-052
+
+---
+
+## Story Dependency Map
+
+- 1.2 depends on 1.1
+- 1.3 depends on 1.1
+- 1.4 depends on 1.2
+- 2.1 depends on 1.2
+- 2.2 depends on 2.1
+- 2.3 depends on 2.2
+- 2.4 depends on 2.2, 3.2
+- 2.5 depends on 2.4
+- 3.1 depends on 1.2
+- 3.2 depends on 3.1
+- 3.3 depends on 3.1
+- 3.4 depends on 3.1
+- 3.5 depends on 3.2, 3.3
+- 4.1 depends on 2.5
+- 4.2 depends on 4.1
+- 4.3 depends on 4.1
+- 4.4 depends on 4.3
+- 4.5 depends on 4.3
+- 5.1 depends on 4.5, 4.2, 3.2, 3.3
+- 5.2 depends on 5.1
+- 5.3 depends on 5.2
+- 5.4 depends on 5.2
+- 5.5 depends on 5.2
+- 6.1 depends on 1.2
+- 6.2 depends on 6.1
+- 6.3 depends on 6.2
+- 6.4 depends on 6.2
+- 6.5 depends on 6.3, 6.4
+- 7.1 depends on 1.2
+- 7.2 depends on 7.1
+- 7.3 depends on 7.1
+- 7.4 depends on 6.2, 7.1
+
+## Definition of Ready for Implementation Phase
+
+1. Every story has explicit acceptance criteria and FR/NFR mapping.
+2. Story sequencing supports incremental, testable delivery.
+3. Lane checks are green for all SignShyft planning artifacts.
+4. Sprint status file generated from this epic/story set.

--- a/_bmad-output/planning-artifacts/epics-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/epics-signshyft-2026-03-03.md
@@ -335,8 +335,13 @@ FR Coverage: FR-SS-036, FR-SS-037
 Acceptance Criteria:
 
 1. Delivery queue tracks attempts, next attempt, last status/error.
-2. Retry policy applies to retryable failure classes only.
-3. Retries reuse same delivery ID for attempt chain.
+2. Retry policy applies to retryable failure classes only (`network/timeouts`, `5xx`, `429`; optional `408`).
+3. Retry schedule is locked to 10 total attempts with full jitter:
+   - attempts 2..10 use `exp = attempt - 2`
+   - `baseDelaySeconds = 10 * (2 ** exp)`
+   - `cappedDelaySeconds = min(baseDelaySeconds, 900)`
+   - `sleepSeconds = random_uniform(0, cappedDelaySeconds)`
+4. Retries reuse same delivery ID for attempt chain.
 
 FR Coverage: FR-SS-038, FR-SS-041
 
@@ -415,9 +420,10 @@ NFR Coverage: NFR-SS-010, NFR-SS-011
 
 Acceptance Criteria:
 
-1. Token TTL conflict is resolved and documented in code + API docs.
-2. Webhook retry limits/backoff values are locked and documented.
-3. Optional admin backup timestamp requirement finalized for MVP scope.
+1. Signer token TTL is locked to `172800` seconds (`48h`) and configured via explicit signer token variable (`SIGNER_TOKEN_TTL_SECONDS`).
+2. Ambiguous signer token config names (e.g., `TOKEN_TTL_DAYS`) are removed or repurposed with token-class-specific names.
+3. Webhook retry limits/backoff are implemented exactly per locked algorithm and documented.
+4. Admin backup indicator is required for MVP and backed by persisted backup run telemetry (`started_at`, `completed_at`, `status`, artifact reference).
 
 FR Coverage: FR-SS-052
 

--- a/_bmad-output/planning-artifacts/implementation-readiness-report-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/implementation-readiness-report-signshyft-2026-03-03.md
@@ -1,0 +1,162 @@
+---
+workflow: check-implementation-readiness
+project: SignShyft
+project_lane: signshyft
+date: 2026-03-03
+status: PASS_WITH_OPEN_DECISIONS
+stepsCompleted:
+  - step-01-document-discovery
+  - step-02-prd-analysis
+  - step-03-epic-coverage-validation
+  - step-04-ux-alignment
+  - step-05-epic-quality-review
+  - step-06-final-assessment
+includedFiles:
+  product_brief: /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/product-brief-signshyft-2026-03-03.md
+  prd: /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/prd-signshyft-2026-03-03.md
+  ux: /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/ux-design-specification-signshyft-2026-03-03.md
+  architecture: /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/architecture-signshyft-2026-03-03.md
+  epics: /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/epics-signshyft-2026-03-03.md
+---
+
+# Implementation Readiness Assessment Report - SignShyft
+
+**Date:** 2026-03-03  
+**Lane:** signshyft
+
+## 1. Document Discovery and Scope Validation
+
+Canonical planning documents were found and are lane-tagged with `project_lane: signshyft`.
+
+Validated artifacts:
+
+1. Product Brief
+2. PRD
+3. UX Design Specification
+4. Architecture Decision Document
+5. Epics and Stories
+
+Lane guard verification status: PASS.
+
+## 2. PRD Completeness Assessment
+
+### 2.1 Functional Requirements
+
+PRD defines FR-SS-001 through FR-SS-053 covering:
+
+1. tenant and refusal governance,
+2. template/version lifecycle,
+3. deterministic rendering,
+4. envelope/signer flows,
+5. webhook integration,
+6. storage/retention,
+7. lane governance.
+
+Assessment: complete and implementation-testable.
+
+### 2.2 Non-Functional Requirements
+
+PRD defines NFR-SS-001 through NFR-SS-012 including RLS isolation, deterministic rendering, constrained-host reliability, secure webhook verification, and backup/restore obligations.
+
+Assessment: complete with measurable operational targets.
+
+## 3. Epic Coverage Validation
+
+### 3.1 Coverage Result
+
+All PRD FR groups are represented by one or more stories:
+
+1. Governance and scope controls: Epic 1
+2. Template/version lifecycle: Epic 2
+3. Rendering determinism and boundaries: Epic 3
+4. Signer workflow and OTP: Epic 4
+5. Finalization/custody/audit: Epic 5
+6. Webhooks and WP integration: Epic 6
+7. Deployment/ops resilience: Epic 7
+
+Coverage status: PASS (no uncovered FR category found).
+
+### 3.2 NFR Coverage Result
+
+NFR families map to implementation epics:
+
+1. Isolation/security: Epic 1 + 4 + 6
+2. Determinism: Epic 3 + 5
+3. Reliability/ops: Epic 3 + 6 + 7
+4. Retention/recovery: Epic 5 + 7
+
+Coverage status: PASS.
+
+## 4. UX Alignment Validation
+
+UX specification aligns with PRD and architecture on:
+
+1. staff template and envelope operations,
+2. signer token + OTP flows,
+3. refusal-state handling,
+4. webhook administration,
+5. system health presentation.
+
+No critical UX/PRD conflicts detected.
+
+## 5. Story Quality Review
+
+### 5.1 Story Structure
+
+Each story contains:
+
+1. explicit acceptance criteria,
+2. requirement mappings,
+3. dependency order compatibility.
+
+### 5.2 Dependency Coherence
+
+Dependency graph supports phased delivery:
+
+1. foundation,
+2. templates,
+3. render engine,
+4. signer flow,
+5. finalization,
+6. webhook integration,
+7. ops hardening.
+
+Assessment: coherent and implementable.
+
+## 6. Risk Review
+
+### 6.1 High-Risk Areas
+
+1. Render determinism drift risk if layout logic duplicates.
+2. 1GB host memory pressure during finalization peak.
+3. Webhook replay/signature verification implementation mistakes.
+
+### 6.2 Mitigations Present in Plan
+
+1. Shared `layout.ts` + golden hash tests (Epic 3).
+2. Concurrency=1 + refusal on saturation + monitoring (Epic 3/7).
+3. Signature test vectors, idempotent delivery IDs, receiver checklist (Epic 6).
+
+## 7. Open Decisions (Must Resolve Before Dev Freeze)
+
+1. Token TTL policy mismatch: OpenAPI guidance (48h) vs env example (`TOKEN_TTL_DAYS=7`).
+2. Final webhook retry attempt count/backoff constants.
+3. MVP scope decision for admin “last backup timestamp” widget.
+
+These are not blockers for story kickoff but must be resolved before production hardening stories are marked done.
+
+## 8. Final Readiness Assessment
+
+Readiness verdict: **PASS WITH OPEN DECISIONS**.
+
+Interpretation:
+
+1. Planning set is sufficient to start implementation in SignShyft lane.
+2. Requirements-to-story traceability is complete at planning level.
+3. Remaining items are policy constant clarifications, not structural planning gaps.
+
+## 9. Go-Forward Checklist
+
+1. Generate/update sprint status file from epics document.
+2. Resolve open decisions in Epic 7 Story 7.4 during early implementation.
+3. Keep lane/policy checks mandatory after each story-level artifact update.

--- a/_bmad-output/planning-artifacts/implementation-readiness-report-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/implementation-readiness-report-signshyft-2026-03-03.md
@@ -3,7 +3,7 @@ workflow: check-implementation-readiness
 project: SignShyft
 project_lane: signshyft
 date: 2026-03-03
-status: PASS_WITH_OPEN_DECISIONS
+status: PASS
 stepsCompleted:
   - step-01-document-discovery
   - step-02-prd-analysis
@@ -137,26 +137,28 @@ Assessment: coherent and implementable.
 2. Concurrency=1 + refusal on saturation + monitoring (Epic 3/7).
 3. Signature test vectors, idempotent delivery IDs, receiver checklist (Epic 6).
 
-## 7. Open Decisions (Must Resolve Before Dev Freeze)
+## 7. Locked V1 Decisions
 
-1. Token TTL policy mismatch: OpenAPI guidance (48h) vs env example (`TOKEN_TTL_DAYS=7`).
-2. Final webhook retry attempt count/backoff constants.
-3. MVP scope decision for admin “last backup timestamp” widget.
-
-These are not blockers for story kickoff but must be resolved before production hardening stories are marked done.
+1. Signer token TTL is locked to 48 hours (`172800` seconds) and must use explicit signer token config naming (`SIGNER_TOKEN_TTL_SECONDS`).
+2. Webhook retry behavior is locked to 10 total attempts with capped exponential backoff and full jitter:
+   - attempts 2..10 use `exp = attempt - 2`
+   - `baseDelaySeconds = 10 * (2 ** exp)`
+   - `cappedDelaySeconds = min(baseDelaySeconds, 900)`
+   - `sleepSeconds = random_uniform(0, cappedDelaySeconds)`
+3. Admin “last backup timestamp” is required for MVP and must display last successful backup timestamp and last backup status (`SUCCESS|FAIL`).
 
 ## 8. Final Readiness Assessment
 
-Readiness verdict: **PASS WITH OPEN DECISIONS**.
+Readiness verdict: **PASS**.
 
 Interpretation:
 
 1. Planning set is sufficient to start implementation in SignShyft lane.
 2. Requirements-to-story traceability is complete at planning level.
-3. Remaining items are policy constant clarifications, not structural planning gaps.
+3. Locked decisions have been incorporated into planning artifacts and implementation criteria.
 
 ## 9. Go-Forward Checklist
 
 1. Generate/update sprint status file from epics document.
-2. Resolve open decisions in Epic 7 Story 7.4 during early implementation.
+2. Implement locked policy constants in Epic 7 Story 7.4 during early implementation.
 3. Keep lane/policy checks mandatory after each story-level artifact update.

--- a/_bmad-output/planning-artifacts/prd-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/prd-signshyft-2026-03-03.md
@@ -1,0 +1,269 @@
+---
+stepsCompleted:
+  - step-01-init
+  - step-02-discovery
+  - step-03-success
+  - step-04-journeys
+  - step-05-domain
+  - step-06-innovation
+  - step-07-project-type
+  - step-08-scoping
+  - step-09-functional
+  - step-10-nonfunctional
+  - step-11-polish
+  - step-12-complete
+workflowType: prd
+project: SignShyft
+project_lane: signshyft
+author: Jeremiah
+date: 2026-03-03
+classification:
+  projectType: modular monolith module expansion
+  domain: e-signature and document custody
+  complexity: high
+  projectContext: brownfield parallel development
+inputDocuments:
+  - /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/product-brief-signshyft-2026-03-03.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/01_SignShyft_Constitution.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/13_OpenAPI.yaml
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/20_DB_DDL_and_RLS.sql
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/SignShyft_Webhook_Signing_Spec.md
+---
+
+# Product Requirements Document - SignShyft
+
+**Author:** Jeremiah  
+**Date:** 2026-03-03
+
+## Executive Summary
+
+SignShyft delivers a canonical e-signature service for all Shyft ecosystem modules requiring electronic signature and final document retention. V1 focuses on staff-driven template authoring, signer completion flows, deterministic final PDF generation, and operationally safe webhook integration for WordPress.
+
+SignShyft must run as a dedicated `signshyft` lane with strict non-interference constraints to protect RouteShyft and ConnectShyft delivery.
+
+## Objectives
+
+1. Provide one reusable signing platform across the ecosystem.
+2. Guarantee deterministic legal artifact generation (preview/final parity).
+3. Guarantee tenant isolation and role-based control on all data paths.
+4. Guarantee canonical custody of finalized PDFs, hashes, and audit trails.
+5. Support WordPress Phase A integration without leaking signer secrets.
+
+## Non-Goals
+
+1. Public template authoring by signers.
+2. Generic cloud document management features.
+3. Multi-tenant cross-share workflows.
+4. Multi-node horizontal scaling in v1.
+
+## Users and Roles
+
+### Primary Roles
+
+1. `staff_admin`: full tenant-scoped operational control.
+2. `staff`: day-to-day template/envelope/webhook operations.
+3. `signer`: recipient completing assigned envelope steps.
+
+### Integration Actors
+
+1. WordPress plugin server integration identity.
+2. Webhook receiver process with signature verification + idempotency.
+
+## Success Criteria
+
+### Product Outcomes
+
+1. `100%` published template versions are immutable.
+2. `100%` finalized envelopes persist PDF + sha256 + audit/hash records.
+3. `100%` business refusals use HTTP `200` with canonical refusal payload.
+4. `100%` webhook deliveries include required signed headers.
+
+### Operational Outcomes
+
+1. Render queue saturation is handled safely via `RENDER_BUSY` without process instability.
+2. Backup/restore drill completes successfully at least quarterly.
+3. 1GB droplet memory remains inside configured container limits under expected load.
+
+### Integration Outcomes
+
+1. WordPress receives envelope status and document retrieval identifiers.
+2. WordPress does not persist signer URLs or canonical PDFs.
+
+## Product Scope
+
+### MVP In Scope
+
+1. Staff template CRUD and versioning (`DRAFT`, `PUBLISHED`, `DEPRECATED`, `ARCHIVED`).
+2. Draft PDF upload with sha256 capture.
+3. Draft schema editing and layout validation.
+4. Preview rendering endpoint for staff.
+5. Envelope creation with explicit `expiresAt` and recipients.
+6. Signer access flow (token + OTP policy).
+7. Signer submit and completion.
+8. Finalization pipeline with certificate page append and flatten.
+9. Staff finalized PDF download endpoint.
+10. Webhook endpoint configuration, test, delivery queue, retry.
+11. WordPress integration contract for creation + webhook consumption.
+
+### MVP Out of Scope
+
+1. Alternate storage backends.
+2. Multi-region HA architecture.
+3. Public unauthenticated staff APIs.
+4. Advanced analytics dashboards.
+
+## User Journeys
+
+### Journey A: Template to Published Version
+
+1. Staff creates template metadata.
+2. Staff creates/edits draft version schema.
+3. Staff uploads source PDF to draft version.
+4. Staff validates layout; blocking errors must be resolved.
+5. Staff publishes version; version becomes immutable.
+
+### Journey B: Envelope Creation to Completion
+
+1. Staff creates envelope with recipients and expiry.
+2. API returns signer URLs per recipient.
+3. Signer opens access link; OTP challenge if required.
+4. Signer submits field values/strokes.
+5. Signer completes; service finalizes deterministic PDF.
+6. Staff downloads finalized PDF and views audit trail.
+
+### Journey C: WordPress Integration
+
+1. WP plugin calls `POST /staff/envelopes` server-to-server.
+2. WP emails signer link and stores only envelope references.
+3. SignShyft emits signed webhook events.
+4. WP verifies HMAC and applies idempotent updates.
+5. Staff retrieves finalized artifact from SignShyft when needed.
+
+## Functional Requirements
+
+### Security, Scope, and Governance
+
+FR-SS-001: Tenant must be resolved by Host header + JWT tenant claim match.
+FR-SS-002: Tenant must never be accepted from request body/query.
+FR-SS-003: Business refusals must return HTTP 200 with `{success:false,reason}`.
+FR-SS-004: API must support canonical refusal reason enum set from spec.
+FR-SS-005: Staff operations require bearer auth and tenant-scoped role resolution.
+FR-SS-006: Signer access attempts must be rate-limited and audited.
+
+### Template and Version Lifecycle
+
+FR-SS-007: Staff can list/create templates.
+FR-SS-008: Staff can get and patch draft template versions.
+FR-SS-009: Patch to non-draft template version is refused.
+FR-SS-010: Draft PDF upload stores object key and sha256.
+FR-SS-011: Invalid/oversize PDF upload must refuse with canonical reasons.
+FR-SS-012: Layout validation endpoint returns warnings and blocking errors.
+FR-SS-013: Publish operation refuses if layout has blocking errors.
+FR-SS-014: Published versions are immutable and cannot be edited.
+FR-SS-015: New draft version can be created from a published version clone.
+
+### Rendering and Determinism
+
+FR-SS-016: Preview and Final rendering must use the same layout implementation.
+FR-SS-017: Render engine imports are restricted to `render/engines/*` only.
+FR-SS-018: Signatures/initials are stored as vector strokes and rasterized deterministically.
+FR-SS-019: Final output must be flattened and include certificate page.
+FR-SS-020: Final PDF bytes must be hashed with sha256 and persisted.
+FR-SS-021: Canonical field payload hash must be computed and persisted in audit payload.
+FR-SS-022: Render concurrency must be fixed to 1 in v1.
+FR-SS-023: If render slot is unavailable, system refuses with `RENDER_BUSY`.
+
+### Envelope and Recipient Flow
+
+FR-SS-024: Envelope creation requires `templateVersionId`, `recipients`, and `expiresAt`.
+FR-SS-025: Envelope status lifecycle supports `DRAFT|SENT|IN_PROGRESS|COMPLETED|VOIDED|EXPIRED|DECLINED|ERROR`.
+FR-SS-026: Recipient model supports `ORDERED` and `PARALLEL` signing modes.
+FR-SS-027: Ordered mode enforces turn-taking with refusal `NOT_YOUR_TURN`.
+FR-SS-028: Signer tokens are single-recipient scoped and expire per policy.
+FR-SS-029: Resend rotates token and invalidates prior token.
+FR-SS-030: Signer submit persists field values and signature strokes by binding key.
+FR-SS-031: Complete operation triggers deterministic finalization workflow.
+FR-SS-032: Staff download endpoint returns finalized PDF for authorized staff only.
+
+### OTP and Access Controls
+
+FR-SS-033: OTP policies `EMAIL|SMS|NONE` are supported per recipient.
+FR-SS-034: OTP challenge stores hashed code, attempt count, expiry, verification timestamp.
+FR-SS-035: Invalid/expired OTP returns canonical refusal (`OTP_INVALID|OTP_EXPIRED`).
+
+### Webhooks and WordPress Integration
+
+FR-SS-036: Staff can configure webhook endpoints (`targetApp`, `url`, enabled state).
+FR-SS-037: Webhook test endpoint queues synthetic delivery.
+FR-SS-038: Webhook worker performs retry with backoff and idempotent delivery IDs.
+FR-SS-039: Outbound webhook signatures follow locked HMAC spec (`v1` format).
+FR-SS-040: Required signed headers must be emitted for every webhook delivery.
+FR-SS-041: Delivery retries must reuse the same `deliveryId` across attempts.
+FR-SS-042: Payload includes `envelopeId`, `status`, `externalRef`, and `document` identifier.
+FR-SS-043: WordPress integration guidance must enforce no signer URL logging/storage.
+
+### Storage, Retention, and Audit
+
+FR-SS-044: Storage driver v1 uses local disk paths under `/var/lib/signshyft`.
+FR-SS-045: Storage paths must not be web-accessible.
+FR-SS-046: Finalized artifacts/audit/hash chain retention defaults to 7 years.
+FR-SS-047: Draft/token/OTP artifacts are purged after 30 days.
+FR-SS-048: Critical actions write immutable audit events.
+FR-SS-049: Document hash chain persists `prev_sha256` linkage per envelope step.
+
+### Lane and Delivery Governance
+
+FR-SS-050: SignShyft planning artifacts must include `project_lane: signshyft`.
+FR-SS-051: SignShyft planning filenames must include `signshyft` token.
+FR-SS-052: Lane policy checks must pass after each planning artifact update.
+FR-SS-053: SignShyft sprint status is isolated in `sprint-status-signshyft.yaml`.
+
+## Non-Functional Requirements
+
+NFR-SS-001: Tenant isolation enforced by DB RLS across all tenant-scoped tables.
+NFR-SS-002: API sets local DB session context (`app.tenant_id`, `app.actor_role`, `app.actor_id`).
+NFR-SS-003: Render determinism is stable across preview/final and CI golden hash tests.
+NFR-SS-004: Service tolerates constrained memory with container hard limits.
+NFR-SS-005: Render path is single-concurrency and fails fast on saturation.
+NFR-SS-006: Webhook verification supports replay resistance via timestamp window + idempotency.
+NFR-SS-007: Secrets are stored as base64 and support dual-secret rotation with grace window.
+NFR-SS-008: Signed webhook verification occurs before JSON parse/business logic.
+NFR-SS-009: Logging excludes tokens, signer URLs, secrets, and full signed payload bodies.
+NFR-SS-010: Backups include DB and filesystem with 14-day retention minimum.
+NFR-SS-011: Restore drill must be executable in staging and validate rendering outputs.
+NFR-SS-012: All planning outputs remain lane-safe and non-interfering with other lanes.
+
+## API Contract Baseline
+
+The OpenAPI document (`13_OpenAPI.yaml`) is the contract source for v1 endpoints and schemas, including:
+
+1. Staff template/version APIs.
+2. Staff envelope APIs.
+3. Staff webhook management APIs.
+4. Signer access/submit/complete APIs.
+5. Refusal payload schema and field schema union types.
+
+## Data Contract Baseline
+
+The SQL DDL (`20_DB_DDL_and_RLS.sql`) is the schema source for v1 including:
+
+1. Tenant + staff users.
+2. Template + template versions.
+3. Envelopes + recipients + tokens + OTP + field values + strokes.
+4. Audit events + document hashes.
+5. Webhook endpoints + webhook deliveries.
+6. RLS policies for tenant-scoped staff access.
+
+## Open Questions
+
+1. Confirm final token TTL policy mismatch between OpenAPI guidance (48 hours) and env example (`TOKEN_TTL_DAYS=7`) before implementation lock.
+2. Confirm exact max retry attempts/backoff constants for webhook delivery worker.
+3. Confirm optional vs required implementation of “last backup timestamp” in admin UI for MVP.
+
+## Release Readiness Gates
+
+1. Product Brief approved.
+2. UX spec confirms operational/admin/signer flows.
+3. Architecture locks bounded module and deterministic render decisions.
+4. Epics/stories map every FR/NFR with no uncovered requirements.
+5. Implementation readiness report shows PASS for scope, traceability, and lane isolation.

--- a/_bmad-output/planning-artifacts/prd-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/prd-signshyft-2026-03-03.md
@@ -179,7 +179,7 @@ FR-SS-024: Envelope creation requires `templateVersionId`, `recipients`, and `ex
 FR-SS-025: Envelope status lifecycle supports `DRAFT|SENT|IN_PROGRESS|COMPLETED|VOIDED|EXPIRED|DECLINED|ERROR`.
 FR-SS-026: Recipient model supports `ORDERED` and `PARALLEL` signing modes.
 FR-SS-027: Ordered mode enforces turn-taking with refusal `NOT_YOUR_TURN`.
-FR-SS-028: Signer tokens are single-recipient scoped and expire per policy.
+FR-SS-028: Signer tokens are single-recipient scoped and expire exactly 48 hours (`172800` seconds) from issuance.
 FR-SS-029: Resend rotates token and invalidates prior token.
 FR-SS-030: Signer submit persists field values and signature strokes by binding key.
 FR-SS-031: Complete operation triggers deterministic finalization workflow.
@@ -195,7 +195,7 @@ FR-SS-035: Invalid/expired OTP returns canonical refusal (`OTP_INVALID|OTP_EXPIR
 
 FR-SS-036: Staff can configure webhook endpoints (`targetApp`, `url`, enabled state).
 FR-SS-037: Webhook test endpoint queues synthetic delivery.
-FR-SS-038: Webhook worker performs retry with backoff and idempotent delivery IDs.
+FR-SS-038: Webhook worker retry policy is locked to 10 total attempts (1 initial + 9 retries), exponential base-2 starting at 10s, full-jitter, and a 15-minute cap.
 FR-SS-039: Outbound webhook signatures follow locked HMAC spec (`v1` format).
 FR-SS-040: Required signed headers must be emitted for every webhook delivery.
 FR-SS-041: Delivery retries must reuse the same `deliveryId` across attempts.
@@ -229,7 +229,7 @@ NFR-SS-006: Webhook verification supports replay resistance via timestamp window
 NFR-SS-007: Secrets are stored as base64 and support dual-secret rotation with grace window.
 NFR-SS-008: Signed webhook verification occurs before JSON parse/business logic.
 NFR-SS-009: Logging excludes tokens, signer URLs, secrets, and full signed payload bodies.
-NFR-SS-010: Backups include DB and filesystem with 14-day retention minimum.
+NFR-SS-010: Backups include DB and filesystem with 14-day retention minimum, and admin UX exposes last successful backup timestamp and last backup status.
 NFR-SS-011: Restore drill must be executable in staging and validate rendering outputs.
 NFR-SS-012: All planning outputs remain lane-safe and non-interfering with other lanes.
 
@@ -254,11 +254,18 @@ The SQL DDL (`20_DB_DDL_and_RLS.sql`) is the schema source for v1 including:
 5. Webhook endpoints + webhook deliveries.
 6. RLS policies for tenant-scoped staff access.
 
-## Open Questions
+## Locked V1 Decisions
 
-1. Confirm final token TTL policy mismatch between OpenAPI guidance (48 hours) and env example (`TOKEN_TTL_DAYS=7`) before implementation lock.
-2. Confirm exact max retry attempts/backoff constants for webhook delivery worker.
-3. Confirm optional vs required implementation of “last backup timestamp” in admin UI for MVP.
+1. Signer token TTL is locked to 48 hours (`172800` seconds) using explicit signer token config naming (`SIGNER_TOKEN_TTL_SECONDS=172800`).
+2. Webhook retries are locked to 10 total attempts with this algorithm for attempts 2..10:
+   - `exp = attempt - 2`
+   - `baseDelaySeconds = 10 * (2 ** exp)`
+   - `cappedDelaySeconds = min(baseDelaySeconds, 900)`
+   - `sleepSeconds = random_uniform(0, cappedDelaySeconds)` (full jitter)
+3. Admin “last backup timestamp” is required for MVP and must show:
+   - last successful backup timestamp
+   - last backup status (`SUCCESS` or `FAIL`)
+4. Token-related configuration must be explicit by token class; ambiguous `TOKEN_TTL_DAYS` usage for signer links is prohibited.
 
 ## Release Readiness Gates
 

--- a/_bmad-output/planning-artifacts/product-brief-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/product-brief-signshyft-2026-03-03.md
@@ -1,0 +1,134 @@
+---
+stepsCompleted: [1, 2, 3, 4, 5, 6]
+workflowType: product-brief
+project: SignShyft
+project_lane: signshyft
+author: Jeremiah
+date: 2026-03-03
+inputDocuments:
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/01_SignShyft_Constitution.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/02_Concrete_Folder_Structure.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/03_RenderEngine_Interface_and_Contract.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/04_Lint_and_Parity_Enforcement.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/05_Refusal_Reasons.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/12_Rendering_Determinism_Spec.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/13_OpenAPI.yaml
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/20_DB_DDL_and_RLS.sql
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/30_Deployment_Runbook.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/31_Backup_and_Restore.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/32_Admin_UI_Requirements.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/33_Build_Sequence.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/34_WordPress_Integration_Phase_A.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/35_Render_Behavior_Under_Load.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/36_Monitoring.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/SignShyft_Webhook_Signing_Spec.md
+---
+
+# Product Brief: SignShyft
+
+## Executive Summary
+
+SignShyft is the e-signature and finalized document custody module for the Shyft ecosystem. It provides template authoring, signer flows, deterministic PDF rendering/finalization, audit/hash chain, and webhook integration for downstream systems such as WordPress.
+
+The module must launch as an isolated lane (`signshyft`) without disrupting RouteShyft or ConnectShyft delivery. Lane isolation is enforced by naming conventions, branch tokens, and policy checks. Runtime isolation is enforced through bounded module folders, strict RenderEngine boundaries, and tenant RLS.
+
+## Problem Statement
+
+The ecosystem currently lacks one canonical e-signature service for legally relevant signed documents. Existing module-specific implementations would create drift in security, retention, and audit behavior.
+
+SignShyft solves this by centralizing:
+
+1. Template/version lifecycle with immutability once published.
+2. Secure signer flows with token + OTP policy support.
+3. Deterministic preview/final render behavior.
+4. Canonical finalized PDF storage with hash chain and audit trail.
+5. Integration-safe webhook and WordPress handoff patterns.
+
+## Product Vision
+
+Create one reusable e-signature platform service that any Shyft module can call while preserving:
+
+1. Tenant data isolation and access governance.
+2. Deterministic legal artifact generation.
+3. Operational safety on constrained infrastructure (1GB droplet).
+4. Clear refusal contracts for all business-rule failures.
+
+## Target Users
+
+### Primary Users
+
+1. Staff admins who create templates, publish versions, and manage envelopes.
+2. Signers (guardians/participants) completing forms through secure signer links.
+3. Operations admins who monitor webhook delivery and retrieval/download paths.
+
+### Secondary Users
+
+1. WordPress plugin maintainers integrating enrollment or consent flows.
+2. Compliance/audit stakeholders reviewing signed artifact integrity.
+3. Platform maintainers managing deployment/backup/restore.
+
+## Success Metrics
+
+1. `100%` of business refusals return HTTP `200` + `{ "success": false, "reason": "..." }`.
+2. `100%` of published template versions are immutable.
+3. `100%` of finalized envelopes store canonical PDF + sha256 + audit/hash chain.
+4. Render queue saturation returns `RENDER_BUSY` with no crash/restart loops.
+5. RLS isolation holds for all tenant-scoped tables.
+6. WordPress integration stores only envelope references/status, never canonical PDFs.
+
+## MVP Scope
+
+### In Scope (V1)
+
+1. Staff template CRUD + template version lifecycle (`DRAFT -> PUBLISHED`).
+2. Draft PDF upload, schema editing, layout validation, and preview rendering.
+3. Envelope creation with recipients, ordered/parallel signing rules, resend and token rotation.
+4. Signer access, submit, and complete flows with OTP policy (`EMAIL|SMS|NONE`).
+5. Finalization pipeline: render final PDF, flatten, append certificate, hash and store.
+6. Staff download path for finalized documents.
+7. Webhook endpoint management + delivery worker + retry/backoff + idempotency.
+8. WordPress Phase A integration contract and webhook signing verification.
+9. Local-disk storage driver under `/var/lib/signshyft` (non-web-accessible).
+
+### Out of Scope (V1)
+
+1. Public/signer template authoring.
+2. Multi-engine rendering abstraction beyond pdf-lib engine implementation.
+3. Cloud object storage migration (S3/GCS).
+4. Multi-node scaling and distributed render queue.
+
+## Non-Negotiable Constraints
+
+1. Tenant resolution from Host header plus JWT tenant claim match only.
+2. No tenant acceptance from request body/query.
+3. Strict RenderEngine import boundary (`apps/signshyft-api/src/render/engines/*` only).
+4. Preview and Final must share identical layout logic (`layout.ts`).
+5. Render concurrency fixed to `1` on the 1GB droplet.
+6. Retention defaults: finalized artifacts 7 years, draft/token/OTP artifacts 30 days.
+7. Canonical storage ownership remains in SignShyft; integrations store references only.
+
+## Lane Safety and Non-Interference Strategy
+
+1. Keep all planning and implementation artifacts lane-tagged with `signshyft`.
+2. Keep SignShyft code under dedicated module paths (`apps/signshyft-*`, `infra/signshyft*`) to avoid cross-lane coupling.
+3. Enforce lane guard + git policy checks after every planning artifact.
+4. Avoid direct imports from RouteShyft/ConnectShyft internals; integration through contracts/events only.
+5. Maintain independent sprint status file `_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml`.
+
+## Key Risks and Mitigations
+
+1. Risk: memory pressure on 1GB droplet during finalization.
+Mitigation: hard container memory limits, concurrency=1, swap, memwatch, refusal-on-busy.
+
+2. Risk: rendering drift between preview and final.
+Mitigation: single shared layout implementation and golden hash tests in CI.
+
+3. Risk: webhook replay or spoofing.
+Mitigation: timestamp window checks, delivery ID idempotency, HMAC signatures, dual-secret rotation.
+
+4. Risk: legal/compliance exposure from weak retention or artifact provenance.
+Mitigation: hash chain, immutable versioning, strict retention policy, staff-only download flow.
+
+## Delivery Recommendation
+
+Execute SignShyft in phased increments from skeleton -> templates -> rendering -> envelopes -> finalization -> webhooks -> WordPress integration, with explicit lane checks and policy gates after each artifact and implementation slice.

--- a/_bmad-output/planning-artifacts/ux-design-specification-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/ux-design-specification-signshyft-2026-03-03.md
@@ -1,0 +1,232 @@
+---
+stepsCompleted: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+workflowType: ux-design
+project: SignShyft
+project_lane: signshyft
+author: Jeremiah
+date: 2026-03-03
+inputDocuments:
+  - /Users/jeremiahotis/projects/routeshyft/_bmad-output/planning-artifacts/prd-signshyft-2026-03-03.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/13_OpenAPI.yaml
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/32_Admin_UI_Requirements.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/12_Rendering_Determinism_Spec.md
+  - /Users/jeremiahotis/Downloads/SignShyft_Implementation_Spec/05_Refusal_Reasons.md
+---
+
+# UX Design Specification - SignShyft
+
+**Author:** Jeremiah  
+**Date:** 2026-03-03
+
+## Executive Summary
+
+SignShyft UX must support two very different use cases in one coherent system:
+
+1. Staff operations (template management, envelope operations, webhook administration).
+2. Low-friction signer completion (token link, OTP verification, field completion, signature/initials).
+
+The UI must make refusal states obvious and recoverable, preserve deterministic rendering expectations, and keep sensitive data handling safe by default.
+
+## UX Principles
+
+1. Clarity over cleverness: signing status and next required action are always explicit.
+2. Deterministic expectations: preview and final look the same in layout behavior.
+3. Security-by-default: avoid exposing signer URLs/tokens in logs or unnecessary UI surfaces.
+4. Operational simplicity: workflows optimized for a small ops team on constrained infra.
+5. Refusal transparency: canonical refusal reasons are user-visible with actionable recovery hints.
+
+## Primary Experience Areas
+
+1. Staff Console
+2. Signer Journey
+3. Admin and Monitoring
+4. WordPress Integration Support Surfaces
+
+## Information Architecture
+
+### Staff Console Navigation
+
+1. Templates
+2. Template Versions
+3. Envelopes
+4. Webhooks
+5. System Health
+
+### Signer Navigation
+
+1. Access gate (`/signer/access/{token}`)
+2. Envelope view (`/signer/envelopes/{token}`)
+3. Submit (`/signer/envelopes/{token}/submit`)
+4. Complete (`/signer/envelopes/{token}/complete`)
+
+## Staff UX Flows
+
+### Flow 1: Template Authoring and Publish
+
+1. Staff opens Templates list with search and archive filters.
+2. Staff creates template metadata.
+3. Staff opens versions for template and selects a draft.
+4. Staff uploads PDF.
+5. Staff edits field schema in placement builder.
+6. Staff runs `Validate Layout` and resolves blocking errors.
+7. Staff runs Preview with sample values.
+8. Staff clicks Publish; UI displays immutable badge and disables draft-only actions.
+
+### Flow 2: Envelope Creation and Lifecycle
+
+1. Staff opens Create Envelope form.
+2. Selects published template version.
+3. Adds recipients, signing mode, and OTP policy.
+4. Sets explicit expiry (`expiresAt`).
+5. Submits and receives recipient signer links (copy/send controls).
+6. Envelope list shows status timeline (`SENT -> IN_PROGRESS -> COMPLETED/VOIDED/EXPIRED`).
+7. Staff can view details, resend recipient link (token rotation), or void if needed.
+
+### Flow 3: Final PDF Retrieval and Audit
+
+1. Completed envelope shows Download button.
+2. Staff downloads finalized PDF via authenticated endpoint.
+3. Audit panel shows major events (created, viewed, otp_verified, submitted, completed, webhook_delivery).
+
+### Flow 4: Webhook Endpoint Operations
+
+1. Staff lists endpoints with status badges (`enabled`, `disabled`, `failing`).
+2. Staff can create/update endpoint URL and enable toggle.
+3. Staff triggers Test Delivery.
+4. Delivery history table shows last status/error/next retry.
+5. Retry Now action available for failed deliveries.
+
+### Flow 5: System Health Surface
+
+1. Queue state card: `available` vs `busy`.
+2. Disk usage card for `/var/lib/signshyft`.
+3. Optional last backup timestamp card.
+4. If render slot is busy, show non-alarm notice with expected retry guidance.
+
+## Signer UX Flows
+
+### Flow 6: Link Access and OTP
+
+1. Signer opens link.
+2. Access screen determines OTP requirement based on recipient policy.
+3. If OTP required, collect code and show remaining attempts.
+4. Refusal states (`OTP_INVALID`, `OTP_EXPIRED`, `EXPIRED_LINK`) show clear recovery path.
+
+### Flow 7: Form Completion
+
+1. Signer sees generated form fields with required markers.
+2. Signature/initials captured as strokes in consistent canvas controls.
+3. Submit saves progress (where allowed by policy).
+4. Complete confirms attestation and triggers finalization.
+
+### Flow 8: Ordered Signing
+
+1. If not signer turn, show refusal `NOT_YOUR_TURN` with explanatory message.
+2. Disable editing controls until turn is active.
+
+## Screen Specifications
+
+### Staff Screen A: Template List
+
+Purpose: discover/manage templates quickly.
+
+Required UI elements:
+
+1. Search field.
+2. Archive filter.
+3. Template cards/table rows with last updated and active version count.
+4. Create template CTA.
+
+### Staff Screen B: Template Version Editor
+
+Purpose: prepare publication-ready template version.
+
+Required UI elements:
+
+1. Version status badge (`DRAFT`, `PUBLISHED`, etc.).
+2. PDF upload zone.
+3. Field schema editor with placement controls.
+4. Validate Layout button with warnings/blocking panels.
+5. Preview panel.
+6. Publish button (disabled until valid).
+
+### Staff Screen C: Envelope List + Detail
+
+Purpose: track and operate signing requests.
+
+Required UI elements:
+
+1. Status filters.
+2. Rows with envelope ID, externalRef summary, expiry, status.
+3. Detail panel with recipients and signer link actions.
+4. Resend/void actions.
+5. Download finalized PDF action when completed.
+
+### Staff Screen D: Webhook Management
+
+Purpose: manage external integration health.
+
+Required UI elements:
+
+1. Endpoint table with target app, url, enabled state.
+2. Create/edit endpoint modal.
+3. Test delivery action.
+4. Delivery history list with status and retry controls.
+
+### Signer Screen E: Access + OTP
+
+Purpose: secure entry into signing flow.
+
+Required UI elements:
+
+1. Access status summary.
+2. OTP input with countdown if required.
+3. Refusal messaging panel with retry or support guidance.
+
+### Signer Screen F: Envelope Completion
+
+Purpose: complete fields and signature.
+
+Required UI elements:
+
+1. Field renderer by schema type.
+2. Signature and initials capture components.
+3. Required-field validator summary.
+4. Submit and Complete actions.
+
+## Refusal and Error UX Rules
+
+1. Business refusals display inline, non-technical copy while preserving canonical reason code.
+2. HTTP-200 refusal responses are visually distinguished from transport/server failures.
+3. `RENDER_BUSY` shows queue-busy guidance and retry messaging.
+4. Immutable violations (`TEMPLATE_VERSION_IMMUTABLE`) disable controls and link to clone-new-version action.
+5. Sensitive details (secret values, raw signatures, signer tokens) are never rendered in debug UI.
+
+## Accessibility and Responsiveness
+
+1. Keyboard-accessible actions for all staff workflows.
+2. Minimum WCAG 2.2 AA contrast and focus indicators.
+3. Signer flow optimized for mobile portrait screens.
+4. Form errors announced with ARIA live regions.
+5. No critical action gated behind hover-only UI.
+
+## Performance UX Expectations
+
+1. Staff list pages show skeleton loading states and empty-state guidance.
+2. Long operations (preview/finalization/test webhook) show progress indicators.
+3. UI prevents duplicate action clicks for idempotent operations.
+4. Completion success screen includes envelope identifier and completion timestamp.
+
+## WordPress Integration UX Notes
+
+1. Staff-facing docs/help include strict guidance not to persist signer URLs.
+2. Webhook test screen includes signing-header checklist for WP receiver verification.
+3. Integration troubleshooting panel maps common failures to quick actions.
+
+## UX Acceptance Checklist
+
+1. Staff can fully author, validate, preview, and publish template versions without DB access.
+2. Staff can create and manage envelopes and retrieve final artifacts.
+3. Signers can complete signing with required OTP and ordered sequencing controls.
+4. Refusal states are understandable and actionable.
+5. Sensitive token/secret handling is safe-by-default in UI behavior.

--- a/_bmad-output/planning-artifacts/ux-design-specification-signshyft-2026-03-03.md
+++ b/_bmad-output/planning-artifacts/ux-design-specification-signshyft-2026-03-03.md
@@ -100,7 +100,9 @@ The UI must make refusal states obvious and recoverable, preserve deterministic 
 
 1. Queue state card: `available` vs `busy`.
 2. Disk usage card for `/var/lib/signshyft`.
-3. Optional last backup timestamp card.
+3. Required backup card showing:
+   - last successful backup timestamp
+   - last backup status (`SUCCESS` or `FAIL`)
 4. If render slot is busy, show non-alarm notice with expected retry guidance.
 
 ## Signer UX Flows

--- a/docs/policies/epic_story_naming_convention.md
+++ b/docs/policies/epic_story_naming_convention.md
@@ -6,6 +6,7 @@ Avoid ambiguity when multiple product streams live in the same monorepo.
 ## Streams
 - `MONO` = monolithic monorepo core stream (Shyft baseline)
 - `CS` = ConnectShyft stream
+- `SS` = SignShyft stream
 
 ## Required References in Communication
 - Epic references must include stream prefix:
@@ -14,18 +15,21 @@ Avoid ambiguity when multiple product streams live in the same monorepo.
 - Story references must include stream prefix:
   - `MONO-S1.1`, `MONO-S1.2`, ...
   - `CS-S1.1`, `CS-S1.2`, ...
+  - `SS-S1.1`, `SS-S1.2`, ...
 
 ## Required References in Workflow Requests
 - Do not use bare `Epic 1` or `Story 1.2`.
 - Always include stream + ID in prompts and commands:
   - `cs MONO-E1 all stories`
   - `create story CS-S3.2`
+  - `create story SS-S1.1`
 
 ## Artifact Naming Guidance
 - New generated planning artifacts should include stream key in filename.
   - Example: `epics-MONO-YYYY-MM-DD.md`, `epics-CS-YYYY-MM-DD.md`
+  - Example: `epics-SS-YYYY-MM-DD.md`
 - New generated sprint status files should include stream key in filename.
-  - Example: `sprint-status-mono.yaml`, `sprint-status-connectshyft.yaml`
+  - Example: `sprint-status-mono.yaml`, `sprint-status-connectshyft.yaml`, `sprint-status-signshyft.yaml`
 - Planning and sprint-status artifacts must also include explicit metadata:
   - `project_lane: <lane-id>`
 
@@ -34,6 +38,7 @@ Avoid ambiguity when multiple product streams live in the same monorepo.
 - When reading legacy files, map them explicitly:
   - `epics.md` + `sprint-status.yaml` => `MONO`
   - `epics-ConnectShyft-*.md` + `sprint-status-connectshyft.yaml` => `CS`
+  - `epics-SignShyft-*.md` + `sprint-status-signshyft.yaml` => `SS`
 
 ## Enforcement Rule
 - Any workflow run request missing stream prefix is considered ambiguous and must be clarified before execution.

--- a/docs/policies/git_policy.md
+++ b/docs/policies/git_policy.md
@@ -180,6 +180,9 @@ Source material was imported from `~/Downloads/git_policy.md` and adapted for th
   - `connectshyft` lane:
     - planning artifacts include `ConnectShyft` in filename
     - sprint status file: `_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml`
+  - `signshyft` lane:
+    - planning artifacts include `SignShyft` in filename
+    - sprint status file: `_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml`
   - `routeshyft` lane:
     - planning artifacts omit `ConnectShyft` token
     - sprint status file: `_bmad-output/implementation-artifacts/sprint-status.yaml`

--- a/docs/policies/project_lanes.json
+++ b/docs/policies/project_lanes.json
@@ -20,6 +20,17 @@
         "connectshyft"
       ],
       "sprintStatusFile": "_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml"
+    },
+    {
+      "id": "signshyft",
+      "displayName": "SignShyft",
+      "branchTokens": [
+        "signshyft"
+      ],
+      "planningFilenameTokens": [
+        "signshyft"
+      ],
+      "sprintStatusFile": "_bmad-output/implementation-artifacts/sprint-status-signshyft.yaml"
     }
   ],
   "planningRules": {


### PR DESCRIPTION
## Summary\n- add SignShyft lane bootstrap governance artifacts\n- add full SignShyft planning chain artifacts (product brief, PRD, UX, architecture, epics, readiness)\n- lock v1 policy decisions (48h signer token TTL, webhook retry algorithm, required MVP backup status indicator)\n- close Story 1.1 with required operability guardrail metadata\n\n## Safety\n- branch built from origin/codex/dev and cherry-picked only SignShyft commits\n- backup branch: codex/backup-signshyft-merge-safety-c733071\n- backup tag: signshyft-merge-safety-20260303-c733071\n\n## Validation\n- PROJECT_LANE=signshyft npm run policy:check\n