### PR TITLE
Docs(spec-001): lock required environment artifact list

### DIFF
--- a/architecture/contracts/developer_execution_packet.md
+++ b/architecture/contracts/developer_execution_packet.md
@@ -33,15 +33,25 @@ Using:
 - `moneyshyft-api` -> `3000`
 - `connectshyft-api` -> `3002`
 
-### Frontend roots
-- `/home/jeremiahotis/projects/shyftunity/apps/admin-web/dist`
-- `/home/jeremiahotis/projects/shyftunity/apps/moneyshyft-web/dist`
-- `/home/jeremiahotis/projects/shyftunity/apps/connectshyft-web/dist`
+### Required environment artifacts (spec 001 deployment-tightening scope only)
+This list is explicit and complete for this round. It is limited to the current three-lane deployment model and must not expand into future lanes, future domains, or unrelated infrastructure.
 
-### Env files
+#### Lane API env files (required)
 - `/opt/shyftunity/env/admin-api.env`
 - `/opt/shyftunity/env/moneyshyft-api.env`
 - `/opt/shyftunity/env/connectshyft-api.env`
+
+#### Required lane API env posture
+- Shared host Postgres connectivity is required via `host.docker.internal` with host-gateway mapping.
+- Each lane API env must set its canonical lane API port: `admin-api=3100`, `moneyshyft-api=3000`, `connectshyft-api=3002`.
+- Scope remains the three lanes only: `admin`, `money`, and `connect`.
+
+#### Current lane frontend URLs and static roots (where relevant)
+- `https://admin.shyftunity.com` -> `/home/jeremiahotis/projects/shyftunity/apps/admin-web/dist`
+- `https://money.shyftunity.com` -> `/home/jeremiahotis/projects/shyftunity/apps/moneyshyft-web/dist`
+- `https://connect.shyftunity.com` -> `/home/jeremiahotis/projects/shyftunity/apps/connectshyft-web/dist`
+
+This artifact contract remains aligned to the current deployment model only: host Nginx, host Postgres, Dockerized Node APIs, static frontend builds, and the three-lane scope.
 
 ## Required implementation work
 

--- a/specs/001-tighten-deployment-contracts/tasks.md
+++ b/specs/001-tighten-deployment-contracts/tasks.md
@@ -42,7 +42,7 @@
 - [x] T007 [P] Lock migration authority language in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/database_ownership_and_migration_authority.md`
 - [x] T008 Define single-server deployment prerequisites in `/Users/jeremiahotis/projects/connectshyft/specs/001-tighten-deployment-contracts/quickstart.md`
 - [x] T009 Align acceptance evidence checkpoints with scope in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/acceptance_test_matrix.md`
-- [ ] T010 Lock required environment artifact list in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/developer_execution_packet.md`
+- [x] T010 Lock required environment artifact list in `/Users/jeremiahotis/projects/connectshyft/architecture/contracts/developer_execution_packet.md`
 
 **Checkpoint**: Foundation ready - user story implementation can now begin in parallel
 


### PR DESCRIPTION
Closes #81\n\n## Summary\n- lock the required environment artifact list for spec 001 to three-lane deployment-tightening scope only\n- require lane API env files for admin, moneyshyft, and connectshyft\n- document shared host Postgres connectivity, canonical API ports, and current lane frontend URLs/static roots\n- prevent scope expansion into future lanes/domains or unrelated infrastructure\n- mark T010 complete in tasks.md