### PR TITLE
Spec 001 – normalize canonical service naming map

### DIFF
--- a/architecture/contracts/production_deployment_contract.md
+++ b/architecture/contracts/production_deployment_contract.md
@@ -38,8 +38,8 @@ It does not yet cover the rest of the commented-out lanes except where future-sa
 
 ### API loopback ports
 - `admin-api` -> `127.0.0.1:3100`
-- `moneyshyft-api` -> `127.0.0.1:3000`
-- `connectshyft-api` -> `127.0.0.1:3002`
+- `money-api` -> `127.0.0.1:3000`
+- `connect-api` -> `127.0.0.1:3002`
 
 ## Routing contract
 
@@ -49,12 +49,12 @@ It does not yet cover the rest of the commented-out lanes except where future-sa
 ### Money
 - `/api/v1/auth/*` -> `admin-api`
 - `/api/v1/platform/admin/*` -> `admin-api`
-- all other `/api/*` -> `moneyshyft-api`
+- all other `/api/*` -> `money-api`
 
 ### Connect
 - `/api/v1/auth/*` -> `admin-api`
 - `/api/v1/platform/admin/*` -> `admin-api`
-- all other `/api/*` -> `connectshyft-api`
+- all other `/api/*` -> `connect-api`
 
 ## Shared Postgres contract
 

--- a/specs/001-tighten-deployment-contracts/tasks.md
+++ b/specs/001-tighten-deployment-contracts/tasks.md
@@ -37,7 +37,7 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T005 Normalize canonical service naming map in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/production_deployment_contract.md`
+- [x] T005 Normalize canonical service naming map in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/production_deployment_contract.md`
 - [ ] T006 [P] Normalize canonical frontend path expectations in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/two_part_brief.md`
 - [ ] T007 [P] Lock migration authority language in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/database_ownership_and_migration_authority.md`
 - [ ] T008 Define single-server deployment prerequisites in `/Users/jeremiahotis/projects/connectshyft/specs/001-tighten-deployment-contracts/quickstart.md`


### PR DESCRIPTION
Closes #76

Normalizes canonical service identifiers and updates tasks.md.