### PR TITLE
Story 6.2: Bridge completion endpoint and idempotency

### DIFF
--- a/apps/routeshyft-api/src/routes/api/v1/__tests__/route.bridge.test.ts
+++ b/apps/routeshyft-api/src/routes/api/v1/__tests__/route.bridge.test.ts
@@ -183,4 +183,210 @@ describe('route bridge api contract', () => {
       refusalType: 'business',
     });
   });
+
+  it('applies completion transition with traceable idempotency and lineage fields', async () => {
+    const { app, commitmentService } = buildApp();
+
+    const created = await commitmentService.createCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      actorId: 'user-route-bridge-1',
+      sourceType: 'wordpress_fulfillment',
+      sourceId: 'wp-fulfillment-complete-1',
+      orgUnitId: 'org-route-bridge-1',
+      externalRef: 'wp-lineage-complete-1',
+    });
+
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      throw new Error('Expected commitment creation to succeed');
+    }
+
+    await commitmentService.transitionCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      commitmentId: created.data.commitment.commitmentId,
+      actorId: 'user-route-bridge-1',
+      nextStatus: 'in_progress',
+      reason: 'Driver started fulfillment',
+    });
+
+    const response = await request(app)
+      .post(`/api/v1/route-bridge/fulfillment/${created.data.commitment.commitmentId}/completion`)
+      .send({
+        idempotencyKey: 'completion-key-1',
+        bridgeLineageId: 'wp-lineage-complete-1',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'ROUTE_BRIDGE_COMPLETION_APPLIED',
+      data: {
+        bridge: {
+          integration: 'wordpress',
+          stateAuthority: 'monolith',
+          lineageId: 'wp-lineage-complete-1',
+        },
+        idempotency: {
+          key: 'completion-key-1',
+          replayed: false,
+        },
+        completion: {
+          commitmentId: created.data.commitment.commitmentId,
+          transitionApplied: true,
+          transitionAuditId: expect.any(String),
+        },
+        canonicalLifecycle: {
+          commitment: {
+            commitmentId: created.data.commitment.commitmentId,
+            status: 'completed',
+            externalRef: 'wp-lineage-complete-1',
+          },
+          state: {
+            status: 'completed',
+            isTerminal: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('returns idempotent replay response for duplicate completion retries', async () => {
+    const { app, commitmentService } = buildApp();
+
+    const created = await commitmentService.createCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      actorId: 'user-route-bridge-1',
+      sourceType: 'wordpress_fulfillment',
+      sourceId: 'wp-fulfillment-complete-2',
+      orgUnitId: 'org-route-bridge-1',
+      externalRef: 'wp-lineage-complete-2',
+    });
+
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      throw new Error('Expected commitment creation to succeed');
+    }
+
+    await commitmentService.transitionCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      commitmentId: created.data.commitment.commitmentId,
+      actorId: 'user-route-bridge-1',
+      nextStatus: 'in_progress',
+      reason: 'Driver started fulfillment',
+    });
+
+    const payload = {
+      idempotencyKey: 'completion-key-2',
+      bridgeLineageId: 'wp-lineage-complete-2',
+    };
+
+    const first = await request(app)
+      .post(`/api/v1/route-bridge/fulfillment/${created.data.commitment.commitmentId}/completion`)
+      .send(payload);
+    const second = await request(app)
+      .post(`/api/v1/route-bridge/fulfillment/${created.data.commitment.commitmentId}/completion`)
+      .send(payload);
+
+    expect(first.status).toBe(200);
+    expect(first.body.code).toBe('ROUTE_BRIDGE_COMPLETION_APPLIED');
+    expect(second.status).toBe(200);
+    expect(second.body).toMatchObject({
+      ok: true,
+      code: 'ROUTE_BRIDGE_COMPLETION_IDEMPOTENT_REPLAY',
+      data: {
+        idempotency: {
+          key: 'completion-key-2',
+          replayed: true,
+        },
+        completion: {
+          commitmentId: created.data.commitment.commitmentId,
+          transitionApplied: false,
+        },
+        canonicalLifecycle: {
+          commitment: {
+            status: 'completed',
+          },
+          state: {
+            status: 'completed',
+            isTerminal: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('refuses completion when bridge lineage identifier does not match commitment lineage', async () => {
+    const { app, commitmentService } = buildApp();
+
+    const created = await commitmentService.createCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      actorId: 'user-route-bridge-1',
+      sourceType: 'wordpress_fulfillment',
+      sourceId: 'wp-fulfillment-complete-3',
+      orgUnitId: 'org-route-bridge-1',
+      externalRef: 'wp-lineage-complete-3',
+    });
+
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      throw new Error('Expected commitment creation to succeed');
+    }
+
+    await commitmentService.transitionCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      commitmentId: created.data.commitment.commitmentId,
+      actorId: 'user-route-bridge-1',
+      nextStatus: 'in_progress',
+      reason: 'Driver started fulfillment',
+    });
+
+    const response = await request(app)
+      .post(`/api/v1/route-bridge/fulfillment/${created.data.commitment.commitmentId}/completion`)
+      .send({
+        idempotencyKey: 'completion-key-3',
+        bridgeLineageId: 'wp-lineage-different',
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'ROUTE_BRIDGE_LINEAGE_MISMATCH',
+      refusalType: 'business',
+      data: {
+        commitmentExternalRef: 'wp-lineage-complete-3',
+        bridgeLineageId: 'wp-lineage-different',
+      },
+    });
+  });
+
+  it('requires idempotency key for completion submissions', async () => {
+    const { app, commitmentService } = buildApp();
+
+    const created = await commitmentService.createCommitment({
+      tenantId: 'tenant-route-bridge-1',
+      actorId: 'user-route-bridge-1',
+      sourceType: 'wordpress_fulfillment',
+      sourceId: 'wp-fulfillment-complete-4',
+      orgUnitId: 'org-route-bridge-1',
+      externalRef: 'wp-lineage-complete-4',
+    });
+
+    expect(created.ok).toBe(true);
+    if (!created.ok) {
+      throw new Error('Expected commitment creation to succeed');
+    }
+
+    const response = await request(app)
+      .post(`/api/v1/route-bridge/fulfillment/${created.data.commitment.commitmentId}/completion`)
+      .send({
+        bridgeLineageId: 'wp-lineage-complete-4',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'ROUTE_BRIDGE_IDEMPOTENCY_KEY_REQUIRED',
+      refusalType: 'client',
+    });
+  });
 });

--- a/apps/routeshyft-api/src/routes/api/v1/route-bridge.ts
+++ b/apps/routeshyft-api/src/routes/api/v1/route-bridge.ts
@@ -157,6 +157,22 @@ const parsePendingLimit = (req: Request): number => {
 const parsePendingOrgUnit = (req: Request): string | null =>
   normalizeNonEmptyString(req.query?.orgUnitId || null) || null;
 
+const parseCommitmentIdParam = (req: Request): string =>
+  normalizeNonEmptyString(req.params.commitmentId || null);
+
+const parseCompletionBody = (req: Request) => ({
+  idempotencyKey: normalizeNonEmptyString(
+    req.body?.idempotencyKey
+    || req.body?.completionIdempotencyKey,
+  ),
+  bridgeLineageId: normalizeNonEmptyString(
+    req.body?.bridgeLineageId
+    || req.body?.externalRef
+    || req.body?.wpRequestId,
+  ),
+  reason: normalizeNonEmptyString(req.body?.reason),
+});
+
 const applyServiceRefusal = (
   res: Response,
   rejected: {
@@ -179,6 +195,61 @@ const applyServiceRefusal = (
 const localizeRouteResponseData = (req: Request, data: unknown): Record<string, unknown> => {
   const timezoneContext = resolveRouteTimezoneContext(req);
   return localizeRouteOperationalData(data, timezoneContext);
+};
+
+const buildCompletionReason = (
+  reason: string,
+  idempotencyKey: string,
+  bridgeLineageId: string,
+): string => {
+  if (reason) {
+    return reason;
+  }
+
+  return `Bridge completion submitted [lineage=${bridgeLineageId}; key=${idempotencyKey}]`;
+};
+
+const applyIdempotentReplaySuccess = (
+  req: Request,
+  res: Response,
+  resolved: {
+    data: {
+      commitment: {
+        commitmentId: string;
+        status: string;
+      };
+      state: unknown;
+    };
+  },
+  idempotencyKey: string,
+  bridgeLineageId: string,
+  transitionApplied: boolean,
+): void => {
+  success(res, {
+    code: transitionApplied
+      ? 'ROUTE_BRIDGE_COMPLETION_APPLIED'
+      : 'ROUTE_BRIDGE_COMPLETION_IDEMPOTENT_REPLAY',
+    message: transitionApplied
+      ? 'Bridge completion applied'
+      : 'Bridge completion replay acknowledged',
+    httpStatus: 200,
+    data: localizeRouteResponseData(req, {
+      bridge: {
+        integration: 'wordpress',
+        stateAuthority: 'monolith',
+        lineageId: bridgeLineageId,
+      },
+      idempotency: {
+        key: idempotencyKey,
+        replayed: !transitionApplied,
+      },
+      completion: {
+        commitmentId: resolved.data.commitment.commitmentId,
+        transitionApplied,
+      },
+      canonicalLifecycle: resolved.data,
+    }),
+  });
 };
 
 export const createRouteBridgeRouter = (
@@ -273,6 +344,145 @@ export const createRouteBridgeRouter = (
         canonicalLifecycle: pending.data,
       }),
     });
+  });
+
+  router.post('/fulfillment/:commitmentId/completion', async (req: Request, res: Response) => {
+    const tenantId = resolveTenantId(req, res);
+    if (!tenantId) {
+      return;
+    }
+
+    const commitmentId = parseCommitmentIdParam(req);
+    if (!commitmentId) {
+      refusal(res, {
+        code: 'ROUTE_COMMITMENT_ID_REQUIRED',
+        message: 'commitmentId is required.',
+        refusalType: 'client',
+        httpStatus: 400,
+      });
+      return;
+    }
+
+    const completion = parseCompletionBody(req);
+    if (!completion.idempotencyKey) {
+      refusal(res, {
+        code: 'ROUTE_BRIDGE_IDEMPOTENCY_KEY_REQUIRED',
+        message: 'idempotencyKey is required for bridge completion submissions.',
+        refusalType: 'client',
+        httpStatus: 400,
+      });
+      return;
+    }
+
+    if (!completion.bridgeLineageId) {
+      refusal(res, {
+        code: 'ROUTE_BRIDGE_LINEAGE_ID_REQUIRED',
+        message: 'bridgeLineageId is required for bridge completion submissions.',
+        refusalType: 'client',
+        httpStatus: 400,
+      });
+      return;
+    }
+
+    const resolved = await commitmentService.resolveCommitment({
+      tenantId,
+      commitmentId,
+    });
+    if (!resolved.ok) {
+      applyServiceRefusal(res, resolved);
+      return;
+    }
+
+    const commitment = resolved.data.commitment;
+    if (commitment.externalRef !== completion.bridgeLineageId) {
+      refusal(res, {
+        code: 'ROUTE_BRIDGE_LINEAGE_MISMATCH',
+        message: 'bridgeLineageId does not match commitment lineage reference.',
+        refusalType: 'business',
+        httpStatus: 409,
+        data: {
+          commitmentId,
+          commitmentExternalRef: commitment.externalRef,
+          bridgeLineageId: completion.bridgeLineageId,
+        },
+      });
+      return;
+    }
+
+    if (commitment.status === 'completed') {
+      applyIdempotentReplaySuccess(
+        req,
+        res,
+        resolved,
+        completion.idempotencyKey,
+        completion.bridgeLineageId,
+        false,
+      );
+      return;
+    }
+
+    const transitioned = await commitmentService.transitionCommitment({
+      tenantId,
+      commitmentId,
+      actorId: resolveActorId(req),
+      nextStatus: 'completed',
+      reason: buildCompletionReason(
+        completion.reason,
+        completion.idempotencyKey,
+        completion.bridgeLineageId,
+      ),
+    });
+
+    if (transitioned.ok) {
+      success(res, {
+        code: 'ROUTE_BRIDGE_COMPLETION_APPLIED',
+        message: 'Bridge completion applied',
+        httpStatus: 200,
+        data: localizeRouteResponseData(req, {
+          bridge: {
+            integration: 'wordpress',
+            stateAuthority: 'monolith',
+            lineageId: completion.bridgeLineageId,
+          },
+          idempotency: {
+            key: completion.idempotencyKey,
+            replayed: false,
+          },
+          completion: {
+            commitmentId,
+            transitionApplied: true,
+            transitionAuditId: transitioned.data.transition.transitionAuditId,
+          },
+          canonicalLifecycle: {
+            commitment: transitioned.data.commitment,
+            state: transitioned.data.state,
+          },
+        }),
+      });
+      return;
+    }
+
+    const resolvedAfterFailure = await commitmentService.resolveCommitment({
+      tenantId,
+      commitmentId,
+    });
+    if (
+      !resolvedAfterFailure.ok
+      || resolvedAfterFailure.data.commitment.status !== 'completed'
+      || resolvedAfterFailure.data.commitment.externalRef !== completion.bridgeLineageId
+    ) {
+      applyServiceRefusal(res, transitioned);
+      return;
+    }
+
+    applyIdempotentReplaySuccess(
+      req,
+      res,
+      resolvedAfterFailure,
+      completion.idempotencyKey,
+      completion.bridgeLineageId,
+      false,
+    );
   });
 
   return router;


### PR DESCRIPTION
## Summary
- add `POST /api/v1/route-bridge/fulfillment/:commitmentId/completion` endpoint for WordPress bridge completion submissions
- enforce required bridge completion fields (`idempotencyKey`, `bridgeLineageId`) with explicit refusal contracts
- preserve bridge lineage by validating `bridgeLineageId` matches commitment `externalRef`
- implement idempotent retry behavior:
  - first completion applies canonical lifecycle transition to `completed`
  - duplicate/retry submissions return deterministic replay response without duplicate transition side effects
- include traceable completion metadata (`idempotency key`, `lineageId`, `transitionAuditId` when applied)

## Validation
- `npm test -- --runInBand src/routes/api/v1/__tests__/route.bridge.test.ts` (apps/routeshyft-api)
- `npm run build` (apps/routeshyft-api)
- `npm run policy:check`
