### PR TITLE
Docs(spec-001): align acceptance evidence checkpoints

### DIFF
--- a/architecture/contracts/acceptance_test_matrix.md
+++ b/architecture/contracts/acceptance_test_matrix.md
@@ -1,5 +1,15 @@
 # Acceptance Test Matrix
 
+## Scope alignment (Spec 001)
+- acceptance evidence for spec 001 is limited to deployment-tightening scope only
+- acceptance criteria in this round must not expand into Product Shell, domain architecture, event bus, reusable UI system, or future-lane scope
+
+## Acceptance evidence checkpoints
+- checkpoints must cover admin, money, connect, routing, shared Postgres authority, ingress/port exposure, and reproducible deployment flow
+- routing checkpoints align with `/Users/jeremiahotis/projects/connectshyft/specs/001-tighten-deployment-contracts/evidence/routing-verification-matrix.md`
+- shared Postgres authority checkpoints align with `/Users/jeremiahotis/projects/connectshyft/specs/001-tighten-deployment-contracts/evidence/database-authority-verification.md`
+- ingress/port exposure checkpoints align with `/Users/jeremiahotis/projects/connectshyft/specs/001-tighten-deployment-contracts/evidence/security-boundary-verification.md`
+
 ## Admin
 
 ### Web
@@ -41,12 +51,13 @@
 - all three API containers show the same target `DATABASE_URL` host and DB name
 - `pg_stat_activity` confirms live connections from all three services
 
-## Visibility and capability posture
-- user with required capability sees lane entry
-- user without required capability does not see lane entry
-- unauthorized direct route access is rejected or redirected correctly
+## Ingress and port exposure
+- public ingress is limited to HTTPS on nginx
+- API services are bound for internal/localhost access only and not publicly exposed
+- direct non-nginx API access is rejected or unavailable
 
 ## Operational checks
 - `nginx -t` passes
 - all three `/health` endpoints pass
 - container logs do not show upstream mismatch or DB connection errors
+- reproducible deployment flow evidence is captured in `/Users/jeremiahotis/projects/connectshyft/specs/001-tighten-deployment-contracts/evidence/runbook-reproducibility.md`

--- a/specs/001-tighten-deployment-contracts/tasks.md
+++ b/specs/001-tighten-deployment-contracts/tasks.md
@@ -41,7 +41,7 @@
 - [x] T006 [P] Normalize canonical frontend path expectations in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/two_part_brief.md`
 - [x] T007 [P] Lock migration authority language in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/database_ownership_and_migration_authority.md`
 - [x] T008 Define single-server deployment prerequisites in `/Users/jeremiahotis/projects/connectshyft/specs/001-tighten-deployment-contracts/quickstart.md`
-- [ ] T009 Align acceptance evidence checkpoints with scope in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/acceptance_test_matrix.md`
+- [x] T009 Align acceptance evidence checkpoints with scope in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/acceptance_test_matrix.md`
 - [ ] T010 Lock required environment artifact list in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/developer_execution_packet.md`
 
 **Checkpoint**: Foundation ready - user story implementation can now begin in parallel


### PR DESCRIPTION
Closes #80\n\n## Summary\n- align acceptance evidence scope to deployment-tightening only for spec 001\n- require checkpoints across admin, money, connect, routing, shared Postgres authority, ingress/port exposure, and reproducible deployment flow\n- align checkpoint references to existing routing, database authority, and security boundary evidence artifacts\n- mark T009 complete in tasks tracker