### PR TITLE
Fix: finalize stale epic status metadata and queue cleanup

### DIFF
--- a/_bmad-output/implementation-artifacts/next-unblocked-queue-connectshyft.md
+++ b/_bmad-output/implementation-artifacts/next-unblocked-queue-connectshyft.md
@@ -1,19 +1,17 @@
 # ConnectShyft Next Unblocked Queue
 
-Generated: 2026-02-26
-Focus: Close b-3 review and unlock b-4 start
+Generated: 2026-03-07
+Focus: Queue closed for Epics A-G (all current stories marked done)
 
 ## Immediate Queue
 
-1. `b-3-relationship-gated-neighbor-edits-with-provenance-audit`
-   - Status: `review`
-   - Next action: final closeout transition to `done`
-2. `b-4-role-restricted-neighbor-merge-with-irreversible-confirmation`
-   - Status: `ready-for-dev`
-   - Dependency status: `b-3-relationship-gated-neighbor-edits-with-provenance-audit: review` (start only after `done`)
+1. No immediate unblocked queue items.
+   - Status: `clear`
+   - Next action: wait for new story creation or approved scope changes.
 
 ## Notes
 
 - Keep `development_status` values constrained to:
   - `backlog`, `ready-for-dev`, `in-progress`, `review`, `done`
 - Track temporary blocked states under `blocked_story_registry` in sprint status.
+- This queue snapshot was refreshed after status synchronization closed stale Epic B/C/D/E and Epic G metadata drift.

--- a/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status-connectshyft.yaml
@@ -50,26 +50,26 @@ development_status:
   a-4-escalation-baseline-and-recipient-configuration: done
   a-5-capability-based-route-access-and-envelope-contract-compliance: done
   epic-a-retrospective: done
-  epic-b: in-progress
+  epic-b: done
   b-1-tenant-scoped-neighbor-creation-with-required-phone: done
   b-2-shared-tenant-identity-and-shared-phone-indicators: done
   b-3-relationship-gated-neighbor-edits-with-provenance-audit: done
   b-4-role-restricted-neighbor-merge-with-irreversible-confirmation: done
   epic-b-retrospective: optional
-  epic-c: in-progress
+  epic-c: done
   c-1-core-connectshyft-thread-schema-and-lifecycle-constraints: done
   c-2-thread-ensure-endpoint-with-conflict-safe-idempotency: done
   c-3-inbox-and-thread-detail-read-contracts: done
   c-4-claim-takeover-and-close-lifecycle-actions: done
   c-5-deterministic-escalation-scheduler-with-claim-only-reset: done
   epic-c-retrospective: optional
-  epic-d: in-progress
+  epic-d: done
   d-1-outbound-sms-call-actions-that-preserve-escalation-semantics: done
   d-2-preference-override-enforcement-for-outbound-sms: done
   d-3-outbound-audit-outbox-and-refusal-envelope-integration: done
   d-4-operator-interaction-contracts-for-outbound-safety: done
   epic-d-retrospective: optional
-  epic-e: in-progress
+  epic-e: done
   e-1-verified-webhook-ingress-and-deterministic-context-routing: done
   e-2-inbound-sms-processing-with-active-thread-ensure: done
   e-3-inbound-voice-webhook-to-voicemail-artifact-pipeline: done

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -100,7 +100,7 @@ development_status:
   7-2-pos-origin-commitment-and-completion-linkage: backlog
   7-3-expansion-guardrails-and-consent-readiness-gates: backlog
   epic-7-retrospective: optional
-  epic-8: in-progress
+  epic-8: done
   8-1-workspace-scaffold-and-nx-baseline: done
   8-2-mechanical-app-moves-with-history-preservation: done
   8-3-explicit-lane-boundary-rules: done


### PR DESCRIPTION
## Summary
- mark stale completed epics as `done` in status files:
  - ConnectShyft: `epic-b`, `epic-c`, `epic-d`, `epic-e`
  - Core sprint status: `epic-8`
- refresh `_bmad-output/implementation-artifacts/next-unblocked-queue-connectshyft.md` to reflect no immediate queue items
- remove stray repository file `done`

## Validation
- `npm run policy:check` (pass)
