### PR TITLE
Story 6.1: Bridge fulfillment and pending endpoints

### DIFF
--- a/apps/routeshyft-api/src/__tests__/app-entrypoint-kernel.test.ts
+++ b/apps/routeshyft-api/src/__tests__/app-entrypoint-kernel.test.ts
@@ -70,6 +70,7 @@ describe('Story 0.1 - canonical app entrypoint and kernel middleware', () => {
         '/api/v1/platform',
         '/api/v1/platform/admin',
         '/api/v1/route',
+        '/api/v1/route-bridge',
         '/api/v1/connectshyft',
         '/api/v1/route',
         '/api/v1/auth',

--- a/apps/routeshyft-api/src/api/registerRoutes.ts
+++ b/apps/routeshyft-api/src/api/registerRoutes.ts
@@ -33,6 +33,7 @@ export const V1_ROUTE_REGISTRATIONS: RouteRegistration[] = [
   { path: '/api/v1/platform', modulePath: '../routes/api/v1/platform-contracts' },
   { path: '/api/v1/platform/admin', modulePath: '../routes/api/v1/platform-admin' },
   { path: '/api/v1/route', modulePath: '../routes/api/v1/route' },
+  { path: '/api/v1/route-bridge', modulePath: '../routes/api/v1/route-bridge' },
   { path: '/api/v1/connectshyft', modulePath: '../routes/api/v1/connectshyft' },
   { path: '/api/v1/route', modulePath: '../routes/api/v1/route' },
   { path: '/api/v1/auth', modulePath: '../routes/api/v1/auth' },

--- a/apps/routeshyft-api/src/modules/route/application/__tests__/commitmentService.test.ts
+++ b/apps/routeshyft-api/src/modules/route/application/__tests__/commitmentService.test.ts
@@ -283,4 +283,67 @@ describe('route commitment service', () => {
       },
     });
   });
+
+  it('lists only pending commitments for bridge fetch with canonical state descriptors', async () => {
+    const pending = await service.createCommitment({
+      tenantId: 'tenant-1',
+      actorId: 'user-1',
+      sourceType: 'route_request',
+      sourceId: 'request-pending',
+      orgUnitId: 'org-1',
+    });
+    const terminal = await service.createCommitment({
+      tenantId: 'tenant-1',
+      actorId: 'user-1',
+      sourceType: 'route_request',
+      sourceId: 'request-terminal',
+      orgUnitId: 'org-1',
+    });
+
+    if (!pending.ok || !terminal.ok) {
+      throw new Error('Expected commitment creation to succeed');
+    }
+
+    await service.transitionCommitment({
+      tenantId: 'tenant-1',
+      actorId: 'user-2',
+      commitmentId: terminal.data.commitment.commitmentId,
+      nextStatus: 'in_progress',
+      reason: 'Dispatch started',
+    });
+
+    await service.transitionCommitment({
+      tenantId: 'tenant-1',
+      actorId: 'user-2',
+      commitmentId: terminal.data.commitment.commitmentId,
+      nextStatus: 'completed',
+      reason: 'Proof recorded',
+    });
+
+    const list = await service.listPendingCommitments({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      limit: 50,
+    });
+
+    expect(list).toMatchObject({
+      ok: true,
+      code: 'ROUTE_COMMITMENT_PENDING_LIST_RESOLVED',
+      data: {
+        total: 1,
+        items: [
+          {
+            commitment: {
+              commitmentId: pending.data.commitment.commitmentId,
+              status: 'scheduled',
+            },
+            state: {
+              status: 'scheduled',
+              isTerminal: false,
+            },
+          },
+        ],
+      },
+    });
+  });
 });

--- a/apps/routeshyft-api/src/modules/route/application/commitmentService.ts
+++ b/apps/routeshyft-api/src/modules/route/application/commitmentService.ts
@@ -63,9 +63,24 @@ type TransitionCommitmentSuccess = {
   };
 };
 
+type ListPendingCommitmentsSuccess = {
+  ok: true;
+  code: 'ROUTE_COMMITMENT_PENDING_LIST_RESOLVED';
+  message: string;
+  httpStatus: 200;
+  data: {
+    items: Array<{
+      commitment: Awaited<ReturnType<CommitmentRepository['createCommitment']>>;
+      state: ReturnType<typeof describeCommitmentState>;
+    }>;
+    total: number;
+  };
+};
+
 export type CreateCommitmentResult = CreateCommitmentSuccess | ServiceRefusalResult;
 export type ResolveCommitmentResult = ResolveCommitmentSuccess | ServiceRefusalResult;
 export type TransitionCommitmentResult = TransitionCommitmentSuccess | ServiceRefusalResult;
+export type ListPendingCommitmentsResult = ListPendingCommitmentsSuccess | ServiceRefusalResult;
 
 export type CreateCommitmentCommand = {
   tenantId: string;
@@ -92,6 +107,13 @@ export type TransitionCommitmentCommand = {
   reason: string;
   policyExceptionCode?: string | null;
   allowPolicyException?: boolean;
+  dbClient?: Knex | Knex.Transaction;
+};
+
+export type ListPendingCommitmentsCommand = {
+  tenantId: string;
+  orgUnitId?: string | null;
+  limit?: number;
   dbClient?: Knex | Knex.Transaction;
 };
 
@@ -356,6 +378,39 @@ export class CommitmentService {
           commitment: persisted.commitment,
           transition: persisted.transitionAudit,
           state: describeCommitmentState(persisted.commitment.status),
+        },
+      };
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error;
+      }
+
+      return toRefusal(
+        'ROUTE_COMMITMENT_PERSISTENCE_UNAVAILABLE',
+        'Commitment persistence is unavailable. Retry after route schema migration.',
+      );
+    }
+  }
+
+  async listPendingCommitments(input: ListPendingCommitmentsCommand): Promise<ListPendingCommitmentsResult> {
+    try {
+      const commitments = await this.repository.listPendingCommitments({
+        tenantId: input.tenantId,
+        orgUnitId: normalizeNonEmptyString(input.orgUnitId || null) || null,
+        limit: Number.isInteger(input.limit) ? (input.limit as number) : undefined,
+      }, input.dbClient);
+
+      return {
+        ok: true,
+        code: 'ROUTE_COMMITMENT_PENDING_LIST_RESOLVED',
+        message: 'Pending commitments resolved',
+        httpStatus: 200,
+        data: {
+          items: commitments.map((commitment) => ({
+            commitment,
+            state: describeCommitmentState(commitment.status),
+          })),
+          total: commitments.length,
         },
       };
     } catch (error) {

--- a/apps/routeshyft-api/src/modules/route/infrastructure/commitmentRepository.ts
+++ b/apps/routeshyft-api/src/modules/route/infrastructure/commitmentRepository.ts
@@ -56,6 +56,12 @@ export type PersistCommitmentTransitionInput = {
   policyExceptionCode: string | null;
 };
 
+export type ListPendingCommitmentsInput = {
+  tenantId: string;
+  orgUnitId?: string | null;
+  limit?: number;
+};
+
 export type PersistCommitmentTransitionResult =
   | {
     ok: true;
@@ -81,6 +87,10 @@ export interface CommitmentRepository {
     input: PersistCommitmentTransitionInput,
     dbClient?: Knex | Knex.Transaction,
   ): Promise<PersistCommitmentTransitionResult>;
+  listPendingCommitments(
+    input: ListPendingCommitmentsInput,
+    dbClient?: Knex | Knex.Transaction,
+  ): Promise<RouteCommitment[]>;
 }
 
 const toIsoUtc = (value: string | Date | null): string | null => {
@@ -227,6 +237,35 @@ export class InMemoryCommitmentRepository implements CommitmentRepository {
       commitment: { ...updated },
       transitionAudit: { ...transitionAudit },
     };
+  }
+
+  async listPendingCommitments(
+    input: ListPendingCommitmentsInput,
+    _dbClient?: Knex | Knex.Transaction,
+  ): Promise<RouteCommitment[]> {
+    const limit = Number.isInteger(input.limit) && (input.limit as number) > 0
+      ? Math.min(input.limit as number, 500)
+      : 100;
+
+    return [...this.commitmentsById.values()]
+      .filter((commitment) => {
+        if (commitment.tenantId !== input.tenantId) {
+          return false;
+        }
+
+        if (input.orgUnitId && commitment.orgUnitId !== input.orgUnitId) {
+          return false;
+        }
+
+        if (commitment.status !== 'scheduled' && commitment.status !== 'in_progress') {
+          return false;
+        }
+
+        return true;
+      })
+      .sort((left, right) => right.updatedAtUtc.localeCompare(left.updatedAtUtc))
+      .slice(0, limit)
+      .map((commitment) => ({ ...commitment }));
   }
 }
 
@@ -396,5 +435,33 @@ export class KnexCommitmentRepository implements CommitmentRepository {
     }
 
     return client.transaction(runTransition);
+  }
+
+  async listPendingCommitments(
+    input: ListPendingCommitmentsInput,
+    dbClient?: Knex | Knex.Transaction,
+  ): Promise<RouteCommitment[]> {
+    const client = this.resolveClient(dbClient);
+    const limit = Number.isInteger(input.limit) && (input.limit as number) > 0
+      ? Math.min(input.limit as number, 500)
+      : 100;
+
+    const query = client
+      .withSchema('route')
+      .table('commitments')
+      .select<DbCommitmentRow[]>(this.commitmentReturningColumns())
+      .where({
+        tenant_id: input.tenantId,
+      })
+      .whereIn('status', ['scheduled', 'in_progress'])
+      .orderBy('updated_at_utc', 'desc')
+      .limit(limit);
+
+    if (input.orgUnitId) {
+      query.andWhere({ org_unit_id: input.orgUnitId });
+    }
+
+    const rows = await query;
+    return rows.map((row) => mapCommitmentRow(row));
   }
 }

--- a/apps/routeshyft-api/src/routes/api/v1/__tests__/route.bridge.test.ts
+++ b/apps/routeshyft-api/src/routes/api/v1/__tests__/route.bridge.test.ts
@@ -1,0 +1,186 @@
+import express from 'express';
+import request from 'supertest';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import { CommitmentService } from '../../../../modules/route/application/commitmentService';
+import { InMemoryCommitmentRepository } from '../../../../modules/route/infrastructure/commitmentRepository';
+import { createRouteBridgeRouter } from '../route-bridge';
+
+jest.mock('../../../../middleware/auth', () => ({
+  authenticateToken: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    const activeOrgUnitOverride = req.header('x-test-route-active-org-unit-id') || 'org-route-bridge-1';
+    req.user = {
+      userId: 'user-route-bridge-1',
+      email: 'bridge@example.com',
+      householdId: 'tenant-route-bridge-1',
+      activeTenantId: 'tenant-route-bridge-1',
+      activeOrgUnitId: activeOrgUnitOverride,
+      role: 'TENANT_STAFF',
+    };
+    req.tenantId = 'tenant-route-bridge-1';
+    req.orgUnitId = activeOrgUnitOverride;
+    req.scopeMode = 'ORG_UNIT';
+    next();
+  },
+}));
+
+describe('route bridge api contract', () => {
+  const buildApp = (): { app: express.Express; commitmentService: CommitmentService } => {
+    const app = express();
+    app.use(express.json());
+    app.use(responseEnvelope);
+
+    const commitmentService = new CommitmentService(new InMemoryCommitmentRepository());
+    app.use('/api/v1/route-bridge', createRouteBridgeRouter(commitmentService));
+    return { app, commitmentService };
+  };
+
+  it('creates fulfillment commitments through bridge endpoint with canonical lifecycle data', async () => {
+    const { app } = buildApp();
+
+    const response = await request(app)
+      .post('/api/v1/route-bridge/fulfillment')
+      .send({
+        sourceType: 'wordpress_fulfillment',
+        sourceId: 'wp-fulfillment-1',
+        orgUnitId: 'org-route-bridge-1',
+        externalRef: 'wp-lineage-1',
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'ROUTE_BRIDGE_FULFILLMENT_CREATED',
+      data: {
+        bridge: {
+          integration: 'wordpress',
+          stateAuthority: 'monolith',
+        },
+        canonicalLifecycle: {
+          commitment: {
+            sourceType: 'wordpress_fulfillment',
+            sourceId: 'wp-fulfillment-1',
+            externalRef: 'wp-lineage-1',
+            status: 'scheduled',
+          },
+          state: {
+            status: 'scheduled',
+            isTerminal: false,
+            availableTransitions: ['in_progress', 'canceled', 'refused'],
+          },
+        },
+      },
+    });
+  });
+
+  it('resolves pending commitments and excludes terminal commitments from bridge fetch', async () => {
+    const { app, commitmentService } = buildApp();
+
+    const pendingCreate = await commitmentService.createCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      actorId: 'user-route-bridge-1',
+      sourceType: 'wordpress_fulfillment',
+      sourceId: 'wp-fulfillment-pending',
+      orgUnitId: 'org-route-bridge-1',
+      externalRef: 'wp-lineage-pending',
+    });
+
+    const terminalCreate = await commitmentService.createCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      actorId: 'user-route-bridge-1',
+      sourceType: 'wordpress_fulfillment',
+      sourceId: 'wp-fulfillment-terminal',
+      orgUnitId: 'org-route-bridge-1',
+      externalRef: 'wp-lineage-terminal',
+    });
+
+    expect(pendingCreate.ok).toBe(true);
+    expect(terminalCreate.ok).toBe(true);
+    if (!pendingCreate.ok || !terminalCreate.ok) {
+      throw new Error('Expected setup commitments to be created');
+    }
+
+    await commitmentService.transitionCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      commitmentId: terminalCreate.data.commitment.commitmentId,
+      actorId: 'user-route-bridge-1',
+      nextStatus: 'in_progress',
+      reason: 'Driver started fulfillment',
+    });
+
+    await commitmentService.transitionCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      commitmentId: terminalCreate.data.commitment.commitmentId,
+      actorId: 'user-route-bridge-1',
+      nextStatus: 'completed',
+      reason: 'Fulfillment completed',
+    });
+
+    const response = await request(app)
+      .get('/api/v1/route-bridge/pending')
+      .query({ orgUnitId: 'org-route-bridge-1' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'ROUTE_BRIDGE_PENDING_FETCH_RESOLVED',
+      data: {
+        bridge: {
+          integration: 'wordpress',
+          stateAuthority: 'monolith',
+        },
+        canonicalLifecycle: {
+          total: 1,
+          items: [
+            {
+              commitment: {
+                commitmentId: pendingCreate.data.commitment.commitmentId,
+                sourceId: 'wp-fulfillment-pending',
+                status: 'scheduled',
+              },
+              state: {
+                status: 'scheduled',
+                isTerminal: false,
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('rejects fulfillment creation when orgUnit scope mismatches active context', async () => {
+    const { app } = buildApp();
+
+    const response = await request(app)
+      .post('/api/v1/route-bridge/fulfillment')
+      .send({
+        sourceType: 'wordpress_fulfillment',
+        sourceId: 'wp-fulfillment-2',
+        orgUnitId: 'org-route-bridge-999',
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'ROUTE_ORG_UNIT_SCOPE_MISMATCH',
+      refusalType: 'security',
+    });
+  });
+
+  it('returns explicit refusal when fulfillment sourceId is missing', async () => {
+    const { app } = buildApp();
+
+    const response = await request(app)
+      .post('/api/v1/route-bridge/fulfillment')
+      .send({
+        sourceType: 'wordpress_fulfillment',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'ROUTE_COMMITMENT_SOURCE_ID_REQUIRED',
+      refusalType: 'business',
+    });
+  });
+});

--- a/apps/routeshyft-api/src/routes/api/v1/route-bridge.ts
+++ b/apps/routeshyft-api/src/routes/api/v1/route-bridge.ts
@@ -1,0 +1,281 @@
+import { Request, Response, Router } from 'express';
+import type { Knex } from 'knex';
+import { authenticateToken } from '../../../middleware/auth';
+import { refusal, success } from '../../../platform/envelopes/response';
+import { requireTenantId, TenantScopeError } from '../../../platform/tenancy/tenantScope';
+import { CommitmentService } from '../../../modules/route/application/commitmentService';
+import { KnexCommitmentRepository } from '../../../modules/route/infrastructure/commitmentRepository';
+import {
+  localizeRouteOperationalData,
+  resolveRouteTimezoneContext,
+} from '../../../modules/route/api/timezoneAdapter';
+
+const TEST_TENANT_HEADER = 'x-test-route-tenant-id';
+const TEST_ACTOR_HEADER = 'x-test-route-actor-id';
+
+const isNodeTestEnv = (): boolean => process.env.NODE_ENV?.trim().toLowerCase() === 'test';
+
+const loadRouteDb = (): Knex => {
+  const knexModule = require('../../../config/knex') as { default: Knex };
+  return knexModule.default;
+};
+
+const defaultCommitmentService = new CommitmentService(
+  new KnexCommitmentRepository(loadRouteDb()),
+);
+
+const normalizeNonEmptyString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const resolveTenantContext = (req: Request): string | null => {
+  const resolvedTenant = normalizeNonEmptyString(
+    req.user?.activeTenantId
+    || req.user?.householdId
+    || req.tenantContext?.tenantId
+    || req.tenantId
+    || null,
+  );
+
+  if (resolvedTenant) {
+    return resolvedTenant;
+  }
+
+  if (!isNodeTestEnv()) {
+    return null;
+  }
+
+  return normalizeNonEmptyString(req.header(TEST_TENANT_HEADER)) || null;
+};
+
+const resolveActorId = (req: Request): string | null => {
+  const actorId = normalizeNonEmptyString(req.user?.userId || null);
+  if (actorId) {
+    return actorId;
+  }
+
+  if (!isNodeTestEnv()) {
+    return null;
+  }
+
+  return normalizeNonEmptyString(req.header(TEST_ACTOR_HEADER)) || null;
+};
+
+const resolveOrgUnitContext = (req: Request): string | null => {
+  const orgUnitId = normalizeNonEmptyString(
+    req.user?.activeOrgUnitId
+    || req.authContext?.orgUnitId
+    || req.tenantContext?.orgUnitId
+    || req.orgUnitId
+    || null,
+  );
+
+  return orgUnitId || null;
+};
+
+const resolveTenantId = (req: Request, res: Response): string | null => {
+  try {
+    return requireTenantId(resolveTenantContext(req));
+  } catch (error) {
+    const message = error instanceof TenantScopeError
+      ? error.message
+      : 'Tenant context is required for Route bridge requests.';
+
+    refusal(res, {
+      code: 'ROUTE_TENANT_CONTEXT_REQUIRED',
+      message,
+      refusalType: 'security',
+      httpStatus: 403,
+    });
+
+    return null;
+  }
+};
+
+const resolveScopedOrgUnitId = (
+  req: Request,
+  res: Response,
+  requestedOrgUnitId: string | null,
+): string | null | undefined => {
+  const scopedOrgUnitId = resolveOrgUnitContext(req);
+  if (requestedOrgUnitId && !scopedOrgUnitId) {
+    refusal(res, {
+      code: 'ROUTE_ORG_UNIT_CONTEXT_REQUIRED',
+      message: 'OrgUnit context is required when orgUnitId is provided.',
+      refusalType: 'security',
+      httpStatus: 403,
+    });
+    return undefined;
+  }
+
+  if (requestedOrgUnitId && scopedOrgUnitId && requestedOrgUnitId !== scopedOrgUnitId) {
+    refusal(res, {
+      code: 'ROUTE_ORG_UNIT_SCOPE_MISMATCH',
+      message: 'orgUnitId must match active orgUnit context.',
+      refusalType: 'security',
+      httpStatus: 403,
+      data: {
+        activeOrgUnitId: scopedOrgUnitId,
+        requestedOrgUnitId,
+      },
+    });
+    return undefined;
+  }
+
+  return scopedOrgUnitId;
+};
+
+const parseFulfillmentCreateBody = (req: Request) => ({
+  sourceType: normalizeNonEmptyString(req.body?.sourceType) || 'wordpress_fulfillment',
+  sourceId: normalizeNonEmptyString(req.body?.sourceId || req.body?.fulfillmentId),
+  orgUnitId: normalizeNonEmptyString(req.body?.orgUnitId) || null,
+  externalRef: normalizeNonEmptyString(
+    req.body?.externalRef
+    || req.body?.bridgeLineageId
+    || req.body?.wpRequestId,
+  ) || null,
+});
+
+const parsePendingLimit = (req: Request): number => {
+  const raw = normalizeNonEmptyString(req.query?.limit || null);
+  if (!raw) {
+    return 100;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return 100;
+  }
+
+  return Math.min(parsed, 500);
+};
+
+const parsePendingOrgUnit = (req: Request): string | null =>
+  normalizeNonEmptyString(req.query?.orgUnitId || null) || null;
+
+const applyServiceRefusal = (
+  res: Response,
+  rejected: {
+    code: string;
+    message: string;
+    refusalType: 'business' | 'client' | 'security';
+    httpStatus: number;
+    data?: unknown;
+  },
+): void => {
+  refusal(res, {
+    code: rejected.code,
+    message: rejected.message,
+    refusalType: rejected.refusalType,
+    httpStatus: rejected.httpStatus,
+    data: rejected.data,
+  });
+};
+
+const localizeRouteResponseData = (req: Request, data: unknown): Record<string, unknown> => {
+  const timezoneContext = resolveRouteTimezoneContext(req);
+  return localizeRouteOperationalData(data, timezoneContext);
+};
+
+export const createRouteBridgeRouter = (
+  commitmentService: CommitmentService = defaultCommitmentService,
+): Router => {
+  const router = Router();
+
+  router.get('/_health', (_req: Request, res: Response) => success(res, {
+    code: 'ROUTE_BRIDGE_MODULE_HEALTHY',
+    message: 'Route bridge module registered and healthy',
+    data: {
+      service: 'route-bridge',
+      feature: 'wordpress-cutover',
+    },
+  }));
+
+  router.use(authenticateToken);
+
+  router.post('/fulfillment', async (req: Request, res: Response) => {
+    const tenantId = resolveTenantId(req, res);
+    if (!tenantId) {
+      return;
+    }
+
+    const body = parseFulfillmentCreateBody(req);
+    const scopedOrgUnitId = resolveScopedOrgUnitId(req, res, body.orgUnitId);
+    if (scopedOrgUnitId === undefined) {
+      return;
+    }
+
+    const created = await commitmentService.createCommitment({
+      tenantId,
+      actorId: resolveActorId(req),
+      sourceType: body.sourceType,
+      sourceId: body.sourceId,
+      orgUnitId: scopedOrgUnitId,
+      externalRef: body.externalRef,
+    });
+
+    if (!created.ok) {
+      applyServiceRefusal(res, created);
+      return;
+    }
+
+    success(res, {
+      code: 'ROUTE_BRIDGE_FULFILLMENT_CREATED',
+      message: 'Bridge fulfillment created',
+      httpStatus: created.httpStatus,
+      data: localizeRouteResponseData(req, {
+        bridge: {
+          integration: 'wordpress',
+          stateAuthority: 'monolith',
+        },
+        canonicalLifecycle: created.data,
+      }),
+    });
+  });
+
+  router.get('/pending', async (req: Request, res: Response) => {
+    const tenantId = resolveTenantId(req, res);
+    if (!tenantId) {
+      return;
+    }
+
+    const requestedOrgUnitId = parsePendingOrgUnit(req);
+    const scopedOrgUnitId = resolveScopedOrgUnitId(req, res, requestedOrgUnitId);
+    if (scopedOrgUnitId === undefined) {
+      return;
+    }
+
+    const pending = await commitmentService.listPendingCommitments({
+      tenantId,
+      orgUnitId: scopedOrgUnitId,
+      limit: parsePendingLimit(req),
+    });
+
+    if (!pending.ok) {
+      applyServiceRefusal(res, pending);
+      return;
+    }
+
+    success(res, {
+      code: 'ROUTE_BRIDGE_PENDING_FETCH_RESOLVED',
+      message: 'Bridge pending commitments resolved',
+      httpStatus: pending.httpStatus,
+      data: localizeRouteResponseData(req, {
+        bridge: {
+          integration: 'wordpress',
+          stateAuthority: 'monolith',
+        },
+        generatedAtUtc: new Date().toISOString(),
+        canonicalLifecycle: pending.data,
+      }),
+    });
+  });
+
+  return router;
+};
+
+export default createRouteBridgeRouter();


### PR DESCRIPTION
## Summary
- add `/api/v1/route-bridge` API surface for WordPress bridge cutover
- implement `POST /fulfillment` for monolith-authoritative commitment creation
- implement `GET /pending` for pending canonical lifecycle fetch
- add pending-list support in route commitment service/repository
- register route-bridge in shared v1 route registry
- add contract coverage for bridge endpoints and pending list behavior

## Validation
- npm test -- --runInBand src/routes/api/v1/__tests__/route.bridge.test.ts src/modules/route/application/__tests__/commitmentService.test.ts src/__tests__/app-entrypoint-kernel.test.ts
- npm test -- --runInBand src/modules/route/infrastructure/__tests__/commitmentRepository.test.ts
- npm test -- --runInBand src/routes/api/v1/__tests__/route.commitments.test.ts src/routes/api/v1/__tests__/route.test.ts
- npm run build (apps/routeshyft-api)
- npm run policy:check
