### PR TITLE
Fix: restore connectshyft-api production build

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts
@@ -691,6 +691,7 @@ export class InMemoryConnectShyftNeighborStore {
       orgUnitId: input.orgUnitId,
       firstName: input.firstName,
       lastName: input.lastName,
+      prefersTexting: 'UNKNOWN',
       phones: input.phones.map((phone) => ({
         phoneId: randomUUID(),
         label: phone.label,

--- a/apps/connectshyft-api/src/platform/middleware/__tests__/csrfProtection.test.ts
+++ b/apps/connectshyft-api/src/platform/middleware/__tests__/csrfProtection.test.ts
@@ -19,9 +19,9 @@ describe('csrfProtection middleware', () => {
 
   it('rejects authenticated state-changing requests without CSRF token', async () => {
     const app = buildApp();
+    const postResource = request(app).post('/resource') as any;
 
-    const response = await request(app)
-      .post('/resource')
+    const response = await postResource
       .set('Cookie', ['access_token=access-token']);
 
     expect(response.status).toBe(403);
@@ -34,9 +34,9 @@ describe('csrfProtection middleware', () => {
 
   it('rejects authenticated state-changing requests with invalid CSRF token', async () => {
     const app = buildApp();
+    const postResource = request(app).post('/resource') as any;
 
-    const response = await request(app)
-      .post('/resource')
+    const response = await postResource
       .set('Cookie', ['access_token=access-token', 'csrf_token=cookie-token'])
       .set('X-CSRF-Token', 'header-token');
 
@@ -50,9 +50,9 @@ describe('csrfProtection middleware', () => {
 
   it('allows authenticated state-changing requests with matching CSRF token', async () => {
     const app = buildApp();
+    const postResource = request(app).post('/resource') as any;
 
-    const response = await request(app)
-      .post('/resource')
+    const response = await postResource
       .set('Cookie', ['access_token=access-token', 'csrf_token=csrf-token'])
       .set('X-CSRF-Token', 'csrf-token');
 
@@ -62,9 +62,9 @@ describe('csrfProtection middleware', () => {
 
   it('does not enforce CSRF on safe methods', async () => {
     const app = buildApp();
+    const getResource = request(app).get('/resource') as any;
 
-    const response = await request(app)
-      .get('/resource')
+    const response = await getResource
       .set('Cookie', ['access_token=access-token']);
 
     expect(response.status).toBe(200);

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -1528,6 +1528,7 @@ const buildSyntheticThreadDetailRecord = (input: {
 
   return {
     threadId: input.threadId,
+    neighborId: input.descriptor.neighborId || null,
     tenantId: input.descriptor.tenantId,
     orgUnitId: input.descriptor.orgUnitId,
     state: input.descriptor.state,

--- a/apps/connectshyft-api/src/utils/logger.ts
+++ b/apps/connectshyft-api/src/utils/logger.ts
@@ -1,5 +1,24 @@
 import winston from 'winston';
 
+type ConsoleTransportOptions = ConstructorParameters<typeof winston.transports.Console>[0];
+type FileTransportOptions = ConstructorParameters<typeof winston.transports.File>[0];
+
+const consoleTransportOptions = {
+  format: winston.format.combine(
+    winston.format.colorize(),
+    winston.format.simple()
+  )
+} as unknown as ConsoleTransportOptions;
+
+const errorFileTransportOptions = {
+  filename: 'error.log',
+  level: 'error'
+} as unknown as FileTransportOptions;
+
+const combinedFileTransportOptions = {
+  filename: 'combined.log'
+} as unknown as FileTransportOptions;
+
 const logger = winston.createLogger({
   level: process.env.LOG_LEVEL || 'info',
   format: winston.format.combine(
@@ -9,19 +28,14 @@ const logger = winston.createLogger({
   ),
   defaultMeta: { service: 'moneyshyft-api' },
   transports: [
-    new winston.transports.Console({
-      format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.simple()
-      )
-    })
+    new winston.transports.Console(consoleTransportOptions)
   ]
 });
 
 // In production, you might want to add file transports
 if (process.env.NODE_ENV === 'production') {
-  logger.add(new winston.transports.File({ filename: 'error.log', level: 'error' }));
-  logger.add(new winston.transports.File({ filename: 'combined.log' }));
+  logger.add(new winston.transports.File(errorFileTransportOptions));
+  logger.add(new winston.transports.File(combinedFileTransportOptions));
 }
 
 export default logger;


### PR DESCRIPTION
## Summary
- restore the ConnectShyft API production build after the volunteer UX merge tightened API type contracts
- add the missing in-memory neighbor preference default and synthetic thread neighbor id required by the updated ConnectShyft read models
- resolve follow-on TypeScript drift in the ConnectShyft API CSRF test and logger transport typing so the production build compiles cleanly

## Local verification
- cd apps/connectshyft-api && npm run build

## Notes
- this PR contains the post-merge follow-up commit on top of the already-merged volunteer UX rebuild
- I could not rerun Docker locally in this workspace because the Docker daemon is unavailable here