### PR TITLE
Feat: implement CS-002 phone identity

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,10 +39,12 @@ module.exports = {
                 "group": [
                   "packages/shared-*/src/*",
                   "**/packages/shared-*/src/*",
+                  "domains/*/*",
+                  "**/domains/*/*",
                   "@*/shared-*/*",
                   "shared-*/*"
                 ],
-                "message": "Deep imports across shared package boundaries are forbidden. Re-export from src/index.ts and import from the package root."
+                "message": "Deep imports across shared package/domain boundaries are forbidden. Re-export from the public root entrypoint and import from that root."
               }
             ]
           }

--- a/apps/connectshyft-api/jest.config.js
+++ b/apps/connectshyft-api/jest.config.js
@@ -1,7 +1,10 @@
 module.exports = {
   testEnvironment: 'node',
-  roots: ['<rootDir>/src'],
-  testMatch: ['<rootDir>/src/**/__tests__/**/*.test.ts'],
+  roots: ['<rootDir>/src', '<rootDir>/../../domains/communication'],
+  testMatch: [
+    '<rootDir>/src/**/__tests__/**/*.test.ts',
+    '<rootDir>/../../domains/communication/**/__tests__/**/*.test.ts',
+  ],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
   moduleFileExtensions: ['ts', 'js', 'json'],
   modulePaths: ['<rootDir>/node_modules'],

--- a/apps/connectshyft-api/package.json
+++ b/apps/connectshyft-api/package.json
@@ -5,7 +5,7 @@
   "main": "dist/server.js",
   "scripts": {
     "dev": "ts-node --transpile-only src/server.ts",
-    "build": "tsc",
+    "build": "tsc && node ./scripts/writeDistServerEntrypoint.js",
     "start": "node dist/server.js",
     "migrate:latest": "node -r ts-node/register ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env development migrate:latest",
     "migrate:latest:prod": "NODE_ENV=production node ./scripts/enforceProdMigrationAuthority.js && NODE_ENV=production node ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env production migrate:latest",
@@ -14,8 +14,8 @@
     "migrate:make": "node -r ts-node/register ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env development migrate:make",
     "seed:run": "node -r ts-node/register ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env development seed:run",
     "seed:run:prod": "NODE_ENV=production node ./scripts/enforceProdMigrationAuthority.js && NODE_ENV=production node ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env production seed:run",
-    "test": "jest --runInBand --testPathPattern=connectshyft",
-    "test:connectshyft": "jest --runInBand --testPathPattern=connectshyft",
+    "test": "NODE_ENV=test jest --runInBand --testPathPattern=connectshyft",
+    "test:connectshyft": "NODE_ENV=test jest --runInBand --testPathPattern=connectshyft",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/apps/connectshyft-api/project.json
+++ b/apps/connectshyft-api/project.json
@@ -14,6 +14,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "inputs": ["default", "{workspaceRoot}/domains/communication/**/*"],
       "options": {
         "cwd": "apps/connectshyft-api",
         "command": "npm run build"
@@ -28,6 +29,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
+      "inputs": ["default", "{workspaceRoot}/domains/communication/**/*"],
       "options": {
         "cwd": "apps/connectshyft-api",
         "command": "npm run test:connectshyft"

--- a/apps/connectshyft-api/scripts/writeDistServerEntrypoint.js
+++ b/apps/connectshyft-api/scripts/writeDistServerEntrypoint.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.resolve(__dirname, '..', 'dist');
+const compiledEntrypoint = path.join(distDir, 'apps', 'connectshyft-api', 'src', 'server.js');
+const bootstrapEntrypoint = path.join(distDir, 'server.js');
+
+if (!fs.existsSync(compiledEntrypoint)) {
+  throw new Error(`Compiled server entrypoint not found at ${compiledEntrypoint}`);
+}
+
+fs.writeFileSync(
+  bootstrapEntrypoint,
+  `'use strict';\nrequire('./apps/connectshyft-api/src/server.js');\n`,
+  'utf8',
+);

--- a/apps/connectshyft-api/src/knexfile.ts
+++ b/apps/connectshyft-api/src/knexfile.ts
@@ -65,6 +65,16 @@ const buildNonProductionConnection = (): string | Knex.StaticConnectionConfig =>
     return process.env.DATABASE_URL;
   }
 
+  if (process.env.NODE_ENV === 'test') {
+    return {
+      host: '127.0.0.1',
+      port: 5432,
+      database: 'connectshyft_test',
+      user: 'postgres',
+      password: 'test-db-password',
+    };
+  }
+
   const portValue = resolveRequiredEnv('DATABASE_PORT', 'DB_PORT');
   const parsedPort = parseInt(portValue, 10);
   if (Number.isNaN(parsedPort)) {

--- a/apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts
+++ b/apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts
@@ -1,0 +1,206 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const NEIGHBOR_PHONES_TABLE = 'cs_neighbor_phones';
+const VALIDATION_STATUS_CHECK = 'cs_neighbor_phones_validation_status_ck';
+const USAGE_TYPE_CHECK = 'cs_neighbor_phones_usage_type_ck';
+const SOURCE_CHECK = 'cs_neighbor_phones_source_ck';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS raw_input TEXT NULL
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS normalized_e164 TEXT
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS display_national TEXT NULL
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS country_code TEXT NULL
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS national_number TEXT NULL
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS extension TEXT NULL
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS validation_status TEXT NOT NULL DEFAULT 'valid'
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS usage_type TEXT NOT NULL DEFAULT 'unknown'
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'user_entered'
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE
+  `);
+
+  await knex.raw(`
+    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+    SET
+      raw_input = COALESCE(raw_input, value_e164),
+      normalized_e164 = value_e164,
+      country_code = COALESCE(country_code, CASE
+        WHEN value_e164 ~ '^\\+1\\d{10}$' THEN '1'
+        ELSE country_code
+      END),
+      national_number = COALESCE(national_number, CASE
+        WHEN value_e164 ~ '^\\+1\\d{10}$' THEN SUBSTRING(value_e164 FROM 3)
+        ELSE national_number
+      END),
+      display_national = COALESCE(display_national, CASE
+        WHEN value_e164 ~ '^\\+1\\d{10}$' THEN
+          '(' || SUBSTRING(value_e164 FROM 3 FOR 3) || ') '
+          || SUBSTRING(value_e164 FROM 6 FOR 3) || '-'
+          || SUBSTRING(value_e164 FROM 9 FOR 4)
+        ELSE display_national
+      END)
+    WHERE normalized_e164 IS NULL
+       OR raw_input IS NULL
+       OR country_code IS NULL
+       OR national_number IS NULL
+       OR display_national IS NULL
+  `);
+
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ALTER COLUMN normalized_e164 SET NOT NULL
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${VALIDATION_STATUS_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+          ADD CONSTRAINT ${VALIDATION_STATUS_CHECK}
+          CHECK (validation_status IN ('valid', 'invalid', 'needs_review'));
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${USAGE_TYPE_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+          ADD CONSTRAINT ${USAGE_TYPE_CHECK}
+          CHECK (usage_type IN ('mobile', 'landline', 'unknown'));
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${SOURCE_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+          ADD CONSTRAINT ${SOURCE_CHECK}
+          CHECK (source IN ('user_entered', 'imported', 'system_generated'));
+      END IF;
+    END $$;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP CONSTRAINT IF EXISTS ${VALIDATION_STATUS_CHECK}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP CONSTRAINT IF EXISTS ${USAGE_TYPE_CHECK}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP CONSTRAINT IF EXISTS ${SOURCE_CHECK}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS raw_input
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS normalized_e164
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS display_national
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS country_code
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS national_number
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS extension
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS validation_status
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS usage_type
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS source
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS is_active
+  `);
+}

--- a/apps/connectshyft-api/src/migrations/20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.ts
+++ b/apps/connectshyft-api/src/migrations/20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const NEIGHBOR_PHONES_TABLE = 'cs_neighbor_phones';
+const CANONICAL_LOOKUP_INDEX = 'connectshyft_cs_neighbor_phones_tenant_normalized_e164_idx';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${CANONICAL_LOOKUP_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} (tenant_id, normalized_e164, neighbor_id, sort_order, id)
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${CANONICAL_LOOKUP_INDEX}
+  `);
+}

--- a/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneIdentityMigration.test.ts
+++ b/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneIdentityMigration.test.ts
@@ -1,0 +1,55 @@
+import {
+  down,
+  up,
+} from '../20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity';
+
+function buildKnexMock() {
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+  };
+
+  return { knex };
+}
+
+describe('20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity migration', () => {
+  it('adds canonical phone identity columns, backfill, and constraints idempotently', async () => {
+    const { knex } = buildKnexMock();
+
+    await up(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS raw_input');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS normalized_e164');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS display_national');
+    expect(rawSql).toContain('country_code TEXT NULL');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS national_number');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS validation_status');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS usage_type');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS source');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS is_active');
+    expect(rawSql).toContain('normalized_e164 = value_e164');
+    expect(rawSql).toContain('cs_neighbor_phones_validation_status_ck');
+    expect(rawSql).toContain('cs_neighbor_phones_usage_type_ck');
+    expect(rawSql).toContain('cs_neighbor_phones_source_ck');
+  });
+
+  it('drops canonical phone identity constraints and columns on down migration', async () => {
+    const { knex } = buildKnexMock();
+
+    await down(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+    expect(rawSql).toContain('DROP CONSTRAINT IF EXISTS cs_neighbor_phones_validation_status_ck');
+    expect(rawSql).toContain('DROP CONSTRAINT IF EXISTS cs_neighbor_phones_usage_type_ck');
+    expect(rawSql).toContain('DROP CONSTRAINT IF EXISTS cs_neighbor_phones_source_ck');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS raw_input');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS normalized_e164');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS display_national');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS country_code');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS national_number');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS validation_status');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS usage_type');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS source');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS is_active');
+  });
+});

--- a/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts
+++ b/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts
@@ -1,0 +1,33 @@
+import {
+  down,
+  up,
+} from '../20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index';
+
+function buildKnexMock() {
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+  };
+
+  return { knex };
+}
+
+describe('20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index migration', () => {
+  it('creates the canonical normalized_e164 lookup index', async () => {
+    const { knex } = buildKnexMock();
+
+    await up(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+    expect(rawSql).toContain('connectshyft_cs_neighbor_phones_tenant_normalized_e164_idx');
+    expect(rawSql).toContain('(tenant_id, normalized_e164, neighbor_id, sort_order, id)');
+  });
+
+  it('drops the canonical normalized_e164 lookup index on down migration', async () => {
+    const { knex } = buildKnexMock();
+
+    await down(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+    expect(rawSql).toContain('DROP INDEX IF EXISTS connectshyft.connectshyft_cs_neighbor_phones_tenant_normalized_e164_idx');
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts
@@ -1,0 +1,136 @@
+import {
+  evaluateConnectShyftIdentityBoundary,
+  type ConnectShyftIdentityBoundaryNeighbor,
+} from '../identityBoundary';
+
+const buildNeighbor = (
+  neighborId: string,
+  value: string,
+  overrides: Partial<ConnectShyftIdentityBoundaryNeighbor['phones'][number]> = {},
+): ConnectShyftIdentityBoundaryNeighbor => ({
+  neighborId,
+  phones: [
+    {
+      phoneId: `${neighborId}-phone-1`,
+      value,
+      isShared: false,
+      verificationStatus: 'verified',
+      ...overrides,
+    },
+  ],
+});
+
+describe('connectshyft identity boundary', () => {
+  it('matches natural ten-digit input to canonical stored phone identity', () => {
+    const result = evaluateConnectShyftIdentityBoundary({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      contactPoint: {
+        label: 'mobile',
+        value: '260-555-1212',
+        verificationStatus: 'verified',
+      },
+    }, [
+      buildNeighbor('neighbor-1', '+12605551212'),
+    ]);
+
+    expect(result).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+      data: {
+        identityMatch: {
+          matchedNeighborId: 'neighbor-1',
+          decision: 'AUTO_MERGE_ALLOWED',
+          reason: 'VERIFIED_NON_SHARED_EXACT_CONTACT_POINT',
+          contactPoint: {
+            value: '+12605551212',
+          },
+        },
+      },
+    });
+  });
+
+  it('returns no-match when no canonical phone identity exists', () => {
+    const result = evaluateConnectShyftIdentityBoundary({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      contactPoint: {
+        label: 'mobile',
+        value: '2605551212',
+        verificationStatus: 'verified',
+      },
+    }, [
+      buildNeighbor('neighbor-1', '+12605550000'),
+    ]);
+
+    expect(result).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+      data: {
+        identityMatch: {
+          matchedNeighborId: null,
+          decision: 'NO_AUTO_MERGE',
+          reason: 'NO_EXACT_CONTACT_POINT_MATCH',
+        },
+      },
+    });
+  });
+
+  it('returns ambiguous when multiple neighbors share the same canonical phone identity', () => {
+    const result = evaluateConnectShyftIdentityBoundary({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      contactPoint: {
+        label: 'mobile',
+        value: '(260) 555-1212',
+        verificationStatus: 'verified',
+      },
+    }, [
+      buildNeighbor('neighbor-1', '+12605551212'),
+      buildNeighbor('neighbor-2', '+12605551212'),
+    ]);
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      data: {
+        identityMatch: {
+          decision: 'AMBIGUOUS',
+          reason: 'MULTIPLE_EXACT_CONTACT_POINT_MATCHES',
+          candidateNeighborIds: ['neighbor-1', 'neighbor-2'],
+        },
+        manualResolution: {
+          required: true,
+          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+        },
+      },
+    });
+  });
+
+  it('refuses auto-merge when the matched canonical phone identity is shared', () => {
+    const result = evaluateConnectShyftIdentityBoundary({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      contactPoint: {
+        label: 'mobile',
+        value: '2605551212',
+        verificationStatus: 'verified',
+      },
+    }, [
+      buildNeighbor('neighbor-1', '+12605551212', { isShared: true }),
+    ]);
+
+    expect(result).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+      data: {
+        identityMatch: {
+          matchedNeighborId: 'neighbor-1',
+          decision: 'NO_AUTO_MERGE',
+          reason: 'MATCH_CONTACT_SHARED',
+          autoMergeAllowed: false,
+        },
+      },
+    });
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts
@@ -5,12 +5,18 @@ import {
 } from '../neighbors';
 
 describe('connectshyft neighbor service', () => {
+  const originalEnv = process.env;
   let store: InMemoryConnectShyftNeighborStore;
   let service: ConnectShyftNeighborService;
 
   beforeEach(() => {
+    process.env = { ...originalEnv };
     store = new InMemoryConnectShyftNeighborStore();
     service = new ConnectShyftNeighborService(store);
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
   });
 
   it('creates tenant-scoped neighbors with normalized phone values', () => {
@@ -41,6 +47,9 @@ describe('connectshyft neighbor service', () => {
             expect.objectContaining({
               label: 'mobile',
               value: '+12605550199',
+              displayNational: '(260) 555-0199',
+              countryCode: '1',
+              nationalNumber: '2605550199',
               sortOrder: 0,
               isPrimary: true,
             }),
@@ -59,6 +68,41 @@ describe('connectshyft neighbor service', () => {
     );
     expect(scopedNeighbors).toHaveLength(1);
     expect(scopedNeighbors[0].neighborId).toBe(result.data.neighbor.neighborId);
+  });
+
+  it('creates tenant-scoped neighbors from seven-digit local input when a default area code is configured', () => {
+    process.env.CONNECTSHYFT_PHONE_DEFAULT_AREA_CODE = '260';
+
+    const result = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      phones: [
+        {
+          label: 'mobile',
+          value: '5550199',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+      data: {
+        neighbor: {
+          phones: [
+            expect.objectContaining({
+              value: '+12605550199',
+              displayNational: '(260) 555-0199',
+              countryCode: '1',
+              nationalNumber: '2605550199',
+            }),
+          ],
+        },
+      },
+    });
   });
 
   it('refuses create requests that omit phone entries', () => {

--- a/apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts
@@ -1,9 +1,7 @@
 import { createHash } from 'node:crypto';
+import { normalizePhone } from '../../../../../domains/communication';
 import { CAPABILITIES, hasCapability } from '../../platform/rbac/capabilities';
-
-const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/;
-const REMOVABLE_PHONE_CHARS_PATTERN = /[\s().-]/g;
-const INVALID_PHONE_CHAR_PATTERN = /[A-Za-z]/;
+import { resolveConnectShyftPhoneNormalizationContext } from './phoneIdentityContext';
 
 const normalizeNonEmptyString = (value: unknown): string => {
   if (typeof value !== 'string') {
@@ -11,29 +9,6 @@ const normalizeNonEmptyString = (value: unknown): string => {
   }
 
   return value.trim();
-};
-
-const normalizePhoneValue = (value: string): string | null => {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  if (INVALID_PHONE_CHAR_PATTERN.test(trimmed)) {
-    return null;
-  }
-
-  const compact = trimmed.replace(REMOVABLE_PHONE_CHARS_PATTERN, '');
-  if (!/^\+?\d+$/.test(compact)) {
-    return null;
-  }
-
-  const normalized = compact.startsWith('+') ? compact : `+${compact}`;
-  if (!E164_PHONE_PATTERN.test(normalized)) {
-    return null;
-  }
-
-  return normalized;
 };
 
 const normalizeVerificationStatus = (
@@ -367,13 +342,13 @@ const buildIdentityMatchInvalidPhoneRefusal = (
 ): ConnectShyftIdentityBoundaryResult => ({
   ok: false,
   code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
-  message: 'Provide a valid phone value (for example, +12605550199).',
+  message: 'Provide a valid phone number (for example, 2605550199).',
   data: {
     fieldErrors: [
       {
         field: 'phones',
         reason: 'INVALID_FORMAT',
-        message: 'Provide a valid phone value (for example, +12605550199).',
+        message: 'Provide a valid phone number (for example, 2605550199).',
       },
     ],
     idempotency,
@@ -433,7 +408,11 @@ type PreparedIdentityBoundaryEvaluation = {
 const prepareIdentityBoundaryEvaluation = (
   input: ConnectShyftIdentityBoundaryRequest,
 ): PreparedIdentityBoundaryEvaluation => {
-  const normalizedContactPointValue = normalizePhoneValue(normalizeNonEmptyString(input.contactPoint?.value));
+  const resolvedPhone = normalizePhone(
+    normalizeNonEmptyString(input.contactPoint?.value),
+    resolveConnectShyftPhoneNormalizationContext('user_entered'),
+  );
+  const normalizedContactPointValue = resolvedPhone.ok ? resolvedPhone.phone.normalizedE164 : null;
   const isShared = input.contactPoint?.isShared === true;
   const verificationStatus = normalizeVerificationStatus(input.contactPoint?.verificationStatus);
   const excludeNeighborId = normalizeNonEmptyString(input.excludeNeighborId);

--- a/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts
@@ -1,4 +1,10 @@
 import { randomUUID } from 'node:crypto';
+import {
+  normalizePhone,
+  type PhoneSource,
+  type PhoneUsageType,
+  type PhoneValidationStatus,
+} from '../../../../../domains/communication';
 import { CAPABILITIES, hasCapability } from '../../platform/rbac/capabilities';
 import db from '../../config/knex';
 import {
@@ -12,6 +18,7 @@ import {
   type ConnectShyftIdentityBoundaryReplay,
   type ConnectShyftIdentityBoundaryResult as ConnectShyftIdentityMatchResult,
 } from './identityBoundary';
+import { resolveConnectShyftPhoneNormalizationContext } from './phoneIdentityContext';
 
 type QueryBuilderLike = {
   withSchema(schema: string): QueryBuilderLike;
@@ -40,9 +47,6 @@ type KnexLike = QueryBuilderLike & {
   transaction<T>(handler: (trx: KnexTransactionLike) => Promise<T>): Promise<T>;
 };
 
-const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/;
-const REMOVABLE_PHONE_CHARS_PATTERN = /[\s().-]/g;
-const INVALID_PHONE_CHAR_PATTERN = /[A-Za-z]/;
 export const CONNECTSHYFT_NEIGHBOR_MERGE_CONFIRMATION_PHRASE = 'IRREVERSIBLE MERGE';
 
 export type ConnectShyftNeighborPhoneInput = {
@@ -55,20 +59,39 @@ export type ConnectShyftNeighborPhoneInput = {
 type NormalizedConnectShyftNeighborPhoneInput = {
   label: string;
   value: string;
+  rawInput: string;
+  normalizedE164: string;
+  displayNational: string;
+  countryCode: string;
+  nationalNumber: string;
+  extension?: string;
+  validationStatus: PhoneValidationStatus;
+  usageType: PhoneUsageType;
+  source: PhoneSource;
   sortOrder: number;
   isPrimary: boolean;
   isShared: boolean;
   verificationStatus: 'verified' | 'unverified';
+  isActive: boolean;
 };
 
 export type ConnectShyftNeighborPhone = {
   phoneId: string;
   label: string;
   value: string;
+  rawInput: string | null;
+  displayNational: string | null;
+  countryCode: string | null;
+  nationalNumber: string | null;
+  extension?: string | null;
+  validationStatus: PhoneValidationStatus;
+  usageType: PhoneUsageType;
+  source: PhoneSource;
   sortOrder: number;
   isPrimary: boolean;
   isShared: boolean;
   verificationStatus: 'verified' | 'unverified';
+  isActive: boolean;
   createdAtUtc: string;
   updatedAtUtc: string;
 };
@@ -286,29 +309,6 @@ const normalizePhoneLabel = (value: unknown): string => {
   return normalized;
 };
 
-const normalizePhoneValue = (value: string): string | null => {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  if (INVALID_PHONE_CHAR_PATTERN.test(trimmed)) {
-    return null;
-  }
-
-  const compact = trimmed.replace(REMOVABLE_PHONE_CHARS_PATTERN, '');
-  if (!/^\+?\d+$/.test(compact)) {
-    return null;
-  }
-
-  const normalized = compact.startsWith('+') ? compact : `+${compact}`;
-  if (!E164_PHONE_PATTERN.test(normalized)) {
-    return null;
-  }
-
-  return normalized;
-};
-
 const normalizeVerificationStatus = (
   value: unknown,
 ): 'verified' | 'unverified' => {
@@ -337,13 +337,13 @@ const buildPhoneRequiredRefusal = (): NeighborRefusalResult => ({
 const buildPhoneInvalidFormatRefusal = (): NeighborRefusalResult => ({
   ok: false,
   code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
-  message: 'Provide a valid phone value (for example, +12605550199).',
+  message: 'Provide a valid phone number (for example, 2605550199).',
   data: {
     fieldErrors: [
       {
         field: 'phones',
         reason: 'INVALID_FORMAT',
-        message: 'Provide a valid phone value (for example, +12605550199).',
+        message: 'Provide a valid phone number (for example, 2605550199).',
       },
     ],
   },
@@ -428,22 +428,32 @@ const normalizePhones = (
     return buildPhoneRequiredRefusal();
   }
 
+  const context = resolveConnectShyftPhoneNormalizationContext('user_entered');
   const normalizedPhones: NormalizedConnectShyftNeighborPhoneInput[] = [];
   for (let index = 0; index < phones.length; index += 1) {
     const phone = phones[index];
-    const normalizedValue = normalizePhoneValue(normalizeNonEmptyString(phone?.value));
-
-    if (!normalizedValue) {
+    const resolvedPhone = normalizePhone(normalizeNonEmptyString(phone?.value), context);
+    if (!resolvedPhone.ok) {
       return buildPhoneInvalidFormatRefusal();
     }
 
     normalizedPhones.push({
       label: normalizePhoneLabel(phone?.label),
-      value: normalizedValue,
+      value: resolvedPhone.phone.normalizedE164,
+      rawInput: resolvedPhone.phone.rawInput,
+      normalizedE164: resolvedPhone.phone.normalizedE164,
+      displayNational: resolvedPhone.phone.displayNational,
+      countryCode: resolvedPhone.phone.countryCode,
+      nationalNumber: resolvedPhone.phone.nationalNumber,
+      extension: resolvedPhone.phone.extension,
+      validationStatus: resolvedPhone.phone.validationStatus,
+      usageType: resolvedPhone.phone.usageType,
+      source: resolvedPhone.phone.source,
       sortOrder: index,
       isPrimary: index === 0,
       isShared: phone?.isShared === true,
       verificationStatus: normalizeVerificationStatus(phone?.verificationStatus),
+      isActive: true,
     });
   }
 
@@ -498,10 +508,20 @@ type DbNeighborPhoneRow = {
   tenant_id: string;
   label: string;
   value_e164: string;
+  raw_input?: string | null;
+  normalized_e164?: string | null;
+  display_national?: string | null;
+  country_code?: string | null;
+  national_number?: string | null;
+  extension?: string | null;
+  validation_status?: PhoneValidationStatus | null;
+  usage_type?: PhoneUsageType | null;
+  source?: PhoneSource | null;
   sort_order: number;
   is_primary: boolean;
   is_shared?: boolean | null;
   verification_status?: string | null;
+  is_active?: boolean | null;
   created_at_utc: string | Date;
   updated_at_utc: string | Date;
 };
@@ -527,6 +547,33 @@ const normalizeTextingPreference = (value: unknown): 'UNKNOWN' | 'YES' | 'NO' =>
   return 'UNKNOWN';
 };
 
+const normalizePhoneValidationStatus = (value: unknown): PhoneValidationStatus => {
+  if (value === 'valid' || value === 'invalid' || value === 'needs_review') {
+    return value;
+  }
+
+  return 'valid';
+};
+
+const normalizePhoneUsageType = (value: unknown): PhoneUsageType => {
+  if (value === 'mobile' || value === 'landline' || value === 'unknown') {
+    return value;
+  }
+
+  return 'unknown';
+};
+
+const normalizePhoneSource = (value: unknown): PhoneSource => {
+  if (value === 'user_entered' || value === 'imported' || value === 'system_generated') {
+    return value;
+  }
+
+  return 'user_entered';
+};
+
+const resolveStoredPhoneValue = (phoneRow: DbNeighborPhoneRow): string =>
+  normalizeNonEmptyString(phoneRow.normalized_e164 || phoneRow.value_e164);
+
 const sortPhones = (phoneRows: DbNeighborPhoneRow[]): DbNeighborPhoneRow[] => {
   return phoneRows
     .slice()
@@ -548,7 +595,7 @@ const mergePhoneRows = (
 
   [...sortPhones(survivorPhoneRows), ...sortPhones(sourcePhoneRows)].forEach((phone) => {
     const label = normalizePhoneLabel(phone.label);
-    const value = normalizeNonEmptyString(phone.value_e164);
+    const value = resolveStoredPhoneValue(phone);
     if (!value) {
       return;
     }
@@ -562,10 +609,20 @@ const mergePhoneRows = (
     merged.push({
       label,
       value,
+      rawInput: normalizeNonEmptyString(phone.raw_input || value),
+      normalizedE164: value,
+      displayNational: normalizeNonEmptyString(phone.display_national || value),
+      countryCode: normalizeNonEmptyString(phone.country_code),
+      nationalNumber: normalizeNonEmptyString(phone.national_number),
+      extension: normalizeNonEmptyString(phone.extension) || undefined,
+      validationStatus: normalizePhoneValidationStatus(phone.validation_status),
+      usageType: normalizePhoneUsageType(phone.usage_type),
+      source: normalizePhoneSource(phone.source),
       sortOrder: merged.length,
       isPrimary: merged.length === 0,
       isShared: phone.is_shared === true,
       verificationStatus: normalizeVerificationStatus(phone.verification_status),
+      isActive: phone.is_active !== false,
     });
   });
 
@@ -614,11 +671,20 @@ const mapRowsToNeighbor = (
   phones: sortPhones(phoneRows).map((phoneRow) => ({
     phoneId: phoneRow.id,
     label: phoneRow.label,
-    value: phoneRow.value_e164,
+    value: resolveStoredPhoneValue(phoneRow),
+    rawInput: phoneRow.raw_input || null,
+    displayNational: phoneRow.display_national || null,
+    countryCode: phoneRow.country_code || null,
+    nationalNumber: phoneRow.national_number || null,
+    extension: phoneRow.extension || null,
+    validationStatus: normalizePhoneValidationStatus(phoneRow.validation_status),
+    usageType: normalizePhoneUsageType(phoneRow.usage_type),
+    source: normalizePhoneSource(phoneRow.source),
     sortOrder: phoneRow.sort_order,
     isPrimary: phoneRow.is_primary,
     isShared: phoneRow.is_shared === true,
     verificationStatus: normalizeVerificationStatus(phoneRow.verification_status),
+    isActive: phoneRow.is_active !== false,
     createdAtUtc: toIsoUtc(phoneRow.created_at_utc),
     updatedAtUtc: toIsoUtc(phoneRow.updated_at_utc),
   })),
@@ -696,10 +762,19 @@ export class InMemoryConnectShyftNeighborStore {
         phoneId: randomUUID(),
         label: phone.label,
         value: phone.value,
+        rawInput: phone.rawInput,
+        displayNational: phone.displayNational,
+        countryCode: phone.countryCode,
+        nationalNumber: phone.nationalNumber,
+        extension: phone.extension || null,
+        validationStatus: phone.validationStatus,
+        usageType: phone.usageType,
+        source: phone.source,
         sortOrder: phone.sortOrder,
         isPrimary: phone.isPrimary,
         isShared: phone.isShared,
         verificationStatus: phone.verificationStatus,
+        isActive: phone.isActive,
         createdAtUtc: now,
         updatedAtUtc: now,
       })),
@@ -743,10 +818,19 @@ export class InMemoryConnectShyftNeighborStore {
         phoneId: randomUUID(),
         label: phone.label,
         value: phone.value,
+        rawInput: phone.rawInput,
+        displayNational: phone.displayNational,
+        countryCode: phone.countryCode,
+        nationalNumber: phone.nationalNumber,
+        extension: phone.extension || null,
+        validationStatus: phone.validationStatus,
+        usageType: phone.usageType,
+        source: phone.source,
         sortOrder: phone.sortOrder,
         isPrimary: phone.isPrimary,
         isShared: phone.isShared,
         verificationStatus: phone.verificationStatus,
+        isActive: phone.isActive,
         createdAtUtc: now,
         updatedAtUtc: now,
       })),
@@ -789,10 +873,20 @@ export class InMemoryConnectShyftNeighborStore {
         tenant_id: survivorNeighbor.tenantId,
         label: phone.label,
         value_e164: phone.value,
+        raw_input: phone.rawInput,
+        normalized_e164: phone.value,
+        display_national: phone.displayNational,
+        country_code: phone.countryCode,
+        national_number: phone.nationalNumber,
+        extension: phone.extension,
+        validation_status: phone.validationStatus,
+        usage_type: phone.usageType,
+        source: phone.source,
         sort_order: phone.sortOrder,
         is_primary: phone.isPrimary,
         is_shared: phone.isShared,
         verification_status: phone.verificationStatus,
+        is_active: phone.isActive,
         created_at_utc: phone.createdAtUtc,
         updated_at_utc: phone.updatedAtUtc,
       })),
@@ -802,10 +896,20 @@ export class InMemoryConnectShyftNeighborStore {
         tenant_id: sourceNeighbor.tenantId,
         label: phone.label,
         value_e164: phone.value,
+        raw_input: phone.rawInput,
+        normalized_e164: phone.value,
+        display_national: phone.displayNational,
+        country_code: phone.countryCode,
+        national_number: phone.nationalNumber,
+        extension: phone.extension,
+        validation_status: phone.validationStatus,
+        usage_type: phone.usageType,
+        source: phone.source,
         sort_order: phone.sortOrder,
         is_primary: phone.isPrimary,
         is_shared: phone.isShared,
         verification_status: phone.verificationStatus,
+        is_active: phone.isActive,
         created_at_utc: phone.createdAtUtc,
         updated_at_utc: phone.updatedAtUtc,
       })),
@@ -819,10 +923,19 @@ export class InMemoryConnectShyftNeighborStore {
         phoneId: randomUUID(),
         label: phone.label,
         value: phone.value,
+        rawInput: phone.rawInput,
+        displayNational: phone.displayNational,
+        countryCode: phone.countryCode,
+        nationalNumber: phone.nationalNumber,
+        extension: phone.extension || null,
+        validationStatus: phone.validationStatus,
+        usageType: phone.usageType,
+        source: phone.source,
         sortOrder: phone.sortOrder,
         isPrimary: phone.isPrimary,
         isShared: phone.isShared,
         verificationStatus: phone.verificationStatus,
+        isActive: phone.isActive,
         createdAtUtc: now,
         updatedAtUtc: now,
       })),
@@ -939,10 +1052,20 @@ export class KnexConnectShyftNeighborStore {
       'tenant_id',
       'label',
       'value_e164',
+      'raw_input',
+      'normalized_e164',
+      'display_national',
+      'country_code',
+      'national_number',
+      'extension',
+      'validation_status',
+      'usage_type',
+      'source',
       'sort_order',
       'is_primary',
       'is_shared',
       'verification_status',
+      'is_active',
       'created_at_utc',
       'updated_at_utc',
     ];
@@ -990,10 +1113,20 @@ export class KnexConnectShyftNeighborStore {
           tenant_id: input.tenantId,
           label: phone.label,
           value_e164: phone.value,
+          raw_input: phone.rawInput,
+          normalized_e164: phone.normalizedE164,
+          display_national: phone.displayNational,
+          country_code: phone.countryCode,
+          national_number: phone.nationalNumber,
+          extension: phone.extension || null,
+          validation_status: phone.validationStatus,
+          usage_type: phone.usageType,
+          source: phone.source,
           sort_order: phone.sortOrder,
           is_primary: phone.isPrimary,
           is_shared: phone.isShared,
           verification_status: phone.verificationStatus,
+          is_active: phone.isActive,
           created_at_utc: trx.fn.now(),
           updated_at_utc: trx.fn.now(),
         }));
@@ -1114,7 +1247,7 @@ export class KnexConnectShyftNeighborStore {
       .table('cs_neighbor_phones')
       .where({
         tenant_id: tenantId,
-        value_e164: phoneValue,
+        normalized_e164: phoneValue,
       })
       .orderBy('neighbor_id', 'asc')
       .orderBy('sort_order', 'asc')
@@ -1136,7 +1269,7 @@ export class KnexConnectShyftNeighborStore {
       const existing = phonesByNeighborId.get(row.neighbor_id) || [];
       existing.push({
         phoneId: row.id,
-        value: row.value_e164,
+        value: resolveStoredPhoneValue(row),
         isShared: row.is_shared === true,
         verificationStatus: normalizeVerificationStatus(row.verification_status),
       });
@@ -1199,10 +1332,20 @@ export class KnexConnectShyftNeighborStore {
           tenant_id: input.tenantId,
           label: phone.label,
           value_e164: phone.value,
+          raw_input: phone.rawInput,
+          normalized_e164: phone.normalizedE164,
+          display_national: phone.displayNational,
+          country_code: phone.countryCode,
+          national_number: phone.nationalNumber,
+          extension: phone.extension || null,
+          validation_status: phone.validationStatus,
+          usage_type: phone.usageType,
+          source: phone.source,
           sort_order: phone.sortOrder,
           is_primary: phone.isPrimary,
           is_shared: phone.isShared,
           verification_status: phone.verificationStatus,
+          is_active: phone.isActive,
           created_at_utc: trx.fn.now(),
           updated_at_utc: trx.fn.now(),
         }));
@@ -1305,10 +1448,20 @@ export class KnexConnectShyftNeighborStore {
               tenant_id: input.tenantId,
               label: phone.label,
               value_e164: phone.value,
+              raw_input: phone.rawInput,
+              normalized_e164: phone.normalizedE164,
+              display_national: phone.displayNational,
+              country_code: phone.countryCode,
+              national_number: phone.nationalNumber,
+              extension: phone.extension || null,
+              validation_status: phone.validationStatus,
+              usage_type: phone.usageType,
+              source: phone.source,
               sort_order: phone.sortOrder,
               is_primary: phone.isPrimary,
               is_shared: phone.isShared,
               verification_status: phone.verificationStatus,
+              is_active: phone.isActive,
               created_at_utc: trx.fn.now(),
               updated_at_utc: trx.fn.now(),
             })),

--- a/apps/connectshyft-api/src/modules/connectshyft/phoneIdentityContext.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/phoneIdentityContext.ts
@@ -1,0 +1,16 @@
+import type { PhoneNormalizationContext, PhoneSource } from '../../../../../domains/communication'
+
+const DEFAULT_COUNTRY = 'US'
+
+const normalizeOptionalEnvValue = (value: string | undefined): string | undefined => {
+  const normalized = value?.trim()
+  return normalized && normalized.length > 0 ? normalized : undefined
+}
+
+export const resolveConnectShyftPhoneNormalizationContext = (
+  source: PhoneSource = 'user_entered',
+): PhoneNormalizationContext => ({
+  defaultCountry: normalizeOptionalEnvValue(process.env.CONNECTSHYFT_PHONE_DEFAULT_COUNTRY) || DEFAULT_COUNTRY,
+  defaultAreaCode: normalizeOptionalEnvValue(process.env.CONNECTSHYFT_PHONE_DEFAULT_AREA_CODE),
+  source,
+})

--- a/apps/connectshyft-api/tsconfig.json
+++ b/apps/connectshyft-api/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "lib": ["ES2022"],
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "../../",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -24,6 +24,6 @@
     "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../../domains/communication/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/domains/communication/README.md
+++ b/domains/communication/README.md
@@ -19,3 +19,5 @@ Does not belong here:
 Rules:
 - Anything reusable across ConnectShyft, ProgramShyft, CaseShyft, or People Core should start here.
 - App code may consume this domain but must not redefine its canonical behavior locally.
+- Consumers should import shared communication APIs from `/Users/jeremiahotis/projects/connectshyft/domains/communication/index.ts`, not deep paths such as `domains/communication/phone/*`.
+- Phone normalization is caller-configured through `PhoneNormalizationContext`; lane code owns env/config resolution while the shared domain stays deterministic and side-effect free.

--- a/domains/communication/phone/__tests__/index.test.ts
+++ b/domains/communication/phone/__tests__/index.test.ts
@@ -1,0 +1,85 @@
+import {
+  comparePhoneIdentity,
+  formatDisplayPhone,
+  normalizePhone,
+  parsePhone,
+  validatePhoneForChannel,
+} from '../index';
+
+describe('communication phone domain', () => {
+  it('normalizes ten-digit domestic input to canonical e164', () => {
+    const result = normalizePhone('2605551212', {
+      defaultCountry: 'US',
+      source: 'user_entered',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      phone: expect.objectContaining({
+        rawInput: '2605551212',
+        normalizedE164: '+12605551212',
+        displayNational: '(260) 555-1212',
+        countryCode: '1',
+        nationalNumber: '2605551212',
+        validationStatus: 'valid',
+        source: 'user_entered',
+        usageType: 'unknown',
+        sharedPhoneFlag: false,
+        smsCapable: null,
+        voiceCapable: null,
+      }),
+    });
+  });
+
+  it('normalizes seven-digit local input when a default area code is supplied', () => {
+    const result = normalizePhone('5551212', {
+      defaultCountry: 'US',
+      defaultAreaCode: '260',
+      source: 'imported',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      phone: expect.objectContaining({
+        normalizedE164: '+12605551212',
+        displayNational: '(260) 555-1212',
+        source: 'imported',
+      }),
+    });
+  });
+
+  it('rejects seven-digit input when the default area code is missing', () => {
+    expect(normalizePhone('5551212', { defaultCountry: 'US' })).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        code: 'PHONE_DEFAULT_AREA_CODE_REQUIRED',
+      }),
+    });
+  });
+
+  it('rejects malformed input with alpha characters', () => {
+    expect(parsePhone('260-ABC-1212', { defaultCountry: 'US' })).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        code: 'PHONE_INVALID_FORMAT',
+      }),
+    });
+  });
+
+  it('formats display output, validates channels, and compares canonical identity', () => {
+    const result = normalizePhone('+12605551212', {
+      defaultCountry: 'US',
+      source: 'system_generated',
+    });
+
+    if (!result.ok) {
+      throw new Error('Expected canonical phone normalization to succeed');
+    }
+
+    expect(formatDisplayPhone(result.phone, 'en-US')).toBe('(260) 555-1212');
+    expect(comparePhoneIdentity(result.phone, '+12605551212')).toBe(true);
+    expect(comparePhoneIdentity(result.phone, '+12605550000')).toBe(false);
+    expect(validatePhoneForChannel(result.phone, 'sms')).toEqual({ ok: true });
+    expect(validatePhoneForChannel(result.phone, 'voice')).toEqual({ ok: true });
+  });
+});

--- a/domains/communication/phone/index.ts
+++ b/domains/communication/phone/index.ts
@@ -1,11 +1,277 @@
-// Starter entrypoint for phone identity logic.
-// CS-002 should populate this module with the real implementation.
+export type PhoneSource = 'user_entered' | 'imported' | 'system_generated'
+
+export type PhoneValidationStatus = 'valid' | 'invalid' | 'needs_review'
+
+export type PhoneUsageType = 'mobile' | 'landline' | 'unknown'
 
 export type PhoneNormalizationContext = {
+  defaultCountry: string
   defaultAreaCode?: string
-  defaultCountry?: string
+  source?: PhoneSource
 }
 
-export function normalizePhone(_input: string, _context: PhoneNormalizationContext = {}) {
-  throw new Error('normalizePhone not implemented yet')
+export type CanonicalPhoneIdentity = {
+  rawInput: string
+  normalizedE164: string
+  displayNational: string
+  countryCode: string
+  nationalNumber: string
+  extension?: string
+  validationStatus: PhoneValidationStatus
+  source: PhoneSource
+  usageType: PhoneUsageType
+  sharedPhoneFlag: boolean
+  smsCapable: boolean | null
+  voiceCapable: boolean | null
+}
+
+export type PhoneNormalizationError = {
+  code:
+    | 'PHONE_EMPTY'
+    | 'PHONE_INVALID_FORMAT'
+    | 'PHONE_DEFAULT_AREA_CODE_REQUIRED'
+    | 'PHONE_DEFAULT_AREA_CODE_INVALID'
+  message: string
+}
+
+export type PhoneNormalizationResult =
+  | {
+    ok: true
+    phone: CanonicalPhoneIdentity
+  }
+  | {
+    ok: false
+    error: PhoneNormalizationError
+  }
+
+type PhoneNormalizationFailure = Extract<PhoneNormalizationResult, { ok: false }>
+
+export type PhoneChannel = 'sms' | 'voice'
+
+export type PhoneChannelValidationResult =
+  | {
+    ok: true
+  }
+  | {
+    ok: false
+    reason: string
+  }
+
+const REMOVABLE_PHONE_CHARS_PATTERN = /[\s().-]/g
+const INVALID_PHONE_CHAR_PATTERN = /[A-Za-z]/
+const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/
+const TEN_DIGIT_PATTERN = /^\d{10}$/
+const ELEVEN_DIGIT_US_PATTERN = /^1\d{10}$/
+const SEVEN_DIGIT_PATTERN = /^\d{7}$/
+const THREE_DIGIT_PATTERN = /^\d{3}$/
+
+const DEFAULT_COUNTRY = 'US'
+const DEFAULT_SOURCE: PhoneSource = 'user_entered'
+
+const buildError = (
+  code: PhoneNormalizationError['code'],
+  message: string,
+): PhoneNormalizationFailure => ({
+  ok: false,
+  error: {
+    code,
+    message,
+  },
+})
+
+const normalizeContext = (
+  context: Partial<PhoneNormalizationContext> = {},
+): PhoneNormalizationContext => ({
+  defaultCountry: context.defaultCountry?.trim() || DEFAULT_COUNTRY,
+  defaultAreaCode: context.defaultAreaCode?.trim() || undefined,
+  source: context.source || DEFAULT_SOURCE,
+})
+
+const formatUsNationalDisplay = (nationalNumber: string): string =>
+  `(${nationalNumber.slice(0, 3)}) ${nationalNumber.slice(3, 6)}-${nationalNumber.slice(6)}`
+
+const resolveUsNationalNumber = (
+  input: string,
+  context: PhoneNormalizationContext,
+): PhoneNormalizationFailure | { ok: true; nationalNumber: string } => {
+  if (!input) {
+    return buildError('PHONE_EMPTY', 'Provide a phone number.')
+  }
+
+  if (INVALID_PHONE_CHAR_PATTERN.test(input)) {
+    return buildError('PHONE_INVALID_FORMAT', 'Provide a valid phone number.')
+  }
+
+  const compact = input.replace(REMOVABLE_PHONE_CHARS_PATTERN, '')
+  if (!compact) {
+    return buildError('PHONE_EMPTY', 'Provide a phone number.')
+  }
+
+  if (!/^\+?\d+$/.test(compact)) {
+    return buildError('PHONE_INVALID_FORMAT', 'Provide a valid phone number.')
+  }
+
+  if (compact.startsWith('+')) {
+    if (!E164_PHONE_PATTERN.test(compact)) {
+      return buildError('PHONE_INVALID_FORMAT', 'Provide a valid phone number.')
+    }
+
+    if (!compact.startsWith('+1') || compact.length !== 12) {
+      return buildError('PHONE_INVALID_FORMAT', 'Provide a valid phone number.')
+    }
+
+    return {
+      ok: true,
+      nationalNumber: compact.slice(2),
+    }
+  }
+
+  if (TEN_DIGIT_PATTERN.test(compact)) {
+    return {
+      ok: true,
+      nationalNumber: compact,
+    }
+  }
+
+  if (ELEVEN_DIGIT_US_PATTERN.test(compact)) {
+    return {
+      ok: true,
+      nationalNumber: compact.slice(1),
+    }
+  }
+
+  if (SEVEN_DIGIT_PATTERN.test(compact)) {
+    if (!context.defaultAreaCode) {
+      return buildError(
+        'PHONE_DEFAULT_AREA_CODE_REQUIRED',
+        'A default area code is required for seven-digit phone numbers.',
+      )
+    }
+
+    if (!THREE_DIGIT_PATTERN.test(context.defaultAreaCode)) {
+      return buildError(
+        'PHONE_DEFAULT_AREA_CODE_INVALID',
+        'Default area code must be exactly three digits.',
+      )
+    }
+
+    return {
+      ok: true,
+      nationalNumber: `${context.defaultAreaCode}${compact}`,
+    }
+  }
+
+  return buildError('PHONE_INVALID_FORMAT', 'Provide a valid phone number.')
+}
+
+const buildCanonicalPhoneIdentity = (
+  rawInput: string,
+  nationalNumber: string,
+  context: PhoneNormalizationContext,
+): CanonicalPhoneIdentity => ({
+  rawInput,
+  normalizedE164: `+1${nationalNumber}`,
+  displayNational: formatUsNationalDisplay(nationalNumber),
+  countryCode: '1',
+  nationalNumber,
+  validationStatus: 'valid',
+  source: context.source || DEFAULT_SOURCE,
+  usageType: 'unknown',
+  sharedPhoneFlag: false,
+  smsCapable: null,
+  voiceCapable: null,
+})
+
+const resolveCanonicalIdentity = (
+  input: string,
+  context: Partial<PhoneNormalizationContext> = {},
+): PhoneNormalizationResult => {
+  const normalizedContext = normalizeContext(context)
+  const trimmedInput = input.trim()
+  const resolved = resolveUsNationalNumber(trimmedInput, normalizedContext)
+  if (!resolved.ok) {
+    return resolved
+  }
+
+  return {
+    ok: true,
+    phone: buildCanonicalPhoneIdentity(trimmedInput, resolved.nationalNumber, normalizedContext),
+  }
+}
+
+const resolveNormalizedValue = (
+  phone: CanonicalPhoneIdentity | string,
+): string | null => {
+  if (typeof phone === 'string') {
+    const normalized = phone.trim()
+    return E164_PHONE_PATTERN.test(normalized) ? normalized : null
+  }
+
+  return phone.normalizedE164
+}
+
+export function parsePhone(
+  input: string,
+  context: Partial<PhoneNormalizationContext> = {},
+): PhoneNormalizationResult {
+  return resolveCanonicalIdentity(input, context)
+}
+
+export function normalizePhone(
+  input: string,
+  context: Partial<PhoneNormalizationContext> = {},
+): PhoneNormalizationResult {
+  return resolveCanonicalIdentity(input, context)
+}
+
+export function formatDisplayPhone(
+  phone: CanonicalPhoneIdentity | string,
+  _locale: string,
+): string {
+  if (typeof phone !== 'string') {
+    return phone.displayNational
+  }
+
+  const normalized = resolveNormalizedValue(phone)
+  if (!normalized || !normalized.startsWith('+1') || normalized.length !== 12) {
+    return phone
+  }
+
+  return formatUsNationalDisplay(normalized.slice(2))
+}
+
+export function validatePhoneForChannel(
+  phone: CanonicalPhoneIdentity | string,
+  channel: PhoneChannel,
+): PhoneChannelValidationResult {
+  const normalized = resolveNormalizedValue(phone)
+  if (!normalized) {
+    return {
+      ok: false,
+      reason: 'Phone identity must be canonical before channel validation.',
+    }
+  }
+
+  if (!['sms', 'voice'].includes(channel)) {
+    return {
+      ok: false,
+      reason: 'Unsupported channel.',
+    }
+  }
+
+  return { ok: true }
+}
+
+export function comparePhoneIdentity(
+  left: CanonicalPhoneIdentity | string,
+  right: CanonicalPhoneIdentity | string,
+): boolean {
+  const leftValue = resolveNormalizedValue(left)
+  const rightValue = resolveNormalizedValue(right)
+
+  if (!leftValue || !rightValue) {
+    return false
+  }
+
+  return leftValue === rightValue
 }

--- a/domains/communication/project.json
+++ b/domains/communication/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "communication-domain",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "domains/communication",
+  "tags": ["scope:shared", "type:domain"]
+}

--- a/scripts/enforce-workspace-boundaries.js
+++ b/scripts/enforce-workspace-boundaries.js
@@ -10,13 +10,14 @@ const repoRoot = process.cwd();
 const LANE_TAGS = ['lane:moneyshyft', 'lane:connectshyft', 'lane:signshyft'];
 const SHARED_TAG = 'scope:shared';
 const LEGACY_LANE_TAGS = ['lane:routeshyft'];
+const SHARED_PROJECT_ROOT_PREFIXES = ['packages/shared-', 'domains/'];
 const DEPENDENCY_RULES = {
   'lane:moneyshyft': ['lane:moneyshyft', SHARED_TAG],
   'lane:connectshyft': ['lane:connectshyft', SHARED_TAG],
   'lane:signshyft': ['lane:signshyft', SHARED_TAG],
   'scope:shared': [SHARED_TAG],
 };
-const SCAN_ROOTS = ['apps', 'tools', 'packages', 'libs'];
+const SCAN_ROOTS = ['apps', 'tools', 'packages', 'libs', 'domains'];
 const IGNORE_DIRS = new Set(['node_modules', '.git', 'dist', 'coverage', '.nx', '.cache']);
 const SOURCE_FILE_PATTERN = /\.(ts|tsx|js|jsx|mjs|cjs|vue)$/i;
 
@@ -93,15 +94,14 @@ function collectProjectJsonFiles() {
   return Array.from(new Set(files)).sort();
 }
 
-function collectSharedPackageDirs() {
-  const packagesRoot = path.join(repoRoot, 'packages');
-  if (!fs.existsSync(packagesRoot)) {
-    return [];
-  }
-  return fs
-    .readdirSync(packagesRoot, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && entry.name.startsWith('shared-'))
-    .map((entry) => normalizeRelative(path.join('packages', entry.name)))
+function isSharedProjectRoot(projectRoot) {
+  return SHARED_PROJECT_ROOT_PREFIXES.some((prefix) => projectRoot.startsWith(prefix));
+}
+
+function collectSharedProjectDirs(projectDescriptors) {
+  return projectDescriptors
+    .filter((descriptor) => descriptor.hasSharedTag)
+    .map((descriptor) => descriptor.projectRoot)
     .sort();
 }
 
@@ -250,10 +250,16 @@ function isWorkspaceSourceFile(filePath) {
 function isDisallowedSharedImport(specifier, sourceFile) {
   const directSharedPathPattern = /packages\/shared-[^/]+\/src(?:\/.*)?$/;
   const directSharedIndexPattern = /packages\/shared-[^/]+\/src\/index(?:\.[a-z0-9]+)?$/i;
+  const directDomainPathPattern = /^domains\/[^/]+\/.+$/;
+  const directDomainIndexPattern = /^domains\/[^/]+\/index(?:\.[a-z0-9]+)?$/i;
   const scopedSharedDeepPattern = /^@[^/]+\/shared-[^/]+\/.+/;
   const unscopedSharedDeepPattern = /^shared-[^/]+\/.+/;
 
   if (scopedSharedDeepPattern.test(specifier) || unscopedSharedDeepPattern.test(specifier)) {
+    return true;
+  }
+
+  if (directDomainPathPattern.test(specifier) && !directDomainIndexPattern.test(specifier)) {
     return true;
   }
 
@@ -267,6 +273,9 @@ function isDisallowedSharedImport(specifier, sourceFile) {
 
   const sourceAbsolute = path.join(repoRoot, sourceFile);
   const resolved = normalizeRelative(path.relative(repoRoot, path.resolve(path.dirname(sourceAbsolute), specifier)));
+  if (directDomainPathPattern.test(resolved) && !directDomainIndexPattern.test(resolved)) {
+    return true;
+  }
   if (directSharedPathPattern.test(resolved) && !directSharedIndexPattern.test(resolved)) {
     return true;
   }
@@ -276,7 +285,7 @@ function isDisallowedSharedImport(specifier, sourceFile) {
 
 function validateProjectTags(projectFiles, issues) {
   for (const descriptor of projectFiles) {
-    const { projectFile, tags, laneTags, hasSharedTag } = descriptor;
+    const { projectFile, projectRoot, tags, laneTags, hasSharedTag } = descriptor;
 
     if (tags.length === 0) {
       issues.push(`${projectFile}: missing tags[] classification. Add exactly one lane:* tag or scope:shared.`);
@@ -300,20 +309,20 @@ function validateProjectTags(projectFiles, issues) {
     const classificationCount = laneTags.length + (hasSharedTag ? 1 : 0);
     if (classificationCount === 0) {
       issues.push(
-        `${projectFile}: must include exactly one lane tag (${LANE_TAGS.join(', ')}) or '${SHARED_TAG}' for shared packages.`,
+        `${projectFile}: must include exactly one lane tag (${LANE_TAGS.join(', ')}) or '${SHARED_TAG}' for shared projects.`,
       );
     }
     if (classificationCount > 1) {
       issues.push(`${projectFile}: ambiguous classification. Do not combine lane:* tags with '${SHARED_TAG}'.`);
     }
 
-    if (projectFile.startsWith('packages/shared-') && !hasSharedTag) {
-      issues.push(`${projectFile}: shared package projects must include '${SHARED_TAG}'.`);
+    if (isSharedProjectRoot(projectRoot) && !hasSharedTag) {
+      issues.push(`${projectFile}: shared projects must include '${SHARED_TAG}'.`);
     }
 
-    if (!projectFile.startsWith('packages/shared-') && hasSharedTag) {
+    if (!isSharedProjectRoot(projectRoot) && hasSharedTag) {
       issues.push(
-        `${projectFile}: '${SHARED_TAG}' is only allowed for projects under packages/shared-*; use exactly one lane tag.`,
+        `${projectFile}: '${SHARED_TAG}' is only allowed for projects under packages/shared-* or domains/*; use exactly one lane tag.`,
       );
     }
   }
@@ -384,24 +393,29 @@ function validateDependencyConstraints(projectFiles, issues) {
   }
 }
 
-function validateSharedPackageEntrypoints(sharedPackageDirs, issues) {
-  for (const packageDir of sharedPackageDirs) {
-    const publicEntrypoint = path.join(repoRoot, packageDir, 'src/index.ts');
-    if (!fs.existsSync(publicEntrypoint)) {
+function validateSharedProjectEntrypoints(sharedProjectDirs, issues) {
+  for (const projectDir of sharedProjectDirs) {
+    const candidateEntrypoints = [
+      path.join(repoRoot, projectDir, 'src/index.ts'),
+      path.join(repoRoot, projectDir, 'index.ts'),
+    ];
+    if (!candidateEntrypoints.some((candidate) => fs.existsSync(candidate))) {
       issues.push(
-        `${packageDir}: missing public entrypoint src/index.ts. Shared packages must expose a single import boundary.`,
+        `${projectDir}: missing public entrypoint src/index.ts or index.ts. Shared projects must expose a single import boundary.`,
       );
     }
   }
 }
 
-function validateDeepImports(issues) {
+function validateDeepImports(projectDescriptors, issues) {
+  const lookup = buildProjectLookup(projectDescriptors);
   let candidateFiles = gatherChangedFiles().filter((file) => isWorkspaceSourceFile(file));
   if (candidateFiles.length === 0) {
     candidateFiles = runLines('git ls-files').filter((file) => isWorkspaceSourceFile(file));
   }
 
   for (const file of candidateFiles) {
+    const sourceProject = findOwningProjectForWorkspacePath(file, lookup);
     const absolutePath = path.join(repoRoot, file);
     if (!fs.existsSync(absolutePath)) {
       continue;
@@ -420,8 +434,13 @@ function validateDeepImports(issues) {
       const specifiers = extractImportSpecifiers(line);
       for (const specifier of specifiers) {
         if (isDisallowedSharedImport(specifier, file)) {
+          const targetProject = findProjectForSpecifier(specifier, file, lookup);
+          if (sourceProject && targetProject && sourceProject.projectFile === targetProject.projectFile) {
+            continue;
+          }
+
           issues.push(
-            `${file}:${index + 1}: deep/shared boundary import '${specifier}' is forbidden. Import shared packages through the package root and re-export via src/index.ts.`,
+            `${file}:${index + 1}: deep/shared boundary import '${specifier}' is forbidden. Import shared projects through their public root entrypoints.`,
           );
         }
       }
@@ -599,7 +618,7 @@ function validateCrossLaneImports(projectDescriptors, issues) {
         }
 
         issues.push(
-          `${file}:${index + 1}: cross-lane import '${specifier}' is forbidden (${sourceClass} -> ${targetClass}). Route cross-lane contracts through packages/shared-* and import from package root APIs.`,
+          `${file}:${index + 1}: cross-lane import '${specifier}' is forbidden (${sourceClass} -> ${targetClass}). Route cross-lane contracts through packages/shared-* or domains/* and import from public root APIs.`,
         );
       }
     }
@@ -613,10 +632,10 @@ function fail(issues) {
   }
   console.error('Remediation:');
   console.error(
-    `  1. Add exactly one lane tag (${LANE_TAGS.join(', ')}) to each workspace project, or '${SHARED_TAG}' for shared packages.`,
+    `  1. Add exactly one lane tag (${LANE_TAGS.join(', ')}) to each workspace project, or '${SHARED_TAG}' for shared projects.`,
   );
   console.error("  2. Keep lane dependencies isolated to same-lane + scope:shared in .eslintrc.cjs.");
-  console.error("  3. Expose shared package APIs via src/index.ts and remove deep imports across package boundaries.");
+  console.error("  3. Expose shared project APIs via src/index.ts or index.ts and remove deep imports across shared boundaries.");
   process.exit(1);
 }
 
@@ -629,12 +648,12 @@ function main() {
   const issues = [];
   const projectFiles = collectProjectJsonFiles();
   const projectDescriptors = extractProjectDescriptors(projectFiles, issues);
-  const sharedPackageDirs = collectSharedPackageDirs();
+  const sharedProjectDirs = collectSharedProjectDirs(projectDescriptors);
 
   validateProjectTags(projectDescriptors, issues);
   validateDependencyConstraints(projectFiles, issues);
-  validateSharedPackageEntrypoints(sharedPackageDirs, issues);
-  validateDeepImports(issues);
+  validateSharedProjectEntrypoints(sharedProjectDirs, issues);
+  validateDeepImports(projectDescriptors, issues);
   validateCrossLaneImports(projectDescriptors, issues);
 
   if (issues.length > 0) {
@@ -642,7 +661,7 @@ function main() {
   }
 
   console.log(
-    `Workspace boundary guard passed (projects=${projectFiles.length}, sharedPackages=${sharedPackageDirs.length})`,
+    `Workspace boundary guard passed (projects=${projectFiles.length}, sharedProjects=${sharedProjectDirs.length})`,
   );
 }
 

--- a/specs/002-phone-identity/contracts/phone-domain-contract.md
+++ b/specs/002-phone-identity/contracts/phone-domain-contract.md
@@ -1,0 +1,139 @@
+# Contract: Shared Phone Domain API
+
+## Location
+
+`/domains/communication/phone/`
+
+## Purpose
+
+Provide the canonical, reusable phone identity API for ConnectShyft and later communication-domain consumers.
+
+## Public Types
+
+### `PhoneNormalizationContext`
+
+- `defaultCountry: string`
+- `defaultAreaCode?: string`
+- `source?: 'user_entered' | 'imported' | 'system_generated'`
+
+### `CanonicalPhoneIdentity`
+
+- `rawInput: string`
+- `normalizedE164: string`
+- `displayNational: string`
+- `countryCode: string`
+- `nationalNumber: string`
+- `extension?: string`
+- `validationStatus: 'valid' | 'invalid' | 'needs_review'`
+- `source: 'user_entered' | 'imported' | 'system_generated'`
+- `usageType: 'mobile' | 'landline' | 'unknown'`
+- `sharedPhoneFlag: boolean`
+- `smsCapable: boolean | null`
+- `voiceCapable: boolean | null`
+
+### `PhoneNormalizationError`
+
+- `code`
+  - expected values:
+    - `PHONE_EMPTY`
+    - `PHONE_INVALID_FORMAT`
+    - `PHONE_DEFAULT_AREA_CODE_REQUIRED`
+    - `PHONE_DEFAULT_AREA_CODE_INVALID`
+- `message`
+
+## Public Functions
+
+### `parsePhone(input, context)`
+
+Input:
+
+- raw user-entered phone string
+- `PhoneNormalizationContext`
+
+Output:
+
+- success: parsed canonical identity with derived fields
+- failure: structured normalization error
+- runtime shape: `{ ok: true, phone } | { ok: false, error }`
+
+Rules:
+
+- accepts natural ten-digit domestic input
+- accepts explicit E.164 input
+- accepts seven-digit local input only when `defaultAreaCode` is supplied
+- rejects alpha characters and malformed numeric input
+
+### `normalizePhone(input, context)`
+
+Input:
+
+- raw user-entered phone string
+- `PhoneNormalizationContext`
+
+Output:
+
+- success: canonical phone identity
+- failure: structured normalization error
+- runtime shape: `{ ok: true, phone } | { ok: false, error }`
+
+Rules:
+
+- `normalizedE164` is always present on success
+- no caller may infer canonical storage from UI formatting alone
+
+### `formatDisplayPhone(phone, locale)`
+
+Input:
+
+- canonical phone identity or canonical E.164 value
+- locale token
+
+Output:
+
+- human-friendly display string
+
+Rules:
+
+- returns national-style formatting for supported domestic numbers
+- must never be used as the canonical lookup value
+
+### `validatePhoneForChannel(phone, channel)`
+
+Input:
+
+- canonical phone identity
+- channel token
+  - initial channels: `sms`, `voice`
+
+Output:
+
+- pass/fail decision with reason
+- runtime shape: `{ ok: true } | { ok: false, reason }`
+
+Rules:
+
+- channel validation is based on canonical phone identity data
+- telephony/provider lookups are out of scope for CS-002
+
+### `comparePhoneIdentity(a, b)`
+
+Input:
+
+- two canonical phone identities or canonical E.164 values
+
+Output:
+
+- boolean equality decision or deterministic comparison result
+
+Rules:
+
+- comparison is based on canonical identity, not raw display formatting
+
+## Example Conversions
+
+- `2605551212` + `{ defaultCountry: 'US' }` -> `+12605551212`
+- `5551212` + `{ defaultCountry: 'US', defaultAreaCode: '260' }` -> `+12605551212`
+- `260-ABC-1212` -> `PHONE_INVALID_FORMAT`
+- `5551212` + `{ defaultCountry: 'US' }` -> `PHONE_DEFAULT_AREA_CODE_REQUIRED`
+- `formatDisplayPhone('+12605551212', 'en-US')` -> `(260) 555-1212`
+- `comparePhoneIdentity('+12605551212', '+12605551212')` -> `true`

--- a/specs/002-phone-identity/data-model.md
+++ b/specs/002-phone-identity/data-model.md
@@ -1,0 +1,162 @@
+# Data Model: CS-002 Phone Identity
+
+## 1. Domain Value: `PhoneNormalizationContext`
+
+Purpose: provide caller-supplied configuration needed to normalize natural input without hardcoding deployment assumptions into the shared domain.
+
+### Fields
+
+- `defaultCountry`
+  - string
+  - initial expected value: `US`
+- `defaultAreaCode`
+  - optional string
+  - used only for seven-digit local input
+- `source`
+  - optional conceptual value
+  - expected values: `user_entered`, `imported`, `system_generated`
+
+### Validation rules
+
+- `defaultAreaCode` must be exactly three digits when supplied.
+- Seven-digit inputs are invalid when `defaultAreaCode` is missing.
+- The shared domain must not read UI or provider state directly; all normalization context must be injected.
+
+## 2. Domain Value: `CanonicalPhoneIdentity`
+
+Purpose: represent the reusable, canonical phone identity returned by the shared communication domain.
+
+### Fields
+
+- `rawInput`
+- `normalizedE164`
+- `displayNational`
+- `countryCode`
+- `nationalNumber`
+- `extension`
+  - optional
+- `validationStatus`
+  - `valid`, `invalid`, `needs_review`
+- `source`
+  - `user_entered`, `imported`, `system_generated`
+- `usageType`
+  - `mobile`, `landline`, `unknown`
+- `sharedPhoneFlag`
+- `smsCapable`
+  - nullable boolean
+- `voiceCapable`
+  - nullable boolean
+
+### Validation rules
+
+- `normalizedE164` is required for any successful parse/normalize result.
+- `displayNational` is derived display data and must never be used as the canonical lookup value.
+- `rawInput` is optional and cannot be required for business logic.
+- `validationStatus` must be deterministic from input plus context.
+
+## 3. Canonical Persistence Entity: `communication_contact_point`
+
+Purpose: store reusable phone contact endpoints in canonical shared-domain form.
+
+### Canonical fields
+
+- `id`
+- `tenant_id`
+- `owner_type`
+- `owner_id`
+- `channel`
+  - initial value: `phone`
+- `label`
+- `raw_input`
+  - optional
+- `normalized_e164`
+- `display_national`
+- `country_code`
+- `national_number`
+- `extension`
+  - optional
+- `validation_status`
+- `usage_type`
+- `is_primary`
+- `is_active`
+- `source`
+- `created_at`
+- `updated_at`
+
+### Relationships
+
+- one owner can have many `communication_contact_point`
+- only one primary contact point per owner/channel should be active at a time
+
+### Validation rules
+
+- `normalized_e164` is the canonical dedupe and lookup value.
+- multiple phone numbers per owner are supported from the start
+- end-user forms must never require E.164 even though persistence uses it canonically
+
+## 4. Current Repo Adapter Entity: `connectshyft.cs_neighbor_phones`
+
+Purpose: serve as the current implementation-time persistence adapter for ConnectShyft while CS-002 moves the repo toward the canonical contact-point shape.
+
+### Current fields already present
+
+- `id`
+- `neighbor_id`
+- `tenant_id`
+- `label`
+- `value_e164`
+- `sort_order`
+- `is_primary`
+- `is_shared`
+- `verification_status`
+- `created_at_utc`
+- `updated_at_utc`
+
+### Required CS-002 shaping
+
+- map `value_e164` to canonical `normalized_e164`
+- add or derive canonical display/parsed fields needed for the shared phone contract
+- keep owner scoping explicit through the current neighbor relationship without inventing a second local phone store
+- keep the table compatible with future migration toward a general `communication_contact_point`
+
+### Relationships
+
+- one ConnectShyft neighbor can have many phone rows
+- a phone row belongs to exactly one tenant-scoped neighbor in the current implementation
+
+## 5. Adjacent Durable Trait Data
+
+Purpose: preserve communication-specific flags that already exist in the current product and must not remain ad hoc UI state.
+
+### Relevant traits
+
+- `shared_phone`
+- `prefers_texting`
+
+### Current repo mapping
+
+- `is_shared` currently lives on `connectshyft.cs_neighbor_phones`
+- `prefers_texting` currently lives on ConnectShyft neighbor records
+
+### CS-002 expectation
+
+- CS-002 must not regress these into local UI-only labels
+- full canonical trait-table migration may be incremental, but the design must remain compatible with `communication_contact_trait`
+
+## 6. Functional State Flow
+
+### Successful normalization
+
+`raw input` -> `trim / sanitize` -> `apply context-driven country/area-code rules` -> `canonical E.164` -> `derived display + parsed fields` -> `persist through contact-point equivalent model`
+
+### Refusal flow
+
+`raw input` -> `trim / sanitize` -> `invalid characters / unsupported shape / seven-digit-without-context` -> `validation refusal`
+
+## 7. Required Invariants for CS-002
+
+- users never need to understand E.164
+- canonical internal storage uses `normalized_e164` or an equivalent field mapped directly to it
+- multiple phone numbers per owner are supported
+- seven-digit input is allowed only with configured context
+- ConnectShyft consumes the shared phone domain instead of redefining normalization locally

--- a/specs/002-phone-identity/plan.md
+++ b/specs/002-phone-identity/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: CS-002 Phone Identity
+
+**Branch**: `002-phone-identity` | **Date**: 2026-03-11 | **Spec**: [spec.md](/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/spec.md)  
+**Input**: Feature specification from `/specs/002-phone-identity/spec.md`
+
+## Summary
+
+Implement CS-002 by replacing ConnectShyft-local phone parsing with a shared communication-domain phone identity module under `domains/communication/phone`, then adopt that module in ConnectShyft API neighbor and identity-boundary flows so users can enter natural phone numbers while the system stores canonical E.164 values internally. The design keeps telephony out of scope, preserves the monolithic monorepo structure, and treats the current ConnectShyft phone table as a temporary equivalent persistence adapter that must be shaped toward the canonical `communication_contact_point` model rather than left as a permanent local fork. Constitution-required no-regression validation for routing ownership, port and binding expectations, shared Postgres compatibility, and runbook-style reproducibility is part of this feature's delivery evidence even though CS-002 does not change deployment topology.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022) on Node.js >=20  
+**Primary Dependencies**: Express, Knex, pg, Jest/ts-jest, root-level shared communication domain source under `domains/communication`  
+**Storage**: Shared PostgreSQL; current ConnectShyft phone persistence in `connectshyft.cs_neighbor_phones` must evolve toward `communication_contact_point`-equivalent canonical fields  
+**Testing**: Jest unit/integration coverage in `apps/connectshyft-api/src/**/__tests__`, plus shared-domain tests executed through the lane API Jest harness and TypeScript build validation  
+**Target Platform**: Linux-hosted monolithic monorepo with lane APIs and SPAs, shared Postgres, and host-managed Nginx  
+**Project Type**: Monolithic monorepo web application with a shared domain module and lane API consumers  
+**Performance Goals**: Synchronous parse/normalize/format operations with no network calls, negligible request-path overhead for neighbor create/update/identity-match flows, and indexed lookup on canonical E.164 values  
+**Constraints**: No E.164 awareness in UI, no ConnectShyft-local normalization forks, configurable seven-digit fallback only when context is supplied, no CS-003/CS-004/CS-005 scope creep, no routing/deployment changes, and no schema choice that blocks future People-safe reuse  
+**Scale/Scope**: CS-002 only; root shared phone domain plus ConnectShyft API consumer adoption, persistence shaping for canonical phone identity, and reusable contracts for later modules
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Initial Gate Review**
+
+- Platform shell authority preserved: PASS. CS-002 changes are limited to shared domain logic and ConnectShyft API/domain consumers; `admin-web`/`admin-api` shell and auth authority remain untouched.
+- Lane isolation preserved: PASS. The feature introduces a root shared domain consumed by lane code but does not add implicit lane-to-lane service calls or new frontend drift.
+- Routing delegation preserved: PASS. No auth/admin route ownership changes are required; ConnectShyft API remains the lane owner for ConnectShyft routes.
+- Deployment topology preserved: PASS. No Nginx, container topology, port, or static-serving changes are required for phone identity.
+- Database ownership preserved: PASS. Any schema evolution remains compatible with shared Postgres and must still respect that production migration execution is owned by `admin-api`, even if development/test migrations live with `connectshyft-api`.
+- Security boundaries preserved: PASS. No public ports, cookie, or ingress behavior changes are introduced.
+- Workflow compliance: CONDITIONAL. This plan is derived directly from CS-002 and produces the required design artifacts, but `spec.md` and `tasks.md` must explicitly carry the constitution-required routing, lane-boundary, shared-database, and validation content.
+- Acceptance criteria present: CONDITIONAL. Core phone-identity acceptance is defined, but constitution-required no-regression scenarios for routing ownership, deployment topology, shared-database compatibility, and runbook evidence must remain explicit in the feature artifacts.
+
+**Post-Design Re-check**
+
+- Platform shell authority preserved: PASS. Shared phone identity stays below shell/auth boundaries.
+- Lane isolation preserved: PASS. The design uses `domains/communication` as a monorepo shared source boundary instead of cross-lane API coupling.
+- Routing delegation preserved: PASS. The design does not add or move any HTTP routes.
+- Deployment topology preserved: PASS. The design requires only code and schema changes inside existing services.
+- Database ownership preserved: PASS. The design treats canonical phone persistence as shared-Postgres-compatible and documents production migration authority as unchanged.
+- Security boundaries preserved: PASS. No ingress, session, or public-port behavior changes are introduced.
+- Workflow compliance: CONDITIONAL. Generated artifacts remain traceable to CS-002, but the final spec and task list must keep constitution-required platform validation tasks and scenarios intact.
+- Acceptance criteria present: CONDITIONAL. Validation is concrete for phone identity, but the feature still depends on explicit artifact coverage for routing, shared Postgres, and runbook-style no-regression evidence.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-phone-identity/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── phone-domain-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+domains/
+└── communication/
+    ├── index.ts
+    └── phone/
+        └── index.ts
+
+apps/
+└── connectshyft-api/
+    ├── src/
+    │   ├── migrations/
+    │   ├── modules/
+    │   │   └── connectshyft/
+    │   │       ├── identityBoundary.ts
+    │   │       └── neighbors.ts
+    │   └── routes/
+    │       └── api/
+    │           └── v1/
+    │               └── connectshyft.ts
+    ├── jest.config.js
+    ├── package.json
+    └── tsconfig.json
+
+apps/
+└── connectshyft-web/
+    └── src/
+        └── [consumer-only surfaces; no redesign planned]
+```
+
+**Structure Decision**: Implement canonical phone identity in the root shared communication domain at `domains/communication/phone`, adapt `apps/connectshyft-api` as the authoritative CS-002 consumer, and only touch frontend code if a consumer must stop redefining canonical phone behavior. The key technical integration work is enabling the lane API build/test tooling to consume a root-level shared domain path without moving the domain into a faux package or recreating ConnectShyft-local logic.
+
+## Complexity Tracking
+
+No constitution violations are required for CS-002. This section is intentionally empty.

--- a/specs/002-phone-identity/quickstart.md
+++ b/specs/002-phone-identity/quickstart.md
@@ -1,0 +1,157 @@
+# Quickstart: CS-002 Phone Identity
+
+## Goal
+
+Validate that ConnectShyft can accept natural phone-number input while storing canonical E.164 through the shared communication domain.
+
+## Implementation sequence
+
+1. Replace the stub implementation in `domains/communication/phone/index.ts` with the shared phone API defined in `contracts/phone-domain-contract.md`.
+2. Update `apps/connectshyft-api` build/test configuration so lane API code can import the root shared domain.
+3. Replace local phone normalization in ConnectShyft neighbor and identity-boundary flows with the shared phone domain.
+4. Shape current ConnectShyft phone persistence toward the canonical contact-point model without creating a second ConnectShyft-only phone store.
+5. Add unit coverage for shared phone-domain behavior and regression coverage for ConnectShyft neighbor/identity flows.
+
+## Example verification scenarios
+
+1. Normalize `2605551212` with domestic context and confirm canonical output is `+12605551212`.
+2. Normalize `5551212` with default area code `260` and confirm canonical output is `+12605551212`.
+3. Normalize `5551212` without a default area code and confirm the request is refused.
+4. Submit malformed input with alpha characters and confirm validation refusal.
+5. Create or update a ConnectShyft neighbor and confirm stored phone identity uses canonical E.164 plus derived display/parsed fields through the shared-domain contract.
+6. Resolve identity-boundary matching by canonical phone identity rather than ConnectShyft-local regex logic.
+
+## Suggested validation commands
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+env NODE_ENV=test npx jest --runInBand --runTestsByPath \
+  ../../domains/communication/phone/__tests__/index.test.ts \
+  src/modules/connectshyft/__tests__/neighbors.test.ts \
+  src/modules/connectshyft/__tests__/identityBoundary.test.ts \
+  src/migrations/__tests__/connectShyftNeighborCanonicalPhoneIdentityMigration.test.ts \
+  src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts
+npm run build
+```
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+node scripts/enforce-workspace-boundaries.js
+npm run policy:check
+```
+
+## Platform no-regression validation
+
+### T024 Route ownership validation
+
+Result: PASS
+
+- `apps/admin-api/src/api/registerRoutes.ts` continues to register `/api/v1/platform/admin` and `/api/v1/auth` under `admin-api`.
+- `apps/connectshyft-api/src/app.ts` continues to mount only `/api/v1/connectshyft` for lane-local ConnectShyft routes.
+- The CS-002 feature diff touches shared phone-domain code, ConnectShyft phone-identity consumers, and feature docs, but does not modify `apps/admin-api`, `apps/connectshyft-api/src/app.ts`, `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`, `docs/PRODUCTION_DEPLOYMENT_GUIDE.md`, or `docker-compose.production.example.yml`.
+
+Validation commands used:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+sed -n '26,30p' apps/admin-api/src/api/registerRoutes.ts
+sed -n '25,31p' apps/connectshyft-api/src/app.ts
+git diff --name-only -- specs/002-phone-identity apps/connectshyft-api apps/admin-api docs docker-compose.production.example.yml domains/communication
+```
+
+### T025 API binding and port validation
+
+Result: PASS
+
+- `apps/connectshyft-api/src/server.ts` keeps canonical production port `3002` and rejects non-canonical production ports.
+- `apps/connectshyft-api/src/server.ts` allows only local-interface bindings in production (`0.0.0.0`, `127.0.0.1`, or `localhost`).
+- `apps/connectshyft-api/.env.example` still documents `PORT=3002` and `HOST=127.0.0.1`.
+- `docker-compose.production.example.yml` still publishes ConnectShyft on loopback-only `127.0.0.1:3002:3002`.
+- `docs/PRODUCTION_DEPLOYMENT_GUIDE.md` still declares `upstream connect_api { server 127.0.0.1:3002; }` and loopback health checks on `http://127.0.0.1:3002/health`.
+
+Validation commands used:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+sed -n '4,18p' apps/connectshyft-api/src/server.ts
+sed -n '1,12p' apps/connectshyft-api/.env.example
+sed -n '52,67p' docker-compose.production.example.yml
+sed -n '157,199p' docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+```
+
+### T026 Shared PostgreSQL connectivity and migration authority validation
+
+Result: PASS
+
+- `apps/connectshyft-api/src/knexfile.ts` still requires `DATABASE_URL` or `DATABASE_HOST`/`DATABASE_PORT`/`DATABASE_NAME`/`DATABASE_USER`/`DATABASE_PASSWORD`, preserving the shared-Postgres connectivity contract.
+- `apps/connectshyft-api/.env.example` still points production configuration at `host.docker.internal:5432`.
+- `apps/connectshyft-api/package.json` still guards `migrate:latest:prod`, `migrate:rollback:prod`, and `seed:run:prod` with `scripts/enforceProdMigrationAuthority.js`.
+- `apps/connectshyft-api/scripts/enforceProdMigrationAuthority.js` still hard-fails with `use admin-api instead`.
+- `apps/admin-api/package.json` remains the only lane package exposing the authoritative production migration command.
+- `docs/DEPLOYMENT_CHECKLIST.md` and `docs/PRODUCTION_DEPLOYMENT_GUIDE.md` still require one shared host Postgres and production migrations executed from `admin-api` only.
+
+Validation commands used:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+sed -n '27,45p' apps/connectshyft-api/src/knexfile.ts
+sed -n '10,16p' apps/connectshyft-api/package.json
+sed -n '1,3p' apps/connectshyft-api/scripts/enforceProdMigrationAuthority.js
+sed -n '10,16p' apps/admin-api/package.json
+sed -n '18,24p' docs/DEPLOYMENT_CHECKLIST.md
+sed -n '174,199p' docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+```
+
+## Reproducible no-regression runbook
+
+Use this sequence when re-validating CS-002 on a deployment candidate or release branch.
+
+1. Confirm route ownership remains unchanged.
+2. Confirm ConnectShyft canonical port and loopback binding expectations remain unchanged.
+3. Confirm shared Postgres and production migration authority remain unchanged.
+4. Execute the deployment-host smoke checks from the normalized production runbook.
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+
+# 1) Route ownership audit
+sed -n '26,30p' apps/admin-api/src/api/registerRoutes.ts
+sed -n '25,31p' apps/connectshyft-api/src/app.ts
+git diff --name-only -- specs/002-phone-identity apps/connectshyft-api apps/admin-api docs docker-compose.production.example.yml domains/communication
+
+# 2) ConnectShyft port/binding audit
+sed -n '4,18p' apps/connectshyft-api/src/server.ts
+sed -n '1,12p' apps/connectshyft-api/.env.example
+sed -n '52,67p' docker-compose.production.example.yml
+
+# 3) Shared Postgres + migration authority audit
+sed -n '27,45p' apps/connectshyft-api/src/knexfile.ts
+sed -n '10,16p' apps/connectshyft-api/package.json
+sed -n '1,3p' apps/connectshyft-api/scripts/enforceProdMigrationAuthority.js
+sed -n '10,16p' apps/admin-api/package.json
+sed -n '18,24p' docs/DEPLOYMENT_CHECKLIST.md
+sed -n '174,199p' docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+
+# 4) Deployment-host smoke sequence (run on the deployment target, not in this workspace)
+cd /home/jeremiahotis/projects/shyftunity
+docker compose build admin-api money-api connect-api
+docker compose run --rm admin-api npm run migrate:latest:prod
+docker compose up -d admin-api money-api connect-api
+curl -f http://127.0.0.1:3100/health
+curl -f http://127.0.0.1:3000/health
+curl -f http://127.0.0.1:3002/health
+curl -i https://money.shyftunity.com/api/v1/auth/me
+curl -i https://connect.shyftunity.com/api/v1/auth/me
+```
+
+## Implementation evidence notes
+
+- Shared-domain normalization now returns discriminated success/error results instead of throwing.
+- ConnectShyft neighbor persistence writes both legacy `value_e164` and canonical `normalized_e164`-equivalent columns while hydrating derived display/parsed fields.
+- Identity-boundary matching now normalizes natural input through the shared domain before canonical lookup on `normalized_e164`.
+
+## Non-goals to enforce during implementation
+
+- do not redesign ConnectShyft UI
+- do not add Telnyx integration
+- do not pull bridge-session or idempotency work into CS-002

--- a/specs/002-phone-identity/research.md
+++ b/specs/002-phone-identity/research.md
@@ -1,0 +1,43 @@
+# Phase 0 Research: CS-002 Phone Identity
+
+## Decision: Implement phone parsing and formatting as a domain-owned deterministic TypeScript module, not a new third-party dependency, for CS-002
+
+- **Rationale**: The repo already contains a stub shared domain at `domains/communication/phone`, but no existing phone parsing library dependency. CS-002 only requires natural domestic input, canonical E.164 storage, configurable seven-digit fallback, shared formatting/comparison behavior, and ConnectShyft API adoption. A deterministic domain-owned parser keeps the feature scoped, avoids dependency churn across the monorepo, and immediately eliminates the current duplicated regex logic in ConnectShyft services.
+- **Alternatives considered**:
+  - Add `libphonenumber`-style dependency now: more comprehensive globally, but unnecessary for the currently specified CS-002 acceptance examples and introduces dependency/workspace integration before the shared-domain boundary is even wired.
+  - Leave the existing regex helpers in app-local modules: violates the ADR and preserves the current duplication in ConnectShyft neighbor and identity-boundary code.
+
+## Decision: Make `PhoneNormalizationContext` the stable configuration boundary for default country and area-code fallback
+
+- **Rationale**: The ADR requires configuration-driven seven-digit fallback and forbids hardcoded area codes in UI/local components. The existing domain stub already exposes `defaultAreaCode` and `defaultCountry`. Keeping configuration as an explicit context object gives the domain a stable public API, lets the lane API decide how configuration is sourced, and leaves room for future org/tenant overrides without coupling the shared domain directly to environment variables.
+- **Alternatives considered**:
+  - Read environment variables directly inside `domains/communication/phone`: couples shared domain logic to runtime configuration and makes tenant/org overrides harder later.
+  - Hardcode a deployment area code in ConnectShyft services or views: explicitly rejected by the ADR and CS-002 guardrails.
+
+## Decision: Integrate the root shared domain by widening lane API TypeScript and Jest boundaries instead of moving the domain into a different package
+
+- **Rationale**: The required domain location is `/domains/communication/`. Today, no app imports that directory, and the lane API TypeScript configs use `rootDir: "./src"` plus Jest roots limited to `src`, which would block adoption. The least-drifting design is to keep the mandated root domain directory and update the lane API compiler/test configuration so that shared-domain source can be imported and tested without creating a second architectural location.
+- **Alternatives considered**:
+  - Create a new package under `packages/*`: would be technically workable, but diverges from the explicitly required `/domains/communication/` boundary.
+  - Copy the domain into each lane API: preserves build convenience at the cost of immediate architectural drift.
+
+## Decision: Treat `connectshyft.cs_neighbor_phones` as the current persistence adapter that must be shaped toward `communication_contact_point`
+
+- **Rationale**: The canonical data model allows exact table names to vary if structure matches. The repo already stores ConnectShyft phone data in `connectshyft.cs_neighbor_phones` with `value_e164`, label, primary/sort metadata, and shared-phone state. CS-002 should not create a second ConnectShyft-local phone store. Instead, it should use the current table as the adapter surface while adding the canonical fields and mapping needed for `communication_contact_point` equivalence.
+- **Alternatives considered**:
+  - Leave `cs_neighbor_phones` as-is with only `value_e164`: insufficient for the ADR/data-model canonical shape.
+  - Create a second ConnectShyft-only canonical phone table: adds a local fork and doubles migration complexity.
+
+## Decision: CS-002 consumer adoption starts with ConnectShyft API neighbor and identity-boundary flows
+
+- **Rationale**: The current duplication that matters for canonical phone identity lives in `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts` and `apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts`, with the same local normalization pattern copied elsewhere. The authoritative recovery target is ConnectShyft, and the issue explicitly excludes UI redesign and telephony integration. Adopting the shared domain in the ConnectShyft API first provides the canonical behavior where persistence and identity resolution already happen.
+- **Alternatives considered**:
+  - Refactor every lane copy and every UI helper as part of CS-002: too broad for the feature boundary.
+  - Leave ConnectShyft API unchanged and only build the shared module: fails to satisfy the “store canonical phone values” and “provide reusable phone utility” outcome in real application flows.
+
+## Decision: Validation evidence should combine shared-domain examples with ConnectShyft API regression coverage
+
+- **Rationale**: The issue requires unit tests and example conversions. Because the feature is a shared domain adopted by ConnectShyft API, the right evidence is: domain-level normalization/formatting/comparison tests, ConnectShyft neighbor/identity-boundary tests proving the domain is consumed, and a lane API build verifying the root shared domain integration.
+- **Alternatives considered**:
+  - Only unit-test the shared module: misses the critical adoption step.
+  - Only test API endpoints: misses the reusable domain contract that later modules must consume.

--- a/specs/002-phone-identity/spec.md
+++ b/specs/002-phone-identity/spec.md
@@ -1,0 +1,86 @@
+# Feature Spec: CS-002 Phone Identity
+
+**Feature Branch**: `002-phone-identity`  
+**Canonical Source**: [CS-002_Phone_Identity_Guardrailed_Spec.md](/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-002_Phone_Identity_Guardrailed_Spec.md)
+
+## Scope
+
+Implement canonical phone identity for ConnectShyft through the shared communication domain.
+
+This feature is limited to:
+
+- natural phone-number input
+- canonical internal E.164 storage
+- reusable shared-domain phone parsing, normalization, formatting, and comparison
+- ConnectShyft API adoption of that shared-domain behavior
+
+This feature explicitly excludes:
+
+- UI redesign
+- telephony integration
+- bridge session work
+- reliability/idempotency/audit work beyond what is required to avoid blocking CS-002 design
+
+## Routing Ownership and Lane Boundaries
+
+- `connectshyft-api` remains the owner of ConnectShyft lane routes affected by this feature.
+- `admin-api` remains the owner of `/api/v1/auth/*` and `/api/v1/platform/admin/*`; CS-002 must not change that delegation.
+- This feature may introduce shared domain code under `domains/communication`, but it must not introduce direct lane-to-lane API calls.
+- Canonical phone identity logic must stay below the Telnyx adapter boundary and must not embed provider-specific behavior.
+- Persistence remains in the shared PostgreSQL deployment model; this feature must remain compatible with production migration ownership by `admin-api`.
+
+## Requirements
+
+1. Phone utilities must live in `/domains/communication/phone/`.
+2. End users must never be required to understand or enter E.164 explicitly.
+3. Ten-digit domestic input must normalize to canonical E.164.
+4. Seven-digit local input is valid only when a default area code is supplied by configuration.
+5. Canonical internal storage must use an equivalent of `normalized_e164`.
+6. The implementation must not create a ConnectShyft-local fork of canonical phone identity.
+7. The implementation must remain compatible with the monolithic monorepo, shared communication domain, Telnyx adapter boundary, and canonical phone identity architecture constraints.
+
+## Acceptance Examples
+
+- Input: `2605551212`
+  Stored canonical value: `+12605551212`
+- Input: `5551212` with configured default area code `260`
+  Stored canonical value: `+12605551212`
+- Input with alpha characters or malformed digits
+  Result: validation refusal
+
+## User Stories
+
+### US1 - Natural Input to Canonical Storage
+
+As a ConnectShyft operator, I want to enter phone numbers in natural domestic formats so that the system stores canonical phone identity without requiring E.164 knowledge.
+
+Acceptance criteria:
+
+- `2605551212` stores as `+12605551212`
+- `5551212` is accepted only when a default area code is configured
+- malformed or alpha-containing input is refused
+- stored records include canonical phone identity fields equivalent to `normalized_e164`
+
+### US2 - Canonical Identity Matching
+
+As a ConnectShyft workflow, I want identity matching to compare canonical phone identity so that differently formatted equivalents resolve consistently.
+
+Acceptance criteria:
+
+- exact equivalent formats match the same canonical identity
+- non-equivalent inputs do not match
+- ambiguous matches remain ambiguous
+- shared-phone cases do not silently auto-merge
+
+## Platform Compatibility Scenarios
+
+- No route ownership changes: ConnectShyft routes stay in `connectshyft-api`; auth/admin routes stay delegated to `admin-api`.
+- Shared database compatibility: schema changes remain compatible with shared Postgres and production migration ownership by `admin-api`.
+- No ingress or port changes: no Nginx, public-port, or container-topology changes are introduced by CS-002.
+- Telnyx boundary compatibility: canonical phone identity stays provider-agnostic and does not move parsing or normalization into Telnyx adapters.
+
+## Evidence Required
+
+- unit tests for normalization behavior
+- example conversions
+- ADR/data-model compliance notes in feature documentation and the PR description

--- a/specs/002-phone-identity/tasks.md
+++ b/specs/002-phone-identity/tasks.md
@@ -1,0 +1,181 @@
+# Tasks: CS-002 Phone Identity
+
+**Input**: Design documents from `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/`
+**Prerequisites**: `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/plan.md`, `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/spec.md`, `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/research.md`, `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/data-model.md`, `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/contracts/phone-domain-contract.md`, `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/quickstart.md`
+**Tests**: Required by `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/spec.md` and `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-002_Phone_Identity_Guardrailed_Spec.md`
+**Organization**: Tasks are grouped by the explicit user stories in `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/spec.md` so each delivery slice can be implemented and validated independently.
+
+## Phase 1: Setup
+
+**Purpose**: Create the shared-domain project boundary required for CS-002 implementation.
+
+- [X] T001 Create shared-domain project metadata for `/Users/jeremiahotis/projects/connectshyft/domains/communication` in `/Users/jeremiahotis/projects/connectshyft/domains/communication/project.json`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Remove repo-level blockers so ConnectShyft API can import and test the root shared communication domain.
+
+**⚠️ CRITICAL**: Complete this phase before starting user story work.
+
+- [X] T002 [P] Update Nx module-boundary constraints to allow `/Users/jeremiahotis/projects/connectshyft/domains/communication` as `scope:shared` in `/Users/jeremiahotis/projects/connectshyft/.eslintrc.cjs`
+- [X] T003 [P] Extend workspace-boundary scanning and shared-project validation for `/Users/jeremiahotis/projects/connectshyft/domains/communication` in `/Users/jeremiahotis/projects/connectshyft/scripts/enforce-workspace-boundaries.js`
+- [X] T004 [P] Widen ConnectShyft API compilation to include root shared-domain imports in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/tsconfig.json`
+- [X] T005 [P] Widen ConnectShyft API Jest roots and shared-domain test discovery in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/jest.config.js`
+- [X] T006 [P] Ensure Nx build/test inputs include `/Users/jeremiahotis/projects/connectshyft/domains/communication` in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/project.json`
+
+**Checkpoint**: The repo can compile, lint, and test ConnectShyft API code that imports the root communication domain.
+
+---
+
+## Phase 3: User Story 1 - Natural Input to Canonical Storage (Priority: P1) 🎯 MVP
+
+**Goal**: ConnectShyft neighbor create/update flows accept natural phone input while persisting canonical E.164 plus derived canonical phone identity fields through the shared communication domain.
+
+**Independent Test**: Run the shared phone-domain tests and neighbor regression tests, then create or update a neighbor with `2605551212` and `5551212` plus configured area code and confirm `connectshyft.cs_neighbor_phones` stores canonical E.164 and derived fields without requiring E.164 input.
+
+### Tests for User Story 1
+
+- [X] T007 [P] [US1] Write shared phone contract and example-conversion tests in `/Users/jeremiahotis/projects/connectshyft/domains/communication/phone/__tests__/index.test.ts`
+- [X] T008 [P] [US1] Add ConnectShyft neighbor regression coverage for ten-digit and seven-digit natural input in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts`
+- [X] T009 [P] [US1] Add migration coverage for canonical contact-point fields on `connectshyft.cs_neighbor_phones` in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneIdentityMigration.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Implement the shared phone domain contract and deterministic normalization rules in `/Users/jeremiahotis/projects/connectshyft/domains/communication/phone/index.ts`
+- [X] T011 [US1] Re-export the shared phone domain public API from `/Users/jeremiahotis/projects/connectshyft/domains/communication/index.ts`
+- [X] T012 [P] [US1] Add ConnectShyft `PhoneNormalizationContext` resolution for default country and area-code fallback in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/phoneIdentityContext.ts`
+- [X] T013 [P] [US1] Shape `connectshyft.cs_neighbor_phones` toward canonical contact-point columns in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts`
+- [X] T014 [US1] Replace ConnectShyft-local phone parsing and refusal handling with shared-domain normalization in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T015 [US1] Persist and hydrate canonical phone identity fields from `connectshyft.cs_neighbor_phones` in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+
+**Checkpoint**: Neighbor create/update behavior is fully functional with natural phone input and canonical persistence.
+
+---
+
+## Phase 4: User Story 2 - Canonical Identity Matching (Priority: P2)
+
+**Goal**: Identity-boundary matching resolves by canonical phone identity instead of ConnectShyft-local regex normalization, using the same shared-domain contract and canonical lookup path introduced in US1.
+
+**Independent Test**: Evaluate identity matching with differently formatted equivalents of the same number and confirm exact-match, no-match, ambiguous, and shared-phone decisions are computed from canonical identity data and canonical lookup columns.
+
+### Tests for User Story 2
+
+- [X] T016 [P] [US2] Add canonical identity-match coverage for exact, no-match, ambiguous, and shared-phone cases in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts`
+- [X] T017 [P] [US2] Add migration coverage for canonical phone lookup indexing in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T018 [US2] Replace ConnectShyft-local phone normalization and comparison logic with shared-domain helpers in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts`
+- [X] T019 [US2] Update canonical phone lookup queries and identity-boundary adapter rows to use `normalized_e164`-equivalent persistence fields in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T020 [P] [US2] Add the canonical phone lookup index migration for ConnectShyft neighbor phones in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.ts`
+
+**Checkpoint**: Identity-boundary matching is fully functional on canonical phone identity and no longer relies on duplicated ConnectShyft-local normalization.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalize reusable documentation plus constitution-required no-regression and validation guidance across the shared domain and the feature docs.
+
+- [X] T021 [P] Update shared communication-domain usage guidance and import rules in `/Users/jeremiahotis/projects/connectshyft/domains/communication/README.md`
+- [X] T022 [P] Refresh the canonical public API examples and error-code table in `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/contracts/phone-domain-contract.md`
+- [X] T023 [P] Record final validation commands, example conversions, and ADR/data-model compliance notes for feature documentation in `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/quickstart.md`
+- [X] T024 [P] Validate that CS-002 does not change ConnectShyft versus admin route ownership and record the result in `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/quickstart.md`
+- [X] T025 [P] Verify ConnectShyft API binding and port expectations remain unchanged for CS-002 in `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/quickstart.md`
+- [X] T026 [P] Validate shared PostgreSQL connectivity and unchanged production migration ownership assumptions for CS-002 in `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/quickstart.md`
+- [X] T027 [P] Record reproducible runbook-style validation steps for CS-002 no-regression checks in `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1) has no dependencies.
+- Foundational (Phase 2) depends on Phase 1 and blocks all user story work.
+- User Story 1 (Phase 3) depends on Phase 2.
+- User Story 2 (Phase 4) depends on Phase 2 and User Story 1 because it consumes the shared phone contract and canonical persistence fields introduced there.
+- Polish (Phase 5) depends on the user stories you intend to ship.
+
+### User Story Dependency Graph
+
+- `Phase 1 -> Phase 2 -> US1 -> US2 -> Phase 5`
+
+### Within Each User Story
+
+- Test tasks must exist and fail before implementation tasks begin.
+- Shared-domain contract changes precede consumer adoption.
+- Migration changes precede persistence/query updates that depend on new columns or indexes.
+- Each user story must pass its independent test before moving to the next story.
+
+### Parallel Opportunities
+
+- Phase 2 tasks `T002` through `T006` touch different files and can run in parallel.
+- US1 test tasks `T007` through `T009` can run in parallel.
+- After US1 tests are in place, `T012` and `T013` can run in parallel while `T010` is implemented.
+- US2 test tasks `T016` and `T017` can run in parallel.
+- After US2 tests are in place, `T018` and `T020` can run in parallel before `T019`.
+- Polish tasks `T021` through `T027` can run in parallel after implementation stabilizes.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch the US1 test tasks together
+T007 /Users/jeremiahotis/projects/connectshyft/domains/communication/phone/__tests__/index.test.ts
+T008 /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts
+T009 /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneIdentityMigration.test.ts
+
+# Then implement the independent setup work in parallel
+T012 /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/phoneIdentityContext.ts
+T013 /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch the US2 tests together
+T016 /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts
+T017 /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts
+
+# Then implement the independent identity-match and index work in parallel
+T018 /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts
+T020 /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.ts
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1.
+2. Complete Phase 2.
+3. Complete Phase 3.
+4. Validate the US1 independent test before expanding scope.
+
+### Incremental Delivery
+
+1. Establish the shared-domain boundary and toolchain support in Phases 1 and 2.
+2. Deliver canonical natural-input storage for neighbors in US1.
+3. Deliver canonical identity matching in US2.
+4. Finish documentation and validation evidence in Phase 5.
+
+### Parallel Team Strategy
+
+1. One engineer handles repo boundary and tooling tasks in Phase 2 while another prepares US1 tests.
+2. Once Phase 2 is complete, domain implementation, phone-context configuration, and migration work for US1 can be split across engineers.
+3. After US1 passes, identity-boundary logic and lookup-index work for US2 can be split across engineers.
+
+---
+
+## Notes
+
+- User story phases map directly to the explicit `US1` and `US2` definitions in `/Users/jeremiahotis/projects/connectshyft/specs/002-phone-identity/spec.md`.
+- All task paths are absolute so the task list is executable without additional path resolution.
+- Every task line follows the required checklist format: checkbox, task ID, optional `[P]`, required story label for story phases, and an exact file path.

--- a/tests/support/factories/connectShyftStoryE6Factory.ts
+++ b/tests/support/factories/connectShyftStoryE6Factory.ts
@@ -30,8 +30,8 @@ export function createStoryE6Context(
     providerRegistryFile: 'apps/moneyshyft-api/src/modules/connectshyft/providerRegistry.ts',
     providerRegistryTestFile:
       'apps/moneyshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts',
-    deploymentChecklistFile: 'DEPLOYMENT_CHECKLIST.md',
-    productionGuideFile: 'PRODUCTION_DEPLOYMENT_GUIDE.md',
+    deploymentChecklistFile: 'docs/DEPLOYMENT_CHECKLIST.md',
+    productionGuideFile: 'docs/PRODUCTION_DEPLOYMENT_GUIDE.md',
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- add the shared communication phone domain and ConnectShyft adoption for canonical phone normalization and identity matching
- shape the ConnectShyft neighbor phone table toward canonical phone identity storage and indexed lookup with migration coverage
- add CS-002 spec, plan, tasks, and quickstart no-regression validation evidence

## Testing
- env NODE_ENV=test npx jest --runInBand --runTestsByPath ../../domains/communication/phone/__tests__/index.test.ts src/modules/connectshyft/__tests__/neighbors.test.ts src/modules/connectshyft/__tests__/identityBoundary.test.ts src/migrations/__tests__/connectShyftNeighborCanonicalPhoneIdentityMigration.test.ts src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts
- npm run build
- node scripts/enforce-workspace-boundaries.js
- npm run policy:check