### PR TITLE
8-7: enforce story file-list hygiene scope

### DIFF
--- a/docs/policies/git_policy.md
+++ b/docs/policies/git_policy.md
@@ -119,7 +119,12 @@ Source material was imported from `~/Downloads/git_policy.md` and adapted for th
 ### Story Artifact Hygiene Guardrail (Mandatory for PR Validation)
 
 - Story implementation artifacts must maintain:
-  - Complete `### File List` coverage for changed `src/`, `tests/`, and `frontend/` files in the story scope.
+  - Complete `### File List` coverage for changed files in enforced hygiene scope:
+    - `apps/routeshyft-api/**`
+    - `apps/routeshyft-web/**`
+    - `tests/**`
+    - `_bmad-output/test-artifacts/epic-f-*`
+    - `apps/*/node_modules` directory markers when present in git status
   - `### Debug Log References` entries that include passing test/build command outcomes.
 - Enforced by:
   - `scripts/enforce-story-artifact-hygiene.sh`

--- a/scripts/enforce-story-artifact-hygiene.sh
+++ b/scripts/enforce-story-artifact-hygiene.sh
@@ -57,6 +57,7 @@ file_list_entries_file="$tmp_dir/file-list.txt"
 debug_refs_file="$tmp_dir/debug-refs.txt"
 changed_candidates_file="$tmp_dir/changed-candidates.txt"
 changed_required_file="$tmp_dir/changed-required.txt"
+ignored_scope_markers_file="$tmp_dir/ignored-scope-markers.txt"
 
 awk '
   BEGIN { in_file_list=0 }
@@ -117,15 +118,30 @@ fi
 
 git diff --name-only >> "$changed_candidates_file"
 git diff --cached --name-only >> "$changed_candidates_file"
+git ls-files --others --exclude-standard >> "$changed_candidates_file"
 
-sort -u "$changed_candidates_file" | awk '
-  /^apps\/routeshyft-api\// || /^apps\/routeshyft-web\// || /^tests\// {
-    print $0
+# Git does not include ignored directories in `git ls-files --others --exclude-standard`,
+# but story auditability still requires explicit node_modules scope markers when present.
+git status --short --ignored=matching --untracked-files=all 2>/dev/null | awk '
+  $1 == "!!" {
+    path=$2
+    sub(/\/$/, "", path)
+    if (path ~ /^apps\/[^\/]+\/node_modules$/) {
+      print path
+    }
   }
-' > "$changed_required_file"
+' > "$ignored_scope_markers_file"
+
+if [[ -s "$ignored_scope_markers_file" ]]; then
+  cat "$ignored_scope_markers_file" >> "$changed_candidates_file"
+fi
+
+sort -u "$changed_candidates_file" \
+  | grep -E '^(apps/routeshyft-api/|apps/routeshyft-web/|tests/|_bmad-output/test-artifacts/epic-f-[^[:space:]]+|apps/[^/]+/node_modules$)' \
+  > "$changed_required_file" || true
 
 if [[ ! -s "$changed_required_file" ]]; then
-  echo "Story artifact hygiene check passed (no RouteShyft app/test story deltas detected)."
+  echo "Story artifact hygiene check passed (no story deltas detected in enforced hygiene scope)."
   exit 0
 fi
 
@@ -150,7 +166,7 @@ while IFS= read -r changed_path; do
 done < "$changed_required_file"
 
 if [[ $missing_file_list_entries -gt 0 ]]; then
-  echo "Story artifact hygiene check failed: $missing_file_list_entries changed RouteShyft app/test file(s) are missing from File List."
+  echo "Story artifact hygiene check failed: $missing_file_list_entries changed file(s) in enforced hygiene scope are missing from File List."
   exit 1
 fi
 

--- a/tests/api/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.api.spec.ts
+++ b/tests/api/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.api.spec.ts
@@ -238,6 +238,111 @@ Status: done
   }
 }
 
+type StoryArtifactHygieneHarnessOptions = {
+  includeEpicFEvidenceInFileList: boolean;
+  includeNodeModulesMarkerInFileList: boolean;
+};
+
+function runStoryArtifactHygieneHarness(
+  storyArtifactScript: string,
+  options: StoryArtifactHygieneHarnessOptions,
+): { output: string; status: number } {
+  const repoDir = mkdtempSync(join(tmpdir(), 'story-artifact-hygiene-harness-'));
+
+  try {
+    mkdirSync(join(repoDir, '_bmad-output/implementation-artifacts'), { recursive: true });
+    mkdirSync(join(repoDir, 'scripts'), { recursive: true });
+    mkdirSync(join(repoDir, 'apps/routeshyft-api'), { recursive: true });
+
+    copyFileSync(storyArtifactScript, join(repoDir, 'scripts/enforce-story-artifact-hygiene.sh'));
+
+    writeFileSync(
+      join(repoDir, '.gitignore'),
+      [
+        'apps/*/node_modules/',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const storyPath = join(
+      repoDir,
+      '_bmad-output/implementation-artifacts/8-7-verified-patch-application-policy.md',
+    );
+
+    const fileListEntries = [
+      '- `_bmad-output/implementation-artifacts/8-7-verified-patch-application-policy.md`',
+    ];
+    if (options.includeEpicFEvidenceInFileList) {
+      fileListEntries.push('- `_bmad-output/test-artifacts/epic-f-performance-evidence.json`');
+    }
+    if (options.includeNodeModulesMarkerInFileList) {
+      fileListEntries.push('- `apps/routeshyft-api/node_modules`');
+    }
+
+    writeFileSync(
+      storyPath,
+      [
+        '# Story 8.7',
+        '',
+        'Status: review',
+        '',
+        '### Debug Log References',
+        '- `npm run policy:check` (pass)',
+        '',
+        '### File List',
+        ...fileListEntries,
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    execFileSync('git', ['init'], { cwd: repoDir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'story-artifact-harness@example.com'], { cwd: repoDir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.name', 'Story Artifact Harness'], { cwd: repoDir, stdio: 'ignore' });
+    execFileSync('git', ['add', '.'], { cwd: repoDir, stdio: 'ignore' });
+    execFileSync('git', ['commit', '-m', 'seed story artifact hygiene harness'], { cwd: repoDir, stdio: 'ignore' });
+
+    mkdirSync(join(repoDir, '_bmad-output/test-artifacts'), { recursive: true });
+    writeFileSync(
+      join(repoDir, '_bmad-output/test-artifacts/epic-f-performance-evidence.json'),
+      JSON.stringify({ ok: true }),
+      'utf8',
+    );
+
+    mkdirSync(join(repoDir, 'apps/routeshyft-api/node_modules'), { recursive: true });
+    writeFileSync(join(repoDir, 'apps/routeshyft-api/node_modules/.keep'), 'ignore-marker\n', 'utf8');
+
+    try {
+      const output = execFileSync(
+        'bash',
+        [
+          'scripts/enforce-story-artifact-hygiene.sh',
+          '--story-file',
+          '_bmad-output/implementation-artifacts/8-7-verified-patch-application-policy.md',
+          '--base-ref',
+          'codex/dev',
+        ],
+        {
+          cwd: repoDir,
+          encoding: 'utf8',
+        },
+      );
+      return {
+        output,
+        status: 0,
+      };
+    } catch (error) {
+      const typed = error as { stdout?: string; stderr?: string; status?: number };
+      return {
+        output: `${typed.stdout ?? ''}${typed.stderr ?? ''}`,
+        status: typed.status ?? 1,
+      };
+    }
+  } finally {
+    rmSync(repoDir, { recursive: true, force: true });
+  }
+}
+
 test.describe('Story 1.5 policy gate and branch workflow guard enforcement API coverage', () => {
   test('[P0] enforces policy-first CI dependency chain and runs backend contracts only after quality gates @P0', async ({
     story15Context,
@@ -373,6 +478,34 @@ test.describe('Story 1.5 policy gate and branch workflow guard enforcement API c
       && /critical\/access-control but missing real-user validation evidence/.test(output)
       && /critical\/access-control but 'Real-User Validation Result' is not 'pass'/.test(output),
     ).toBe(true);
+  });
+
+  test('[P1] story artifact hygiene guard fails when epic-f evidence and node_modules markers are missing from File List @P1', async ({
+    story15Context,
+  }) => {
+    const storyArtifactScript = resolve(dirname(story15Context.policyScript), 'enforce-story-artifact-hygiene.sh');
+    const { output, status } = runStoryArtifactHygieneHarness(storyArtifactScript, {
+      includeEpicFEvidenceInFileList: false,
+      includeNodeModulesMarkerInFileList: false,
+    });
+
+    expect(
+      status !== 0
+      && /changed file missing from File List -> _bmad-output\/test-artifacts\/epic-f-performance-evidence\.json/.test(output)
+      && /changed file missing from File List -> apps\/routeshyft-api\/node_modules/.test(output),
+    ).toBe(true);
+  });
+
+  test('[P1] story artifact hygiene guard passes when File List covers epic-f evidence and node_modules markers @P1', async ({
+    story15Context,
+  }) => {
+    const storyArtifactScript = resolve(dirname(story15Context.policyScript), 'enforce-story-artifact-hygiene.sh');
+    const { output, status } = runStoryArtifactHygieneHarness(storyArtifactScript, {
+      includeEpicFEvidenceInFileList: true,
+      includeNodeModulesMarkerInFileList: true,
+    });
+
+    expect(status === 0 && /Story artifact hygiene check passed\./.test(output)).toBe(true);
   });
 
   test('[P1] rejects epic workflow branch mismatch with explicit expected epic branch diagnostic @P1', async ({


### PR DESCRIPTION
## Summary
- strengthen `scripts/enforce-story-artifact-hygiene.sh` to enforce File List coverage for additional audit-critical scope:
  - untracked `_bmad-output/test-artifacts/epic-f-*`
  - ignored `apps/*/node_modules` directory markers when present in git status
- keep existing RouteShyft app/web/tests coverage and debug log pass-marker requirement
- document expanded enforcement scope in `docs/policies/git_policy.md`
- add policy API regression coverage for both fail and pass cases of the new scope

## Why
Review finding showed story File Lists can drift from real working-tree deltas for generated Epic F evidence and untracked node_modules markers, weakening auditability.

## Validation
- `npm run test:e2e -- tests/api/platform/1-5-policy-gate-and-branch-workflow-guard-enforcement.api.spec.ts`
- `npm run policy:check`
