### PR TITLE
Fix: resolve a.4 escalation review findings and mark done

### DIFF
--- a/_bmad-output/implementation-artifacts/a-4-escalation-baseline-and-recipient-configuration.md
+++ b/_bmad-output/implementation-artifacts/a-4-escalation-baseline-and-recipient-configuration.md
@@ -1,6 +1,6 @@
 # Story a.4: Escalation Baseline and Recipient Configuration
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -86,11 +86,12 @@ GPT-5 Codex
 
 ### Debug Log References
 
-- `cd src && npm test -- src/modules/connectshyft/__tests__/escalationConfig.test.ts src/migrations/__tests__/connectShyftEscalationConfigMigration.test.ts` (pass, 2 suites / 9 tests)
+- `cd src && npm test -- src/modules/connectshyft/__tests__/escalationConfig.test.ts src/migrations/__tests__/connectShyftEscalationConfigMigration.test.ts` (pass, 2 suites / 10 tests)
+- `cd src && npm test -- src/modules/connectshyft/__tests__/escalationConfig.test.ts` (pass, 1 suite / 8 tests)
 - `cd src && npm run build` (pass)
 - `cd frontend && npm run build` (pass)
-- `npm run test:e2e -- tests/api/platform/a-4-escalation-baseline-and-recipient-configuration.api.spec.ts` (pass, 7 tests)
-- `npm run test:e2e -- tests/e2e/platform/a-4-escalation-baseline-and-recipient-configuration.spec.ts` (pass, 4 tests)
+- `npm run test:e2e -- tests/api/platform/a-4-escalation-baseline-and-recipient-configuration.api.spec.ts` (pass, 8 tests)
+- `npm run test:e2e -- tests/e2e/platform/a-4-escalation-baseline-and-recipient-configuration.spec.ts` (pass, 5 tests)
 - `npm run test:e2e -- tests/api/platform/a-3-orgunit-number-mapping-management.api.spec.ts tests/e2e/platform/a-3-orgunit-number-mapping-management.spec.ts` (pass, 9 tests regression)
 
 ### Completion Notes List
@@ -100,18 +101,18 @@ GPT-5 Codex
 - Added `GET /api/v1/connectshyft/escalation/recipients` and switched the escalation settings UI to backend-sourced recipient options.
 - Updated frontend config-loading behavior to surface business refusal envelopes instead of silently defaulting to baseline values.
 - Re-ran story a.4 API + E2E suites and adjacent story a.3 API/E2E regression coverage after route/service updates.
+- Added explicit claim-only reset and scheduler-impacting configuration guidance copy to escalation settings UI.
+- Preserved recipient scope metadata client-side and filtered recipient controls by scope so cross-tenant test-only options are not shown in admin selectors.
+- Replaced silent recipient-directory fallback with actionable refusal/error messaging in UI initialization flow.
+- Added API and E2E regression coverage to verify refused invalid updates never overwrite previously persisted escalation configuration.
 
 ### File List
 
 - _bmad-output/implementation-artifacts/a-4-escalation-baseline-and-recipient-configuration.md
-- src/src/migrations/20260222100000_create_connectshyft_escalation_config.ts
-- src/src/migrations/__tests__/connectShyftEscalationConfigMigration.test.ts
-- src/src/modules/connectshyft/escalationConfig.ts
-- src/src/modules/connectshyft/__tests__/escalationConfig.test.ts
-- src/src/routes/api/v1/connectshyft.ts
 - frontend/src/features/connectshyft/escalation.ts
 - frontend/src/views/ConnectShyft/ConnectShyftEscalationSettingsView.vue
 - tests/api/platform/a-4-escalation-baseline-and-recipient-configuration.api.spec.ts
+- tests/e2e/platform/a-4-escalation-baseline-and-recipient-configuration.spec.ts
 
 ### Change Log
 
@@ -119,3 +120,5 @@ GPT-5 Codex
 - 2026-02-22: Added and passed backend unit tests plus Playwright API/E2E suites for accepted/invalid escalation configuration paths.
 - 2026-02-22: Ran adjacent ConnectShyft a.3 API/E2E suites as regression validation after connectshyft route updates.
 - 2026-02-22: Resolved review findings by adding durable DB persistence, authoritative recipient scope validation, backend-sourced recipient options, and explicit frontend refusal handling for config fetch.
+- 2026-03-04: Resolved follow-up review gaps by adding claim-only reset UX copy, scope-aware recipient filtering, non-silent recipient fetch failures, and persistence-invariance API/E2E coverage.
+- 2026-03-04: Story status moved to done after resolving all review findings and syncing sprint tracking.

--- a/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
@@ -47,7 +47,7 @@ development_status:
   a-1-connectshyft-feature-flag-and-availability-guardrails: done
   a-2-tenant-and-orgunit-context-enforcement-for-connectshyft-routes: done
   a-3-orgunit-number-mapping-management: done
-  a-4-escalation-baseline-and-recipient-configuration: review
+  a-4-escalation-baseline-and-recipient-configuration: done
   a-5-capability-based-route-access-and-envelope-contract-compliance: done
   epic-a-retrospective: done
   epic-b: in-progress

--- a/frontend/src/features/connectshyft/escalation.ts
+++ b/frontend/src/features/connectshyft/escalation.ts
@@ -16,7 +16,17 @@ export type ConnectShyftEscalationConfig = {
 export type ConnectShyftEscalationRecipientOption = {
   value: string;
   label: string;
+  scope: ConnectShyftEscalationRecipientScope;
 };
+
+export const connectShyftEscalationRecipientScopes = {
+  ORG_UNIT: 'ORG_UNIT',
+  TENANT: 'TENANT',
+  TEST_ONLY: 'TEST_ONLY',
+} as const;
+
+export type ConnectShyftEscalationRecipientScope =
+  (typeof connectShyftEscalationRecipientScopes)[keyof typeof connectShyftEscalationRecipientScopes];
 
 export type ConnectShyftEscalationFieldError = {
   field: string;
@@ -35,6 +45,7 @@ type ConnectShyftEscalationEnvelope = {
     recipientOptions?: Array<{
       value?: string;
       label?: string;
+      scope?: string;
     }>;
     fieldErrors?: Array<{
       field?: string;
@@ -150,14 +161,23 @@ const parseRecipientOptions = (payload: unknown): ConnectShyftEscalationRecipien
       const label = typeof recipientOption?.label === 'string'
         ? recipientOption.label.trim()
         : '';
+      const rawScope = typeof recipientOption?.scope === 'string'
+        ? recipientOption.scope.trim().toUpperCase()
+        : '';
+      const scope = rawScope === connectShyftEscalationRecipientScopes.ORG_UNIT
+        || rawScope === connectShyftEscalationRecipientScopes.TENANT
+        || rawScope === connectShyftEscalationRecipientScopes.TEST_ONLY
+        ? rawScope as ConnectShyftEscalationRecipientScope
+        : null;
 
-      if (!value) {
+      if (!value || !scope) {
         return null;
       }
 
       return {
         value,
         label: label || value,
+        scope,
       };
     })
     .filter((recipientOption): recipientOption is ConnectShyftEscalationRecipientOption => recipientOption !== null);
@@ -222,12 +242,17 @@ export const fetchConnectShyftEscalationRecipientOptions = async (): Promise<Con
 
     const envelope = response.data as ConnectShyftEscalationEnvelope;
     if (envelope?.ok !== true) {
-      return [];
+      throw new Error(parseRefusalMessage(response.data, 'Unable to load escalation recipients right now.'));
     }
 
     return parseRecipientOptions(response.data);
-  } catch (_error) {
-    return [];
+  } catch (error: unknown) {
+    if (error instanceof Error && error.message.trim().length > 0) {
+      throw error;
+    }
+
+    const errorPayload = (error as { response?: { data?: unknown } })?.response?.data;
+    throw new Error(parseRefusalMessage(errorPayload, 'Unable to load escalation recipients right now.'));
   }
 };
 

--- a/frontend/src/views/ConnectShyft/ConnectShyftEscalationSettingsView.vue
+++ b/frontend/src/views/ConnectShyft/ConnectShyftEscalationSettingsView.vue
@@ -8,6 +8,9 @@
         <p class="mt-2 text-sm text-slate-600">
           Configure orgUnit escalation baseline and recipient targets.
         </p>
+        <p class="mt-2 text-sm text-slate-600">
+          Escalation resets only when a thread is claimed. Outbound actions without claim do not reset escalation, and baseline hours directly affect scheduler timing.
+        </p>
       </header>
 
       <form class="rounded-md border border-slate-200 p-4" novalidate @submit.prevent="handleSave">
@@ -41,7 +44,7 @@
             >
               <option value="">Select recipient</option>
               <option
-                v-for="option in recipientOptions"
+                v-for="option in primaryRecipientOptions"
                 :key="`primary-${option.value}`"
                 :value="option.value"
               >
@@ -60,7 +63,7 @@
             >
               <option value="">None</option>
               <option
-                v-for="option in recipientOptions"
+                v-for="option in secondaryRecipientOptions"
                 :key="`secondary-${option.value}`"
                 :value="option.value"
               >
@@ -79,7 +82,7 @@
             >
               <option value="">None</option>
               <option
-                v-for="option in recipientOptions"
+                v-for="option in tenantStaffRecipientOptions"
                 :key="`tenant-staff-${option.value}`"
                 :value="option.value"
               >
@@ -135,8 +138,9 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import {
+  connectShyftEscalationRecipientScopes,
   fetchConnectShyftEscalationRecipientOptions,
   fetchConnectShyftEscalationConfig,
   saveConnectShyftEscalationConfig,
@@ -155,6 +159,19 @@ const primaryRecipientError = ref('');
 const saveSuccessMessage = ref('');
 const isInitializing = ref(true);
 const isSaving = ref(false);
+
+const primaryRecipientOptions = computed(() =>
+  recipientOptions.value.filter(
+    (option) => option.scope === connectShyftEscalationRecipientScopes.ORG_UNIT,
+  ));
+const secondaryRecipientOptions = computed(() =>
+  recipientOptions.value.filter(
+    (option) => option.scope === connectShyftEscalationRecipientScopes.ORG_UNIT,
+  ));
+const tenantStaffRecipientOptions = computed(() =>
+  recipientOptions.value.filter(
+    (option) => option.scope !== connectShyftEscalationRecipientScopes.TEST_ONLY,
+  ));
 
 const clearFeedback = (): void => {
   validationError.value = '';
@@ -226,19 +243,30 @@ onMounted(async () => {
   clearFeedback();
 
   try {
-    const [config, options] = await Promise.all([
-      fetchConnectShyftEscalationConfig(),
-      fetchConnectShyftEscalationRecipientOptions(),
-    ]);
-
-    recipientOptions.value = options;
+    const config = await fetchConnectShyftEscalationConfig();
     syncFromServer(config.escalationBaselineHours, config.recipients);
   } catch (error: unknown) {
     validationError.value = error instanceof Error
       ? error.message
       : 'Unable to load escalation settings right now.';
-  } finally {
-    isInitializing.value = false;
   }
+
+  try {
+    const options = await fetchConnectShyftEscalationRecipientOptions();
+    recipientOptions.value = options;
+    if (options.length === 0 && !validationError.value) {
+      validationError.value = 'No eligible recipients are available for this orgUnit. Ask a tenant administrator to assign orgUnit or tenant members.';
+    }
+  } catch (error: unknown) {
+    recipientOptions.value = [];
+    const message = error instanceof Error
+      ? error.message
+      : 'Unable to load escalation recipients right now.';
+    validationError.value = validationError.value
+      ? `${validationError.value} ${message}`
+      : message;
+  }
+
+  isInitializing.value = false;
 });
 </script>

--- a/tests/api/platform/a-4-escalation-baseline-and-recipient-configuration.api.spec.ts
+++ b/tests/api/platform/a-4-escalation-baseline-and-recipient-configuration.api.spec.ts
@@ -193,6 +193,68 @@ test.describe(
     );
 
     test(
+      '[P1] keeps previously saved configuration unchanged after a refused invalid update @P1',
+      async ({ request, storyA4Context, storyA4AdminHeaders, storyA4ValidConfigPayload }) => {
+        const initialSaveResponse = await apiRequest(request, {
+          method: 'PUT',
+          path: storyA4Context.paths.escalationConfig,
+          headers: storyA4AdminHeaders,
+          data: storyA4ValidConfigPayload,
+        });
+        expect(initialSaveResponse.status()).toBe(200);
+        const initialSaveBody = await initialSaveResponse.json();
+        expect(initialSaveBody).toMatchObject({
+          ok: true,
+          code: 'CONNECTSHYFT_ESCALATION_CONFIG_SAVED',
+          data: {
+            orgUnitId: storyA4Context.orgUnitId,
+            escalationBaselineHours: storyA4Context.validBaselineHours,
+          },
+        });
+
+        const refusedUpdateResponse = await apiRequest(request, {
+          method: 'PUT',
+          path: storyA4Context.paths.escalationConfig,
+          headers: storyA4AdminHeaders,
+          data: {
+            orgUnitId: storyA4Context.orgUnitId,
+            escalationBaselineHours: storyA4Context.invalidBaselineHigh,
+            recipients: {
+              ...storyA4Context.recipients,
+            },
+          },
+        });
+        expect(refusedUpdateResponse.status()).toBe(200);
+        const refusedUpdateBody = await refusedUpdateResponse.json();
+        expect(refusedUpdateBody).toMatchObject({
+          ok: false,
+          code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_RANGE',
+        });
+
+        const resolvedConfigResponse = await apiRequest(request, {
+          method: 'GET',
+          path: storyA4Context.paths.escalationConfig,
+          headers: storyA4AdminHeaders,
+        });
+        expect(resolvedConfigResponse.status()).toBe(200);
+        const resolvedConfigBody = await resolvedConfigResponse.json();
+        expect(resolvedConfigBody).toMatchObject({
+          ok: true,
+          code: 'CONNECTSHYFT_ESCALATION_CONFIG_RESOLVED',
+          data: {
+            orgUnitId: storyA4Context.orgUnitId,
+            escalationBaselineHours: storyA4Context.validBaselineHours,
+            recipients: {
+              primaryOrgUnitAdminUserId: storyA4Context.recipients.primaryOrgUnitAdminUserId,
+              secondaryOrgUnitAdminUserId: storyA4Context.recipients.secondaryOrgUnitAdminUserId,
+              tenantStaffUserId: storyA4Context.recipients.tenantStaffUserId,
+            },
+          },
+        });
+      },
+    );
+
+    test(
       '[P1] refuses cross-tenant recipient assignments with deterministic refusal semantics @P1',
       async ({ request, storyA4Context }) => {
         const headers = createStoryA4Headers(storyA4Context, {

--- a/tests/e2e/platform/a-4-escalation-baseline-and-recipient-configuration.spec.ts
+++ b/tests/e2e/platform/a-4-escalation-baseline-and-recipient-configuration.spec.ts
@@ -102,7 +102,7 @@ test.describe(
     );
 
     test(
-      '[P1] cross-tenant recipient selections are rejected with deterministic refusal messaging and no persisted state @P1',
+      '[P1] refused invalid update does not overwrite the last saved escalation configuration @P1',
       async ({ page }) => {
         await login(page);
         await page.goto(
@@ -111,29 +111,62 @@ test.describe(
           ),
         );
 
-        await page.getByTestId('connectshyft-escalation-baseline-input').fill('8');
-        await page.getByTestId('connectshyft-escalation-recipient-primary').selectOption(
-          'user-connectshyft-a4-cross-tenant-recipient',
-        );
-        await page.getByTestId('connectshyft-escalation-recipient-secondary').selectOption(
-          'user-connectshyft-a4-secondary-recipient',
-        );
-        await page.getByTestId('connectshyft-escalation-recipient-tenant-staff').selectOption(
-          'user-connectshyft-a4-tenant-staff-recipient',
-        );
+        await page.getByTestId('connectshyft-escalation-baseline-input').fill('7');
+        await fillValidRecipients(page);
 
-        const saveResponse = page.waitForResponse(
+        const initialSaveResponse = page.waitForResponse(
           (response) =>
             response.url().includes('/api/v1/connectshyft/escalation/config')
             && response.request().method() === 'PUT',
         );
         await page.getByRole('button', { name: 'Save Escalation Settings' }).click();
-        await saveResponse;
+        await initialSaveResponse;
+
+        await expect(page.getByTestId('connectshyft-escalation-baseline-display')).toHaveText('7 hours');
+
+        await page.getByTestId('connectshyft-escalation-baseline-input').fill('25');
+        await page.getByRole('button', { name: 'Save Escalation Settings' }).click();
 
         await expect(page.getByTestId('connectshyft-escalation-validation-error')).toContainText(
-          'Recipient must belong to the active tenant and orgUnit scope',
+          'Use whole hours between 1 and 24',
         );
-        await expect(page.getByTestId('connectshyft-escalation-save-success')).toHaveCount(0);
+
+        await page.reload();
+        await expect(
+          page.getByRole('heading', {
+            name: 'ConnectShyft Escalation Settings',
+          }),
+        ).toBeVisible();
+        await expect(page.getByTestId('connectshyft-escalation-baseline-display')).toHaveText('7 hours');
+        await expect(page.getByTestId('connectshyft-escalation-baseline-input')).toHaveValue('7');
+      },
+    );
+
+    test(
+      '[P1] cross-tenant recipient options are excluded from escalation recipient selectors @P1',
+      async ({ page }) => {
+        await login(page);
+        await page.goto(
+          buildEscalationUrl(
+            'tenantId=tenant-connectshyft-alpha&orgUnitId=org-connectshyft-alpha-east&tenantRole=ORGUNIT_ADMIN',
+          ),
+        );
+
+        await expect(
+          page.locator(
+            '[data-testid="connectshyft-escalation-recipient-primary"] option[value="user-connectshyft-a4-cross-tenant-recipient"]',
+          ),
+        ).toHaveCount(0);
+        await expect(
+          page.locator(
+            '[data-testid="connectshyft-escalation-recipient-secondary"] option[value="user-connectshyft-a4-cross-tenant-recipient"]',
+          ),
+        ).toHaveCount(0);
+        await expect(
+          page.locator(
+            '[data-testid="connectshyft-escalation-recipient-tenant-staff"] option[value="user-connectshyft-a4-cross-tenant-recipient"]',
+          ),
+        ).toHaveCount(0);
       },
     );
   },


### PR DESCRIPTION
## Summary
- fix Story a.4 review findings across escalation UX and validation handling
- preserve recipient scope metadata in frontend and filter recipient selectors by scope
- add claim-only reset/scheduler-impact copy and non-silent recipient-load refusal messaging
- expand API and E2E coverage to verify refused invalid updates do not overwrite persisted config
- sync story artifact and ConnectShyft sprint status to done

## Verification
- cd frontend && npm run build
- cd src && npm test -- src/modules/connectshyft/__tests__/escalationConfig.test.ts
- npm run test:e2e -- tests/api/platform/a-4-escalation-baseline-and-recipient-configuration.api.spec.ts
- npm run test:e2e -- tests/e2e/platform/a-4-escalation-baseline-and-recipient-configuration.spec.ts