### PR TITLE
Feat: CS-004 call bridge flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ Docker:
 - Shared host-managed PostgreSQL (single instance) (001-tighten-deployment-contracts)
 - TypeScript (ES2022) on Node.js >=20 + Express, Knex, pg, Jest/ts-jest, root-level shared communication domain source under `domains/communication` (002-phone-identity)
 - Shared PostgreSQL; current ConnectShyft phone persistence in `connectshyft.cs_neighbor_phones` must evolve toward `communication_contact_point`-equivalent canonical fields (002-phone-identity)
+- TypeScript (ES2022) on Node.js >=20 + Express, Knex, pg, Jest/ts-jest, root shared communication domain source under `domains/communication`, root infrastructure adapter source under `infrastructure/communications`, existing ConnectShyft provider registry and outbound route contracts (003-telnyx-outbound-adapter)
+- Shared PostgreSQL; current ConnectShyft provider correlation and webhook receipt tables (`connectshyft.cs_provider_identifier_mappings`, `connectshyft.cs_webhook_receipts`) remain the CS-003 persistence equivalents for provider references and replay-safe receipts (003-telnyx-outbound-adapter)
 
 ## Recent Changes
 - 001-tighten-deployment-contracts: Added TypeScript (Node.js APIs), Vue 3 TypeScript frontends + Express APIs, host Nginx reverse proxy, Docker Compose

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,6 @@ Docker:
 - Shared host-managed PostgreSQL (single instance) (001-tighten-deployment-contracts)
 - TypeScript (ES2022) on Node.js >=20 + Express, Knex, pg, Jest/ts-jest, root-level shared communication domain source under `domains/communication` (002-phone-identity)
 - Shared PostgreSQL; current ConnectShyft phone persistence in `connectshyft.cs_neighbor_phones` must evolve toward `communication_contact_point`-equivalent canonical fields (002-phone-identity)
-- TypeScript (ES2022) on Node.js >=20 + Express, Knex, pg, Jest/ts-jest, root shared communication domain source under `domains/communication`, root infrastructure adapter source under `infrastructure/communications`, existing ConnectShyft provider registry and outbound route contracts (003-telnyx-outbound-adapter)
-- Shared PostgreSQL; current ConnectShyft provider correlation and webhook receipt tables (`connectshyft.cs_provider_identifier_mappings`, `connectshyft.cs_webhook_receipts`) remain the CS-003 persistence equivalents for provider references and replay-safe receipts (003-telnyx-outbound-adapter)
 
 ## Recent Changes
 - 001-tighten-deployment-contracts: Added TypeScript (Node.js APIs), Vue 3 TypeScript frontends + Express APIs, host Nginx reverse proxy, Docker Compose

--- a/apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts
+++ b/apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts
@@ -1,0 +1,92 @@
+import type { Knex } from 'knex'
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft'
+const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions'
+const BRIDGE_LEGS_TABLE = 'cs_bridge_legs'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}`)
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE} (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      operator_participant_id TEXT NOT NULL,
+      neighbor_participant_id TEXT NOT NULL,
+      operator_contact_point_id TEXT NOT NULL,
+      neighbor_contact_point_id TEXT NOT NULL,
+      selected_outbound_contact_point_id TEXT NULL,
+      bridge_status TEXT NOT NULL,
+      failure_code TEXT NULL,
+      failure_message TEXT NULL,
+      ended_by TEXT NULL,
+      idempotency_key TEXT NULL,
+      audit_correlation_id TEXT NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      completed_at_utc TIMESTAMPTZ NULL,
+      CONSTRAINT cs_bridge_sessions_status_ck CHECK (
+        bridge_status IN (
+          'created',
+          'operator_dialing',
+          'operator_answered',
+          'neighbor_dialing',
+          'neighbor_answered',
+          'bridged',
+          'completed',
+          'failed',
+          'canceled',
+          'expired'
+        )
+      )
+    )
+  `)
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_LEGS_TABLE} (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      bridge_session_id TEXT NOT NULL REFERENCES ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}(id) ON DELETE CASCADE,
+      leg_role TEXT NOT NULL,
+      contact_point_id TEXT NOT NULL,
+      provider_call_id TEXT NULL,
+      leg_status TEXT NOT NULL,
+      started_at_utc TIMESTAMPTZ NULL,
+      answered_at_utc TIMESTAMPTZ NULL,
+      ended_at_utc TIMESTAMPTZ NULL,
+      failure_code TEXT NULL,
+      failure_message TEXT NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT cs_bridge_legs_role_ck CHECK (leg_role IN ('operator', 'neighbor')),
+      CONSTRAINT cs_bridge_legs_status_ck CHECK (
+        leg_status IN ('created', 'dialing', 'ringing', 'answered', 'failed', 'completed', 'canceled')
+      ),
+      CONSTRAINT cs_bridge_legs_session_role_uq UNIQUE (bridge_session_id, leg_role)
+    )
+  `)
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS connectshyft_cs_bridge_sessions_scope_idx
+    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE} (tenant_id, org_unit_id, thread_id, created_at_utc DESC, id)
+  `)
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS connectshyft_cs_bridge_legs_session_idx
+    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_LEGS_TABLE} (bridge_session_id, leg_role, id)
+  `)
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS connectshyft_cs_bridge_legs_provider_call_id_uq
+    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_LEGS_TABLE} (provider_call_id)
+    WHERE provider_call_id IS NOT NULL
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(BRIDGE_LEGS_TABLE)
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(BRIDGE_SESSIONS_TABLE)
+}

--- a/apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts
+++ b/apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts
@@ -1,0 +1,57 @@
+import { down, up } from '../20260311110000_create_connectshyft_bridge_sessions'
+
+function buildKnexMock() {
+  const dropped: string[] = []
+
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+    schema: {
+      withSchema: (schema: string) => ({
+        dropTableIfExists: async (tableName: string) => {
+          dropped.push(`${schema}.${tableName}`)
+        },
+      }),
+    },
+  }
+
+  return {
+    knex,
+    dropped,
+  }
+}
+
+describe('20260311110000_create_connectshyft_bridge_sessions migration', () => {
+  it('creates bridge session and bridge leg persistence with scope and provider-call indexes', async () => {
+    const { knex } = buildKnexMock()
+
+    await up(knex)
+
+    const rawCalls = knex.raw.mock.calls.map((call: [string]) => call[0])
+
+    expect(rawCalls).toEqual(expect.arrayContaining([
+      'CREATE SCHEMA IF NOT EXISTS connectshyft',
+    ]))
+    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_bridge_sessions'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('bridge_status TEXT NOT NULL'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('CONSTRAINT cs_bridge_sessions_status_ck CHECK'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('operator_contact_point_id TEXT NOT NULL'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_bridge_legs'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes("CONSTRAINT cs_bridge_legs_role_ck CHECK (leg_role IN ('operator', 'neighbor'))"))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes("leg_status IN ('created', 'dialing', 'ringing', 'answered', 'failed', 'completed', 'canceled')"))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('CONSTRAINT cs_bridge_legs_session_role_uq UNIQUE'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_bridge_sessions_scope_idx'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_bridge_legs_session_idx'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_bridge_legs_provider_call_id_uq'))).toBe(true)
+  })
+
+  it('drops bridge leg and bridge session tables in down migration', async () => {
+    const { knex, dropped } = buildKnexMock()
+
+    await down(knex)
+
+    expect(dropped).toEqual([
+      'connectshyft.cs_bridge_legs',
+      'connectshyft.cs_bridge_sessions',
+    ])
+  })
+})

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts
@@ -1,0 +1,302 @@
+import {
+  handleConnectShyftBridgeWebhookEvent,
+  loadConnectShyftBridgeAggregateByProviderCallId,
+  loadConnectShyftBridgeAggregateBySessionId,
+  resetConnectShyftBridgeSessionStateForTests,
+  startConnectShyftBridgeSession,
+} from '../bridgeSessions'
+import { resetConnectShyftProviderCorrelationStateForTests } from '../providerCorrelationMappings'
+import type { ConnectShyftProviderAdapter } from '../providerRegistry'
+
+const sendSmsMock = jest.fn()
+const startOutboundCallMock = jest.fn()
+const startBridgeOutboundCallMock = jest.fn(async (input: { legRole: string; threadId: string }) => ({
+  providerKey: 'telnyx',
+  channel: 'call' as const,
+  providerLegId: input.legRole === 'operator'
+    ? `telnyx-leg-operator-${input.threadId}`
+    : `telnyx-leg-neighbor-${input.threadId}`,
+  providerMessageId: null,
+  providerRequestId: `req-${input.legRole}-${input.threadId}`,
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:00:00.000Z',
+}))
+const startBridgeSessionMock = jest.fn(async (input: { bridgeSessionId: string }) => ({
+  providerKey: 'telnyx',
+  bridgeSessionId: input.bridgeSessionId,
+  bridgeEstablished: true as const,
+  providerRequestId: 'req-bridge-1001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:05:00.000Z',
+}))
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }))
+const translateProviderEventMock = jest.fn(({ rawEventType, payload }: { rawEventType: string; payload: unknown }) => ({
+  eventType: rawEventType,
+  payload: (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>,
+  providerNeutral: true as const,
+  providerSpecificFieldsStripped: true as const,
+  providerBranchingInDomain: false as const,
+}))
+
+const providerAdapter: ConnectShyftProviderAdapter = {
+  providerKey: 'telnyx',
+  adapterInterfaceVersion: 'v1',
+  sendSms: sendSmsMock,
+  startOutboundCall: startOutboundCallMock,
+  startBridgeOutboundCall: startBridgeOutboundCallMock,
+  verifyWebhook: verifyWebhookMock,
+  translateProviderEvent: translateProviderEventMock,
+  startBridgeSession: startBridgeSessionMock,
+}
+
+const baseInput = {
+  tenantId: 'tenant-connectshyft-f1',
+  orgUnitId: 'org-connectshyft-f1-east',
+  threadId: 'thread-f1-unclaimed-1001',
+  operatorParticipantId: 'user-connectshyft-f1-primary-operator',
+  neighborParticipantId: 'neighbor-f1-1001',
+  operatorContactPointId: '+12605550155',
+  neighborContactPointId: '+12605550111',
+  selectedOutboundContactPointId: 'cs-number-501',
+  providerKey: 'telnyx',
+  providerAdapter,
+} as const
+
+describe('connectshyft bridgeSessions', () => {
+  const previousNodeEnv = process.env.NODE_ENV
+  const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true'
+  })
+
+  beforeEach(() => {
+    sendSmsMock.mockReset()
+    startOutboundCallMock.mockReset()
+    startBridgeOutboundCallMock.mockClear()
+    startBridgeSessionMock.mockClear()
+    verifyWebhookMock.mockClear()
+    translateProviderEventMock.mockClear()
+    resetConnectShyftBridgeSessionStateForTests()
+    resetConnectShyftProviderCorrelationStateForTests()
+  })
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags
+  })
+
+  it('persists a created bridge session with operator and neighbor legs on startup', async () => {
+    const result = await startConnectShyftBridgeSession(baseInput)
+
+    expect(result.aggregate.session.status).toBe('operator_dialing')
+    expect(result.aggregate.operatorLeg.status).toBe('ringing')
+    expect(result.aggregate.neighborLeg.status).toBe('created')
+    expect(result.correlationMapping).toEqual({
+      deterministic: true,
+      operatorLegMapping: 'created',
+      neighborLegMapping: 'ignored',
+      error: null,
+    })
+
+    const persistedBySession = await loadConnectShyftBridgeAggregateBySessionId(result.aggregate.session.id)
+    const persistedByProviderCallId = await loadConnectShyftBridgeAggregateByProviderCallId({
+      providerCallId: result.aggregate.operatorLeg.providerCallId || '',
+    })
+
+    expect(persistedBySession).toMatchObject({
+      session: {
+        id: result.aggregate.session.id,
+        status: 'operator_dialing',
+      },
+      operatorLeg: {
+        status: 'ringing',
+      },
+      neighborLeg: {
+        status: 'created',
+      },
+    })
+    expect(persistedByProviderCallId?.session.id).toBe(result.aggregate.session.id)
+    expect(startBridgeOutboundCallMock).toHaveBeenCalledTimes(1)
+    expect(startBridgeOutboundCallMock).toHaveBeenCalledWith(expect.objectContaining({
+      legRole: 'operator',
+      targetPhone: '+12605550155',
+    }))
+  })
+
+  it('rehydrates by provider leg id and persists neighbor dialing after operator answer', async () => {
+    const started = await startConnectShyftBridgeSession(baseInput)
+
+    const progressed = await handleConnectShyftBridgeWebhookEvent({
+      tenantId: baseInput.tenantId,
+      orgUnitId: baseInput.orgUnitId,
+      threadId: baseInput.threadId,
+      providerKey: 'telnyx',
+      providerAdapter,
+      providerLegId: started.aggregate.operatorLeg.providerCallId || null,
+      eventType: 'CallAnswered',
+      occurredAt: new Date('2026-03-11T12:01:00.000Z'),
+    })
+
+    expect(progressed).toMatchObject({
+      handled: true,
+      domainEvent: {
+        type: 'operator_answered',
+      },
+      aggregate: {
+        session: {
+          status: 'neighbor_dialing',
+        },
+        operatorLeg: {
+          status: 'answered',
+        },
+        neighborLeg: {
+          status: 'ringing',
+        },
+      },
+      correlationMapping: {
+        deterministic: true,
+        operatorLegMapping: 'duplicate',
+        neighborLegMapping: 'created',
+        error: null,
+      },
+    })
+
+    const persistedNeighbor = await loadConnectShyftBridgeAggregateByProviderCallId({
+      providerCallId: progressed.aggregate?.neighborLeg.providerCallId || '',
+    })
+
+    expect(persistedNeighbor).toMatchObject({
+      session: {
+        status: 'neighbor_dialing',
+      },
+      neighborLeg: {
+        providerCallId: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        status: 'ringing',
+      },
+    })
+    expect(startBridgeOutboundCallMock).toHaveBeenCalledTimes(2)
+    expect(startBridgeOutboundCallMock).toHaveBeenLastCalledWith(expect.objectContaining({
+      legRole: 'neighbor',
+      targetPhone: '+12605550111',
+    }))
+  })
+
+  it('persists completed bridge sessions after both legs answer and the bridge ends', async () => {
+    const started = await startConnectShyftBridgeSession(baseInput)
+
+    const afterOperatorAnswer = await handleConnectShyftBridgeWebhookEvent({
+      tenantId: baseInput.tenantId,
+      orgUnitId: baseInput.orgUnitId,
+      threadId: baseInput.threadId,
+      providerKey: 'telnyx',
+      providerAdapter,
+      providerLegId: started.aggregate.operatorLeg.providerCallId || null,
+      eventType: 'CallAnswered',
+      occurredAt: new Date('2026-03-11T12:01:00.000Z'),
+    })
+    const afterNeighborAnswer = await handleConnectShyftBridgeWebhookEvent({
+      tenantId: baseInput.tenantId,
+      orgUnitId: baseInput.orgUnitId,
+      threadId: baseInput.threadId,
+      providerKey: 'telnyx',
+      providerAdapter,
+      providerLegId: afterOperatorAnswer.aggregate?.neighborLeg.providerCallId || null,
+      eventType: 'CallAnswered',
+      occurredAt: new Date('2026-03-11T12:02:00.000Z'),
+    })
+    const completed = await handleConnectShyftBridgeWebhookEvent({
+      tenantId: baseInput.tenantId,
+      orgUnitId: baseInput.orgUnitId,
+      threadId: baseInput.threadId,
+      providerKey: 'telnyx',
+      providerAdapter,
+      providerLegId: afterNeighborAnswer.aggregate?.neighborLeg.providerCallId || null,
+      eventType: 'CallCompleted',
+      occurredAt: new Date('2026-03-11T12:03:00.000Z'),
+    })
+
+    expect(afterNeighborAnswer.aggregate?.session.status).toBe('bridged')
+    expect(completed).toMatchObject({
+      handled: true,
+      domainEvent: {
+        type: 'completed',
+      },
+      aggregate: {
+        session: {
+          status: 'completed',
+        },
+        operatorLeg: {
+          status: 'completed',
+        },
+        neighborLeg: {
+          status: 'completed',
+        },
+      },
+    })
+
+    const persisted = await loadConnectShyftBridgeAggregateBySessionId(started.aggregate.session.id)
+    expect(persisted?.session.status).toBe('completed')
+    expect(startBridgeSessionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists failed bridge sessions when the neighbor leg fails before bridge completion', async () => {
+    const started = await startConnectShyftBridgeSession(baseInput)
+
+    const afterOperatorAnswer = await handleConnectShyftBridgeWebhookEvent({
+      tenantId: baseInput.tenantId,
+      orgUnitId: baseInput.orgUnitId,
+      threadId: baseInput.threadId,
+      providerKey: 'telnyx',
+      providerAdapter,
+      providerLegId: started.aggregate.operatorLeg.providerCallId || null,
+      eventType: 'CallAnswered',
+      occurredAt: new Date('2026-03-11T12:01:00.000Z'),
+    })
+    const failed = await handleConnectShyftBridgeWebhookEvent({
+      tenantId: baseInput.tenantId,
+      orgUnitId: baseInput.orgUnitId,
+      threadId: baseInput.threadId,
+      providerKey: 'telnyx',
+      providerAdapter,
+      providerLegId: afterOperatorAnswer.aggregate?.neighborLeg.providerCallId || null,
+      eventType: 'CallFailed',
+      reason: 'neighbor_declined',
+      occurredAt: new Date('2026-03-11T12:02:00.000Z'),
+    })
+
+    expect(failed).toMatchObject({
+      handled: true,
+      domainEvent: {
+        type: 'neighbor_failed',
+      },
+      aggregate: {
+        session: {
+          status: 'failed',
+          failureCode: 'neighbor_failed',
+        },
+        neighborLeg: {
+          status: 'failed',
+          failureCode: 'neighbor_failed',
+          failureMessage: 'neighbor_declined',
+        },
+      },
+    })
+
+    const persisted = await loadConnectShyftBridgeAggregateBySessionId(started.aggregate.session.id)
+    expect(persisted).toMatchObject({
+      session: {
+        status: 'failed',
+        failureCode: 'neighbor_failed',
+      },
+      neighborLeg: {
+        status: 'failed',
+        failureCode: 'neighbor_failed',
+        failureMessage: 'neighbor_declined',
+      },
+    })
+  })
+})

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupConnectShyftWebhookReceipts,
   loadConnectShyftWebhookReceiptMetrics,
   markConnectShyftWebhookReceiptProcessingResult,
+  recordConnectShyftBridgeLegProviderIdentifierMapping,
   recordConnectShyftWebhookReceipt,
   recordConnectShyftProviderIdentifierMapping,
   resetConnectShyftProviderCorrelationStateForTests,
@@ -64,6 +65,40 @@ describe('connectshyft provider correlation mappings', () => {
       providerIdentifier: 'telnyx-msg-f3-1001',
       threadId: 'thread-f3-unclaimed-1001',
       internalReferenceId: 'canonical-message-f3-1001',
+    });
+  });
+
+  it('records provider call-leg mappings against persisted bridge-leg ids', async () => {
+    const mapping = await recordConnectShyftBridgeLegProviderIdentifierMapping({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'telnyx',
+      providerIdentifier: 'telnyx-leg-bridge-f3-1001',
+      bridgeLegId: 'bridge-leg-neighbor-f3-1001',
+    });
+
+    expect(mapping).toMatchObject({
+      status: 'created',
+      mapping: {
+        providerName: 'telnyx',
+        identifierKind: 'call_leg',
+        providerIdentifier: 'telnyx-leg-bridge-f3-1001',
+        internalReferenceId: 'bridge-leg-neighbor-f3-1001',
+      },
+    });
+
+    const resolved = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: 'telnyx',
+      providerLegId: 'telnyx-leg-bridge-f3-1001',
+    });
+
+    expect(resolved).toMatchObject({
+      ok: true,
+      source: 'provider_leg_id',
+      correlation: {
+        internalCallReferenceId: 'bridge-leg-neighbor-f3-1001',
+      },
     });
   });
 

--- a/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts
@@ -1,0 +1,918 @@
+import { randomUUID } from 'node:crypto'
+import type { Knex } from 'knex'
+import db from '../../config/knex'
+import {
+  buildHandleProviderBridgeEvent,
+  buildStartBridgeSession,
+  type BridgeSessionAggregate,
+  type BridgeLegRecord,
+  type BridgeSessionRecord,
+  type BridgeSessionRepository,
+  type BridgeTelephonyProvider,
+  type ProviderBridgeEvent,
+  type StartBridgeSessionCommand,
+} from '../../../../../domains/communication'
+import { recordConnectShyftBridgeLegProviderIdentifierMapping } from './providerCorrelationMappings'
+import { isConnectShyftTestOverrideEnabled } from './featureFlags'
+import type {
+  ConnectShyftOutboundCallDispatchPolicy,
+  ConnectShyftProviderAdapter,
+} from './providerRegistry'
+
+const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions'
+const BRIDGE_LEGS_TABLE = 'cs_bridge_legs'
+
+type DbBridgeSessionRow = {
+  id: string
+  tenant_id: string
+  org_unit_id: string
+  thread_id: string
+  operator_participant_id: string
+  neighbor_participant_id: string
+  operator_contact_point_id: string
+  neighbor_contact_point_id: string
+  selected_outbound_contact_point_id?: string | null
+  bridge_status: string
+  failure_code?: string | null
+  failure_message?: string | null
+  ended_by?: string | null
+  idempotency_key?: string | null
+  audit_correlation_id?: string | null
+  created_at_utc: string | Date
+  updated_at_utc: string | Date
+  completed_at_utc?: string | Date | null
+}
+
+type DbBridgeLegRow = {
+  id: string
+  tenant_id: string
+  org_unit_id: string
+  bridge_session_id: string
+  leg_role: 'operator' | 'neighbor'
+  contact_point_id: string
+  provider_call_id?: string | null
+  leg_status: string
+  started_at_utc?: string | Date | null
+  answered_at_utc?: string | Date | null
+  ended_at_utc?: string | Date | null
+  failure_code?: string | null
+  failure_message?: string | null
+  created_at_utc: string | Date
+  updated_at_utc: string | Date
+}
+
+type StartConnectShyftBridgeSessionInput = {
+  tenantId: string
+  orgUnitId: string
+  threadId: string
+  operatorParticipantId: string
+  neighborParticipantId: string
+  operatorContactPointId: string
+  neighborContactPointId: string
+  selectedOutboundContactPointId?: string | null
+  providerKey: string
+  providerAdapter: ConnectShyftProviderAdapter
+  idempotencyKey?: string | null
+  auditCorrelationId?: string | null
+  callPolicy?: ConnectShyftOutboundCallDispatchPolicy
+}
+
+type HandleConnectShyftBridgeWebhookEventInput = {
+  tenantId: string
+  orgUnitId: string
+  threadId: string
+  providerKey: string
+  providerAdapter: ConnectShyftProviderAdapter
+  providerLegId: string | null
+  eventType: string
+  occurredAt?: Date
+  reason?: string | null
+  callPolicy?: ConnectShyftOutboundCallDispatchPolicy
+}
+
+type BridgeMappingStatus = 'created' | 'duplicate' | 'ignored' | 'error'
+
+type BridgeMappingResult = {
+  deterministic: true
+  operatorLegMapping: BridgeMappingStatus
+  neighborLegMapping: BridgeMappingStatus
+  error: {
+    code: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE'
+    message: string
+  } | null
+}
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim()
+}
+
+const toIsoString = (value: string | Date | null | undefined): string | null => {
+  if (!value) {
+    return null
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  const parsed = new Date(value)
+  if (!Number.isNaN(parsed.valueOf())) {
+    return parsed.toISOString()
+  }
+
+  return normalizeString(value) || null
+}
+
+const toDate = (value: string | Date | null | undefined): Date | null => {
+  const iso = toIsoString(value)
+  return iso ? new Date(iso) : null
+}
+
+const isMissingPersistenceError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const candidate = error as { code?: string }
+  return candidate.code === '42P01'
+    || candidate.code === '3F000'
+    || candidate.code === '42703'
+}
+
+const mapSessionRow = (row: DbBridgeSessionRow): BridgeSessionRecord => ({
+  id: row.id,
+  tenantId: row.tenant_id,
+  orgUnitId: row.org_unit_id,
+  threadId: row.thread_id,
+  operatorParticipantId: row.operator_participant_id,
+  neighborParticipantId: row.neighbor_participant_id,
+  operatorContactPointId: row.operator_contact_point_id,
+  neighborContactPointId: row.neighbor_contact_point_id,
+  selectedOutboundContactPointId: normalizeString(row.selected_outbound_contact_point_id) || null,
+  status: row.bridge_status as BridgeSessionRecord['status'],
+  failureCode: normalizeString(row.failure_code) as BridgeSessionRecord['failureCode'],
+  failureMessage: normalizeString(row.failure_message) || null,
+  endedBy: normalizeString(row.ended_by) || null,
+  idempotencyKey: normalizeString(row.idempotency_key) || null,
+  auditCorrelationId: normalizeString(row.audit_correlation_id) || null,
+  createdAt: new Date(toIsoString(row.created_at_utc) || new Date().toISOString()),
+  updatedAt: new Date(toIsoString(row.updated_at_utc) || new Date().toISOString()),
+  completedAt: toDate(row.completed_at_utc),
+})
+
+const mapLegRow = (row: DbBridgeLegRow): BridgeLegRecord => ({
+  id: row.id,
+  tenantId: row.tenant_id,
+  orgUnitId: row.org_unit_id,
+  bridgeSessionId: row.bridge_session_id,
+  legRole: row.leg_role,
+  contactPointId: row.contact_point_id,
+  providerCallId: normalizeString(row.provider_call_id) || null,
+  status: row.leg_status as BridgeLegRecord['status'],
+  startedAt: toDate(row.started_at_utc),
+  answeredAt: toDate(row.answered_at_utc),
+  endedAt: toDate(row.ended_at_utc),
+  failureCode: normalizeString(row.failure_code) as BridgeLegRecord['failureCode'],
+  failureMessage: normalizeString(row.failure_message) || null,
+  createdAt: new Date(toIsoString(row.created_at_utc) || new Date().toISOString()),
+  updatedAt: new Date(toIsoString(row.updated_at_utc) || new Date().toISOString()),
+})
+
+const sessionToRow = (session: BridgeSessionRecord) => ({
+  id: session.id,
+  tenant_id: session.tenantId,
+  org_unit_id: session.orgUnitId,
+  thread_id: session.threadId,
+  operator_participant_id: session.operatorParticipantId,
+  neighbor_participant_id: session.neighborParticipantId,
+  operator_contact_point_id: session.operatorContactPointId,
+  neighbor_contact_point_id: session.neighborContactPointId,
+  selected_outbound_contact_point_id: session.selectedOutboundContactPointId ?? null,
+  bridge_status: session.status,
+  failure_code: session.failureCode ?? null,
+  failure_message: session.failureMessage ?? null,
+  ended_by: session.endedBy ?? null,
+  idempotency_key: session.idempotencyKey ?? null,
+  audit_correlation_id: session.auditCorrelationId ?? null,
+  created_at_utc: session.createdAt.toISOString(),
+  updated_at_utc: session.updatedAt.toISOString(),
+  completed_at_utc: session.completedAt ? session.completedAt.toISOString() : null,
+})
+
+const legToRow = (leg: BridgeLegRecord) => ({
+  id: leg.id,
+  tenant_id: leg.tenantId,
+  org_unit_id: leg.orgUnitId,
+  bridge_session_id: leg.bridgeSessionId,
+  leg_role: leg.legRole,
+  contact_point_id: leg.contactPointId,
+  provider_call_id: leg.providerCallId ?? null,
+  leg_status: leg.status,
+  started_at_utc: leg.startedAt ? leg.startedAt.toISOString() : null,
+  answered_at_utc: leg.answeredAt ? leg.answeredAt.toISOString() : null,
+  ended_at_utc: leg.endedAt ? leg.endedAt.toISOString() : null,
+  failure_code: leg.failureCode ?? null,
+  failure_message: leg.failureMessage ?? null,
+  created_at_utc: leg.createdAt.toISOString(),
+  updated_at_utc: leg.updatedAt.toISOString(),
+})
+
+class InMemoryConnectShyftBridgeSessionStore implements BridgeSessionRepository {
+  private sessions = new Map<string, BridgeSessionRecord>()
+  private legsBySessionId = new Map<string, Map<'operator' | 'neighbor', BridgeLegRecord>>()
+  private sessionIdByProviderCallId = new Map<string, string>()
+
+  createSession(session: BridgeSessionRecord): Promise<void> {
+    this.sessions.set(session.id, { ...session })
+    return Promise.resolve()
+  }
+
+  createLeg(leg: BridgeLegRecord): Promise<void> {
+    const current = this.legsBySessionId.get(leg.bridgeSessionId) || new Map()
+    current.set(leg.legRole, { ...leg })
+    this.legsBySessionId.set(leg.bridgeSessionId, current)
+    if (leg.providerCallId) {
+      this.sessionIdByProviderCallId.set(leg.providerCallId, leg.bridgeSessionId)
+    }
+    return Promise.resolve()
+  }
+
+  saveAggregate(aggregate: BridgeSessionAggregate): Promise<void> {
+    this.sessions.set(aggregate.session.id, { ...aggregate.session })
+    const legs = new Map<'operator' | 'neighbor', BridgeLegRecord>()
+    legs.set('operator', { ...aggregate.operatorLeg })
+    legs.set('neighbor', { ...aggregate.neighborLeg })
+    this.legsBySessionId.set(aggregate.session.id, legs)
+    if (aggregate.operatorLeg.providerCallId) {
+      this.sessionIdByProviderCallId.set(aggregate.operatorLeg.providerCallId, aggregate.session.id)
+    }
+    if (aggregate.neighborLeg.providerCallId) {
+      this.sessionIdByProviderCallId.set(aggregate.neighborLeg.providerCallId, aggregate.session.id)
+    }
+    return Promise.resolve()
+  }
+
+  getAggregateBySessionId(sessionId: string): Promise<BridgeSessionAggregate | null> {
+    const session = this.sessions.get(sessionId)
+    const legs = this.legsBySessionId.get(sessionId)
+    const operatorLeg = legs?.get('operator')
+    const neighborLeg = legs?.get('neighbor')
+    if (!session || !operatorLeg || !neighborLeg) {
+      return Promise.resolve(null)
+    }
+
+    return Promise.resolve({
+      session: { ...session },
+      operatorLeg: { ...operatorLeg },
+      neighborLeg: { ...neighborLeg },
+    })
+  }
+
+  getAggregateByProviderCallId(input: {
+    tenantId?: string | null
+    providerCallId: string
+  }): Promise<BridgeSessionAggregate | null> {
+    const sessionId = this.sessionIdByProviderCallId.get(input.providerCallId)
+    if (!sessionId) {
+      return Promise.resolve(null)
+    }
+
+    return this.getAggregateBySessionId(sessionId)
+  }
+
+  getAggregateByThreadId(input: {
+    tenantId?: string | null
+    threadId: string
+  }): Promise<BridgeSessionAggregate | null> {
+    const tenantId = normalizeString(input.tenantId || null)
+    const latestSession = Array.from(this.sessions.values())
+      .filter((session) => {
+        if (session.threadId !== input.threadId) {
+          return false
+        }
+        return !tenantId || session.tenantId === tenantId
+      })
+      .sort((left, right) => right.updatedAt.getTime() - left.updatedAt.getTime())[0]
+
+    if (!latestSession) {
+      return Promise.resolve(null)
+    }
+
+    return this.getAggregateBySessionId(latestSession.id)
+  }
+
+  reset(): void {
+    this.sessions.clear()
+    this.legsBySessionId.clear()
+    this.sessionIdByProviderCallId.clear()
+  }
+}
+
+class KnexConnectShyftBridgeSessionStore implements BridgeSessionRepository {
+  constructor(private readonly knexClient: Knex = db) {}
+
+  async createSession(session: BridgeSessionRecord): Promise<void> {
+    await this.knexClient
+      .withSchema('connectshyft')
+      .table(BRIDGE_SESSIONS_TABLE)
+      .insert(sessionToRow(session))
+  }
+
+  async createLeg(leg: BridgeLegRecord): Promise<void> {
+    await this.knexClient
+      .withSchema('connectshyft')
+      .table(BRIDGE_LEGS_TABLE)
+      .insert(legToRow(leg))
+  }
+
+  async saveAggregate(aggregate: BridgeSessionAggregate): Promise<void> {
+    await this.knexClient.transaction(async (trx) => {
+      await trx
+        .withSchema('connectshyft')
+        .table(BRIDGE_SESSIONS_TABLE)
+        .insert(sessionToRow(aggregate.session))
+        .onConflict(['id'])
+        .merge()
+
+      await trx
+        .withSchema('connectshyft')
+        .table(BRIDGE_LEGS_TABLE)
+        .insert([legToRow(aggregate.operatorLeg), legToRow(aggregate.neighborLeg)])
+        .onConflict(['id'])
+        .merge()
+    })
+  }
+
+  async getAggregateBySessionId(sessionId: string): Promise<BridgeSessionAggregate | null> {
+    const sessionRow = await this.knexClient
+      .withSchema('connectshyft')
+      .table(BRIDGE_SESSIONS_TABLE)
+      .where({ id: sessionId })
+      .first<DbBridgeSessionRow>()
+
+    if (!sessionRow) {
+      return null
+    }
+
+    const legRows = await this.knexClient
+      .withSchema('connectshyft')
+      .table(BRIDGE_LEGS_TABLE)
+      .where({ bridge_session_id: sessionId })
+      .select<DbBridgeLegRow[]>([
+        'id',
+        'tenant_id',
+        'org_unit_id',
+        'bridge_session_id',
+        'leg_role',
+        'contact_point_id',
+        'provider_call_id',
+        'leg_status',
+        'started_at_utc',
+        'answered_at_utc',
+        'ended_at_utc',
+        'failure_code',
+        'failure_message',
+        'created_at_utc',
+        'updated_at_utc',
+      ])
+
+    const operatorLeg = legRows.find((row) => row.leg_role === 'operator')
+    const neighborLeg = legRows.find((row) => row.leg_role === 'neighbor')
+    if (!operatorLeg || !neighborLeg) {
+      return null
+    }
+
+    return {
+      session: mapSessionRow(sessionRow),
+      operatorLeg: mapLegRow(operatorLeg),
+      neighborLeg: mapLegRow(neighborLeg),
+    }
+  }
+
+  async getAggregateByProviderCallId(input: {
+    tenantId?: string | null
+    providerCallId: string
+  }): Promise<BridgeSessionAggregate | null> {
+    const legQuery = this.knexClient
+      .withSchema('connectshyft')
+      .table(`${BRIDGE_LEGS_TABLE} as bl`)
+      .join(`${BRIDGE_SESSIONS_TABLE} as bs`, 'bs.id', 'bl.bridge_session_id')
+      .where('bl.provider_call_id', input.providerCallId)
+
+    const tenantId = normalizeString(input.tenantId || null)
+    if (tenantId) {
+      legQuery.andWhere('bs.tenant_id', tenantId)
+    }
+
+    const legRow = await legQuery
+      .first<{ bridgeSessionId?: string }>('bl.bridge_session_id as bridgeSessionId')
+
+    const sessionId = normalizeString(legRow?.bridgeSessionId)
+    if (!sessionId) {
+      return null
+    }
+
+    return this.getAggregateBySessionId(sessionId)
+  }
+
+  async getAggregateByThreadId(input: {
+    tenantId?: string | null
+    threadId: string
+  }): Promise<BridgeSessionAggregate | null> {
+    const sessionQuery = this.knexClient
+      .withSchema('connectshyft')
+      .table(BRIDGE_SESSIONS_TABLE)
+      .where({ thread_id: input.threadId })
+      .orderBy('updated_at_utc', 'desc')
+
+    const tenantId = normalizeString(input.tenantId || null)
+    if (tenantId) {
+      sessionQuery.andWhere('tenant_id', tenantId)
+    }
+
+    const sessionRow = await sessionQuery.first<DbBridgeSessionRow>()
+    if (!sessionRow) {
+      return null
+    }
+
+    return this.getAggregateBySessionId(sessionRow.id)
+  }
+}
+
+const inMemoryBridgeSessionStore = new InMemoryConnectShyftBridgeSessionStore()
+const knexBridgeSessionStore = new KnexConnectShyftBridgeSessionStore()
+
+const callPolicyOrDefault = (
+  callPolicy?: ConnectShyftOutboundCallDispatchPolicy,
+): ConnectShyftOutboundCallDispatchPolicy => ({
+  transport: normalizeString(callPolicy?.transport) || 'bridge',
+  autoRetry: callPolicy?.autoRetry === true,
+  redialPolicy: normalizeString(callPolicy?.redialPolicy) || 'manual_only',
+})
+
+const buildBridgeTelephonyProvider = (input: {
+  tenantId: string
+  orgUnitId: string
+  threadId: string
+  providerKey: string
+  providerAdapter: ConnectShyftProviderAdapter
+  idempotencyKey?: string | null
+  callPolicy?: ConnectShyftOutboundCallDispatchPolicy
+}): BridgeTelephonyProvider => ({
+  async startOutboundCall(command) {
+    const startBridgeOutboundCall = input.providerAdapter.startBridgeOutboundCall
+    const dispatchResult = startBridgeOutboundCall
+      ? await startBridgeOutboundCall({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        threadId: input.threadId,
+        providerKey: input.providerKey,
+        bridgeSessionId: command.bridgeSessionId,
+        legId: command.legId,
+        legRole: command.legRole,
+        targetPhone: command.toContactPointId,
+        fromContactPointId: command.fromContactPointId ?? null,
+        idempotencyKey: input.idempotencyKey ?? undefined,
+      })
+      : await input.providerAdapter.startOutboundCall({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        threadId: input.threadId,
+        providerKey: input.providerKey,
+        targetPhone: command.toContactPointId,
+        idempotencyKey: input.idempotencyKey ?? undefined,
+        callPolicy: callPolicyOrDefault(input.callPolicy),
+      })
+
+    const providerCallId = normalizeString(dispatchResult.providerLegId)
+    if (!providerCallId) {
+      throw new Error('Bridge outbound call requires a provider call id.')
+    }
+
+    return {
+      providerCallId,
+    }
+  },
+  async startBridgeSession(command) {
+    if (!input.providerAdapter.startBridgeSession) {
+      throw new Error(`Provider ${input.providerKey} does not support bridge control.`)
+    }
+
+    await input.providerAdapter.startBridgeSession({
+      providerKey: input.providerKey,
+      bridgeSessionId: command.bridgeSessionId,
+      operatorProviderCallId: command.operatorProviderCallId,
+      neighborProviderCallId: command.neighborProviderCallId,
+      idempotencyKey: input.idempotencyKey ?? undefined,
+    })
+  },
+})
+
+const persistLegMapping = async (input: {
+  tenantId: string
+  orgUnitId: string
+  threadId: string
+  providerName: string
+  leg: BridgeLegRecord
+}): Promise<BridgeMappingStatus> => {
+  if (!input.leg.providerCallId) {
+    return 'ignored'
+  }
+
+  const result = await recordConnectShyftBridgeLegProviderIdentifierMapping({
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    threadId: input.threadId,
+    providerName: input.providerName,
+    providerIdentifier: input.leg.providerCallId,
+    bridgeLegId: input.leg.id,
+    db: isConnectShyftTestOverrideEnabled() ? undefined : db,
+  })
+
+  return result.status
+}
+
+const persistBridgeProviderMappings = async (input: {
+  aggregate: BridgeSessionAggregate
+  providerName: string
+}): Promise<BridgeMappingResult> => {
+  try {
+    const operatorLegMapping = await persistLegMapping({
+      tenantId: input.aggregate.session.tenantId,
+      orgUnitId: input.aggregate.session.orgUnitId,
+      threadId: input.aggregate.session.threadId,
+      providerName: input.providerName,
+      leg: input.aggregate.operatorLeg,
+    })
+    const neighborLegMapping = await persistLegMapping({
+      tenantId: input.aggregate.session.tenantId,
+      orgUnitId: input.aggregate.session.orgUnitId,
+      threadId: input.aggregate.session.threadId,
+      providerName: input.providerName,
+      leg: input.aggregate.neighborLeg,
+    })
+
+    return {
+      deterministic: true,
+      operatorLegMapping,
+      neighborLegMapping,
+      error: null,
+    }
+  } catch (error) {
+    return {
+      deterministic: true,
+      operatorLegMapping: 'error',
+      neighborLegMapping: 'error',
+      error: {
+        code: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE',
+        message: error instanceof Error
+          ? error.message
+          : 'Provider correlation mapping persistence unavailable.',
+      },
+    }
+  }
+}
+
+const resolveBridgeWebhookEvent = (input: {
+  aggregate: BridgeSessionAggregate
+  providerLegId: string
+  eventType: string
+  occurredAt?: Date
+  reason?: string | null
+}): ProviderBridgeEvent | null => {
+  const normalizedEventType = normalizeString(input.eventType).toLowerCase()
+  const legRole = input.aggregate.operatorLeg.providerCallId === input.providerLegId
+    ? 'operator'
+    : input.aggregate.neighborLeg.providerCallId === input.providerLegId
+      ? 'neighbor'
+      : null
+
+  if (normalizedEventType === 'callanswered' || normalizedEventType === 'voiceanswered') {
+    if (legRole === 'operator') {
+      return {
+        type: 'operator_answered',
+        bridgeSessionId: input.aggregate.session.id,
+        providerCallId: input.providerLegId,
+        occurredAt: input.occurredAt,
+      }
+    }
+
+    if (legRole === 'neighbor') {
+      return {
+        type: 'neighbor_answered',
+        bridgeSessionId: input.aggregate.session.id,
+        providerCallId: input.providerLegId,
+        occurredAt: input.occurredAt,
+      }
+    }
+  }
+
+  if (
+    normalizedEventType === 'callbridged'
+    || normalizedEventType === 'callconnected'
+  ) {
+    return {
+      type: 'bridge_connected',
+      bridgeSessionId: input.aggregate.session.id,
+      occurredAt: input.occurredAt,
+    }
+  }
+
+  if (
+    normalizedEventType === 'callhangup'
+    || normalizedEventType === 'callcompleted'
+    || normalizedEventType === 'callended'
+  ) {
+    if (input.aggregate.session.status === 'bridged' || input.aggregate.session.status === 'completed') {
+      return {
+        type: 'completed',
+        bridgeSessionId: input.aggregate.session.id,
+        providerCallId: input.providerLegId,
+        occurredAt: input.occurredAt,
+      }
+    }
+
+    if (legRole === 'operator') {
+      return {
+        type: 'operator_failed',
+        bridgeSessionId: input.aggregate.session.id,
+        providerCallId: input.providerLegId,
+        reason: input.reason || 'call_hangup',
+        occurredAt: input.occurredAt,
+      }
+    }
+
+    if (legRole === 'neighbor') {
+      return {
+        type: 'neighbor_failed',
+        bridgeSessionId: input.aggregate.session.id,
+        providerCallId: input.providerLegId,
+        reason: input.reason || 'call_hangup',
+        occurredAt: input.occurredAt,
+      }
+    }
+  }
+
+  if (
+    normalizedEventType === 'callfailed'
+    || normalizedEventType === 'callfailure'
+    || normalizedEventType === 'callrejected'
+  ) {
+    if (legRole === 'operator') {
+      return {
+        type: 'operator_failed',
+        bridgeSessionId: input.aggregate.session.id,
+        providerCallId: input.providerLegId,
+        reason: input.reason || 'call_failed',
+        occurredAt: input.occurredAt,
+      }
+    }
+
+    if (legRole === 'neighbor') {
+      return {
+        type: 'neighbor_failed',
+        bridgeSessionId: input.aggregate.session.id,
+        providerCallId: input.providerLegId,
+        reason: input.reason || 'call_failed',
+        occurredAt: input.occurredAt,
+      }
+    }
+  }
+
+  return null
+}
+
+const repositoryProxy: BridgeSessionRepository = {
+  async createSession(session) {
+    if (isConnectShyftTestOverrideEnabled()) {
+      await inMemoryBridgeSessionStore.createSession(session)
+      return
+    }
+
+    try {
+      await knexBridgeSessionStore.createSession(session)
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error
+      }
+      await inMemoryBridgeSessionStore.createSession(session)
+    }
+  },
+  async createLeg(leg) {
+    if (isConnectShyftTestOverrideEnabled()) {
+      await inMemoryBridgeSessionStore.createLeg(leg)
+      return
+    }
+
+    try {
+      await knexBridgeSessionStore.createLeg(leg)
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error
+      }
+      await inMemoryBridgeSessionStore.createLeg(leg)
+    }
+  },
+  async saveAggregate(aggregate) {
+    if (isConnectShyftTestOverrideEnabled()) {
+      await inMemoryBridgeSessionStore.saveAggregate(aggregate)
+      return
+    }
+
+    try {
+      await knexBridgeSessionStore.saveAggregate(aggregate)
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error
+      }
+      await inMemoryBridgeSessionStore.saveAggregate(aggregate)
+    }
+  },
+  async getAggregateBySessionId(sessionId) {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryBridgeSessionStore.getAggregateBySessionId(sessionId)
+    }
+
+    try {
+      return await knexBridgeSessionStore.getAggregateBySessionId(sessionId)
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error
+      }
+      return inMemoryBridgeSessionStore.getAggregateBySessionId(sessionId)
+    }
+  },
+  async getAggregateByThreadId(input) {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryBridgeSessionStore.getAggregateByThreadId(input)
+    }
+
+    try {
+      return await knexBridgeSessionStore.getAggregateByThreadId(input)
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error
+      }
+      return inMemoryBridgeSessionStore.getAggregateByThreadId(input)
+    }
+  },
+  async getAggregateByProviderCallId(input) {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryBridgeSessionStore.getAggregateByProviderCallId(input)
+    }
+
+    try {
+      return await knexBridgeSessionStore.getAggregateByProviderCallId(input)
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error
+      }
+      return inMemoryBridgeSessionStore.getAggregateByProviderCallId(input)
+    }
+  },
+}
+
+export const resetConnectShyftBridgeSessionStateForTests = (): void => {
+  inMemoryBridgeSessionStore.reset()
+}
+
+export const loadConnectShyftBridgeAggregateBySessionId = async (
+  sessionId: string,
+): Promise<BridgeSessionAggregate | null> => repositoryProxy.getAggregateBySessionId(sessionId)
+
+export const loadConnectShyftBridgeAggregateByThreadId = async (input: {
+  tenantId?: string | null
+  threadId: string
+}): Promise<BridgeSessionAggregate | null> => repositoryProxy.getAggregateByThreadId(input)
+
+export const loadConnectShyftBridgeAggregateByProviderCallId = async (input: {
+  tenantId?: string | null
+  providerCallId: string
+}): Promise<BridgeSessionAggregate | null> => repositoryProxy.getAggregateByProviderCallId(input)
+
+export const startConnectShyftBridgeSession = async (
+  input: StartConnectShyftBridgeSessionInput,
+): Promise<{
+  aggregate: BridgeSessionAggregate
+  correlationMapping: BridgeMappingResult
+}> => {
+  const telephonyProvider = buildBridgeTelephonyProvider({
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    threadId: input.threadId,
+    providerKey: input.providerKey,
+    providerAdapter: input.providerAdapter,
+    idempotencyKey: input.idempotencyKey ?? null,
+    callPolicy: input.callPolicy,
+  })
+  const startBridgeSession = buildStartBridgeSession({
+    repository: repositoryProxy,
+    telephonyProvider,
+    idGenerator: randomUUID,
+  })
+
+  const aggregate = await startBridgeSession({
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    threadId: input.threadId,
+    operatorParticipantId: input.operatorParticipantId,
+    neighborParticipantId: input.neighborParticipantId,
+    operatorContactPointId: input.operatorContactPointId,
+    neighborContactPointId: input.neighborContactPointId,
+    selectedOutboundContactPointId: input.selectedOutboundContactPointId ?? undefined,
+    idempotencyKey: input.idempotencyKey ?? undefined,
+    auditCorrelationId: input.auditCorrelationId ?? undefined,
+  } satisfies StartBridgeSessionCommand)
+
+  return {
+    aggregate,
+    correlationMapping: await persistBridgeProviderMappings({
+      aggregate,
+      providerName: input.providerKey,
+    }),
+  }
+}
+
+export const handleConnectShyftBridgeWebhookEvent = async (
+  input: HandleConnectShyftBridgeWebhookEventInput,
+): Promise<{
+  handled: boolean
+  aggregate: BridgeSessionAggregate | null
+  domainEvent: ProviderBridgeEvent | null
+  correlationMapping: BridgeMappingResult | null
+}> => {
+  const providerLegId = normalizeString(input.providerLegId)
+  if (!providerLegId) {
+    return {
+      handled: false,
+      aggregate: null,
+      domainEvent: null,
+      correlationMapping: null,
+    }
+  }
+
+  const existingAggregate = await repositoryProxy.getAggregateByProviderCallId({
+    tenantId: input.tenantId,
+    providerCallId: providerLegId,
+  })
+  if (!existingAggregate) {
+    return {
+      handled: false,
+      aggregate: null,
+      domainEvent: null,
+      correlationMapping: null,
+    }
+  }
+
+  const domainEvent = resolveBridgeWebhookEvent({
+    aggregate: existingAggregate,
+    providerLegId,
+    eventType: input.eventType,
+    occurredAt: input.occurredAt,
+    reason: input.reason ?? null,
+  })
+  if (!domainEvent) {
+    return {
+      handled: false,
+      aggregate: existingAggregate,
+      domainEvent: null,
+      correlationMapping: null,
+    }
+  }
+
+  const telephonyProvider = buildBridgeTelephonyProvider({
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    threadId: input.threadId,
+    providerKey: input.providerKey,
+    providerAdapter: input.providerAdapter,
+    callPolicy: input.callPolicy,
+  })
+  const handleProviderBridgeEvent = buildHandleProviderBridgeEvent({
+    repository: repositoryProxy,
+    telephonyProvider,
+  })
+  const aggregate = await handleProviderBridgeEvent(domainEvent)
+  if (!aggregate) {
+    return {
+      handled: false,
+      aggregate: null,
+      domainEvent,
+      correlationMapping: null,
+    }
+  }
+
+  return {
+    handled: true,
+    aggregate,
+    domainEvent,
+    correlationMapping: await persistBridgeProviderMappings({
+      aggregate,
+      providerName: input.providerKey,
+    }),
+  }
+}

--- a/apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts
@@ -595,6 +595,34 @@ export const recordConnectShyftProviderIdentifierMapping = async (input: {
   }
 };
 
+export const recordConnectShyftBridgeLegProviderIdentifierMapping = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  providerIdentifier: string;
+  bridgeLegId: string;
+  createdAtUtc?: string;
+  db?: Knex;
+}): Promise<{
+  status: 'created' | 'duplicate' | 'ignored' | 'error';
+  mapping: ConnectShyftProviderIdentifierMapping | null;
+  errorCode?: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE';
+  errorMessage?: string;
+}> => {
+  return recordConnectShyftProviderIdentifierMapping({
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    threadId: input.threadId,
+    providerName: input.providerName,
+    identifierKind: 'call_leg',
+    providerIdentifier: input.providerIdentifier,
+    internalReferenceId: input.bridgeLegId,
+    createdAtUtc: input.createdAtUtc,
+    db: input.db,
+  });
+};
+
 export const resolveConnectShyftProviderCorrelationByIdentifiers = async (input: {
   providerName: string;
   providerLegId?: string | null;

--- a/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts
@@ -666,6 +666,25 @@ const buildMockSandboxAdapter = (
       providerBranchingInDomain: false,
     });
   },
+  async startBridgeOutboundCall(command) {
+    return assertValidCallDispatchResult({
+      providerKey,
+      channel: 'call',
+      providerLegId: `${providerKey}-bridge-leg-${command.legRole}-${command.bridgeSessionId}`,
+      providerMessageId: null,
+      adapterInvoked: true,
+      providerBranchingInDomain: false,
+    });
+  },
+  async startBridgeSession(command) {
+    return {
+      providerKey,
+      bridgeSessionId: command.bridgeSessionId,
+      bridgeEstablished: true,
+      adapterInvoked: true,
+      providerBranchingInDomain: false,
+    };
+  },
   verifyWebhook(input) {
     if (input.verification?.enforceValidation === false) {
       return { ok: true };
@@ -729,11 +748,37 @@ const createGuardrailedAdapter = (
 
     return baseAdapter.startOutboundCall(command);
   },
+  async startBridgeOutboundCall(command) {
+    if (!baseAdapter.startBridgeOutboundCall) {
+      return baseAdapter.startOutboundCall({
+        tenantId: command.tenantId,
+        orgUnitId: command.orgUnitId,
+        threadId: command.threadId,
+        providerKey: command.providerKey,
+        idempotencyKey: command.idempotencyKey,
+        targetPhone: command.targetPhone,
+        callPolicy: {
+          transport: CONNECTSHYFT_REQUIRED_CALL_TRANSPORT,
+          autoRetry: false,
+          redialPolicy: CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY,
+        },
+      });
+    }
+
+    return baseAdapter.startBridgeOutboundCall(command);
+  },
   verifyWebhook(input) {
     return baseAdapter.verifyWebhook(input);
   },
   translateProviderEvent(input) {
     return baseAdapter.translateProviderEvent(input);
+  },
+  async startBridgeSession(command) {
+    if (!baseAdapter.startBridgeSession) {
+      throw new Error(`Provider ${baseAdapter.providerKey} does not support bridge control.`);
+    }
+
+    return baseAdapter.startBridgeSession(command);
   },
 });
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
@@ -1,0 +1,631 @@
+import connectShyftRouter from '../connectshyft'
+import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions'
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents'
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings'
+
+const toCanonicalEventType = (rawEventType: string): string => rawEventType
+  .split(/[._-]+/)
+  .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : ''))
+  .join('')
+
+const sendSmsMock = jest.fn()
+const startOutboundCallMock = jest.fn(async (command: { threadId: string; targetPhone?: string }) => ({
+  providerKey: 'telnyx',
+  channel: 'call' as const,
+  providerLegId: command.targetPhone === '+12605550155'
+    ? `telnyx-leg-operator-${command.threadId}`
+    : `telnyx-leg-neighbor-${command.threadId}`,
+  providerMessageId: null,
+  providerRequestId: 'req-call-2001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:05:00.000Z',
+}))
+const startBridgeSessionMock = jest.fn(async (command: {
+  bridgeSessionId: string
+  operatorProviderCallId: string
+  neighborProviderCallId: string
+}) => ({
+  providerKey: 'telnyx',
+  bridgeSessionId: command.bridgeSessionId,
+  bridgeEstablished: true as const,
+  providerRequestId: 'req-bridge-3001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:06:00.000Z',
+}))
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }))
+const translateProviderEventMock = jest.fn(({ rawEventType, payload }: { rawEventType: string; payload: unknown }) => ({
+  eventType: toCanonicalEventType(rawEventType),
+  payload: (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>,
+  providerNeutral: true as const,
+  providerSpecificFieldsStripped: true as const,
+  providerBranchingInDomain: false as const,
+}))
+
+jest.mock('../../../../../../../infrastructure/communications/telnyx', () => ({
+  createTelnyxAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}))
+
+const buildHeaders = (extra: Record<string, string> = {}): Record<string, string> => ({
+  'x-test-connectshyft-tenant-id': 'tenant-connectshyft-f1',
+  'x-test-connectshyft-orgunit-id': 'org-connectshyft-f1-east',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify(['org-connectshyft-f1-east']),
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-f1-primary-operator',
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+  ...extra,
+})
+
+const invokeRoute = async (input: {
+  method?: 'GET' | 'POST'
+  url: string
+  body?: Record<string, unknown>
+  headers?: Record<string, string>
+}): Promise<{ status: number; body: unknown }> => {
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(input.headers || {}).map(([key, value]) => [key.toLowerCase(), value]),
+  )
+
+  return new Promise((resolve, reject) => {
+    let resolved = false
+    const req = {
+      method: input.method || 'POST',
+      url: input.url,
+      originalUrl: input.url,
+      path: input.url,
+      protocol: 'https',
+      body: input.body || {},
+      headers: normalizedHeaders,
+      params: {},
+      query: {},
+      tenantContext: undefined,
+      tenantId: undefined,
+      orgUnitId: undefined,
+      user: undefined,
+      header(name: string): string | undefined {
+        return normalizedHeaders[name.toLowerCase()]
+      },
+      get(name: string): string | undefined {
+        return normalizedHeaders[name.toLowerCase()]
+      },
+    } as any
+
+    const res = {
+      locals: {},
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code
+        return this
+      },
+      json(payload: unknown) {
+        resolved = true
+        resolve({
+          status: this.statusCode,
+          body: payload,
+        })
+        return this
+      },
+      send(payload: unknown) {
+        resolved = true
+        resolve({
+          status: this.statusCode,
+          body: payload,
+        })
+        return this
+      },
+      setHeader() {
+        return this
+      },
+      getHeader() {
+        return undefined
+      },
+      end(payload?: unknown) {
+        if (!resolved) {
+          resolved = true
+          resolve({
+            status: this.statusCode,
+            body: payload,
+          })
+        }
+        return this
+      },
+    } as any
+
+    ;(connectShyftRouter as any).handle(req, res, (error?: unknown) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      if (!resolved) {
+        resolve({
+          status: res.statusCode,
+          body: null,
+        })
+      }
+    })
+  })
+}
+
+describe('connectshyft bridge webhook flow', () => {
+  const previousNodeEnv = process.env.NODE_ENV
+  const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true'
+  })
+
+  beforeEach(() => {
+    sendSmsMock.mockClear()
+    startOutboundCallMock.mockClear()
+    startBridgeSessionMock.mockClear()
+    verifyWebhookMock.mockClear()
+    translateProviderEventMock.mockClear()
+    resetConnectShyftCanonicalEventsForTests()
+    resetConnectShyftBridgeSessionStateForTests()
+    resetConnectShyftProviderCorrelationStateForTests()
+  })
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags
+  })
+
+  it('creates a persisted bridge session on call start with operator-first dialing', async () => {
+    const response = await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/call',
+      headers: buildHeaders(),
+      body: {
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED',
+      data: {
+        dispatch: {
+          providerKey: 'telnyx',
+          providerLegId: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+        },
+        bridgeSession: {
+          bridgeSessionId: expect.any(String),
+          status: 'operator_dialing',
+          sessionState: 'operator_dialing',
+          operatorLegState: 'ringing',
+          neighborLegState: 'created',
+          failureCode: null,
+          failureMessage: null,
+          operatorLeg: {
+            status: 'ringing',
+            failureCode: null,
+            failureMessage: null,
+          },
+          neighborLeg: {
+            status: 'created',
+            failureCode: null,
+            failureMessage: null,
+          },
+        },
+      },
+    })
+    expect(startOutboundCallMock).toHaveBeenCalledTimes(1)
+    expect(startOutboundCallMock).toHaveBeenCalledWith(expect.objectContaining({
+      targetPhone: '+12605550155',
+    }))
+  })
+
+  it('advances operator answered to neighbor dialing and bridges on neighbor answered', async () => {
+    const startResponse = await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/call',
+      headers: buildHeaders(),
+      body: {
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      },
+    })
+
+    expect(startResponse.status).toBe(200)
+    expect(startOutboundCallMock).toHaveBeenCalledTimes(1)
+
+    const operatorAnswered = await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.answered',
+        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+      },
+    })
+
+    expect(operatorAnswered.status).toBe(200)
+    expect(operatorAnswered.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        bridgeSession: {
+          status: 'neighbor_dialing',
+          sessionState: 'neighbor_dialing',
+          operatorLegState: 'answered',
+          neighborLegState: 'ringing',
+          failureCode: null,
+          failureMessage: null,
+          operatorLeg: {
+            status: 'answered',
+          },
+          neighborLeg: {
+            status: 'ringing',
+          },
+        },
+        bridgeEvent: {
+          type: 'operator_answered',
+        },
+      },
+    })
+    expect(startOutboundCallMock).toHaveBeenCalledTimes(2)
+    expect(startOutboundCallMock).toHaveBeenLastCalledWith(expect.objectContaining({
+      targetPhone: '+12605550111',
+    }))
+
+    const neighborAnswered = await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.answered',
+        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+      },
+    })
+
+    expect(neighborAnswered.status).toBe(200)
+    expect(neighborAnswered.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        bridgeSession: {
+          status: 'bridged',
+          sessionState: 'bridged',
+          operatorLegState: 'answered',
+          neighborLegState: 'answered',
+          failureCode: null,
+          failureMessage: null,
+          operatorLeg: {
+            status: 'answered',
+          },
+          neighborLeg: {
+            status: 'answered',
+          },
+        },
+        bridgeEvent: {
+          type: 'neighbor_answered',
+        },
+      },
+    })
+    expect(startBridgeSessionMock).toHaveBeenCalledTimes(1)
+    expect(startBridgeSessionMock).toHaveBeenCalledWith(expect.objectContaining({
+      operatorProviderCallId: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+      neighborProviderCallId: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+    }))
+  })
+
+  it('suppresses duplicate webhook receipts before bridge side effects are re-applied', async () => {
+    await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/call',
+      headers: buildHeaders(),
+      body: {
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      },
+    })
+
+    const operatorAnswered = await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.answered',
+        provider_event_id: 'bridge-operator-answered-1001',
+        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+      },
+    })
+    const operatorAnsweredDuplicate = await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.answered',
+        provider_event_id: 'bridge-operator-answered-1001',
+        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+      },
+    })
+
+    expect(operatorAnswered.status).toBe(200)
+    expect(operatorAnswered.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+        },
+        bridgeSession: {
+          sessionState: 'neighbor_dialing',
+          operatorLegState: 'answered',
+          neighborLegState: 'ringing',
+        },
+      },
+    })
+    expect(operatorAnsweredDuplicate.status).toBe(200)
+    expect(operatorAnsweredDuplicate.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        replaySafe: {
+          duplicate: true,
+          suppressedDomainWrites: true,
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+      },
+    })
+    expect((operatorAnsweredDuplicate.body as any).data.replaySafe.dedupeKey)
+      .toContain('bridge-operator-answered-1001')
+    expect(startOutboundCallMock).toHaveBeenCalledTimes(2)
+    expect(startBridgeSessionMock).toHaveBeenCalledTimes(0)
+  })
+
+  it('persists terminal completion without repeating side effects on duplicate webhook delivery', async () => {
+    await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/call',
+      headers: buildHeaders(),
+      body: {
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      },
+    })
+
+    await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.answered',
+        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+      },
+    })
+    await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.answered',
+        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+      },
+    })
+
+    const completed = await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.completed',
+        provider_event_id: 'bridge-completed-1001',
+        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+      },
+    })
+    const completedReplay = await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.completed',
+        provider_event_id: 'bridge-completed-1001',
+        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+      },
+    })
+
+    expect(completed.status).toBe(200)
+    expect(completed.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        bridgeSession: {
+          status: 'completed',
+          sessionState: 'completed',
+          operatorLegState: 'completed',
+          neighborLegState: 'completed',
+          failureCode: null,
+          failureMessage: null,
+          operatorLeg: {
+            status: 'completed',
+          },
+          neighborLeg: {
+            status: 'completed',
+          },
+        },
+        bridgeEvent: {
+          type: 'completed',
+        },
+      },
+    })
+    expect(completedReplay.status).toBe(200)
+    expect(completedReplay.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        replaySafe: {
+          duplicate: true,
+          suppressedDomainWrites: true,
+        },
+      },
+    })
+    expect(startBridgeSessionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists terminal bridge failure when the neighbor leg fails before bridge completion', async () => {
+    await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/call',
+      headers: buildHeaders(),
+      body: {
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      },
+    })
+
+    await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.answered',
+        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+      },
+    })
+
+    const failed = await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.failed',
+        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        reason: 'neighbor_declined',
+      },
+    })
+
+    expect(failed.status).toBe(200)
+    expect(failed.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      data: {
+        bridgeSession: {
+          status: 'failed',
+          sessionState: 'failed',
+          operatorLegState: 'answered',
+          neighborLegState: 'failed',
+          failureCode: 'neighbor_failed',
+          failureMessage: 'neighbor_declined',
+          neighborLeg: {
+            status: 'failed',
+            failureCode: 'neighbor_failed',
+            failureMessage: 'neighbor_declined',
+          },
+        },
+        bridgeEvent: {
+          type: 'neighbor_failed',
+        },
+      },
+    })
+    expect(startBridgeSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('loads persisted bridge state from a fresh thread detail read after completion', async () => {
+    await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/call',
+      headers: buildHeaders(),
+      body: {
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      },
+    })
+
+    await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.answered',
+        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+      },
+    })
+    await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.answered',
+        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+      },
+    })
+    await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        eventType: 'call.completed',
+        provider_event_id: 'bridge-completed-refresh-1001',
+        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+      },
+    })
+
+    const detailResponse = await invokeRoute({
+      method: 'GET',
+      url: '/threads/thread-f1-unclaimed-1001',
+      headers: buildHeaders(),
+    })
+
+    expect(detailResponse.status).toBe(200)
+    expect(detailResponse.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+      data: {
+        bridgeSession: {
+          bridgeSessionId: expect.any(String),
+          status: 'completed',
+          sessionState: 'completed',
+          operatorLegState: 'completed',
+          neighborLegState: 'completed',
+          failureCode: null,
+          failureMessage: null,
+        },
+      },
+    })
+  })
+})

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
@@ -62,6 +62,12 @@ const buildHeaders = (extra: Record<string, string> = {}): Record<string, string
   'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
   'x-test-connectshyft-user-id': 'user-connectshyft-f1-primary-operator',
   'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+  'x-test-connectshyft-flags': JSON.stringify({
+    connectshyft_enabled: true,
+    connectshyft_inbox_enabled: true,
+    connectshyft_escalation_enabled: true,
+    connectshyft_webhooks_enabled: true,
+  }),
   ...extra,
 })
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
@@ -1,6 +1,12 @@
 import connectShyftRouter, { resetConnectShyftOutboundDispatchReplayLedgerForTests } from '../connectshyft';
+import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
 import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
 import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+
+const toCanonicalEventType = (rawEventType: string): string => rawEventType
+  .split(/[._-]+/)
+  .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : ''))
+  .join('');
 
 const sendSmsMock = jest.fn(async (command: { threadId: string }) => ({
   providerKey: 'telnyx',
@@ -13,20 +19,31 @@ const sendSmsMock = jest.fn(async (command: { threadId: string }) => ({
   requestedAt: '2026-03-11T12:00:00.000Z',
 }));
 
-const startOutboundCallMock = jest.fn(async (command: { threadId: string }) => ({
+const startOutboundCallMock = jest.fn(async (command: { threadId: string; targetPhone?: string }) => ({
   providerKey: 'telnyx',
   channel: 'call' as const,
-  providerLegId: `telnyx-leg-${command.threadId}`,
+  providerLegId: command.targetPhone === '+12605550155'
+    ? `telnyx-leg-operator-${command.threadId}`
+    : `telnyx-leg-neighbor-${command.threadId}`,
   providerMessageId: null,
   providerRequestId: 'req-call-2001',
   adapterInvoked: true as const,
   providerBranchingInDomain: false as const,
   requestedAt: '2026-03-11T12:05:00.000Z',
 }));
+const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+  providerKey: 'telnyx',
+  bridgeSessionId: command.bridgeSessionId,
+  bridgeEstablished: true as const,
+  providerRequestId: 'req-bridge-3001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:06:00.000Z',
+}));
 
 const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
 const translateProviderEventMock = jest.fn(({ rawEventType, payload }: { rawEventType: string; payload: unknown }) => ({
-  eventType: rawEventType,
+  eventType: toCanonicalEventType(rawEventType),
   payload: (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>,
   providerNeutral: true as const,
   providerSpecificFieldsStripped: true as const,
@@ -39,6 +56,7 @@ jest.mock('../../../../../../../infrastructure/communications/telnyx', () => ({
     adapterInterfaceVersion: 'v1',
     sendSms: sendSmsMock,
     startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
     verifyWebhook: verifyWebhookMock,
     translateProviderEvent: translateProviderEventMock,
   })),
@@ -158,7 +176,9 @@ describe('connectshyft outbound dispatch routes', () => {
     startOutboundCallMock.mockClear();
     verifyWebhookMock.mockClear();
     translateProviderEventMock.mockClear();
+    startBridgeSessionMock.mockClear();
     resetConnectShyftCanonicalEventsForTests();
+    resetConnectShyftBridgeSessionStateForTests();
     resetConnectShyftProviderCorrelationStateForTests();
     resetConnectShyftOutboundDispatchReplayLedgerForTests();
   });
@@ -235,12 +255,13 @@ describe('connectshyft outbound dispatch routes', () => {
     }));
   });
 
-  it('returns providerLegId values for outbound calls without exposing bridge-session state', async () => {
+  it('starts a persisted bridge session for outbound calls and returns bridge-session state', async () => {
     const response = await invokeRoute({
       url: '/threads/thread-f1-unclaimed-1001/call',
       headers: buildHeaders(),
       body: {
         providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
         targetPhone: '+12605550111',
       },
     });
@@ -252,7 +273,7 @@ describe('connectshyft outbound dispatch routes', () => {
       data: {
         dispatch: {
           providerKey: 'telnyx',
-          providerLegId: 'telnyx-leg-thread-f1-unclaimed-1001',
+          providerLegId: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
           providerMessageId: null,
         },
         call: {
@@ -260,21 +281,53 @@ describe('connectshyft outbound dispatch routes', () => {
           autoRetry: false,
           redialPolicy: 'manual_only',
         },
+        bridgeSession: {
+          status: 'operator_dialing',
+          operatorLeg: {
+            status: 'ringing',
+          },
+          neighborLeg: {
+            status: 'created',
+          },
+        },
+        correlationMapping: {
+          deterministic: true,
+          operatorLegMapping: 'created',
+          neighborLegMapping: 'ignored',
+        },
         replaySafe: {
           duplicate: false,
         },
       },
     });
-    expect((response.body as any).data.bridgeSession).toBeUndefined();
+    expect((response.body as any).data.bridgeSession.bridgeSessionId).toBeTruthy();
     expect(startOutboundCallMock).toHaveBeenCalledTimes(1);
     expect(startOutboundCallMock).toHaveBeenCalledWith(expect.objectContaining({
       providerKey: 'telnyx',
-      targetPhone: '+12605550111',
+      targetPhone: '+12605550155',
       callPolicy: {
         transport: 'bridge',
         autoRetry: false,
         redialPolicy: 'manual_only',
       },
     }));
+  });
+
+  it('refuses outbound bridge calls when no operator callback number is provided', async () => {
+    const response = await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/call',
+      headers: buildHeaders(),
+      body: {
+        providerKey: 'telnyx',
+        targetPhone: '+12605550111',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_OPERATOR_CALLBACK_REQUIRED',
+    });
+    expect(startOutboundCallMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -114,6 +114,11 @@ import {
   recordConnectShyftProviderIdentifierMapping,
   resolveConnectShyftProviderCorrelationByIdentifiers,
 } from '../../../modules/connectshyft/providerCorrelationMappings';
+import {
+  handleConnectShyftBridgeWebhookEvent,
+  loadConnectShyftBridgeAggregateByThreadId,
+  startConnectShyftBridgeSession,
+} from '../../../modules/connectshyft/bridgeSessions';
 import { isStrictUtcIsoTimestamp } from '../../../platform/time/timezoneService';
 
 const router = Router();
@@ -890,6 +895,47 @@ const normalizeLifecycleString = (value: unknown): string => {
   return value.trim();
 };
 
+const buildProviderNeutralBridgeSessionState = (aggregate: {
+  session: {
+    id: string;
+    status: string;
+    failureCode?: string | null;
+    failureMessage?: string | null;
+  };
+  operatorLeg: {
+    id: string;
+    status: string;
+    failureCode?: string | null;
+    failureMessage?: string | null;
+  };
+  neighborLeg: {
+    id: string;
+    status: string;
+    failureCode?: string | null;
+    failureMessage?: string | null;
+  };
+}): ConnectShyftBridgeSessionStateContract => ({
+  bridgeSessionId: aggregate.session.id,
+  status: aggregate.session.status,
+  sessionState: aggregate.session.status,
+  failureCode: normalizeLifecycleString(aggregate.session.failureCode) || null,
+  failureMessage: normalizeLifecycleString(aggregate.session.failureMessage) || null,
+  operatorLegState: aggregate.operatorLeg.status,
+  neighborLegState: aggregate.neighborLeg.status,
+  operatorLeg: {
+    legId: aggregate.operatorLeg.id,
+    status: aggregate.operatorLeg.status,
+    failureCode: normalizeLifecycleString(aggregate.operatorLeg.failureCode) || null,
+    failureMessage: normalizeLifecycleString(aggregate.operatorLeg.failureMessage) || null,
+  },
+  neighborLeg: {
+    legId: aggregate.neighborLeg.id,
+    status: aggregate.neighborLeg.status,
+    failureCode: normalizeLifecycleString(aggregate.neighborLeg.failureCode) || null,
+    failureMessage: normalizeLifecycleString(aggregate.neighborLeg.failureMessage) || null,
+  },
+});
+
 type ConnectShyftWebhookCorrelationSource = 'metadata' | 'provider_fallback' | 'number_mapping';
 
 type ConnectShyftResolvedWebhookCorrelation =
@@ -919,6 +965,38 @@ type ConnectShyftResolvedWebhookCorrelation =
     providerEventId: string | null;
     providerNumberE164: string | null;
   };
+
+type ConnectShyftBridgeCorrelationMapping = {
+  deterministic: true;
+  operatorLegMapping: 'created' | 'duplicate' | 'ignored' | 'error';
+  neighborLegMapping: 'created' | 'duplicate' | 'ignored' | 'error';
+  error: {
+    code: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE';
+    message: string;
+  } | null;
+};
+
+type ConnectShyftBridgeSessionStateContract = {
+  bridgeSessionId: string;
+  status: string;
+  sessionState: string;
+  failureCode: string | null;
+  failureMessage: string | null;
+  operatorLegState: string;
+  neighborLegState: string;
+  operatorLeg: {
+    legId: string;
+    status: string;
+    failureCode: string | null;
+    failureMessage: string | null;
+  };
+  neighborLeg: {
+    legId: string;
+    status: string;
+    failureCode: string | null;
+    failureMessage: string | null;
+  };
+};
 
 const asRecord = (value: unknown): Record<string, unknown> | null => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -3268,6 +3346,7 @@ const parseOutboundCallRequestPolicy = (req: Request): {
   redialPolicy: string | null;
   retryCount: number | null;
   targetPhone: string | null;
+  operatorContactPointId: string | null;
 } => {
   const rawBody = req.body && typeof req.body === 'object'
     ? req.body as Record<string, unknown>
@@ -3290,6 +3369,12 @@ const parseOutboundCallRequestPolicy = (req: Request): {
     ?? resolveField('targetPhoneE164')
     ?? resolveField('recipientPhone'),
   );
+  const operatorContactPointId = normalizeLifecycleString(
+    resolveField('operatorPhoneId')
+    ?? resolveField('operatorContactPointId')
+    ?? resolveField('operatorPhone')
+    ?? resolveField('operatorCallbackPhone'),
+  );
 
   return {
     transport: transport || null,
@@ -3299,6 +3384,7 @@ const parseOutboundCallRequestPolicy = (req: Request): {
       parseOptionalNonNegativeInteger(resolveField('retryCount'))
       ?? parseOptionalNonNegativeInteger(resolveField('maxRetries')),
     targetPhone: targetPhone || null,
+    operatorContactPointId: operatorContactPointId || null,
   };
 };
 
@@ -5684,6 +5770,10 @@ router.get('/threads/:threadId', async (req: Request, res: Response) => {
     statusDerivedFromCanonicalEvents: true as const,
     timeline: resolvedTimeline,
   };
+  const activeBridgeSession = await loadConnectShyftBridgeAggregateByThreadId({
+    tenantId: context.tenantId,
+    threadId,
+  });
 
   return success(res, {
     code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
@@ -5695,6 +5785,9 @@ router.get('/threads/:threadId', async (req: Request, res: Response) => {
         bypassedOrgUnitMembership: context.bypassedOrgUnitMembership,
       },
       thread: threadWithCanonicalTimeline,
+      bridgeSession: activeBridgeSession
+        ? buildProviderNeutralBridgeSessionState(activeBridgeSession)
+        : null,
       voicemailArtifacts,
       actions: threadWithCanonicalTimeline.actions,
       actionMatrix: {
@@ -6071,6 +6164,9 @@ const performOutboundAction = async (
     targetPhone: outboundAction === 'call'
       ? outboundCallPolicyRequest?.targetPhone || null
       : outboundMessagePolicy?.targetPhone || null,
+    operatorContactPointId: outboundAction === 'call'
+      ? outboundCallPolicyRequest?.operatorContactPointId || null
+      : null,
     body: outboundMessagePolicy?.body || null,
     callPolicy: outboundCallDispatchPolicy,
   });
@@ -6127,6 +6223,8 @@ const performOutboundAction = async (
   let persistedSmsOverride: ConnectShyftPersistedSmsOverride | null = null;
   let sideEffectsPersisted = false;
   let escalationReset: { stage: number; inactivityWindow: 'reset' } | null = null;
+  let bridgeSessionState: ConnectShyftBridgeSessionStateContract | null = null;
+  let bridgeCorrelationMapping: ConnectShyftBridgeCorrelationMapping | null = null;
 
   if (lifecycleContext.detail) {
     thread = buildThreadFromDetailRecord(lifecycleContext.detail, {
@@ -6397,18 +6495,105 @@ const performOutboundAction = async (
     }
   };
 
+  let operatorContactPointId: string | null = null;
+  let neighborContactPointId: string | null = null;
+  if (outboundAction === 'call') {
+    operatorContactPointId = outboundCallPolicyRequest?.operatorContactPointId || null;
+    if (!operatorContactPointId) {
+      respondConnectShyftBusinessRefusal(res, {
+        code: 'CONNECTSHYFT_OPERATOR_CALLBACK_REQUIRED',
+        message: 'Outbound bridge calls require an operator callback number.',
+        data: {
+          context,
+          threadId,
+          providerResolution: {
+            ...providerSelection.providerResolution,
+            adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+            providerBranchingInDomain: false,
+          },
+          sideEffects: {
+            dispatchAttempted: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+
+    neighborContactPointId = outboundCallPolicyRequest?.targetPhone || null;
+    if (!neighborContactPointId && thread.neighborId) {
+      const resolvedNeighbor = await connectShyftNeighborServiceAsync.resolveNeighbor({
+        tenantId: context.tenantId,
+        neighborId: thread.neighborId,
+        actorRoles,
+      });
+      if (resolvedNeighbor.ok) {
+        neighborContactPointId = resolvedNeighbor.data.neighbor.phones
+          .filter((phone) => phone.isActive !== false)
+          .sort((left, right) => left.sortOrder - right.sortOrder)
+          [0]?.value || null;
+      }
+    }
+
+    if (!neighborContactPointId) {
+      respondConnectShyftBusinessRefusal(res, {
+        code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+        message: 'Outbound bridge calls require a dialable neighbor phone.',
+        data: {
+          context,
+          threadId,
+          providerResolution: {
+            ...providerSelection.providerResolution,
+            adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+            providerBranchingInDomain: false,
+          },
+          sideEffects: {
+            dispatchAttempted: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+  }
+
   let providerDispatch: ConnectShyftProviderDispatchResult;
   try {
     providerDispatch = outboundAction === 'call'
-      ? await providerSelection.adapter.startOutboundCall({
-        tenantId: context.tenantId,
-        orgUnitId: context.orgUnitId,
-        threadId,
-        providerKey: providerSelection.providerResolution.resolvedProvider,
-        idempotencyKey: outboundDispatchIdempotencyKey || undefined,
-        targetPhone: outboundCallPolicyRequest?.targetPhone || undefined,
-        callPolicy: outboundCallDispatchPolicy || undefined,
-      })
+      ? await (async () => {
+        const bridgeStart = await startConnectShyftBridgeSession({
+          tenantId: context.tenantId,
+          orgUnitId: context.orgUnitId,
+          threadId,
+          operatorParticipantId: actorUserId || 'unknown-operator',
+          neighborParticipantId: thread.neighborId,
+          operatorContactPointId: operatorContactPointId || '',
+          neighborContactPointId: neighborContactPointId || '',
+          selectedOutboundContactPointId: thread.preferredOutboundCsNumberId || null,
+          providerKey: providerSelection.providerResolution.resolvedProvider,
+          providerAdapter: providerSelection.adapter,
+          idempotencyKey: outboundDispatchIdempotencyKey || undefined,
+          auditCorrelationId: outboundDispatchReplayKey || undefined,
+          callPolicy: outboundCallDispatchPolicy || undefined,
+        });
+
+        bridgeSessionState = buildProviderNeutralBridgeSessionState(bridgeStart.aggregate);
+        bridgeCorrelationMapping = bridgeStart.correlationMapping;
+
+        return {
+          providerKey: providerSelection.providerResolution.resolvedProvider,
+          channel: 'call' as const,
+          providerLegId: bridgeStart.aggregate.operatorLeg.providerCallId || null,
+          providerMessageId: null,
+          adapterInvoked: true as const,
+          providerBranchingInDomain: false as const,
+          requestedAt: bridgeStart.aggregate.operatorLeg.updatedAt.toISOString(),
+        };
+      })()
       : await providerSelection.adapter.sendSms({
         tenantId: context.tenantId,
         orgUnitId: context.orgUnitId,
@@ -6547,14 +6732,26 @@ const performOutboundAction = async (
     });
   }
 
-  let correlationMapping: Awaited<ReturnType<typeof persistOutboundProviderIdentifierMappings>> = {
+  let correlationMapping: Record<string, unknown> = {
     deterministic: true,
     callLegMapping: 'ignored',
     messageMapping: 'ignored',
     error: null,
   };
 
-  if (canonicalEvent) {
+  const resolvedBridgeCorrelationMapping =
+    bridgeCorrelationMapping as ConnectShyftBridgeCorrelationMapping | null;
+
+  if (outboundAction === 'call' && resolvedBridgeCorrelationMapping) {
+    correlationMapping = resolvedBridgeCorrelationMapping;
+    if (resolvedBridgeCorrelationMapping.error) {
+      postDispatchWarnings.push({
+        stage: 'provider-correlation',
+        code: resolvedBridgeCorrelationMapping.error.code,
+        message: resolvedBridgeCorrelationMapping.error.message,
+      });
+    }
+  } else if (canonicalEvent) {
     correlationMapping = await persistOutboundProviderIdentifierMappings({
       tenantId: context.tenantId,
       orgUnitId: context.orgUnitId,
@@ -6563,11 +6760,13 @@ const performOutboundAction = async (
       dispatch: providerDispatch,
       canonicalEventId: canonicalEvent.eventId,
     });
-    if (correlationMapping.error) {
+    const outboundProviderCorrelation =
+      correlationMapping as Awaited<ReturnType<typeof persistOutboundProviderIdentifierMappings>>;
+    if (outboundProviderCorrelation.error) {
       postDispatchWarnings.push({
         stage: 'provider-correlation',
-        code: correlationMapping.error.code,
-        message: correlationMapping.error.message,
+        code: outboundProviderCorrelation.error.code,
+        message: outboundProviderCorrelation.error.message,
       });
     }
   } else if (providerDispatch.providerLegId || providerDispatch.providerMessageId) {
@@ -6665,6 +6864,7 @@ const performOutboundAction = async (
       ? {
           call: CONNECTSHYFT_OUTBOUND_CALL_POLICY,
           autoClaimPolicy: CONNECTSHYFT_OUTBOUND_CALL_AUTO_CLAIM_POLICY,
+          bridgeSession: bridgeSessionState,
         }
       : {
           preferencePolicy: {
@@ -6845,6 +7045,9 @@ const handleInboundWebhook = async (
   const tenantId = correlation.tenantId;
   const orgUnitId = correlation.orgUnitId;
   const threadId = correlation.threadId;
+  const webhookPersistenceDb = isConnectShyftTestOverrideEnabled()
+    ? undefined
+    : loadPlatformDb();
   const requestWithRawBody = req as Request & { rawBody?: Buffer | string };
 
   const rolloutContextValidation = resolveConnectShyftProviderAdapter({
@@ -6949,7 +7152,7 @@ const handleInboundWebhook = async (
         callbackProviderEventId: callbackPayload.correlation.providerEventId || null,
         voicemailArtifactId: callbackPayload.correlation.voicemailArtifactId || null,
       },
-      db: loadPlatformDb(),
+      db: webhookPersistenceDb,
     });
     if (transcriptionReceipt.error) {
       refusal(res, {
@@ -7083,7 +7286,7 @@ const handleInboundWebhook = async (
           : !hasPersistedVoicemailCorrelation
             ? 'callback_correlation_unresolved'
             : 'transcript_text_missing',
-        db: loadPlatformDb(),
+        db: webhookPersistenceDb,
       });
       refusal(res, {
         code: 'CONNECTSHYFT_TRANSCRIPTION_CORRELATION_INVALID',
@@ -7165,7 +7368,7 @@ const handleInboundWebhook = async (
         providerMessageId: correlation.providerMessageId,
         status: 'FAILED_RETRYABLE',
         failureReason: 'canonical_event_persistence_error',
-        db: loadPlatformDb(),
+        db: webhookPersistenceDb,
       });
       refusal(res, {
         code: 'CONNECTSHYFT_TRANSCRIPTION_ATTACHMENT_UNAVAILABLE',
@@ -7207,7 +7410,7 @@ const handleInboundWebhook = async (
       providerLegId: correlation.providerLegId,
       providerMessageId: correlation.providerMessageId,
       status: 'APPLIED',
-      db: loadPlatformDb(),
+      db: webhookPersistenceDb,
     });
 
     success(res, {
@@ -7270,7 +7473,7 @@ const handleInboundWebhook = async (
       providerMessageId: correlation.providerMessageId,
       providerNumberE164: correlation.providerNumberE164,
     },
-    db: loadPlatformDb(),
+    db: webhookPersistenceDb,
   });
   if (webhookReceipt.error) {
     refusal(res, {
@@ -7328,7 +7531,7 @@ const handleInboundWebhook = async (
       providerMessageId: correlation.providerMessageId,
       status,
       failureReason: failureReason || null,
-      db: loadPlatformDb(),
+      db: webhookPersistenceDb,
     });
   };
 
@@ -7365,6 +7568,66 @@ const handleInboundWebhook = async (
           suppressedDomainWrites: true,
           dedupeKey: webhookReceipt.dedupeKey,
         },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+      },
+    });
+    return;
+  }
+
+  const bridgeWebhookProgression = await handleConnectShyftBridgeWebhookEvent({
+    tenantId,
+    orgUnitId,
+    threadId,
+    providerKey: providerSelection.providerResolution.resolvedProvider,
+    providerAdapter: providerSelection.adapter,
+    providerLegId: correlation.providerLegId,
+    eventType,
+    occurredAt: isStrictUtcIsoTimestamp(normalizeLifecycleString(req.body?.occurredAt))
+      ? new Date(normalizeLifecycleString(req.body?.occurredAt))
+      : undefined,
+    reason:
+      normalizeLifecycleString(req.body?.reason)
+      || normalizeLifecycleString(req.body?.hangupCause)
+      || normalizeLifecycleString(req.body?.hangup_cause)
+      || null,
+    callPolicy: CONNECTSHYFT_OUTBOUND_CALL_POLICY,
+  });
+  if (bridgeWebhookProgression.handled) {
+    await markWebhookReceipt('APPLIED');
+    success(res, {
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      message: 'Inbound webhook accepted',
+      data: {
+        eventType,
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: correlation.source,
+          deterministic: true,
+          threadId,
+          tenantId,
+          orgUnitId,
+          providerLegId: correlation.providerLegId,
+          providerMessageId: correlation.providerMessageId,
+          providerEventId: correlation.providerEventId,
+          providerNumberE164: correlation.providerNumberE164,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: webhookReceipt.dedupeKey,
+        },
+        bridgeSession: bridgeWebhookProgression.aggregate
+          ? buildProviderNeutralBridgeSessionState(bridgeWebhookProgression.aggregate)
+          : null,
+        bridgeEvent: bridgeWebhookProgression.domainEvent,
+        correlationMapping: bridgeWebhookProgression.correlationMapping,
         sideEffects: {
           lifecycleMutationApplied: false,
           canonicalEventPersisted: false,

--- a/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts
+++ b/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts
@@ -1,0 +1,255 @@
+import { applyProviderBridgeEvent, transitionLeg, transitionSession } from '../bridgeStateMachine'
+import type { BridgeSessionAggregate } from '../bridgeSessionTypes'
+
+const buildAggregate = (): BridgeSessionAggregate => {
+  const now = new Date('2026-03-11T12:00:00.000Z')
+  return {
+    session: {
+      id: 'bridge-session-1001',
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-f1-unclaimed-1001',
+      operatorParticipantId: 'user-connectshyft-f1-primary-operator',
+      neighborParticipantId: 'neighbor-f1-1001',
+      operatorContactPointId: '+12605550155',
+      neighborContactPointId: '+12605550111',
+      selectedOutboundContactPointId: 'cs-number-501',
+      status: 'created',
+      failureCode: null,
+      failureMessage: null,
+      endedBy: null,
+      idempotencyKey: null,
+      auditCorrelationId: null,
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+    },
+    operatorLeg: {
+      id: 'bridge-leg-operator-1001',
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      bridgeSessionId: 'bridge-session-1001',
+      legRole: 'operator',
+      contactPointId: '+12605550155',
+      providerCallId: null,
+      status: 'created',
+      startedAt: null,
+      answeredAt: null,
+      endedAt: null,
+      failureCode: null,
+      failureMessage: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+    neighborLeg: {
+      id: 'bridge-leg-neighbor-1001',
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      bridgeSessionId: 'bridge-session-1001',
+      legRole: 'neighbor',
+      contactPointId: '+12605550111',
+      providerCallId: null,
+      status: 'created',
+      startedAt: null,
+      answeredAt: null,
+      endedAt: null,
+      failureCode: null,
+      failureMessage: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+  }
+}
+
+describe('bridge state machine', () => {
+  it('initializes into operator dialing and ringing without mutating the neighbor leg', () => {
+    const created = buildAggregate()
+
+    const operatorDialing = {
+      session: transitionSession(created.session, 'operator_dialing'),
+      operatorLeg: transitionLeg(created.operatorLeg, 'dialing'),
+      neighborLeg: created.neighborLeg,
+    }
+    const operatorCreated = applyProviderBridgeEvent(operatorDialing, {
+      type: 'operator_call_created',
+      bridgeSessionId: created.session.id,
+      providerCallId: 'provider-operator-1001',
+    })
+
+    expect(operatorDialing.session.status).toBe('operator_dialing')
+    expect(operatorCreated.operatorLeg.status).toBe('ringing')
+    expect(operatorCreated.operatorLeg.providerCallId).toBe('provider-operator-1001')
+    expect(operatorCreated.neighborLeg.status).toBe('created')
+  })
+
+  it('advances operator and neighbor legs through the bridged path', () => {
+    const created = buildAggregate()
+    const operatorDialing = {
+      session: transitionSession(created.session, 'operator_dialing'),
+      operatorLeg: transitionLeg(created.operatorLeg, 'dialing'),
+      neighborLeg: created.neighborLeg,
+    }
+    const operatorCreated = applyProviderBridgeEvent(operatorDialing, {
+      type: 'operator_call_created',
+      bridgeSessionId: created.session.id,
+      providerCallId: 'provider-operator-1001',
+    })
+    const operatorAnswered = applyProviderBridgeEvent(operatorCreated, {
+      type: 'operator_answered',
+      bridgeSessionId: created.session.id,
+      providerCallId: 'provider-operator-1001',
+      occurredAt: new Date('2026-03-11T12:01:00.000Z'),
+    })
+    const neighborDialing = {
+      session: transitionSession(operatorAnswered.session, 'neighbor_dialing'),
+      operatorLeg: operatorAnswered.operatorLeg,
+      neighborLeg: transitionLeg(operatorAnswered.neighborLeg, 'dialing'),
+    }
+    const neighborCreated = applyProviderBridgeEvent(neighborDialing, {
+      type: 'neighbor_call_created',
+      bridgeSessionId: created.session.id,
+      providerCallId: 'provider-neighbor-1001',
+    })
+    const neighborAnswered = applyProviderBridgeEvent(neighborCreated, {
+      type: 'neighbor_answered',
+      bridgeSessionId: created.session.id,
+      providerCallId: 'provider-neighbor-1001',
+      occurredAt: new Date('2026-03-11T12:02:00.000Z'),
+    })
+    const bridged = applyProviderBridgeEvent(neighborAnswered, {
+      type: 'bridge_connected',
+      bridgeSessionId: created.session.id,
+      occurredAt: new Date('2026-03-11T12:03:00.000Z'),
+    })
+
+    expect(operatorCreated.operatorLeg.status).toBe('ringing')
+    expect(operatorAnswered.session.status).toBe('operator_answered')
+    expect(operatorAnswered.operatorLeg.status).toBe('answered')
+    expect(neighborCreated.neighborLeg.status).toBe('ringing')
+    expect(neighborAnswered.session.status).toBe('neighbor_answered')
+    expect(neighborAnswered.neighborLeg.status).toBe('answered')
+    expect(bridged.session.status).toBe('bridged')
+  })
+
+  it('suppresses backward transitions and preserves terminal outcomes on replay', () => {
+    const aggregate = buildAggregate()
+    const completed = applyProviderBridgeEvent({
+      session: {
+        ...aggregate.session,
+        status: 'bridged',
+      },
+      operatorLeg: {
+        ...aggregate.operatorLeg,
+        status: 'answered',
+      },
+      neighborLeg: {
+        ...aggregate.neighborLeg,
+        status: 'answered',
+      },
+    }, {
+      type: 'completed',
+      bridgeSessionId: aggregate.session.id,
+      occurredAt: new Date('2026-03-11T12:04:00.000Z'),
+    })
+    const replayedOperatorAnswer = applyProviderBridgeEvent(completed, {
+      type: 'operator_answered',
+      bridgeSessionId: aggregate.session.id,
+      providerCallId: 'provider-operator-1001',
+      occurredAt: new Date('2026-03-11T12:05:00.000Z'),
+    })
+
+    expect(completed.session.status).toBe('completed')
+    expect(completed.operatorLeg.status).toBe('completed')
+    expect(completed.neighborLeg.status).toBe('completed')
+    expect(replayedOperatorAnswer.session.status).toBe('completed')
+    expect(replayedOperatorAnswer.operatorLeg.status).toBe('completed')
+  })
+
+  it('persists failure metadata for operator, neighbor, and bridge terminal failures', () => {
+    const aggregate = buildAggregate()
+
+    const operatorFailed = applyProviderBridgeEvent(aggregate, {
+      type: 'operator_failed',
+      bridgeSessionId: aggregate.session.id,
+      providerCallId: 'provider-operator-1001',
+      reason: 'operator_declined',
+      occurredAt: new Date('2026-03-11T12:01:00.000Z'),
+    })
+    const neighborFailed = applyProviderBridgeEvent({
+      session: {
+        ...aggregate.session,
+        status: 'neighbor_dialing',
+      },
+      operatorLeg: {
+        ...aggregate.operatorLeg,
+        status: 'answered',
+      },
+      neighborLeg: {
+        ...aggregate.neighborLeg,
+        status: 'ringing',
+        providerCallId: 'provider-neighbor-1001',
+      },
+    }, {
+      type: 'neighbor_failed',
+      bridgeSessionId: aggregate.session.id,
+      providerCallId: 'provider-neighbor-1001',
+      reason: 'neighbor_declined',
+      occurredAt: new Date('2026-03-11T12:02:00.000Z'),
+    })
+    const bridgeFailed = applyProviderBridgeEvent({
+      session: {
+        ...aggregate.session,
+        status: 'neighbor_answered',
+      },
+      operatorLeg: {
+        ...aggregate.operatorLeg,
+        status: 'answered',
+      },
+      neighborLeg: {
+        ...aggregate.neighborLeg,
+        status: 'answered',
+      },
+    }, {
+      type: 'bridge_failed',
+      bridgeSessionId: aggregate.session.id,
+      reason: 'bridge_control_timeout',
+      occurredAt: new Date('2026-03-11T12:03:00.000Z'),
+    })
+
+    expect(operatorFailed).toMatchObject({
+      session: {
+        status: 'failed',
+        failureCode: 'operator_failed',
+        failureMessage: 'operator_declined',
+      },
+      operatorLeg: {
+        status: 'failed',
+        failureMessage: 'operator_declined',
+      },
+    })
+    expect(neighborFailed).toMatchObject({
+      session: {
+        status: 'failed',
+        failureCode: 'neighbor_failed',
+        failureMessage: 'neighbor_declined',
+      },
+      neighborLeg: {
+        status: 'failed',
+        failureMessage: 'neighbor_declined',
+      },
+    })
+    expect(bridgeFailed).toMatchObject({
+      session: {
+        status: 'failed',
+        failureCode: 'bridge_failed',
+        failureMessage: 'bridge_control_timeout',
+      },
+      operatorLeg: {
+        status: 'answered',
+      },
+      neighborLeg: {
+        status: 'answered',
+      },
+    })
+  })
+})

--- a/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts
+++ b/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts
@@ -1,0 +1,233 @@
+import { buildHandleProviderBridgeEvent } from '../handleProviderBridgeEvent'
+import { buildStartBridgeSession } from '../startBridgeSession'
+import type {
+  BridgeSessionAggregate,
+  BridgeSessionRepository,
+  BridgeTelephonyProvider,
+} from '../bridgeSessionTypes'
+
+class InMemoryRepository implements BridgeSessionRepository {
+  private aggregate: BridgeSessionAggregate | null = null
+
+  async createSession(): Promise<void> {}
+
+  async createLeg(): Promise<void> {}
+
+  async saveAggregate(aggregate: BridgeSessionAggregate): Promise<void> {
+    this.aggregate = {
+      session: { ...aggregate.session },
+      operatorLeg: { ...aggregate.operatorLeg },
+      neighborLeg: { ...aggregate.neighborLeg },
+    }
+  }
+
+  async getAggregateBySessionId(): Promise<BridgeSessionAggregate | null> {
+    return this.aggregate
+  }
+
+  async getAggregateByThreadId(input: {
+    threadId: string
+  }): Promise<BridgeSessionAggregate | null> {
+    if (!this.aggregate) {
+      return null
+    }
+
+    return this.aggregate.session.threadId === input.threadId
+      ? this.aggregate
+      : null
+  }
+
+  async getAggregateByProviderCallId(input: {
+    providerCallId: string
+  }): Promise<BridgeSessionAggregate | null> {
+    if (!this.aggregate) {
+      return null
+    }
+
+    if (
+      this.aggregate.operatorLeg.providerCallId === input.providerCallId
+      || this.aggregate.neighborLeg.providerCallId === input.providerCallId
+    ) {
+      return this.aggregate
+    }
+
+    return null
+  }
+}
+
+describe('handleProviderBridgeEvent', () => {
+  it('starts a persisted bridge session by dialing only the operator leg first', async () => {
+    const repository = new InMemoryRepository()
+    const startOutboundCall = jest.fn(async () => ({
+      providerCallId: 'provider-operator-1001',
+    }))
+    const startBridgeSession = jest.fn(async () => undefined)
+    const telephonyProvider: BridgeTelephonyProvider = {
+      startOutboundCall,
+      startBridgeSession,
+    }
+
+    const startBridge = buildStartBridgeSession({
+      repository,
+      telephonyProvider,
+      idGenerator: (() => {
+        const ids = ['bridge-session-1001', 'bridge-leg-operator-1001', 'bridge-leg-neighbor-1001']
+        return () => ids.shift() || 'bridge-generated-fallback'
+      })(),
+    })
+    const aggregate = await startBridge({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-f1-unclaimed-1001',
+      operatorParticipantId: 'user-connectshyft-f1-primary-operator',
+      neighborParticipantId: 'neighbor-f1-1001',
+      operatorContactPointId: '+12605550155',
+      neighborContactPointId: '+12605550111',
+      selectedOutboundContactPointId: 'cs-number-501',
+    })
+
+    expect(aggregate.session.status).toBe('operator_dialing')
+    expect(aggregate.operatorLeg.status).toBe('ringing')
+    expect(aggregate.neighborLeg.status).toBe('created')
+    expect(startOutboundCall).toHaveBeenCalledTimes(1)
+    expect(startBridgeSession).not.toHaveBeenCalled()
+  })
+
+  it('dials the neighbor once after operator answer and bridges once after neighbor answer', async () => {
+    const repository = new InMemoryRepository()
+    const startOutboundCall = jest.fn(async (input: { legRole: string }) => ({
+      providerCallId: input.legRole === 'operator'
+        ? 'provider-operator-1001'
+        : 'provider-neighbor-1001',
+    }))
+    const startBridgeSession = jest.fn(async () => undefined)
+    const telephonyProvider: BridgeTelephonyProvider = {
+      startOutboundCall,
+      startBridgeSession,
+    }
+
+    const startBridge = buildStartBridgeSession({
+      repository,
+      telephonyProvider,
+      idGenerator: (() => {
+        const ids = ['bridge-session-1001', 'bridge-leg-operator-1001', 'bridge-leg-neighbor-1001']
+        return () => ids.shift() || 'bridge-generated-fallback'
+      })(),
+    })
+    await startBridge({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-f1-unclaimed-1001',
+      operatorParticipantId: 'user-connectshyft-f1-primary-operator',
+      neighborParticipantId: 'neighbor-f1-1001',
+      operatorContactPointId: '+12605550155',
+      neighborContactPointId: '+12605550111',
+      selectedOutboundContactPointId: 'cs-number-501',
+    })
+
+    const handleEvent = buildHandleProviderBridgeEvent({
+      repository,
+      telephonyProvider,
+    })
+
+    const afterOperatorAnswer = await handleEvent({
+      type: 'operator_answered',
+      providerCallId: 'provider-operator-1001',
+      occurredAt: new Date('2026-03-11T12:01:00.000Z'),
+    })
+    const afterDuplicateOperatorAnswer = await handleEvent({
+      type: 'operator_answered',
+      providerCallId: 'provider-operator-1001',
+      occurredAt: new Date('2026-03-11T12:01:30.000Z'),
+    })
+    const afterNeighborAnswer = await handleEvent({
+      type: 'neighbor_answered',
+      providerCallId: 'provider-neighbor-1001',
+      occurredAt: new Date('2026-03-11T12:02:00.000Z'),
+    })
+    const afterDuplicateNeighborAnswer = await handleEvent({
+      type: 'neighbor_answered',
+      providerCallId: 'provider-neighbor-1001',
+      occurredAt: new Date('2026-03-11T12:02:30.000Z'),
+    })
+
+    expect(afterOperatorAnswer?.session.status).toBe('neighbor_dialing')
+    expect(afterOperatorAnswer?.neighborLeg.status).toBe('ringing')
+    expect(afterDuplicateOperatorAnswer?.session.status).toBe('neighbor_dialing')
+    expect(afterNeighborAnswer?.session.status).toBe('bridged')
+    expect(afterDuplicateNeighborAnswer?.session.status).toBe('bridged')
+    expect(startOutboundCall).toHaveBeenCalledTimes(2)
+    expect(startBridgeSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps terminal completion replay-safe without re-triggering bridge control', async () => {
+    const repository = new InMemoryRepository()
+    const startOutboundCall = jest.fn(async (input: { legRole: string }) => ({
+      providerCallId: input.legRole === 'operator'
+        ? 'provider-operator-1001'
+        : 'provider-neighbor-1001',
+    }))
+    const startBridgeSession = jest.fn(async () => undefined)
+    const telephonyProvider: BridgeTelephonyProvider = {
+      startOutboundCall,
+      startBridgeSession,
+    }
+
+    const startBridge = buildStartBridgeSession({
+      repository,
+      telephonyProvider,
+      idGenerator: (() => {
+        const ids = ['bridge-session-1001', 'bridge-leg-operator-1001', 'bridge-leg-neighbor-1001']
+        return () => ids.shift() || 'bridge-generated-fallback'
+      })(),
+    })
+    await startBridge({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-f1-unclaimed-1001',
+      operatorParticipantId: 'user-connectshyft-f1-primary-operator',
+      neighborParticipantId: 'neighbor-f1-1001',
+      operatorContactPointId: '+12605550155',
+      neighborContactPointId: '+12605550111',
+      selectedOutboundContactPointId: 'cs-number-501',
+    })
+
+    const handleEvent = buildHandleProviderBridgeEvent({
+      repository,
+      telephonyProvider,
+    })
+
+    await handleEvent({
+      type: 'operator_answered',
+      providerCallId: 'provider-operator-1001',
+      occurredAt: new Date('2026-03-11T12:01:00.000Z'),
+    })
+    await handleEvent({
+      type: 'neighbor_answered',
+      providerCallId: 'provider-neighbor-1001',
+      occurredAt: new Date('2026-03-11T12:02:00.000Z'),
+    })
+    const completed = await handleEvent({
+      type: 'completed',
+      providerCallId: 'provider-neighbor-1001',
+      occurredAt: new Date('2026-03-11T12:03:00.000Z'),
+    })
+    const completedReplay = await handleEvent({
+      type: 'completed',
+      providerCallId: 'provider-neighbor-1001',
+      occurredAt: new Date('2026-03-11T12:03:30.000Z'),
+    })
+    const failureReplay = await handleEvent({
+      type: 'neighbor_failed',
+      providerCallId: 'provider-neighbor-1001',
+      reason: 'late_failure',
+      occurredAt: new Date('2026-03-11T12:04:00.000Z'),
+    })
+
+    expect(completed?.session.status).toBe('completed')
+    expect(completedReplay?.session.status).toBe('completed')
+    expect(failureReplay?.session.status).toBe('completed')
+    expect(startOutboundCall).toHaveBeenCalledTimes(2)
+    expect(startBridgeSession).toHaveBeenCalledTimes(1)
+  })
+})

--- a/domains/communication/bridge/bridgeSessionTypes.ts
+++ b/domains/communication/bridge/bridgeSessionTypes.ts
@@ -1,0 +1,141 @@
+export type BridgeSessionStatus =
+  | 'created'
+  | 'operator_dialing'
+  | 'operator_answered'
+  | 'neighbor_dialing'
+  | 'neighbor_answered'
+  | 'bridged'
+  | 'completed'
+  | 'failed'
+  | 'canceled'
+  | 'expired'
+
+export type BridgeLegRole = 'operator' | 'neighbor'
+
+export type BridgeLegStatus =
+  | 'created'
+  | 'dialing'
+  | 'ringing'
+  | 'answered'
+  | 'failed'
+  | 'completed'
+  | 'canceled'
+
+export type BridgeFailureCode =
+  | 'operator_call_failed'
+  | 'neighbor_call_failed'
+  | 'bridge_failed'
+  | 'provider_error'
+  | 'timeout'
+  | 'canceled'
+  | 'unknown'
+
+export type BridgeSessionRecord = {
+  id: string
+  tenantId: string
+  threadId: string
+  operatorParticipantId: string
+  targetParticipantId: string
+  operatorContactPointId: string
+  targetContactPointId: string
+  selectedOutboundContactPointId?: string | null
+  status: BridgeSessionStatus
+  failureCode?: BridgeFailureCode | null
+  failureMessage?: string | null
+  endedBy?: string | null
+  idempotencyKey?: string | null
+  auditCorrelationId?: string | null
+  createdAt: Date
+  updatedAt: Date
+  completedAt?: Date | null
+}
+
+export type BridgeLegRecord = {
+  id: string
+  tenantId: string
+  bridgeSessionId: string
+  legRole: BridgeLegRole
+  contactPointId: string
+  providerCallId?: string | null
+  status: BridgeLegStatus
+  startedAt?: Date | null
+  answeredAt?: Date | null
+  endedAt?: Date | null
+  failureCode?: BridgeFailureCode | null
+  failureMessage?: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type StartBridgeSessionCommand = {
+  tenantId: string
+  threadId: string
+  operatorParticipantId: string
+  targetParticipantId: string
+  operatorContactPointId: string
+  targetContactPointId: string
+  selectedOutboundContactPointId?: string
+  idempotencyKey?: string
+  auditCorrelationId?: string
+}
+
+export type ProviderBridgeEvent =
+  | {
+      type: 'operator_call_created'
+      bridgeSessionId: string
+      providerCallId: string
+    }
+  | {
+      type: 'neighbor_call_created'
+      bridgeSessionId: string
+      providerCallId: string
+    }
+  | {
+      type: 'operator_answered'
+      bridgeSessionId: string
+      providerCallId: string
+      occurredAt?: Date
+    }
+  | {
+      type: 'neighbor_answered'
+      bridgeSessionId: string
+      providerCallId: string
+      occurredAt?: Date
+    }
+  | {
+      type: 'bridge_connected'
+      bridgeSessionId: string
+      occurredAt?: Date
+    }
+  | {
+      type: 'operator_failed'
+      bridgeSessionId: string
+      providerCallId?: string
+      reason?: string
+      occurredAt?: Date
+    }
+  | {
+      type: 'neighbor_failed'
+      bridgeSessionId: string
+      providerCallId?: string
+      reason?: string
+      occurredAt?: Date
+    }
+  | {
+      type: 'bridge_failed'
+      bridgeSessionId: string
+      reason?: string
+      occurredAt?: Date
+    }
+  | {
+      type: 'completed'
+      bridgeSessionId: string
+      providerCallId?: string
+      occurredAt?: Date
+    }
+
+export type BridgeSessionAggregate = {
+  session: BridgeSessionRecord
+  operatorLeg: BridgeLegRecord
+  neighborLeg: BridgeLegRecord
+}

--- a/domains/communication/bridge/bridgeSessionTypes.ts
+++ b/domains/communication/bridge/bridgeSessionTypes.ts
@@ -22,8 +22,8 @@ export type BridgeLegStatus =
   | 'canceled'
 
 export type BridgeFailureCode =
-  | 'operator_call_failed'
-  | 'neighbor_call_failed'
+  | 'operator_failed'
+  | 'neighbor_failed'
   | 'bridge_failed'
   | 'provider_error'
   | 'timeout'
@@ -33,11 +33,12 @@ export type BridgeFailureCode =
 export type BridgeSessionRecord = {
   id: string
   tenantId: string
+  orgUnitId: string
   threadId: string
   operatorParticipantId: string
-  targetParticipantId: string
+  neighborParticipantId: string
   operatorContactPointId: string
-  targetContactPointId: string
+  neighborContactPointId: string
   selectedOutboundContactPointId?: string | null
   status: BridgeSessionStatus
   failureCode?: BridgeFailureCode | null
@@ -53,6 +54,7 @@ export type BridgeSessionRecord = {
 export type BridgeLegRecord = {
   id: string
   tenantId: string
+  orgUnitId: string
   bridgeSessionId: string
   legRole: BridgeLegRole
   contactPointId: string
@@ -69,11 +71,12 @@ export type BridgeLegRecord = {
 
 export type StartBridgeSessionCommand = {
   tenantId: string
+  orgUnitId: string
   threadId: string
   operatorParticipantId: string
-  targetParticipantId: string
+  neighborParticipantId: string
   operatorContactPointId: string
-  targetContactPointId: string
+  neighborContactPointId: string
   selectedOutboundContactPointId?: string
   idempotencyKey?: string
   auditCorrelationId?: string
@@ -82,54 +85,54 @@ export type StartBridgeSessionCommand = {
 export type ProviderBridgeEvent =
   | {
       type: 'operator_call_created'
-      bridgeSessionId: string
+      bridgeSessionId?: string
       providerCallId: string
     }
   | {
       type: 'neighbor_call_created'
-      bridgeSessionId: string
+      bridgeSessionId?: string
       providerCallId: string
     }
   | {
       type: 'operator_answered'
-      bridgeSessionId: string
+      bridgeSessionId?: string
       providerCallId: string
       occurredAt?: Date
     }
   | {
       type: 'neighbor_answered'
-      bridgeSessionId: string
+      bridgeSessionId?: string
       providerCallId: string
       occurredAt?: Date
     }
   | {
       type: 'bridge_connected'
-      bridgeSessionId: string
+      bridgeSessionId?: string
       occurredAt?: Date
     }
   | {
       type: 'operator_failed'
-      bridgeSessionId: string
+      bridgeSessionId?: string
       providerCallId?: string
       reason?: string
       occurredAt?: Date
     }
   | {
       type: 'neighbor_failed'
-      bridgeSessionId: string
+      bridgeSessionId?: string
       providerCallId?: string
       reason?: string
       occurredAt?: Date
     }
   | {
       type: 'bridge_failed'
-      bridgeSessionId: string
+      bridgeSessionId?: string
       reason?: string
       occurredAt?: Date
     }
   | {
       type: 'completed'
-      bridgeSessionId: string
+      bridgeSessionId?: string
       providerCallId?: string
       occurredAt?: Date
     }
@@ -138,4 +141,42 @@ export type BridgeSessionAggregate = {
   session: BridgeSessionRecord
   operatorLeg: BridgeLegRecord
   neighborLeg: BridgeLegRecord
+}
+
+export type BridgeSessionRepository = {
+  createSession(session: BridgeSessionRecord): Promise<void>
+  createLeg(leg: BridgeLegRecord): Promise<void>
+  saveAggregate(aggregate: BridgeSessionAggregate): Promise<void>
+  getAggregateBySessionId(sessionId: string): Promise<BridgeSessionAggregate | null>
+  getAggregateByThreadId(input: {
+    tenantId?: string | null
+    threadId: string
+  }): Promise<BridgeSessionAggregate | null>
+  getAggregateByProviderCallId(input: {
+    tenantId?: string | null
+    providerCallId: string
+  }): Promise<BridgeSessionAggregate | null>
+}
+
+export type BridgeStartOutboundCallInput = {
+  bridgeSessionId: string
+  legId: string
+  legRole: BridgeLegRole
+  toContactPointId: string
+  fromContactPointId?: string | null
+}
+
+export type BridgeStartOutboundCallResult = {
+  providerCallId: string
+}
+
+export type BridgeStartBridgeControlInput = {
+  bridgeSessionId: string
+  operatorProviderCallId: string
+  neighborProviderCallId: string
+}
+
+export type BridgeTelephonyProvider = {
+  startOutboundCall(input: BridgeStartOutboundCallInput): Promise<BridgeStartOutboundCallResult>
+  startBridgeSession(input: BridgeStartBridgeControlInput): Promise<void>
 }

--- a/domains/communication/bridge/bridgeStateMachine.ts
+++ b/domains/communication/bridge/bridgeStateMachine.ts
@@ -1,4 +1,5 @@
 import {
+  BridgeFailureCode,
   BridgeLegRecord,
   BridgeLegStatus,
   BridgeSessionAggregate,
@@ -7,39 +8,71 @@ import {
   ProviderBridgeEvent,
 } from './bridgeSessionTypes'
 
-const allowedSessionTransitions: Record<BridgeSessionStatus, BridgeSessionStatus[]> = {
-  created: ['operator_dialing', 'canceled', 'expired', 'failed'],
-  operator_dialing: ['operator_answered', 'failed', 'canceled', 'expired'],
-  operator_answered: ['neighbor_dialing', 'failed', 'canceled'],
-  neighbor_dialing: ['neighbor_answered', 'failed', 'canceled', 'expired'],
-  neighbor_answered: ['bridged', 'failed', 'canceled'],
-  bridged: ['completed', 'failed', 'canceled'],
-  completed: [],
-  failed: [],
-  canceled: [],
-  expired: [],
+const sessionOrder: Record<BridgeSessionStatus, number> = {
+  created: 0,
+  operator_dialing: 1,
+  operator_answered: 2,
+  neighbor_dialing: 3,
+  neighbor_answered: 4,
+  bridged: 5,
+  completed: 6,
+  failed: 6,
+  canceled: 6,
+  expired: 6,
 }
 
-const allowedLegTransitions: Record<BridgeLegStatus, BridgeLegStatus[]> = {
-  created: ['dialing', 'canceled', 'failed'],
-  dialing: ['ringing', 'answered', 'failed', 'canceled'],
-  ringing: ['answered', 'failed', 'canceled'],
-  answered: ['completed', 'failed', 'canceled'],
-  completed: [],
-  failed: [],
-  canceled: [],
+const legOrder: Record<BridgeLegStatus, number> = {
+  created: 0,
+  dialing: 1,
+  ringing: 2,
+  answered: 3,
+  completed: 4,
+  failed: 4,
+  canceled: 4,
 }
 
-function assertSessionTransition(from: BridgeSessionStatus, to: BridgeSessionStatus): void {
-  if (!allowedSessionTransitions[from].includes(to)) {
-    throw new Error(`Invalid bridge session transition: ${from} -> ${to}`)
+const terminalSessionStatuses = new Set<BridgeSessionStatus>(['completed', 'failed', 'canceled', 'expired'])
+const terminalLegStatuses = new Set<BridgeLegStatus>(['completed', 'failed', 'canceled'])
+
+const resolveEventTime = (occurredAt?: Date): Date => occurredAt ?? new Date()
+
+const isSessionTerminal = (status: BridgeSessionStatus): boolean => terminalSessionStatuses.has(status)
+
+const isLegTerminal = (status: BridgeLegStatus): boolean => terminalLegStatuses.has(status)
+
+const shouldAdvanceSession = (
+  current: BridgeSessionStatus,
+  next: BridgeSessionStatus,
+): boolean => {
+  if (current === next) {
+    return false
   }
+
+  if (isSessionTerminal(current)) {
+    return false
+  }
+
+  if (isSessionTerminal(next)) {
+    return true
+  }
+
+  return sessionOrder[next] >= sessionOrder[current]
 }
 
-function assertLegTransition(from: BridgeLegStatus, to: BridgeLegStatus): void {
-  if (!allowedLegTransitions[from].includes(to)) {
-    throw new Error(`Invalid bridge leg transition: ${from} -> ${to}`)
+const shouldAdvanceLeg = (current: BridgeLegStatus, next: BridgeLegStatus): boolean => {
+  if (current === next) {
+    return false
   }
+
+  if (isLegTerminal(current)) {
+    return false
+  }
+
+  if (isLegTerminal(next)) {
+    return true
+  }
+
+  return legOrder[next] >= legOrder[current]
 }
 
 export function transitionSession(
@@ -47,13 +80,25 @@ export function transitionSession(
   nextStatus: BridgeSessionStatus,
   changes: Partial<BridgeSessionRecord> = {},
 ): BridgeSessionRecord {
-  assertSessionTransition(session.status, nextStatus)
+  if (!shouldAdvanceSession(session.status, nextStatus)) {
+    return {
+      ...session,
+      ...changes,
+      updatedAt: changes.updatedAt ?? session.updatedAt,
+    }
+  }
+
+  const updatedAt = changes.updatedAt instanceof Date ? changes.updatedAt : new Date()
+  const completedAt = nextStatus === 'completed'
+    ? (changes.completedAt instanceof Date ? changes.completedAt : session.completedAt ?? updatedAt)
+    : session.completedAt ?? null
+
   return {
     ...session,
     ...changes,
     status: nextStatus,
-    updatedAt: new Date(),
-    completedAt: nextStatus === 'completed' ? new Date() : session.completedAt ?? null,
+    updatedAt,
+    completedAt,
   }
 }
 
@@ -62,20 +107,81 @@ export function transitionLeg(
   nextStatus: BridgeLegStatus,
   changes: Partial<BridgeLegRecord> = {},
 ): BridgeLegRecord {
-  assertLegTransition(leg.status, nextStatus)
-  const now = new Date()
+  if (!shouldAdvanceLeg(leg.status, nextStatus)) {
+    return {
+      ...leg,
+      ...changes,
+      updatedAt: changes.updatedAt ?? leg.updatedAt,
+    }
+  }
+
+  const updatedAt = changes.updatedAt instanceof Date ? changes.updatedAt : new Date()
+  const startedAt = nextStatus === 'dialing'
+    ? (changes.startedAt instanceof Date ? changes.startedAt : leg.startedAt ?? updatedAt)
+    : leg.startedAt ?? null
+  const answeredAt = nextStatus === 'answered'
+    ? (changes.answeredAt instanceof Date ? changes.answeredAt : leg.answeredAt ?? updatedAt)
+    : leg.answeredAt ?? null
+  const endedAt = isLegTerminal(nextStatus)
+    ? (changes.endedAt instanceof Date ? changes.endedAt : leg.endedAt ?? updatedAt)
+    : leg.endedAt ?? null
 
   return {
     ...leg,
     ...changes,
     status: nextStatus,
-    updatedAt: now,
-    startedAt: nextStatus === 'dialing' && !leg.startedAt ? now : leg.startedAt ?? null,
-    answeredAt: nextStatus === 'answered' && !leg.answeredAt ? now : leg.answeredAt ?? null,
-    endedAt:
-      nextStatus === 'completed' || nextStatus === 'failed' || nextStatus === 'canceled'
-        ? now
-        : leg.endedAt ?? null,
+    updatedAt,
+    startedAt,
+    answeredAt,
+    endedAt,
+  }
+}
+
+const applyFailure = (input: {
+  aggregate: BridgeSessionAggregate
+  legRole: 'operator' | 'neighbor' | 'bridge'
+  failureCode: BridgeFailureCode
+  failureMessage?: string
+  occurredAt?: Date
+}): BridgeSessionAggregate => {
+  const failureMessage = input.failureMessage ?? null
+  const failureAt = resolveEventTime(input.occurredAt)
+  const session = transitionSession(input.aggregate.session, 'failed', {
+    failureCode: input.failureCode,
+    failureMessage,
+    updatedAt: failureAt,
+  })
+
+  if (input.legRole === 'operator') {
+    return {
+      session,
+      operatorLeg: transitionLeg(input.aggregate.operatorLeg, 'failed', {
+        failureCode: input.failureCode,
+        failureMessage,
+        endedAt: failureAt,
+        updatedAt: failureAt,
+      }),
+      neighborLeg: input.aggregate.neighborLeg,
+    }
+  }
+
+  if (input.legRole === 'neighbor') {
+    return {
+      session,
+      operatorLeg: input.aggregate.operatorLeg,
+      neighborLeg: transitionLeg(input.aggregate.neighborLeg, 'failed', {
+        failureCode: input.failureCode,
+        failureMessage,
+        endedAt: failureAt,
+        updatedAt: failureAt,
+      }),
+    }
+  }
+
+  return {
+    session,
+    operatorLeg: input.aggregate.operatorLeg,
+    neighborLeg: input.aggregate.neighborLeg,
   }
 }
 
@@ -83,102 +189,110 @@ export function applyProviderBridgeEvent(
   aggregate: BridgeSessionAggregate,
   event: ProviderBridgeEvent,
 ): BridgeSessionAggregate {
-  const { session, operatorLeg, neighborLeg } = aggregate
-
   switch (event.type) {
-    case 'operator_call_created':
+    case 'operator_call_created': {
+      const updatedAt = new Date()
+      const operatorLeg = transitionLeg(aggregate.operatorLeg, 'ringing', {
+        providerCallId: event.providerCallId,
+        updatedAt,
+      })
       return {
-        session,
-        operatorLeg: { ...operatorLeg, providerCallId: event.providerCallId, updatedAt: new Date() },
+        session: transitionSession(aggregate.session, 'operator_dialing', { updatedAt }),
+        operatorLeg,
+        neighborLeg: aggregate.neighborLeg,
+      }
+    }
+    case 'neighbor_call_created': {
+      const updatedAt = new Date()
+      const neighborLeg = transitionLeg(aggregate.neighborLeg, 'ringing', {
+        providerCallId: event.providerCallId,
+        updatedAt,
+      })
+      return {
+        session: transitionSession(aggregate.session, 'neighbor_dialing', { updatedAt }),
+        operatorLeg: aggregate.operatorLeg,
         neighborLeg,
       }
-
-    case 'neighbor_call_created':
-      return {
-        session,
-        operatorLeg,
-        neighborLeg: { ...neighborLeg, providerCallId: event.providerCallId, updatedAt: new Date() },
-      }
-
+    }
     case 'operator_answered': {
-      const preparedSession =
-        session.status === 'operator_dialing' ? session : transitionSession(session, 'operator_dialing')
-      const preparedLeg =
-        operatorLeg.status === 'ringing' ? operatorLeg : transitionLeg(operatorLeg, 'ringing')
-
+      const occurredAt = resolveEventTime(event.occurredAt)
       return {
-        session: transitionSession(preparedSession, 'operator_answered'),
-        operatorLeg: transitionLeg(preparedLeg, 'answered'),
-        neighborLeg,
+        session: transitionSession(aggregate.session, 'operator_answered', {
+          updatedAt: occurredAt,
+        }),
+        operatorLeg: transitionLeg(aggregate.operatorLeg, 'answered', {
+          providerCallId: event.providerCallId,
+          answeredAt: occurredAt,
+          updatedAt: occurredAt,
+        }),
+        neighborLeg: aggregate.neighborLeg,
       }
     }
-
     case 'neighbor_answered': {
-      const preparedSession =
-        session.status === 'neighbor_dialing' ? session : transitionSession(session, 'neighbor_dialing')
-      const preparedLeg =
-        neighborLeg.status === 'ringing' ? neighborLeg : transitionLeg(neighborLeg, 'ringing')
-
+      const occurredAt = resolveEventTime(event.occurredAt)
       return {
-        session: transitionSession(preparedSession, 'neighbor_answered'),
-        operatorLeg,
-        neighborLeg: transitionLeg(preparedLeg, 'answered'),
+        session: transitionSession(aggregate.session, 'neighbor_answered', {
+          updatedAt: occurredAt,
+        }),
+        operatorLeg: aggregate.operatorLeg,
+        neighborLeg: transitionLeg(aggregate.neighborLeg, 'answered', {
+          providerCallId: event.providerCallId,
+          answeredAt: occurredAt,
+          updatedAt: occurredAt,
+        }),
       }
     }
-
-    case 'bridge_connected':
+    case 'bridge_connected': {
+      const occurredAt = resolveEventTime(event.occurredAt)
       return {
-        session: transitionSession(session, 'bridged'),
-        operatorLeg,
-        neighborLeg,
+        session: transitionSession(aggregate.session, 'bridged', {
+          updatedAt: occurredAt,
+        }),
+        operatorLeg: aggregate.operatorLeg,
+        neighborLeg: aggregate.neighborLeg,
       }
-
+    }
     case 'operator_failed':
-      return {
-        session: transitionSession(session, 'failed', {
-          failureCode: 'operator_call_failed',
-          failureMessage: event.reason ?? null,
-        }),
-        operatorLeg: transitionLeg(operatorLeg, 'failed', {
-          failureCode: 'operator_call_failed',
-          failureMessage: event.reason ?? null,
-        }),
-        neighborLeg,
-      }
-
+      return applyFailure({
+        aggregate,
+        legRole: 'operator',
+        failureCode: 'operator_failed',
+        failureMessage: event.reason,
+        occurredAt: event.occurredAt,
+      })
     case 'neighbor_failed':
-      return {
-        session: transitionSession(session, 'failed', {
-          failureCode: 'neighbor_call_failed',
-          failureMessage: event.reason ?? null,
-        }),
-        operatorLeg,
-        neighborLeg: transitionLeg(neighborLeg, 'failed', {
-          failureCode: 'neighbor_call_failed',
-          failureMessage: event.reason ?? null,
-        }),
-      }
-
+      return applyFailure({
+        aggregate,
+        legRole: 'neighbor',
+        failureCode: 'neighbor_failed',
+        failureMessage: event.reason,
+        occurredAt: event.occurredAt,
+      })
     case 'bridge_failed':
-      return {
-        session: transitionSession(session, 'failed', {
-          failureCode: 'bridge_failed',
-          failureMessage: event.reason ?? null,
-        }),
-        operatorLeg,
-        neighborLeg,
-      }
-
+      return applyFailure({
+        aggregate,
+        legRole: 'bridge',
+        failureCode: 'bridge_failed',
+        failureMessage: event.reason,
+        occurredAt: event.occurredAt,
+      })
     case 'completed': {
-      const preparedSession =
-        session.status === 'bridged' ? session : transitionSession(session, 'bridged')
+      const occurredAt = resolveEventTime(event.occurredAt)
+      const session = transitionSession(aggregate.session, 'completed', {
+        completedAt: occurredAt,
+        updatedAt: occurredAt,
+      })
 
       return {
-        session: transitionSession(preparedSession, 'completed'),
-        operatorLeg:
-          operatorLeg.status === 'answered' ? transitionLeg(operatorLeg, 'completed') : operatorLeg,
-        neighborLeg:
-          neighborLeg.status === 'answered' ? transitionLeg(neighborLeg, 'completed') : neighborLeg,
+        session,
+        operatorLeg: transitionLeg(aggregate.operatorLeg, 'completed', {
+          endedAt: occurredAt,
+          updatedAt: occurredAt,
+        }),
+        neighborLeg: transitionLeg(aggregate.neighborLeg, 'completed', {
+          endedAt: occurredAt,
+          updatedAt: occurredAt,
+        }),
       }
     }
   }

--- a/domains/communication/bridge/bridgeStateMachine.ts
+++ b/domains/communication/bridge/bridgeStateMachine.ts
@@ -1,0 +1,185 @@
+import {
+  BridgeLegRecord,
+  BridgeLegStatus,
+  BridgeSessionAggregate,
+  BridgeSessionRecord,
+  BridgeSessionStatus,
+  ProviderBridgeEvent,
+} from './bridgeSessionTypes'
+
+const allowedSessionTransitions: Record<BridgeSessionStatus, BridgeSessionStatus[]> = {
+  created: ['operator_dialing', 'canceled', 'expired', 'failed'],
+  operator_dialing: ['operator_answered', 'failed', 'canceled', 'expired'],
+  operator_answered: ['neighbor_dialing', 'failed', 'canceled'],
+  neighbor_dialing: ['neighbor_answered', 'failed', 'canceled', 'expired'],
+  neighbor_answered: ['bridged', 'failed', 'canceled'],
+  bridged: ['completed', 'failed', 'canceled'],
+  completed: [],
+  failed: [],
+  canceled: [],
+  expired: [],
+}
+
+const allowedLegTransitions: Record<BridgeLegStatus, BridgeLegStatus[]> = {
+  created: ['dialing', 'canceled', 'failed'],
+  dialing: ['ringing', 'answered', 'failed', 'canceled'],
+  ringing: ['answered', 'failed', 'canceled'],
+  answered: ['completed', 'failed', 'canceled'],
+  completed: [],
+  failed: [],
+  canceled: [],
+}
+
+function assertSessionTransition(from: BridgeSessionStatus, to: BridgeSessionStatus): void {
+  if (!allowedSessionTransitions[from].includes(to)) {
+    throw new Error(`Invalid bridge session transition: ${from} -> ${to}`)
+  }
+}
+
+function assertLegTransition(from: BridgeLegStatus, to: BridgeLegStatus): void {
+  if (!allowedLegTransitions[from].includes(to)) {
+    throw new Error(`Invalid bridge leg transition: ${from} -> ${to}`)
+  }
+}
+
+export function transitionSession(
+  session: BridgeSessionRecord,
+  nextStatus: BridgeSessionStatus,
+  changes: Partial<BridgeSessionRecord> = {},
+): BridgeSessionRecord {
+  assertSessionTransition(session.status, nextStatus)
+  return {
+    ...session,
+    ...changes,
+    status: nextStatus,
+    updatedAt: new Date(),
+    completedAt: nextStatus === 'completed' ? new Date() : session.completedAt ?? null,
+  }
+}
+
+export function transitionLeg(
+  leg: BridgeLegRecord,
+  nextStatus: BridgeLegStatus,
+  changes: Partial<BridgeLegRecord> = {},
+): BridgeLegRecord {
+  assertLegTransition(leg.status, nextStatus)
+  const now = new Date()
+
+  return {
+    ...leg,
+    ...changes,
+    status: nextStatus,
+    updatedAt: now,
+    startedAt: nextStatus === 'dialing' && !leg.startedAt ? now : leg.startedAt ?? null,
+    answeredAt: nextStatus === 'answered' && !leg.answeredAt ? now : leg.answeredAt ?? null,
+    endedAt:
+      nextStatus === 'completed' || nextStatus === 'failed' || nextStatus === 'canceled'
+        ? now
+        : leg.endedAt ?? null,
+  }
+}
+
+export function applyProviderBridgeEvent(
+  aggregate: BridgeSessionAggregate,
+  event: ProviderBridgeEvent,
+): BridgeSessionAggregate {
+  const { session, operatorLeg, neighborLeg } = aggregate
+
+  switch (event.type) {
+    case 'operator_call_created':
+      return {
+        session,
+        operatorLeg: { ...operatorLeg, providerCallId: event.providerCallId, updatedAt: new Date() },
+        neighborLeg,
+      }
+
+    case 'neighbor_call_created':
+      return {
+        session,
+        operatorLeg,
+        neighborLeg: { ...neighborLeg, providerCallId: event.providerCallId, updatedAt: new Date() },
+      }
+
+    case 'operator_answered': {
+      const preparedSession =
+        session.status === 'operator_dialing' ? session : transitionSession(session, 'operator_dialing')
+      const preparedLeg =
+        operatorLeg.status === 'ringing' ? operatorLeg : transitionLeg(operatorLeg, 'ringing')
+
+      return {
+        session: transitionSession(preparedSession, 'operator_answered'),
+        operatorLeg: transitionLeg(preparedLeg, 'answered'),
+        neighborLeg,
+      }
+    }
+
+    case 'neighbor_answered': {
+      const preparedSession =
+        session.status === 'neighbor_dialing' ? session : transitionSession(session, 'neighbor_dialing')
+      const preparedLeg =
+        neighborLeg.status === 'ringing' ? neighborLeg : transitionLeg(neighborLeg, 'ringing')
+
+      return {
+        session: transitionSession(preparedSession, 'neighbor_answered'),
+        operatorLeg,
+        neighborLeg: transitionLeg(preparedLeg, 'answered'),
+      }
+    }
+
+    case 'bridge_connected':
+      return {
+        session: transitionSession(session, 'bridged'),
+        operatorLeg,
+        neighborLeg,
+      }
+
+    case 'operator_failed':
+      return {
+        session: transitionSession(session, 'failed', {
+          failureCode: 'operator_call_failed',
+          failureMessage: event.reason ?? null,
+        }),
+        operatorLeg: transitionLeg(operatorLeg, 'failed', {
+          failureCode: 'operator_call_failed',
+          failureMessage: event.reason ?? null,
+        }),
+        neighborLeg,
+      }
+
+    case 'neighbor_failed':
+      return {
+        session: transitionSession(session, 'failed', {
+          failureCode: 'neighbor_call_failed',
+          failureMessage: event.reason ?? null,
+        }),
+        operatorLeg,
+        neighborLeg: transitionLeg(neighborLeg, 'failed', {
+          failureCode: 'neighbor_call_failed',
+          failureMessage: event.reason ?? null,
+        }),
+      }
+
+    case 'bridge_failed':
+      return {
+        session: transitionSession(session, 'failed', {
+          failureCode: 'bridge_failed',
+          failureMessage: event.reason ?? null,
+        }),
+        operatorLeg,
+        neighborLeg,
+      }
+
+    case 'completed': {
+      const preparedSession =
+        session.status === 'bridged' ? session : transitionSession(session, 'bridged')
+
+      return {
+        session: transitionSession(preparedSession, 'completed'),
+        operatorLeg:
+          operatorLeg.status === 'answered' ? transitionLeg(operatorLeg, 'completed') : operatorLeg,
+        neighborLeg:
+          neighborLeg.status === 'answered' ? transitionLeg(neighborLeg, 'completed') : neighborLeg,
+      }
+    }
+  }
+}

--- a/domains/communication/bridge/handleProviderBridgeEvent.ts
+++ b/domains/communication/bridge/handleProviderBridgeEvent.ts
@@ -1,0 +1,122 @@
+import {
+  BridgeSessionAggregate,
+  BridgeSessionRepository,
+  BridgeTelephonyProvider,
+  ProviderBridgeEvent,
+} from './bridgeSessionTypes'
+import { applyProviderBridgeEvent, transitionLeg, transitionSession } from './bridgeStateMachine'
+
+const isOperatorAnsweredReplay = (aggregate: BridgeSessionAggregate): boolean =>
+  aggregate.session.status === 'neighbor_dialing'
+  || aggregate.session.status === 'neighbor_answered'
+  || aggregate.session.status === 'bridged'
+  || aggregate.session.status === 'completed'
+  || aggregate.session.status === 'failed'
+  || aggregate.session.status === 'canceled'
+  || aggregate.session.status === 'expired'
+
+const isNeighborAnsweredReplay = (aggregate: BridgeSessionAggregate): boolean =>
+  aggregate.session.status === 'bridged'
+  || aggregate.session.status === 'completed'
+  || aggregate.session.status === 'failed'
+  || aggregate.session.status === 'canceled'
+  || aggregate.session.status === 'expired'
+
+export function buildHandleProviderBridgeEvent(deps: {
+  repository: BridgeSessionRepository
+  telephonyProvider: BridgeTelephonyProvider
+}) {
+  const { repository, telephonyProvider } = deps
+
+  return async function handleProviderBridgeEvent(
+    event: ProviderBridgeEvent,
+  ): Promise<BridgeSessionAggregate | null> {
+    let aggregate = event.bridgeSessionId
+      ? await repository.getAggregateBySessionId(event.bridgeSessionId)
+      : null
+
+    if (!aggregate && 'providerCallId' in event && event.providerCallId) {
+      aggregate = await repository.getAggregateByProviderCallId({
+        providerCallId: event.providerCallId,
+      })
+    }
+
+    if (!aggregate) {
+      return null
+    }
+
+    if (event.type === 'operator_answered') {
+      const operatorAdvancedAggregate = applyProviderBridgeEvent(aggregate, event)
+      const neighborDialingAggregate: BridgeSessionAggregate = {
+        session: transitionSession(operatorAdvancedAggregate.session, 'neighbor_dialing'),
+        operatorLeg: operatorAdvancedAggregate.operatorLeg,
+        neighborLeg: transitionLeg(operatorAdvancedAggregate.neighborLeg, 'dialing'),
+      }
+
+      if (isOperatorAnsweredReplay(aggregate) || aggregate.neighborLeg.providerCallId) {
+        await repository.saveAggregate(neighborDialingAggregate)
+        return neighborDialingAggregate
+      }
+
+      const neighborCall = await telephonyProvider.startOutboundCall({
+        bridgeSessionId: aggregate.session.id,
+        legId: aggregate.neighborLeg.id,
+        legRole: 'neighbor',
+        toContactPointId: aggregate.neighborLeg.contactPointId,
+        fromContactPointId: aggregate.session.selectedOutboundContactPointId ?? null,
+      })
+
+      const bridgedProgressAggregate = applyProviderBridgeEvent(neighborDialingAggregate, {
+        type: 'neighbor_call_created',
+        bridgeSessionId: aggregate.session.id,
+        providerCallId: neighborCall.providerCallId,
+      })
+
+      await repository.saveAggregate(bridgedProgressAggregate)
+      return bridgedProgressAggregate
+    }
+
+    if (event.type === 'neighbor_answered') {
+      const answeredAggregate = applyProviderBridgeEvent(aggregate, event)
+      if (
+        isNeighborAnsweredReplay(aggregate)
+        || aggregate.session.status === 'bridged'
+      ) {
+        await repository.saveAggregate(answeredAggregate)
+        return answeredAggregate
+      }
+
+      const operatorProviderCallId = answeredAggregate.operatorLeg.providerCallId
+      const neighborProviderCallId = answeredAggregate.neighborLeg.providerCallId
+      if (!operatorProviderCallId || !neighborProviderCallId) {
+        const failedAggregate = applyProviderBridgeEvent(answeredAggregate, {
+          type: 'bridge_failed',
+          bridgeSessionId: answeredAggregate.session.id,
+          reason: 'Missing provider call id required for bridge control.',
+          occurredAt: event.occurredAt,
+        })
+        await repository.saveAggregate(failedAggregate)
+        return failedAggregate
+      }
+
+      await telephonyProvider.startBridgeSession({
+        bridgeSessionId: answeredAggregate.session.id,
+        operatorProviderCallId,
+        neighborProviderCallId,
+      })
+
+      const bridgedAggregate = applyProviderBridgeEvent(answeredAggregate, {
+        type: 'bridge_connected',
+        bridgeSessionId: answeredAggregate.session.id,
+        occurredAt: event.occurredAt,
+      })
+
+      await repository.saveAggregate(bridgedAggregate)
+      return bridgedAggregate
+    }
+
+    const nextAggregate = applyProviderBridgeEvent(aggregate, event)
+    await repository.saveAggregate(nextAggregate)
+    return nextAggregate
+  }
+}

--- a/domains/communication/bridge/index.ts
+++ b/domains/communication/bridge/index.ts
@@ -1,0 +1,3 @@
+export * from './bridgeSessionTypes'
+export * from './bridgeStateMachine'
+export * from './startBridgeSession'

--- a/domains/communication/bridge/index.ts
+++ b/domains/communication/bridge/index.ts
@@ -1,3 +1,4 @@
 export * from './bridgeSessionTypes'
 export * from './bridgeStateMachine'
 export * from './startBridgeSession'
+export * from './handleProviderBridgeEvent'

--- a/domains/communication/bridge/startBridgeSession.ts
+++ b/domains/communication/bridge/startBridgeSession.ts
@@ -1,0 +1,128 @@
+import {
+  BridgeLegRecord,
+  BridgeSessionAggregate,
+  BridgeSessionRecord,
+  StartBridgeSessionCommand,
+} from './bridgeSessionTypes'
+import { transitionLeg, transitionSession } from './bridgeStateMachine'
+
+export type BridgeSessionRepository = {
+  createSession(session: BridgeSessionRecord): Promise<void>
+  createLeg(leg: BridgeLegRecord): Promise<void>
+  saveAggregate(aggregate: BridgeSessionAggregate): Promise<void>
+  getAggregateBySessionId(sessionId: string): Promise<BridgeSessionAggregate | null>
+}
+
+export type StartOutboundCallInput = {
+  bridgeSessionId: string
+  legRole: 'operator' | 'neighbor'
+  toContactPointId: string
+  fromContactPointId?: string
+}
+
+export type BridgeTelephonyProvider = {
+  startOutboundCall(input: StartOutboundCallInput): Promise<{ providerCallId: string }>
+  startBridgeSession(input: {
+    bridgeSessionId: string
+    operatorProviderCallId: string
+    neighborProviderCallId: string
+  }): Promise<void>
+}
+
+export type IdGenerator = () => string
+
+export function buildStartBridgeSession(deps: {
+  repository: BridgeSessionRepository
+  telephonyProvider: BridgeTelephonyProvider
+  idGenerator: IdGenerator
+}) {
+  const { repository, telephonyProvider, idGenerator } = deps
+
+  return async function startBridgeSession(
+    command: StartBridgeSessionCommand,
+  ): Promise<BridgeSessionAggregate> {
+    const now = new Date()
+    const sessionId = idGenerator()
+
+    const session: BridgeSessionRecord = {
+      id: sessionId,
+      tenantId: command.tenantId,
+      threadId: command.threadId,
+      operatorParticipantId: command.operatorParticipantId,
+      targetParticipantId: command.targetParticipantId,
+      operatorContactPointId: command.operatorContactPointId,
+      targetContactPointId: command.targetContactPointId,
+      selectedOutboundContactPointId: command.selectedOutboundContactPointId ?? null,
+      status: 'created',
+      failureCode: null,
+      failureMessage: null,
+      endedBy: null,
+      idempotencyKey: command.idempotencyKey ?? null,
+      auditCorrelationId: command.auditCorrelationId ?? null,
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+    }
+
+    const operatorLeg: BridgeLegRecord = {
+      id: idGenerator(),
+      tenantId: command.tenantId,
+      bridgeSessionId: sessionId,
+      legRole: 'operator',
+      contactPointId: command.operatorContactPointId,
+      providerCallId: null,
+      status: 'created',
+      startedAt: null,
+      answeredAt: null,
+      endedAt: null,
+      failureCode: null,
+      failureMessage: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    const neighborLeg: BridgeLegRecord = {
+      id: idGenerator(),
+      tenantId: command.tenantId,
+      bridgeSessionId: sessionId,
+      legRole: 'neighbor',
+      contactPointId: command.targetContactPointId,
+      providerCallId: null,
+      status: 'created',
+      startedAt: null,
+      answeredAt: null,
+      endedAt: null,
+      failureCode: null,
+      failureMessage: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    await repository.createSession(session)
+    await repository.createLeg(operatorLeg)
+    await repository.createLeg(neighborLeg)
+
+    const dialingSession = transitionSession(session, 'operator_dialing')
+    const dialingOperatorLeg = transitionLeg(operatorLeg, 'dialing')
+
+    const operatorCall = await telephonyProvider.startOutboundCall({
+      bridgeSessionId: sessionId,
+      legRole: 'operator',
+      toContactPointId: command.operatorContactPointId,
+      fromContactPointId: command.selectedOutboundContactPointId,
+    })
+
+    const aggregate: BridgeSessionAggregate = {
+      session: dialingSession,
+      operatorLeg: {
+        ...dialingOperatorLeg,
+        providerCallId: operatorCall.providerCallId,
+      },
+      neighborLeg,
+    }
+
+    await repository.saveAggregate(aggregate)
+
+    return aggregate
+  }
+}

--- a/domains/communication/bridge/startBridgeSession.ts
+++ b/domains/communication/bridge/startBridgeSession.ts
@@ -1,33 +1,12 @@
 import {
-  BridgeLegRecord,
   BridgeSessionAggregate,
   BridgeSessionRecord,
+  BridgeLegRecord,
+  BridgeSessionRepository,
+  BridgeTelephonyProvider,
   StartBridgeSessionCommand,
 } from './bridgeSessionTypes'
-import { transitionLeg, transitionSession } from './bridgeStateMachine'
-
-export type BridgeSessionRepository = {
-  createSession(session: BridgeSessionRecord): Promise<void>
-  createLeg(leg: BridgeLegRecord): Promise<void>
-  saveAggregate(aggregate: BridgeSessionAggregate): Promise<void>
-  getAggregateBySessionId(sessionId: string): Promise<BridgeSessionAggregate | null>
-}
-
-export type StartOutboundCallInput = {
-  bridgeSessionId: string
-  legRole: 'operator' | 'neighbor'
-  toContactPointId: string
-  fromContactPointId?: string
-}
-
-export type BridgeTelephonyProvider = {
-  startOutboundCall(input: StartOutboundCallInput): Promise<{ providerCallId: string }>
-  startBridgeSession(input: {
-    bridgeSessionId: string
-    operatorProviderCallId: string
-    neighborProviderCallId: string
-  }): Promise<void>
-}
+import { applyProviderBridgeEvent, transitionLeg, transitionSession } from './bridgeStateMachine'
 
 export type IdGenerator = () => string
 
@@ -47,11 +26,12 @@ export function buildStartBridgeSession(deps: {
     const session: BridgeSessionRecord = {
       id: sessionId,
       tenantId: command.tenantId,
+      orgUnitId: command.orgUnitId,
       threadId: command.threadId,
       operatorParticipantId: command.operatorParticipantId,
-      targetParticipantId: command.targetParticipantId,
+      neighborParticipantId: command.neighborParticipantId,
       operatorContactPointId: command.operatorContactPointId,
-      targetContactPointId: command.targetContactPointId,
+      neighborContactPointId: command.neighborContactPointId,
       selectedOutboundContactPointId: command.selectedOutboundContactPointId ?? null,
       status: 'created',
       failureCode: null,
@@ -67,6 +47,7 @@ export function buildStartBridgeSession(deps: {
     const operatorLeg: BridgeLegRecord = {
       id: idGenerator(),
       tenantId: command.tenantId,
+      orgUnitId: command.orgUnitId,
       bridgeSessionId: sessionId,
       legRole: 'operator',
       contactPointId: command.operatorContactPointId,
@@ -84,9 +65,10 @@ export function buildStartBridgeSession(deps: {
     const neighborLeg: BridgeLegRecord = {
       id: idGenerator(),
       tenantId: command.tenantId,
+      orgUnitId: command.orgUnitId,
       bridgeSessionId: sessionId,
       legRole: 'neighbor',
-      contactPointId: command.targetContactPointId,
+      contactPointId: command.neighborContactPointId,
       providerCallId: null,
       status: 'created',
       startedAt: null,
@@ -102,24 +84,25 @@ export function buildStartBridgeSession(deps: {
     await repository.createLeg(operatorLeg)
     await repository.createLeg(neighborLeg)
 
-    const dialingSession = transitionSession(session, 'operator_dialing')
-    const dialingOperatorLeg = transitionLeg(operatorLeg, 'dialing')
+    const dialingAggregate: BridgeSessionAggregate = {
+      session: transitionSession(session, 'operator_dialing'),
+      operatorLeg: transitionLeg(operatorLeg, 'dialing'),
+      neighborLeg,
+    }
 
     const operatorCall = await telephonyProvider.startOutboundCall({
       bridgeSessionId: sessionId,
+      legId: operatorLeg.id,
       legRole: 'operator',
       toContactPointId: command.operatorContactPointId,
-      fromContactPointId: command.selectedOutboundContactPointId,
+      fromContactPointId: command.selectedOutboundContactPointId ?? null,
     })
 
-    const aggregate: BridgeSessionAggregate = {
-      session: dialingSession,
-      operatorLeg: {
-        ...dialingOperatorLeg,
-        providerCallId: operatorCall.providerCallId,
-      },
-      neighborLeg,
-    }
+    const aggregate = applyProviderBridgeEvent(dialingAggregate, {
+      type: 'operator_call_created',
+      bridgeSessionId: sessionId,
+      providerCallId: operatorCall.providerCallId,
+    })
 
     await repository.saveAggregate(aggregate)
 

--- a/domains/communication/index.ts
+++ b/domains/communication/index.ts
@@ -3,3 +3,4 @@
 
 export * from './phone'
 export * from './telephony'
+export * from './bridge'

--- a/domains/communication/telephony/index.ts
+++ b/domains/communication/telephony/index.ts
@@ -31,6 +31,33 @@ export type TelephonyStartOutboundCallCommand = TelephonyDispatchCommandBase & {
   callPolicy?: TelephonyOutboundCallPolicy
 }
 
+export type TelephonyBridgeLegRole = 'operator' | 'neighbor'
+
+export type TelephonyStartBridgeOutboundCallCommand = TelephonyDispatchCommandBase & {
+  bridgeSessionId: string
+  legId: string
+  legRole: TelephonyBridgeLegRole
+  fromContactPointId?: string | null
+}
+
+export type TelephonyStartBridgeSessionCommand = {
+  providerKey: string
+  bridgeSessionId: string
+  operatorProviderCallId: string
+  neighborProviderCallId: string
+  idempotencyKey?: string
+}
+
+export type TelephonyStartBridgeSessionResult = {
+  providerKey: string
+  bridgeSessionId: string
+  bridgeEstablished: true
+  providerRequestId?: string | null
+  adapterInvoked: true
+  providerBranchingInDomain: false
+  requestedAt?: string
+}
+
 export type TelephonyDispatchResult = {
   providerKey: string
   channel: TelephonyDispatchChannel
@@ -88,9 +115,14 @@ export interface TelephonyProviderAdapter {
   adapterInterfaceVersion: 'v1'
   sendSms(command: TelephonySendSmsCommand): Promise<TelephonyDispatchResult>
   startOutboundCall(command: TelephonyStartOutboundCallCommand): Promise<TelephonyDispatchResult>
+  startBridgeOutboundCall?: (
+    command: TelephonyStartBridgeOutboundCallCommand,
+  ) => Promise<TelephonyDispatchResult>
   verifyWebhook(input: TelephonyWebhookVerificationInput): TelephonyWebhookVerificationResult
   translateProviderEvent(input: TelephonyProviderEventTranslationInput): TelephonyProviderEvent
-  startBridgeSession?: (command: unknown) => Promise<unknown>
+  startBridgeSession?: (
+    command: TelephonyStartBridgeSessionCommand,
+  ) => Promise<TelephonyStartBridgeSessionResult>
   endCall?: (command: unknown) => Promise<unknown>
 }
 
@@ -102,6 +134,7 @@ export type TelephonyDispatchReplayKeyInput = {
   action: 'call' | 'message'
   idempotencyKey?: string | null
   targetPhone?: string | null
+  operatorContactPointId?: string | null
   body?: string | null
   callPolicy?: TelephonyOutboundCallPolicy | null
 }
@@ -138,6 +171,7 @@ export const buildTelephonyDispatchReplayKey = (
 
   const fingerprint = JSON.stringify({
     targetPhone: normalizeString(input.targetPhone),
+    operatorContactPointId: normalizeString(input.operatorContactPointId),
     body: normalizeString(input.body),
     callPolicy: sanitizeReplayCallPolicy(input.callPolicy),
   })

--- a/infrastructure/communications/telnyx/__tests__/index.test.ts
+++ b/infrastructure/communications/telnyx/__tests__/index.test.ts
@@ -79,6 +79,7 @@ describe('Telnyx adapter', () => {
       buildResponse({
         data: {
           call_leg_id: 'telnyx-leg-2001',
+          call_control_id: 'telnyx-control-2001',
         },
       }),
     )
@@ -123,11 +124,70 @@ describe('Telnyx adapter', () => {
     expect(result).toMatchObject({
       providerKey: 'telnyx',
       channel: 'call',
-      providerLegId: 'telnyx-leg-2001',
+      providerLegId: 'telnyx-control-2001',
       providerMessageId: null,
       adapterInvoked: true,
       providerBranchingInDomain: false,
       requestedAt: '2026-03-11T12:05:00.000Z',
+    })
+  })
+
+  it('bridges two provider call legs through the Telnyx call-control endpoint', async () => {
+    const fetchMock: jest.MockedFunction<typeof fetch> = jest.fn()
+    fetchMock.mockResolvedValue(
+      buildResponse(
+        {
+          data: {
+            result: 'ok',
+          },
+        },
+        {
+          headers: {
+            'x-request-id': 'req-bridge-3001',
+          },
+        },
+      ),
+    )
+
+    const adapter = createTelnyxAdapter({
+      apiKey: 'telnyx-test-key',
+      fromNumber: '+12605550199',
+      connectionId: '2084000000000000001',
+      fetchImpl: fetchMock,
+      now: () => Date.parse('2026-03-11T12:06:00.000Z'),
+    })
+
+    const result = await adapter.startBridgeSession?.({
+      providerKey: 'telnyx',
+      bridgeSessionId: 'bridge-session-1001',
+      operatorProviderCallId: 'telnyx-control-operator-1001',
+      neighborProviderCallId: 'telnyx-control-neighbor-1001',
+      idempotencyKey: 'idem-bridge-001',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.telnyx.com/v2/calls/telnyx-control-operator-1001/actions/bridge',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer telnyx-test-key',
+          'Idempotency-Key': 'idem-bridge-001',
+        }),
+      }),
+    )
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
+      call_control_id: 'telnyx-control-neighbor-1001',
+      call_control_id_to_bridge_with: 'telnyx-control-neighbor-1001',
+      command_id: 'idem-bridge-001',
+    })
+    expect(result).toEqual({
+      providerKey: 'telnyx',
+      bridgeSessionId: 'bridge-session-1001',
+      bridgeEstablished: true,
+      providerRequestId: 'req-bridge-3001',
+      adapterInvoked: true,
+      providerBranchingInDomain: false,
+      requestedAt: '2026-03-11T12:06:00.000Z',
     })
   })
 
@@ -237,6 +297,38 @@ describe('Telnyx adapter', () => {
         eventType: 'call.connected',
         delivery: {
           status: 'connected',
+        },
+      },
+      providerNeutral: true,
+      providerSpecificFieldsStripped: true,
+      providerBranchingInDomain: false,
+    })
+  })
+
+  it('translates answered bridge-leg events without leaking Telnyx identifiers', () => {
+    const adapter = createTelnyxAdapter({
+      apiKey: 'telnyx-test-key',
+    })
+
+    expect(
+      adapter.translateProviderEvent({
+        rawEventType: 'call.answered',
+        payload: {
+          call_control_id: 'telnyx-control-operator-1001',
+          call_leg_id: 'telnyx-leg-operator-1001',
+          eventType: 'call.answered',
+          call_session_id: 'telnyx-session-1001',
+          occurrence: {
+            leg: 'operator',
+          },
+        },
+      }),
+    ).toEqual({
+      eventType: 'CallAnswered',
+      payload: {
+        eventType: 'call.answered',
+        occurrence: {
+          leg: 'operator',
         },
       },
       providerNeutral: true,

--- a/infrastructure/communications/telnyx/index.ts
+++ b/infrastructure/communications/telnyx/index.ts
@@ -7,6 +7,9 @@ import {
   type TelephonyProviderEvent,
   type TelephonyProviderEventTranslationInput,
   type TelephonySendSmsCommand,
+  type TelephonyStartBridgeOutboundCallCommand,
+  type TelephonyStartBridgeSessionCommand,
+  type TelephonyStartBridgeSessionResult,
   type TelephonyStartOutboundCallCommand,
   type TelephonyWebhookHeaders,
   type TelephonyWebhookVerificationInput,
@@ -27,6 +30,7 @@ const PROVIDER_SPECIFIC_KEYS = new Set([
   'callControlId',
   'call_leg_id',
   'call_control_id',
+  'call_session_id',
   'message_id',
   'telnyxMessageId',
   'telnyxCallControlId',
@@ -319,7 +323,7 @@ const buildSmsPayload = (
 
 const buildOutboundCallPayload = (
   config: ReturnType<typeof resolveConfig>,
-  command: TelephonyStartOutboundCallCommand,
+  command: TelephonyStartOutboundCallCommand | TelephonyStartBridgeOutboundCallCommand,
 ): Record<string, unknown> => {
   if (!config.connectionId) {
     throw new Error('Set TELNYX_CONNECTION_ID for Telnyx outbound call initiation.')
@@ -334,6 +338,22 @@ const buildOutboundCallPayload = (
     from: config.fromNumber,
     to: assertConfiguredTargetPhone(command.targetPhone),
   }
+}
+
+const buildBridgePayload = (
+  command: TelephonyStartBridgeSessionCommand,
+): Record<string, unknown> => {
+  const payload: Record<string, unknown> = {
+    call_control_id: command.neighborProviderCallId,
+    call_control_id_to_bridge_with: command.neighborProviderCallId,
+  }
+
+  const idempotencyKey = normalizeString(command.idempotencyKey)
+  if (idempotencyKey) {
+    payload.command_id = idempotencyKey
+  }
+
+  return payload
 }
 
 const requestTelnyx = async (
@@ -514,8 +534,8 @@ export function createTelnyxAdapter(
       })
 
       const providerLegId =
-        normalizeString(data.data?.call_leg_id)
-        || normalizeString(data.data?.call_control_id)
+        normalizeString(data.data?.call_control_id)
+        || normalizeString(data.data?.call_leg_id)
         || normalizeString(data.data?.id)
 
       return assertValidCallDispatchResult({
@@ -528,6 +548,50 @@ export function createTelnyxAdapter(
         providerBranchingInDomain: false,
         requestedAt: requestStartedAt,
       })
+    },
+    async startBridgeOutboundCall(command) {
+      const requestStartedAt = new Date((options.now ?? Date.now)()).toISOString()
+      const { response, data } = await requestTelnyx({
+        options,
+        path: '/calls',
+        body: buildOutboundCallPayload(resolveConfig(options), command),
+        idempotencyKey: command.idempotencyKey,
+      })
+
+      const providerLegId =
+        normalizeString(data.data?.call_control_id)
+        || normalizeString(data.data?.call_leg_id)
+        || normalizeString(data.data?.id)
+
+      return assertValidCallDispatchResult({
+        providerKey: 'telnyx',
+        channel: 'call',
+        providerLegId,
+        providerMessageId: null,
+        providerRequestId: normalizeString(response.headers.get('x-request-id')),
+        adapterInvoked: true,
+        providerBranchingInDomain: false,
+        requestedAt: requestStartedAt,
+      })
+    },
+    async startBridgeSession(command): Promise<TelephonyStartBridgeSessionResult> {
+      const requestStartedAt = new Date((options.now ?? Date.now)()).toISOString()
+      const { response } = await requestTelnyx({
+        options,
+        path: `/calls/${encodeURIComponent(command.operatorProviderCallId)}/actions/bridge`,
+        body: buildBridgePayload(command),
+        idempotencyKey: command.idempotencyKey,
+      })
+
+      return {
+        providerKey: 'telnyx',
+        bridgeSessionId: command.bridgeSessionId,
+        bridgeEstablished: true,
+        providerRequestId: normalizeString(response.headers.get('x-request-id')),
+        adapterInvoked: true,
+        providerBranchingInDomain: false,
+        requestedAt: requestStartedAt,
+      }
     },
     verifyWebhook(input) {
       return verifyTelnyxWebhook(input, options)

--- a/specs/connectshyft-recovery/architecture/CS-004_bridge_flow_sequence_diagram.md
+++ b/specs/connectshyft-recovery/architecture/CS-004_bridge_flow_sequence_diagram.md
@@ -1,0 +1,88 @@
+# CS-004 Bridge Flow Sequence Diagram
+
+This diagram is the reference flow for `CS-004_Call_Bridge_Guardrailed_Spec.md`.
+
+It shows the intended orchestration boundary:
+
+- UI triggers an action
+- application service starts the bridge session
+- bridge domain owns state transitions
+- telephony provider interface is used
+- Telnyx remains behind the adapter boundary
+
+## Mermaid Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant UI as ConnectShyft UI
+    participant APP as Application Service
+    participant BRIDGE as Bridge Domain
+    participant TELE as Telephony Provider Interface
+    participant TELNYX as Telnyx Adapter
+    participant DB as Persistence
+
+    UI->>APP: Start bridge call(threadId, operator, neighbor)
+    APP->>BRIDGE: startBridgeSession(command)
+
+    BRIDGE->>DB: create bridge_session(status=created)
+    BRIDGE->>DB: create operator bridge_leg(status=created)
+    BRIDGE->>DB: create neighbor bridge_leg(status=created)
+
+    BRIDGE->>DB: transition session -> operator_dialing
+    BRIDGE->>DB: transition operator leg -> dialing
+    BRIDGE->>TELE: startOutboundCall(operator leg)
+
+    TELE->>TELNYX: create operator call
+    TELNYX-->>TELE: operator provider call id
+    TELE-->>BRIDGE: operator call accepted
+
+    BRIDGE->>DB: update operator leg(provider_call_id, status=ringing)
+
+    Note over TELNYX,BRIDGE: Later provider events arrive
+    TELNYX-->>TELE: operator answered event
+    TELE-->>BRIDGE: provider event translated -> operator_answered
+
+    BRIDGE->>DB: transition operator leg -> answered
+    BRIDGE->>DB: transition session -> operator_answered
+    BRIDGE->>DB: transition session -> neighbor_dialing
+    BRIDGE->>DB: transition neighbor leg -> dialing
+    BRIDGE->>TELE: startOutboundCall(neighbor leg)
+
+    TELE->>TELNYX: create neighbor call
+    TELNYX-->>TELE: neighbor provider call id
+    TELE-->>BRIDGE: neighbor call accepted
+
+    BRIDGE->>DB: update neighbor leg(provider_call_id, status=ringing)
+
+    TELNYX-->>TELE: neighbor answered event
+    TELE-->>BRIDGE: provider event translated -> neighbor_answered
+
+    BRIDGE->>DB: transition neighbor leg -> answered
+    BRIDGE->>DB: transition session -> neighbor_answered
+    BRIDGE->>TELE: startBridgeSession(operator call id, neighbor call id)
+
+    TELE->>TELNYX: bridge both call legs
+    TELNYX-->>TELE: bridge success
+    TELE-->>BRIDGE: bridged
+
+    BRIDGE->>DB: transition session -> bridged
+
+    alt call ends normally
+        TELNYX-->>TELE: completed event(s)
+        TELE-->>BRIDGE: completed
+        BRIDGE->>DB: update leg statuses -> completed
+        BRIDGE->>DB: transition session -> completed
+    else leg fails or bridge fails
+        TELNYX-->>TELE: failed event
+        TELE-->>BRIDGE: failed(reason)
+        BRIDGE->>DB: update leg/session -> failed
+    end
+```
+
+## Non-Negotiable Notes
+
+- The UI is not the source of truth.
+- The bridge domain owns the session and leg state.
+- The bridge domain must not import raw Telnyx payload types.
+- Provider events must be translated before entering the bridge domain.
+- Session state must persist outside frontend state.

--- a/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/bridge-domain-service.md
+++ b/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/bridge-domain-service.md
@@ -1,0 +1,100 @@
+# Contract: Bridge Domain Service
+
+## Purpose
+
+Define the provider-neutral domain boundary for persisted bridge-session orchestration.
+
+## Ownership
+
+- Domain owner: `domains/communication/bridge`
+- Infrastructure consumer: `infrastructure/communications/*`
+- App-layer consumer: `apps/connectshyft-api`
+
+## Rules
+
+- The bridge domain owns session and leg state transitions.
+- The bridge domain must not import Telnyx payload types or route-layer request types.
+- The UI is not the source of truth for bridge progression.
+- Bridge-side effects are described in provider-neutral terms and executed by app or infrastructure collaborators.
+
+## Service Surface
+
+### `startBridgeSession(command)`
+
+**Input**
+
+- `tenantId`
+- `orgUnitId`
+- `threadId`
+- `operatorParticipantId`
+- `neighborParticipantId`
+- `operatorContactPointId`
+- `neighborContactPointId`
+- `selectedOutboundContactPointId`
+  - optional
+- `idempotencyKey`
+  - optional
+- `auditCorrelationId`
+  - optional
+
+**Behavior**
+
+- create one bridge session aggregate
+- create operator and neighbor bridge legs
+- persist initial `created` state before dispatch side effects
+- transition session to `operator_dialing`
+- transition operator leg to `dialing`, then `ringing` after provider call creation
+- request provider-neutral operator outbound call side effect through `BridgeTelephonyProvider.startOutboundCall`
+- persist the authoritative aggregate after provider call creation
+
+**Output**
+
+- provider-neutral bridge aggregate snapshot with persisted operator and neighbor legs
+
+### `handleProviderBridgeEvent(event)`
+
+**Input**
+
+- `ProviderBridgeEvent`
+- repository and provider side-effect collaborators supplied by the application layer
+
+**Behavior**
+
+- load authoritative aggregate from persistence
+- apply replay-tolerant transition rules
+- persist aggregate updates
+- when `operator_answered` arrives for the first time:
+  - persist `operator_answered`
+  - transition to `neighbor_dialing`
+  - start the neighbor leg outbound call
+  - persist `neighbor_call_created`
+- when `neighbor_answered` arrives for the first time:
+  - persist `neighbor_answered`
+  - invoke bridge control through `BridgeTelephonyProvider.startBridgeSession`
+  - persist `bridge_connected`
+- when terminal events arrive:
+  - persist `completed` or `failed` session state
+  - preserve terminal outcomes on replay
+- suppress duplicate already-applied work
+
+**Output**
+
+- updated bridge aggregate or `null` when no matching aggregate exists
+
+## Repository Contract
+
+The bridge domain requires a repository that can:
+
+- create a session
+- create both legs
+- load an aggregate by session ID
+- load an aggregate by provider leg ID
+- persist the aggregate atomically after transitions
+
+## State Guarantees
+
+- one bridge session per call attempt
+- one operator leg and one neighbor leg per session
+- neighbor dialing does not occur before operator answer
+- bridge control does not occur before both legs are answered
+- duplicate provider events do not produce duplicate domain side effects

--- a/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/connectshyft-call-route.md
+++ b/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/connectshyft-call-route.md
@@ -1,0 +1,86 @@
+# Contract: ConnectShyft Call Route
+
+## Purpose
+
+Document the ConnectShyft application-facing contract for starting and observing bridge-session orchestration.
+
+## Route Ownership
+
+- `connectshyft-api` owns `POST /api/v1/connectshyft/threads/:threadId/call`
+- `connectshyft-api` also owns `GET /api/v1/connectshyft/threads/:threadId` for authoritative bridge-state readback
+- `admin-api` continues to own `/api/v1/auth/*` and `/api/v1/platform/admin/*`
+
+## Request Expectations
+
+- `threadId` comes from the route path
+- existing ConnectShyft request context still provides:
+  - `tenantId`
+  - `orgUnitId`
+  - actor/user context
+  - optional `providerKey`
+  - optional `Idempotency-Key`
+- the route accepts an operator callback contact point through `operatorPhoneId`, `operatorContactPointId`, `operatorPhone`, or `operatorCallbackPhone`
+- the route may continue to accept existing call-policy inputs, but the application normalizes them into bridge-session orchestration rather than direct provider dispatch
+- the route still accepts a neighbor callback through `targetPhone`
+
+## Response Expectations
+
+- success uses the canonical shared response envelope
+- success returns provider-neutral bridge session information at `data.bridgeSession` with the canonical shape:
+
+```json
+{
+  "bridgeSessionId": "bridge-session-1001",
+  "status": "neighbor_dialing",
+  "sessionState": "neighbor_dialing",
+  "failureCode": null,
+  "failureMessage": null,
+  "operatorLegState": "answered",
+  "neighborLegState": "ringing",
+  "operatorLeg": {
+    "legId": "bridge-leg-operator-1001",
+    "status": "answered",
+    "failureCode": null,
+    "failureMessage": null
+  },
+  "neighborLeg": {
+    "legId": "bridge-leg-neighbor-1001",
+    "status": "ringing",
+    "failureCode": null,
+    "failureMessage": null
+  }
+}
+```
+
+- `sessionState`, `operatorLegState`, `neighborLegState`, `failureCode`, and `failureMessage` are the authoritative UI-facing fields
+- `status` remains present for backward-compatible server consumers, but the UI must treat the provider-neutral aliases above as canonical
+- success still includes deterministic provider resolution metadata and replay-safe metadata when applicable
+- success still includes `dispatch.providerKey` and operator-leg `providerLegId` for existing backend reconciliation behavior
+- success must not expose raw Telnyx request or response payloads
+- provider identifiers may be persisted server-side for reconciliation, but they must not be required by the UI to drive bridge state
+
+## Thread Detail Read Expectations
+
+- `GET /api/v1/connectshyft/threads/:threadId` returns the same provider-neutral `data.bridgeSession` summary when a bridge session exists for the thread
+- the thread detail route must read persisted bridge state so refresh and re-entry do not depend on frontend memory
+
+## Behavioral Guarantees
+
+- the route starts persisted bridge orchestration rather than a one-off direct call-leg dispatch
+- bridge session state is authoritative outside frontend state
+- operator leg initiation happens through the provider-neutral telephony interface
+- route handlers do not perform Telnyx-specific branching
+
+## Failure Expectations
+
+- refusal paths remain truthful about whether provider dispatch was attempted
+- persistence failures prevent the route from claiming a bridge session exists when it does not
+- provider dispatch failures surface as route-level failures without moving bridge orchestration into the UI
+- if no operator callback number is available, the route returns a truthful business refusal instead of pretending a one-leg call was started
+
+## Webhook Integration Expectations
+
+- provider webhook events still enter through the existing ConnectShyft webhook ingress
+- webhook verification and translation occur before bridge orchestration
+- webhook replay suppression occurs before duplicate bridge progression side effects are applied
+- bridge-capable webhook handling loads persisted bridge aggregates by provider leg id and returns the updated provider-neutral bridge state in the response body

--- a/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/telephony-bridge-provider-interface.md
+++ b/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/telephony-bridge-provider-interface.md
@@ -1,0 +1,98 @@
+# Contract: Telephony Bridge Provider Interface
+
+## Purpose
+
+Define the provider-neutral telephony surface required for CS-004 bridge orchestration.
+
+## Ownership
+
+- Contract owner: `domains/communication/telephony`
+- Provider implementation owner: `infrastructure/communications/telnyx`
+- App/domain consumers: `domains/communication/bridge`, `apps/connectshyft-api`
+
+## Rules
+
+- App and domain code may depend on this contract, but not on Telnyx call-control payload shapes.
+- Provider payload translation happens once at the infrastructure edge.
+- Provider identifiers may be persisted for reconciliation, but provider semantics do not leak into the bridge domain API.
+
+## Required Interface Surface
+
+### `startOutboundCall(command)`
+
+**Input**
+
+- `tenantId`
+- `orgUnitId`
+- `threadId`
+- `bridgeSessionId`
+- `legId`
+- `legRole`
+  - `operator` or `neighbor`
+- `toContactPointId`
+- `fromContactPointId`
+  - optional
+
+**Output**
+
+- `providerCallId`
+
+### `startBridgeSession(command)`
+
+**Input**
+
+- `bridgeSessionId`
+- `operatorProviderCallId`
+- `neighborProviderCallId`
+
+**Output**
+
+- bridge-control completion with no raw provider payload required by the caller
+
+### `verifyWebhook(input)`
+
+**Input**
+
+- provider-neutral webhook verification input already used by ConnectShyft
+
+**Output**
+
+- `ok = true` on valid signature
+- provider-neutral refusal metadata on invalid or missing signature state
+
+### `translateProviderEvent(input)`
+
+**Input**
+
+- raw event type
+- raw provider payload
+
+**Output**
+
+- provider-neutral event type plus sanitized payload suitable for bridge-event mapping
+
+## Required Provider-Neutral Bridge Events
+
+Translated bridge orchestration must be able to produce:
+
+- `operator_call_created`
+- `neighbor_call_created`
+- `operator_answered`
+- `neighbor_answered`
+- `bridge_connected`
+- `operator_failed`
+- `neighbor_failed`
+- `bridge_failed`
+- `completed`
+
+## Current CS-004 Telnyx Binding
+
+- Telnyx implements `startBridgeOutboundCall` for operator and neighbor dialing.
+- Telnyx implements `startBridgeSession` by calling `POST /calls/{operatorCallControlId}/actions/bridge`.
+- The infrastructure adapter normalizes outbound call results so the bridge domain receives a single `providerCallId` field regardless of provider response shape.
+
+## Deferred Surface
+
+- full provider lookup/status polling remains optional
+- full end-call and call-cancel orchestration can stay minimal unless directly required by CS-004 acceptance
+- full communication-domain audit and idempotency ledger integration remains deferred to CS-005

--- a/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/data-model.md
+++ b/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/data-model.md
@@ -1,0 +1,246 @@
+# Data Model: CS-004 Call Bridge Flow
+
+## Overview
+
+CS-004 introduces persisted bridge-session orchestration. It adds canonical-equivalent `bridge_session` and `bridge_leg` persistence, uses provider-neutral bridge events in the domain layer, and reuses existing ConnectShyft provider-correlation and replay-safe webhook receipt persistence for webhook processing.
+
+## Entities
+
+### 1. bridge_session
+
+**Purpose**: Represent one operator-to-neighbor call attempt whose state is authoritative across route calls, page refreshes, and provider webhook events.
+
+**Canonical Equivalent**
+
+- `bridge_session`
+
+**Fields**
+
+- `id`
+- `tenant_id`
+- `org_unit_id`
+- `thread_id`
+- `operator_participant_id`
+- `target_participant_id`
+- `operator_contact_point_id`
+- `target_contact_point_id`
+- `selected_outbound_contact_point_id`
+  - nullable
+- `bridge_status`
+  - `created`
+  - `operator_dialing`
+  - `operator_answered`
+  - `neighbor_dialing`
+  - `neighbor_answered`
+  - `bridged`
+  - `completed`
+  - `failed`
+  - `canceled`
+  - `expired`
+- `failure_code`
+  - nullable
+- `failure_message`
+  - nullable
+- `ended_by`
+  - nullable
+- `idempotency_key`
+  - nullable
+- `audit_correlation_id`
+  - nullable
+- `created_at_utc`
+- `updated_at_utc`
+- `completed_at_utc`
+  - nullable
+
+**Validation Rules**
+
+- One bridge session represents one contact attempt only.
+- Session state is authoritative and must be persisted before and after progression side effects.
+- Session state must not be owned by frontend state.
+- Terminal states are `completed`, `failed`, `canceled`, and `expired`.
+
+**Relationships**
+
+- One `bridge_session` has exactly two bridge legs for CS-004: one operator leg and one neighbor leg.
+- One `bridge_session` belongs to one ConnectShyft thread.
+
+### 2. bridge_leg
+
+**Purpose**: Represent each provider-controlled leg inside a bridge session so operator and neighbor progression can reconcile independently.
+
+**Canonical Equivalent**
+
+- `bridge_leg`
+
+**Fields**
+
+- `id`
+- `tenant_id`
+- `org_unit_id`
+- `bridge_session_id`
+- `leg_role`
+  - `operator`
+  - `neighbor`
+- `contact_point_id`
+- `provider_call_id`
+  - nullable until provider accepts the call
+- `leg_status`
+  - `created`
+  - `dialing`
+  - `ringing`
+  - `answered`
+  - `failed`
+  - `completed`
+  - `canceled`
+- `started_at_utc`
+  - nullable
+- `answered_at_utc`
+  - nullable
+- `ended_at_utc`
+  - nullable
+- `failure_code`
+  - nullable
+- `failure_message`
+  - nullable
+- `created_at_utc`
+- `updated_at_utc`
+
+**Validation Rules**
+
+- Every session has one `operator` leg and one `neighbor` leg.
+- Provider call IDs are unique per leg once assigned.
+- Leg failures roll up into the owning session through orchestration logic.
+- Replayed provider events update the existing leg instead of creating a new one.
+
+**Relationships**
+
+- Each leg belongs to one `bridge_session`.
+- Each leg may map to one provider call identifier through provider-correlation persistence.
+
+### 3. ProviderBridgeEvent
+
+**Purpose**: Represent the provider-neutral event shape that bridge orchestration consumes after infrastructure translation.
+
+**Fields**
+
+- `type`
+  - `operator_call_created`
+  - `neighbor_call_created`
+  - `operator_answered`
+  - `neighbor_answered`
+  - `bridge_connected`
+  - `operator_failed`
+  - `neighbor_failed`
+  - `bridge_failed`
+  - `completed`
+- `bridgeSessionId`
+- `providerCallId`
+  - optional on non-created events
+- `occurredAt`
+  - optional
+- `reason`
+  - optional
+
+**Validation Rules**
+
+- Raw Telnyx payloads must be translated before constructing this event.
+- The bridge domain must be able to apply these events without importing provider-specific payload shapes.
+
+**Relationships**
+
+- Produced by telephony provider translation plus ConnectShyft webhook correlation.
+- Consumed by bridge domain/application orchestration.
+
+### 4. telephony_provider_reference
+
+**Purpose**: Map internal bridge-leg records to external provider call identifiers.
+
+**Current CS-004 Representation**
+
+- `connectshyft.cs_provider_identifier_mappings`
+
+**Relevant Fields**
+
+- `tenant_id`
+- `org_unit_id`
+- `thread_id`
+- `provider_name`
+- `identifier_kind`
+  - `call_leg`
+- `provider_identifier`
+- `internal_reference_id`
+  - bridge leg ID for bridge call flows
+- `created_at_utc`
+
+**Validation Rules**
+
+- Each provider call identifier maps to one internal bridge-leg record.
+- Correlation lookup must resolve the session and thread scope needed for webhook progression.
+- Bridge flows must not continue using call-leg mappings that point only to old canonical dispatch events.
+
+**Relationships**
+
+- Operator and neighbor legs each create one call-leg mapping after provider acceptance.
+- Webhook correlation resolves to the owning bridge leg and then the owning bridge session.
+
+### 5. communication_webhook_receipt
+
+**Purpose**: Provide replay-safe persistence for provider webhook events that may advance bridge state.
+
+**Current CS-004 Representation**
+
+- `connectshyft.cs_webhook_receipts`
+
+**Relevant Fields**
+
+- `tenant_id`
+- `org_unit_id`
+- `thread_id`
+- `provider_name`
+- `provider_event_id`
+- `canonical_event_type`
+- `sid`
+- `event_type`
+- `dedupe_key`
+- `processing_status`
+  - current implementation equivalent
+- `processed_at_utc`
+- `last_seen_at_utc`
+
+**Validation Rules**
+
+- Duplicate provider bridge events must be detectable before domain side effects are re-applied.
+- Receipt persistence must happen before bridge domain mutation when practical.
+
+**Relationships**
+
+- A webhook receipt may drive one bridge-session mutation or be suppressed as a duplicate.
+
+## State Transition Rules
+
+### Bridge Session
+
+- `created` -> `operator_dialing`
+- `operator_dialing` -> `operator_answered`
+- `operator_answered` -> `neighbor_dialing`
+- `neighbor_dialing` -> `neighbor_answered`
+- `neighbor_answered` -> `bridged`
+- `bridged` -> `completed`
+- any non-terminal in-flight state -> `failed`
+- in-flight states may also move to `canceled` or `expired` when explicitly ended
+
+### Bridge Leg
+
+- `created` -> `dialing`
+- `dialing` -> `ringing`
+- `ringing` -> `answered`
+- `answered` -> `completed`
+- in-flight states may move to `failed` or `canceled`
+
+## Invariants
+
+- A bridge session may exist before either provider call ID exists.
+- Neighbor dialing must not begin until the operator leg is answered.
+- Bridge control must not run until both leg provider call IDs exist and both legs are answered.
+- Duplicate or out-of-order webhook events must not create new sessions or new legs.
+- Session and leg timestamps must reflect authoritative progression rather than frontend render time.

--- a/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/plan.md
+++ b/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan: CS-004 Call Bridge Flow
+
+**Branch**: `004-cs-004-call-bridge-flow` | **Date**: 2026-03-11 | **Spec**: [spec.md](/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/spec.md)  
+**Input**: Feature specification from `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/spec.md`  
+**Source Input**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-004_Call_Bridge_Guardrailed_Spec.md`
+
+## Summary
+
+Implement CS-004 by turning ConnectShyft call initiation into persisted bridge-session orchestration owned by `domains/communication/bridge`, backed by durable bridge session and bridge leg persistence, integrated into `connectshyft-api` thread call and webhook flows, and executed through provider-neutral telephony interfaces with Telnyx bridge control isolated in infrastructure. The design intentionally reuses existing provider-correlation and webhook-receipt primitives for event replay and correlation, but it does not expand into the full CS-005 reliability, idempotency, or audit epic.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022) on Node.js >=20  
+**Primary Dependencies**: Express, Knex, pg, Jest/ts-jest, shared communication domain modules under `domains/communication`, shared provider infrastructure under `infrastructure/communications`, existing ConnectShyft route, provider registry, provider correlation, and webhook receipt modules  
+**Storage**: Shared PostgreSQL using persisted `bridge_session` and `bridge_leg` records in the `connectshyft` schema, plus existing `connectshyft.cs_provider_identifier_mappings` and unchanged `connectshyft.cs_webhook_receipts`. Webhook receipts remain the ingress deduplication layer; bridge-domain replay tolerance suppresses duplicate or out-of-order translated events after aggregate rehydration.  
+**Testing**: Jest unit and integration coverage in the bridge domain, ConnectShyft module tests, route and webhook tests, infrastructure adapter tests, and TypeScript build validation  
+**Target Platform**: Linux-hosted Shyft Nx monorepo with host-managed Nginx, Dockerized APIs, static frontends, and shared Postgres  
+**Project Type**: Monolithic Nx web application with shared domain modules, shared infrastructure adapters, and lane API consumers  
+**Performance Goals**: Duplicate translated or replayed provider events MUST NOT trigger more than one neighbor-dial or bridge-control side effect for the same session transition, and bridge state MUST remain reload-safe from persisted storage.  
+**Minimum Persisted Fields**: `bridge_session(id, thread_id, state, failure_code, failure_message, created_at, updated_at, completed_at, failed_at)` and `bridge_leg(id, bridge_session_id, role, state, provider_call_id, started_at, answered_at, completed_at, failed_at)`  
+**Constraints**: No provider-specific logic under `apps/`, no UI redesign, no architecture redesign outside the ADR, no moving domain boundaries, no bridge orchestration in frontend state, no full reliability epic expansion, no audit ledger, retry worker, reconciliation backfill, or webhook-receipt schema changes in CS-004, and no raw Telnyx types above infrastructure  
+**Scale/Scope**: CS-004 only; one call action route, bridge domain orchestration, bridge persistence, webhook-driven progression, Telnyx bridge control, and targeted test coverage
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Initial Gate Review**
+
+- Platform shell authority preserved: PASS. CS-004 changes are limited to shared communication logic, shared infrastructure, and `connectshyft-api`; `admin-web` and `admin-api` remain shell/auth owners.
+- Lane isolation preserved: PASS. The design keeps call orchestration in shared communication code and ConnectShyft lane APIs without introducing cross-lane service coupling.
+- Routing delegation preserved: PASS. The existing ConnectShyft lane route for thread calls stays lane-owned, and `/api/v1/auth/*` plus `/api/v1/platform/admin/*` remain delegated to `admin-api`.
+- Deployment topology preserved: PASS. No Nginx, container, or public-port topology changes are required.
+- Database ownership preserved: CONDITIONAL. CS-004 requires new shared-Postgres persistence for bridge sessions and legs, but the plan preserves centralized production migration authority and avoids schema forks outside the shared model.
+- Security boundaries preserved: PASS. Telnyx credentials remain server-side only, ingress stays Nginx-only, and no public API surface is added.
+- Workflow compliance: PASS. This plan, research, data model, quickstart, and contracts are generated for the CS-004 issue scope and remain traceable to the governing ADR and data model note.
+- Acceptance criteria present: CONDITIONAL. Feature acceptance is concrete, but implementation tasks must still carry route, persistence, webhook, and no-regression validation evidence.
+
+**Post-Design Re-check**
+
+- Platform shell authority preserved: PASS. No shell/auth ownership moved during design.
+- Lane isolation preserved: PASS. Bridge orchestration remains in `domains/communication`, and provider control remains in `infrastructure/communications`.
+- Routing delegation preserved: PASS. The design evolves ConnectShyft lane-owned call/webhook behavior without changing admin-owned routes.
+- Deployment topology preserved: PASS. The solution is code and schema only.
+- Database ownership preserved: PASS. The design adds bridge persistence compatible with the shared Postgres model and keeps centralized production migration execution intact.
+- Security boundaries preserved: PASS. Provider secrets and raw provider payload handling remain server-side and infrastructure-scoped.
+- Workflow compliance: PASS. The plan produces the expected planning artifacts and preserves a tasks-driven follow-on path.
+- Acceptance criteria present: PASS. The design specifies start, progression, bridge control, failure, completion, persistence, and replay-safety checks.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── contracts/
+    ├── bridge-domain-service.md
+    ├── connectshyft-call-route.md
+    └── telephony-bridge-provider-interface.md
+```
+
+### Source Code (repository root)
+
+```text
+domains/
+└── communication/
+    ├── index.ts
+    ├── telephony/
+    │   └── index.ts
+    └── bridge/
+        ├── bridgeSessionTypes.ts
+        ├── bridgeStateMachine.ts
+        ├── startBridgeSession.ts
+        ├── handleProviderBridgeEvent.ts
+        ├── index.ts
+        └── __tests__/
+
+infrastructure/
+└── communications/
+    ├── telnyx/
+    │   ├── index.ts
+    │   └── __tests__/
+    └── webhooks/
+
+apps/
+└── connectshyft-api/
+    └── src/
+        ├── migrations/
+        ├── modules/
+        │   └── connectshyft/
+        │       ├── bridgeSessions.ts
+        │       ├── providerCorrelationMappings.ts
+        │       ├── providerRegistry.ts
+        │       └── __tests__/
+        └── routes/
+            └── api/
+                └── v1/
+                    ├── connectshyft.ts
+                    └── __tests__/
+```
+
+**Structure Decision**: Keep bridge lifecycle rules in `domains/communication/bridge`, keep provider control and bridge call execution in `infrastructure/communications/telnyx`, and let `apps/connectshyft-api` own only ConnectShyft thread-action routing, persistence adapters, and webhook integration. This preserves the ADR boundary while still allowing CS-004 to replace the current single-leg direct dispatch path.
+
+## Complexity Tracking
+
+No constitution violations are required for CS-004. This section is intentionally empty.

--- a/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/quickstart.md
+++ b/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/quickstart.md
@@ -1,0 +1,194 @@
+# Quickstart: CS-004 Call Bridge Flow
+
+## Prerequisites
+
+- Node.js 20+
+- access to the monorepo workspace
+- a ConnectShyft API development database
+- Telnyx non-production credentials if live bridge validation is attempted
+
+## Environment
+
+Required for bridge-capable provider validation:
+
+- `TELNYX_API_KEY`
+
+Recommended:
+
+- `TELNYX_PUBLIC_KEY`
+- `TELNYX_CONNECTION_ID`
+- `TELNYX_API_BASE_URL`
+- `CONNECTSHYFT_ENABLED_PROVIDERS=telnyx`
+- `CONNECTSHYFT_PROVIDER_ROLLOUT_ALLOWLIST`
+
+## Build and Targeted Tests
+
+Executed during CS-004 reconciliation on March 11, 2026:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+npx jest --runInBand --runTestsByPath \
+  src/modules/connectshyft/__tests__/bridgeSessions.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+  src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts
+```
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+apps/connectshyft-api/node_modules/.bin/jest --runInBand --config apps/connectshyft-api/jest.config.js \
+  domains/communication/bridge/__tests__/bridgeStateMachine.test.ts \
+  domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts \
+  infrastructure/communications/telnyx/__tests__/index.test.ts
+```
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+npm run build
+```
+
+Observed result:
+
+- route suites passed
+- bridge domain suites passed
+- Telnyx adapter suite passed
+- migration suite passed
+- `apps/connectshyft-api` TypeScript build passed
+
+Recommended rerun if the branch changes:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+npx jest --runInBand --runTestsByPath \
+  src/modules/connectshyft/__tests__/bridgeSessions.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+  src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts
+cd /Users/jeremiahotis/projects/connectshyft
+apps/connectshyft-api/node_modules/.bin/jest --runInBand --config apps/connectshyft-api/jest.config.js \
+  domains/communication/bridge/__tests__/bridgeStateMachine.test.ts \
+  domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts \
+  infrastructure/communications/telnyx/__tests__/index.test.ts
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+npm run build
+```
+
+Shared-boundary validation:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+node scripts/enforce-workspace-boundaries.js
+```
+
+Observed result:
+
+- shared communication and infrastructure boundaries remained intact after the CS-004 updates
+
+## Host Routing Delegation Validation
+
+Static verification executed on March 11, 2026:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+rg -n "/api/v1/auth|/api/v1/platform/admin|127.0.0.1:3002" \
+  nginx/host-managed-subdomains.example.conf \
+  docs/PRODUCTION_DEPLOYMENT_GUIDE.md \
+  docs/DEPLOYMENT_CHECKLIST.md
+```
+
+Observed result:
+
+- `nginx/host-managed-subdomains.example.conf` keeps the ConnectShyft upstream on `127.0.0.1:3002`
+- `docs/PRODUCTION_DEPLOYMENT_GUIDE.md` states that `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain delegated to `admin_api`
+- `docs/DEPLOYMENT_CHECKLIST.md` repeats the same delegated-routing rule and loopback upstream expectations
+- CS-004 does not require any Nginx route ownership changes
+
+## API Binding, Port, Shared Postgres, and Migration Authority Validation
+
+Static verification executed on March 11, 2026:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+rg -n "PORT=3002|HOST=127.0.0.1|migrate:latest:prod|shared host-managed Postgres" \
+  apps/connectshyft-api/.env.example \
+  docs/PRODUCTION_DEPLOYMENT_GUIDE.md \
+  docs/DEPLOYMENT_CHECKLIST.md
+```
+
+Observed result:
+
+- `apps/connectshyft-api/.env.example` pins `PORT=3002` and `HOST=127.0.0.1`
+- deployment docs continue to require loopback-only API binding for `connectshyft-api`
+- deployment docs continue to treat PostgreSQL as the shared host-managed production database
+- production migrations remain authority-owned by `admin-api` via `docker compose run --rm admin-api npm run migrate:latest:prod`
+- CS-004 bridge persistence stays within ConnectShyft-owned tables on the shared database and does not introduce lane-local migration authority
+
+## Reproducible Runbook Verification
+
+Validation executed on March 11, 2026:
+
+1. Run the targeted Jest suites listed above.
+2. Run the root bridge-domain and Telnyx adapter suites listed above.
+3. Run `npm run build` in `apps/connectshyft-api`.
+4. Run `node scripts/enforce-workspace-boundaries.js` from repo root.
+
+Observed result:
+
+- every listed command completed successfully without manual file edits between runs
+- no extra environment variables or ad hoc deployment steps were required beyond the documented prerequisites
+- the existing deployment guide and checklist remain sufficient for CS-004 because routing, port binding, and migration authority stay unchanged
+
+## Local Bridge Validation Flow
+
+Run these checks after the implementation exists:
+
+1. Start `connectshyft-api` with bridge-capable Telnyx configuration.
+2. Send `POST /api/v1/connectshyft/threads/:threadId/call`.
+3. Verify:
+   - one persisted bridge session exists
+   - exactly two persisted bridge legs exist
+   - session status is `operator_dialing`
+   - operator leg status is `dialing` or `ringing`
+4. Deliver a translated provider event equivalent to `operator_answered`.
+5. Verify:
+   - session status advances to `operator_answered`, then `neighbor_dialing`
+   - neighbor leg provider call is initiated exactly once
+6. Deliver a translated provider event equivalent to `neighbor_answered`.
+7. Verify:
+   - provider bridge control is invoked exactly once
+   - session status advances to `bridged`
+8. Deliver either completion or failure events.
+9. Verify:
+   - session and legs move to authoritative terminal states
+   - reloading the thread reads persisted session state rather than frontend-only state
+
+## Replay-Safety Validation
+
+1. Re-send the same translated `operator_answered` or `neighbor_answered` event.
+2. Verify:
+   - no duplicate session or leg rows are created
+   - no duplicate provider bridge-control request is sent
+   - webhook receipt handling marks the event as duplicate or already applied
+
+## Telnyx Sandbox Evidence
+
+Record the following for PR evidence after implementation:
+
+- redacted operator leg creation request and response
+- redacted neighbor leg creation request and response
+- redacted bridge-control request and response
+- proof that translated provider events enter the bridge domain without raw Telnyx payload shapes
+- proof that the route response exposes provider-neutral bridge session state rather than provider identifiers
+
+These live Telnyx sandbox checks were not executed as part of the local automated validation captured here.
+
+## Platform No-Regression Checks
+
+- `connectshyft-api` remains the owner of `POST /api/v1/connectshyft/threads/:threadId/call`
+- `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain owned by `admin-api`
+- bridge orchestration lives under `domains/communication/bridge`
+- Telnyx call-control remains under `infrastructure/communications/telnyx`
+- session state persists outside frontend state and outside `apps/connectshyft-web`
+- persistence remains on shared PostgreSQL through ConnectShyft-owned tables in the `connectshyft` schema:
+  - `connectshyft.cs_bridge_sessions`
+  - `connectshyft.cs_bridge_legs`

--- a/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/research.md
+++ b/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/research.md
@@ -1,0 +1,49 @@
+# Research: CS-004 Call Bridge Flow
+
+## Decision 1
+
+- **Decision**: Keep bridge orchestration in `domains/communication/bridge` and extend the starter scaffold into an authoritative domain service surface with `startBridgeSession(...)` and provider-event handling that returns provider-neutral side effects.
+- **Rationale**: The ADR and issue spec both require bridge orchestration to live in the communication domain rather than in UI or provider adapters. The current starter files are the correct location, but they stop after initial operator dialing and do not yet model full progression or replay-safe event handling.
+- **Alternatives considered**: Put bridge progression in `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` or provider registry code. Rejected because that would collapse domain boundaries and reintroduce app-local orchestration logic.
+
+## Decision 2
+
+- **Decision**: Persist bridge session state in dedicated `bridge_session` and `bridge_leg` equivalents in the shared Postgres `connectshyft` schema, with one session and exactly two leg records per call attempt.
+- **Rationale**: CS-004 requires persisted bridge-session orchestration outside frontend state. The canonical data model explicitly requires authoritative persisted session and leg state, and the current repo has no bridge persistence yet.
+- **Alternatives considered**: Keep bridge state only in memory or only in the UI. Rejected because it violates both the ADR and the issue guardrails and cannot survive retries, reloads, or webhook races.
+
+## Decision 3
+
+- **Decision**: Reuse existing provider correlation and webhook receipt persistence (`connectshyft.cs_provider_identifier_mappings` and `connectshyft.cs_webhook_receipts`) for bridge-event correlation and replay suppression, while changing bridge-leg correlation to point provider call identifiers at persisted bridge-leg IDs.
+- **Rationale**: The repo already has replay-safe webhook receipts and provider identifier mapping primitives that fit CS-004. Reusing them keeps bridge event correlation consistent with existing infrastructure and avoids inventing a second replay store. Mapping bridge provider call IDs to bridge-leg records also aligns provider reconciliation with the new persisted state model.
+- **Alternatives considered**: Build a new bridge-only provider correlation table or keep mapping call-leg identifiers to canonical event IDs from the old direct-dispatch flow. Rejected because the former is redundant for CS-004 and the latter makes bridge webhook reconciliation ambiguous once provider leg IDs represent durable bridge legs instead of a one-off dispatch event.
+
+## Decision 4
+
+- **Decision**: Keep the existing `POST /api/v1/connectshyft/threads/:threadId/call` route as the user action entry point, but change its behavior from direct single-leg provider dispatch to bridge-session creation plus operator-leg initiation.
+- **Rationale**: The user interaction does not need a new route, and the issue explicitly excludes UI redesign. Reusing the current call action entry point limits blast radius while letting the backend move from synthetic or single-leg semantics to persisted bridge orchestration.
+- **Alternatives considered**: Introduce a brand-new bridge route or keep the existing route performing only a direct call-leg dispatch. Rejected because the former is unnecessary API churn for CS-004 and the latter fails the issue objective.
+
+## Decision 5
+
+- **Decision**: Route bridge-relevant provider events through the existing webhook verification and receipt-processing path, then hand them to a bridge application service after provider event translation and correlation resolution.
+- **Rationale**: The current inbound webhook flow already verifies signatures, resolves correlation, and persists replay-safe receipts. Bridge progression needs those same safety properties. The missing piece is the application/domain handoff that applies translated bridge events to persisted bridge aggregates.
+- **Alternatives considered**: Let provider adapters update bridge state directly or bolt bridge updates onto generic inbound voice logic. Rejected because provider adapters must not own business workflow state, and the voice timeline flow is not the same concern as bridge orchestration.
+
+## Decision 6
+
+- **Decision**: Extend the provider-neutral telephony contract with typed bridge-control inputs and outputs for bridge leg creation and bridge connection, while keeping raw Telnyx call-control identifiers inside infrastructure and persistence layers only.
+- **Rationale**: CS-004 needs real provider-backed operator leg creation, neighbor leg creation, and bridge control. The telephony boundary already anticipates `startBridgeSession(...)`, but it is still untyped and unimplemented. Typing it now keeps provider specifics isolated and gives the bridge domain a stable capability surface.
+- **Alternatives considered**: Call Telnyx bridge-control APIs directly from route handlers or domain code. Rejected because it violates the architecture contract and couples domain behavior to a provider implementation.
+
+## Decision 7
+
+- **Decision**: Make bridge state transitions replay-tolerant rather than purely strict forward-only assertions by separating event normalization from transition validation and by suppressing duplicate terminal or already-applied events.
+- **Rationale**: The starter state machine currently assumes ideal in-order transitions. The issue and ADR both require repeated or out-of-order provider events to be safe to replay. CS-004 therefore needs transition logic that can recognize already-applied state and avoid double side effects.
+- **Alternatives considered**: Keep only strict transition assertions and rely on providers to deliver perfect ordering. Rejected because webhook ordering is not guaranteed and this would fail the guardrails immediately.
+
+## Decision 8
+
+- **Decision**: Keep CS-004’s audit and idempotency scope minimal: carry `idempotencyKey` and `auditCorrelationId` through session creation, reuse existing replay-safe webhook receipts, and defer full communication-domain audit ledger work to CS-005.
+- **Rationale**: The ADR requires bridge sessions to carry idempotency and audit identifiers, but the issue explicitly says not to turn this work into the full reliability epic. CS-004 only needs enough structure to keep bridge orchestration compatible with later reliability work.
+- **Alternatives considered**: Implement the full `communication_idempotency_record` and `communication_audit_log` stack in this issue. Rejected because it expands scope beyond CS-004 and duplicates work reserved for CS-005.

--- a/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/spec.md
+++ b/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: CS-004 Call Bridge Flow
+
+**Feature Branch**: `004-cs-004-call-bridge-flow`  
+**Created**: 2026-03-11  
+**Status**: Ready for Review  
+**Input**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/spec.md`  
+**Source Input**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-004_Call_Bridge_Guardrailed_Spec.md`  
+**Reference Flow**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/architecture/CS-004_bridge_flow_sequence_diagram.md`
+
+## User Stories & Priorities
+
+### User Story 1 - Start a Persisted Bridge Session (Priority: P1)
+
+As a ConnectShyft operator, I can press Call on a thread and the system creates a durable bridge session with operator and neighbor legs before any bridge progression continues.
+
+**Independent Test**: Invoke `POST /api/v1/connectshyft/threads/:threadId/call` and verify one persisted bridge session plus exactly two persisted bridge legs are created, with the session moved to `operator_dialing` and the operator leg moved to `dialing` or `ringing`.
+
+**Acceptance Criteria**:
+1. The call action creates one `bridge_session` equivalent record and one operator plus one neighbor `bridge_leg` equivalent record.
+2. The UI receives provider-neutral bridge session state and does not become the source of truth for bridge progression.
+3. The first telephony action is an operator leg outbound call initiated through the provider-neutral telephony boundary.
+4. No Telnyx request or response shape is exposed above infrastructure.
+
+### User Story 2 - Advance the Bridge via Provider-Neutral Events (Priority: P1)
+
+As the system receives translated provider events, it can move the bridge session from operator dialing through neighbor dialing to bridged without UI-managed step chaining.
+
+**Independent Test**: Rehydrate a persisted bridge aggregate, apply translated `operator_answered` and `neighbor_answered` events, and verify the operator answer triggers neighbor dialing and the neighbor answer triggers bridge control exactly once.
+
+**Acceptance Criteria**:
+1. Provider events are translated before they enter bridge orchestration.
+2. `operator_answered` advances the session to `operator_answered`, then initiates the neighbor leg and advances the session to `neighbor_dialing`.
+3. `neighbor_answered` advances the session to `neighbor_answered`, then invokes bridge control and advances the session to `bridged` after provider success.
+4. Duplicate or out-of-order provider events must not create duplicate sessions, duplicate legs, or repeated bridge-control side effects.
+
+### User Story 3 - Persist Terminal Bridge Outcomes (Priority: P2)
+
+As an operator returning to a thread later, I can rely on persisted bridge completion or failure state rather than ephemeral frontend state.
+
+**Independent Test**: Apply translated `completed`, `operator_failed`, `neighbor_failed`, and `bridge_failed` events to persisted aggregates and verify the authoritative session and leg states can be reloaded from storage after refresh or webhook retry.
+
+**Acceptance Criteria**:
+1. Operator, neighbor, and bridge failures roll up to the persisted session with a terminal failure code and message.
+2. Completed bridge flows persist final session and leg terminal states.
+3. Session state survives page refresh and webhook replay.
+
+## Functional Requirements
+
+- FR-001: `POST /api/v1/connectshyft/threads/:threadId/call` MUST create exactly one persisted bridge session and exactly two persisted bridge legs (`operator`, `neighbor`) before any bridge progression continues.
+- FR-002: The call-start response and any thread refresh response that includes call state MUST expose only provider-neutral bridge fields: `bridgeSessionId`, `sessionState`, `operatorLegState`, `neighborLegState`, `failureCode`, `failureMessage`, and relevant timestamps.
+- FR-003: Raw provider webhooks MUST be deduplicated by existing webhook-receipt handling before bridge orchestration; only translated provider-neutral events may enter `domains/communication/bridge`.
+- FR-004: The first translated `operator_answered` event MUST initiate neighbor dialing exactly once and transition the session to `neighbor_dialing`.
+- FR-005: The first translated `neighbor_answered` event MUST invoke bridge control exactly once and transition the session to `bridged` only after provider success.
+- FR-006: Terminal outcomes MUST persist authoritative session and leg states. `failureCode` MUST be one of `operator_failed`, `neighbor_failed`, or `bridge_failed`; `failureMessage` MUST come from the translated event or provider-neutral error mapping.
+- FR-007: Persisted bridge state MUST be recoverable after page refresh and duplicate webhook delivery without relying on frontend memory.
+
+## Non-Functional Requirements
+
+- NFR-001: Raw Telnyx payloads and types MUST remain confined to `infrastructure/communications/telnyx`.
+- NFR-002: No provider-specific logic may be introduced under `apps/`.
+- NFR-003: CS-004 reuses existing webhook-receipt deduplication and does not add audit history, retry scheduling, reconciliation jobs, or new cross-request idempotency workflows.
+- NFR-004: Existing routing delegation and shared-Postgres production migration ownership MUST remain unchanged and be validated.
+
+## Edge Cases
+
+- Duplicate webhook delivery after the receipt has already been recorded.
+- Out-of-order translated events, including `neighbor_answered` arriving before `operator_answered`.
+- Thread refresh or re-entry between operator dial start and terminal completion.
+- Bridge-control failure after neighbor answer but before `bridged` is persisted.
+
+## Compatibility Acceptance Scenarios
+
+1. `/api/v1/auth/*` and `/api/v1/platform/admin/*` continue to resolve through `admin-api`, while `/api/v1/connectshyft/*` remains lane-owned.
+2. Bridge-session persistence uses shared Postgres and shared migration authority; `connectshyft-api` does not assume independent production migration execution.
+
+## Non-Goals
+
+- No UI redesign.
+- No analytics or reporting work.
+- No provider-specific logic under `apps/`.
+- No relocation of communication, infrastructure, or UI/domain boundaries.
+- No full CS-005 audit/idempotency implementation beyond what CS-004 already depends on.
+- No CS-005 audit trail, retry scheduler, reconciliation job, or new idempotency workflow work in CS-004.
+- No SMS feature work or unrelated thread UX changes.
+
+## Testing Requirements
+
+- Add communication-domain tests for bridge session transitions and replay-safe provider event handling.
+- Add application persistence tests for bridge session and leg storage plus provider-leg lookup/correlation.
+- Add route and webhook integration tests proving the call action creates a bridge session and translated provider events advance it correctly.
+- Preserve existing boundary tests that ensure Telnyx remains behind infrastructure and bridge logic remains outside UI state.
+
+## Boundary and Delegation Compatibility
+
+1. `domains/communication/bridge` owns bridge-session orchestration and state transitions.
+2. `infrastructure/communications/telnyx` owns Telnyx call-control and bridge-control integration.
+3. `apps/connectshyft-api` may orchestrate thread actions and route/webhook integration, but it must call shared domain and provider-neutral interfaces only.
+4. `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain delegated to `admin-api`.
+5. Session state must persist outside frontend state and remain replay-safe for repeated provider events.
+
+## Evidence Expectations
+
+1. State-machine test coverage for operator leg, neighbor leg, bridge success, completion, and failure paths.
+2. Persistence evidence for one bridge session plus two bridge legs per call attempt.
+3. Webhook-driven progression evidence showing operator answered -> neighbor dialing -> bridged.
+4. Proof that the route and webhook layers do not import raw Telnyx payload types into the bridge domain.

--- a/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/tasks.md
+++ b/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/tasks.md
@@ -1,0 +1,223 @@
+# Tasks: CS-004 Call Bridge Flow
+
+**Input**: Design documents from `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/`  
+**Prerequisites**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/plan.md`, `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/spec.md`, `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/research.md`, `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/data-model.md`, `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/`
+
+**Tests**: Jest coverage is required because the feature spec explicitly calls for domain, persistence, route, and webhook automation for bridge-session orchestration.
+
+**Organization**: Tasks are grouped by user story so each bridge-flow slice remains independently implementable and testable while preserving the ADR boundaries.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the bridge issue workspace and test harnesses before bridge behavior is implemented.
+
+- [x] T001 Create bridge domain test scaffolding in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts`
+- [x] T002 [P] Create bridge orchestration test scaffolding in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts`
+- [x] T003 [P] Create ConnectShyft bridge persistence test scaffolding in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- [x] T004 [P] Create call-route and webhook bridge integration test scaffolding in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- [x] T005 [P] Create bridge migration test scaffolding in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared bridge contract, persistence, and provider boundary required by every user story.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [x] T006 Extend bridge command, aggregate, repository, and provider-event types in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/bridgeSessionTypes.ts`
+- [x] T007 [P] Make bridge session and leg transitions replay-tolerant in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/bridgeStateMachine.ts`
+- [x] T008 [P] Define typed bridge telephony command/result contracts in `/Users/jeremiahotis/projects/connectshyft/domains/communication/telephony/index.ts`
+- [x] T009 Export the bridge domain surface from `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/index.ts` and `/Users/jeremiahotis/projects/connectshyft/domains/communication/index.ts`
+- [x] T010 Create persisted bridge session and bridge leg storage in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts`
+- [x] T011 Create the ConnectShyft bridge session repository and persistence adapter in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
+- [x] T012 Update provider call-leg correlation persistence to map provider identifiers to bridge-leg records in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts`
+- [x] T013 Extend ConnectShyft provider registry wiring for typed bridge-control methods in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts`
+- [x] T014 Implement the typed Telnyx bridge-capable adapter surface in `/Users/jeremiahotis/projects/connectshyft/infrastructure/communications/telnyx/index.ts`
+
+**Checkpoint**: Shared bridge types, persistence scaffolding, and provider-neutral bridge capabilities exist and compile.
+
+---
+
+## Phase 3: User Story 1 - Start a Persisted Bridge Session (Priority: P1) 🎯 MVP
+
+**Goal**: Replace direct call dispatch with persisted bridge-session creation plus operator-leg initiation.
+
+**Independent Test**: Call `POST /api/v1/connectshyft/threads/:threadId/call` and verify one bridge session plus two bridge legs are persisted, the session is in `operator_dialing`, and the operator leg is in `dialing` or `ringing`.
+
+### Tests for User Story 1
+
+- [x] T015 [P] [US1] Add bridge-session initialization and operator-leg transition coverage in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts`
+- [x] T016 [P] [US1] Add start-bridge-session orchestration tests in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts`
+- [x] T017 [P] [US1] Add persistence tests for created session and two created legs in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- [x] T018 [P] [US1] Add route contract coverage for persisted bridge-session creation and provider-neutral response fields (`bridgeSessionId`, `sessionState`, `operatorLegState`, `neighborLegState`, `failureCode`, `failureMessage`) in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+
+### Implementation for User Story 1
+
+- [x] T019 [US1] Update bridge-session startup orchestration in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/startBridgeSession.ts`
+- [x] T020 [US1] Persist created bridge aggregates and operator-leg startup updates in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
+- [x] T021 [US1] Update the thread call route to create a bridge session instead of dispatching a one-off call leg in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [x] T022 [US1] Persist operator-leg provider call mappings to bridge-leg IDs in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts`
+
+**Checkpoint**: User Story 1 is complete with persisted bridge-session creation, provider-neutral route payload coverage, and operator-leg initiation validation.
+
+---
+
+## Phase 4: User Story 2 - Advance the Bridge via Provider-Neutral Events (Priority: P1)
+
+**Goal**: Progress operator answer -> neighbor dialing -> bridged through translated provider events and persisted orchestration.
+
+**Independent Test**: Rehydrate a persisted aggregate, apply translated `operator_answered` and `neighbor_answered` events, and verify neighbor dialing and bridge control each happen exactly once.
+
+### Tests for User Story 2
+
+- [x] T023 [P] [US2] Add operator-answered and neighbor-answered progression tests in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts`
+- [x] T024 [P] [US2] Add persistence tests for provider-leg lookup and aggregate save-after-event in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- [x] T025 [P] [US2] Add webhook integration tests for operator answered -> neighbor dialing -> bridged and verify duplicate webhook receipts are ignored before bridge orchestration in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- [x] T026 [P] [US2] Add Telnyx bridge-control and translated bridge-event tests in `/Users/jeremiahotis/projects/connectshyft/infrastructure/communications/telnyx/__tests__/index.test.ts`
+
+### Implementation for User Story 2
+
+- [x] T027 [US2] Create provider-event bridge orchestration in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/handleProviderBridgeEvent.ts`
+- [x] T028 [US2] Update bridge-state transitions for neighbor dialing and bridge connection in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/bridgeStateMachine.ts`
+- [x] T029 [US2] Add aggregate lookup by provider leg and save-after-event semantics in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
+- [x] T030 [US2] Route translated bridge webhook events into the bridge application flow in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [x] T031 [US2] Implement Telnyx bridge control and bridge-event translation in `/Users/jeremiahotis/projects/connectshyft/infrastructure/communications/telnyx/index.ts`
+- [x] T032 [US2] Pass bridge-capable provider methods through the guardrailed provider registry in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts`
+
+**Checkpoint**: User Story 2 is complete with provider-neutral webhook progression, duplicate-receipt suppression, and single-fire bridge control validation.
+
+---
+
+## Phase 5: User Story 3 - Persist Terminal Bridge Outcomes (Priority: P2)
+
+**Goal**: Persist authoritative completion and failure states that survive refreshes and webhook retries.
+
+**Independent Test**: Apply `completed`, `operator_failed`, `neighbor_failed`, and `bridge_failed` events to persisted bridge aggregates and verify terminal states are durable and duplicate terminal events are suppressed.
+
+### Tests for User Story 3
+
+- [x] T033 [P] [US3] Add completion and failure transition coverage in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts`
+- [x] T034 [P] [US3] Add terminal-state replay-suppression tests in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts`
+- [x] T035 [P] [US3] Add terminal persistence tests for completed and failed sessions, including canonical `failureCode` mapping (`operator_failed`, `neighbor_failed`, `bridge_failed`), in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- [x] T036 [P] [US3] Add route/webhook integration tests for completion, failure handling, duplicate terminal-webhook suppression, and reload-after-refresh state rehydration in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- [x] T037 [P] [US3] Add migration assertions for bridge table constraints and indexes in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts`
+- [x] T049 [P] [US3] Add integration coverage proving a fresh API read returns persisted bridge state after simulated refresh, so the frontend is not the source of truth, in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+
+### Implementation for User Story 3
+
+- [x] T038 [US3] Persist terminal bridge session and leg timestamps plus failure metadata in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/bridgeStateMachine.ts`
+- [x] T039 [US3] Finalize terminal-event orchestration and duplicate suppression in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/handleProviderBridgeEvent.ts`
+- [x] T040 [US3] Persist terminal bridge aggregate updates and bridge-leg reconciliation in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
+- [x] T041 [US3] Update webhook handling to report terminal bridge outcomes without duplicate side effects in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [x] T042 [US3] Finalize bridge-session schema constraints and indexes in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts`
+
+**Checkpoint**: User Story 3 is complete with canonical failure-code persistence, duplicate terminal-webhook suppression, and refresh-safe thread readback validation.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Capture final bridge contracts, validation steps, and no-regression evidence.
+
+- [x] T043 [P] Update bridge domain contract details in `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/bridge-domain-service.md`
+- [x] T044 [P] Update call-route bridge contract details, including the authoritative provider-neutral bridge-state payload returned to the UI, in `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/connectshyft-call-route.md`
+- [x] T045 [P] Update provider-neutral bridge interface details in `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/contracts/telephony-bridge-provider-interface.md`
+- [x] T046 [P] Record Nginx routing delegation validation for `/api/v1/auth/*`, `/api/v1/platform/admin/*`, and `/api/v1/connectshyft/*` in `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/quickstart.md`
+- [x] T047 [P] Record ConnectShyft API localhost-only binding / canonical port validation and shared Postgres connectivity plus production migration ownership evidence in `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/quickstart.md`
+- [x] T048 Run targeted CS-004 build and Jest suites, then record reproducible deployment/runbook verification with no manual adjustments in `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup** has no dependencies and can begin immediately.
+- **Phase 2: Foundational** depends on Phase 1 and blocks all story work.
+- **Phase 3: User Story 1** depends on Phase 2 and delivers the MVP bridge-session start flow.
+- **Phase 4: User Story 2** depends on Phase 3 because provider-event progression requires persisted session and leg creation to exist first.
+- **Phase 5: User Story 3** depends on Phase 4 because terminal outcomes rely on the event-handling and bridge-control path already being in place.
+- **Phase 6: Polish** depends on the stories intended for shipment and the resulting validation evidence.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start immediately after Foundational and is the MVP slice.
+- **US2 (P1)**: Depends on US1 because bridge progression cannot happen before bridge-session startup exists.
+- **US3 (P2)**: Depends on US2 because terminal outcome handling builds on the same webhook-driven progression path.
+
+### Within Each User Story
+
+- Write the story tests first and confirm they fail before implementation.
+- Complete domain transition logic before route or webhook wiring that depends on it.
+- Complete persistence support before provider-correlation changes that rely on persisted bridge-leg IDs.
+- Keep raw Telnyx handling confined to infrastructure during every story.
+
+### Recommended Completion Order
+
+1. Phase 1: Setup
+2. Phase 2: Foundational
+3. Phase 3: US1
+4. Phase 4: US2
+5. Phase 5: US3
+6. Phase 6: Polish
+
+---
+
+## Parallel Execution Examples
+
+### User Story 1
+
+```bash
+Task: "T015 [US1] Add bridge-session initialization and operator-leg transition coverage in /Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts"
+Task: "T017 [US1] Add persistence tests for created session and two created legs in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts"
+Task: "T018 [US1] Add route contract coverage for persisted bridge-session creation in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts"
+```
+
+### User Story 2
+
+```bash
+Task: "T023 [US2] Add operator-answered and neighbor-answered progression tests in /Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts"
+Task: "T025 [US2] Add webhook integration tests for operator answered -> neighbor dialing -> bridged in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts"
+Task: "T026 [US2] Add Telnyx bridge-control and translated bridge-event tests in /Users/jeremiahotis/projects/connectshyft/infrastructure/communications/telnyx/__tests__/index.test.ts"
+```
+
+### User Story 3
+
+```bash
+Task: "T033 [US3] Add completion and failure transition coverage in /Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts"
+Task: "T035 [US3] Add terminal persistence tests for completed and failed sessions in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts"
+Task: "T037 [US3] Add migration assertions for bridge table constraints and indexes in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. Validate the US1 independent test before advancing to webhook-driven progression.
+
+### Incremental Delivery
+
+1. Deliver US1 to create authoritative persisted bridge sessions.
+2. Add US2 to progress the bridge from translated provider events.
+3. Add US3 to finalize durable completion and failure handling.
+4. Finish with the Phase 6 validation and documentation evidence.
+
+### Parallel Team Strategy
+
+1. One developer completes the shared domain and persistence foundation.
+2. After Phase 2, one developer can focus on domain tests and orchestration while another prepares route and infrastructure tests.
+3. Serialize edits to `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`, and `/Users/jeremiahotis/projects/connectshyft/infrastructure/communications/telnyx/index.ts` to avoid conflicts.
+
+---
+
+## Notes
+
+- `[P]` means the task is parallelizable because it targets a different file or documentation artifact with no incomplete upstream dependency.
+- No tasks modify `apps/connectshyft-web` or introduce provider-specific code under `apps/`.
+- No tasks turn CS-004 into the full CS-005 reliability or audit epic; they stay limited to persisted bridge orchestration, bridge control, and replay-safe progression already required by the issue.


### PR DESCRIPTION
# CS-004 Call Bridge Flow PR

Issue:
CS-004 Call Bridge Flow

Governing Documents:
- /specs/connectshyft-recovery/developer_execution_packet.md
- /specs/connectshyft-recovery/ADR-00X_communication_infrastructure.md
- /specs/connectshyft-recovery/communication_data_model_note.md
- /specs/connectshyft-recovery/issues/CS-004_Call_Bridge_Guardrailed_Spec.md
- /specs/connectshyft-recovery/architecture/CS-004_bridge_flow_sequence_diagram.md

Starter Scaffold:
- /domains/communication/bridge/bridgeSessionTypes.ts
- /domains/communication/bridge/bridgeStateMachine.ts
- /domains/communication/bridge/startBridgeSession.ts
- /domains/communication/bridge/index.ts

---

## Summary

Implements persisted bridge-session orchestration for operator leg, neighbor leg, and bridge control using the shared communication domain and telephony provider interface. Companion PR #217 carries the non-CS-004 CI/workflow and regression follow-up changes that were intentionally kept out of this feature branch.

---

## Scope Confirmation

This PR is limited to CS-004.

Confirm:

- [x] No UI redesign work included
- [x] No direct Telnyx calls added under `/apps`
- [x] No full reliability/idempotency subsystem added beyond minimal required safeguards
- [x] No unrelated architecture changes included

---

## Architecture Compliance

Confirm the implementation follows the ADR and execution packet.

- [x] Bridge orchestration lives under `/domains/communication/bridge`
- [x] Provider-specific logic remains under `/infrastructure/communications`
- [x] Application code uses telephony provider interfaces, not raw provider calls
- [x] Bridge session state persists outside frontend state
- [x] No raw Telnyx payload types are imported into bridge domain files

If any deviation occurred, explain it here:

None.

---

## Scaffold Adoption Check

Confirm how the starter scaffold was used.

- [x] `bridgeSessionTypes.ts` used or extended
- [x] `bridgeStateMachine.ts` used or extended
- [x] `startBridgeSession.ts` used or extended
- [x] sequence diagram behavior preserved

If any scaffold file was replaced rather than extended, explain why:

None.

---

## Persistence Compliance

Confirm the implementation persists the canonical shape required for bridge orchestration.

- [x] `bridge_session` equivalent persists session state
- [x] `bridge_leg` equivalent persists operator and neighbor legs separately
- [x] provider call identifiers are stored outside the UI
- [x] session failure state persists cleanly
- [x] session completion state persists cleanly

Describe the persistence implementation:

`apps/connectshyft-api` adds shared-Postgres bridge-session and bridge-leg persistence, stores provider correlation identifiers outside the UI, and rehydrates authoritative bridge state for route responses and webhook progression.

---

## Provider Interface Compliance

Confirm bridge orchestration uses the provider-neutral telephony boundary.

- [x] bridge flow depends on telephony interface
- [x] bridge flow does not depend directly on Telnyx request/response shapes
- [x] provider event translation occurs before entering bridge domain logic

Describe the provider integration path:

ConnectShyft route handlers call provider-neutral telephony operations, Telnyx-specific translation stays in `/infrastructure/communications/telnyx`, and translated provider events feed the bridge domain through persisted aggregate rehydration.

---

## State Machine Coverage

Confirm state transitions are explicit and tested.

- [x] created → operator_dialing
- [x] operator_dialing → operator_answered
- [x] operator_answered → neighbor_dialing
- [x] neighbor_dialing → neighbor_answered
- [x] neighbor_answered → bridged
- [x] bridged → completed
- [x] failure transitions handled cleanly

List any intentional transition constraints or deviations:

Bridge control only promotes the session to `bridged` after provider success, and duplicate or out-of-order translated events are suppressed after aggregate rehydration.

---

## Event Handling

Confirm provider events can drive bridge state changes.

- [x] operator answered event handled
- [x] neighbor answered event handled
- [x] bridge connected event handled
- [x] failure event handled
- [x] completion event handled

Describe the event handling entrypoint(s):

Provider webhooks enter through the ConnectShyft API route layer, provider-specific payloads are translated by the registry/adapter layer, and the bridge domain applies the normalized events against persisted session state.

---

## Tests

List test coverage included in this PR.

- [x] unit tests for bridge state machine
- [x] unit tests for transition validation
- [x] integration test for session creation
- [x] integration test for operator leg creation
- [x] integration test for neighbor leg creation
- [x] integration test for bridged transition
- [x] integration test for failure path

Test notes:

Targeted bridge-flow Jest coverage passed in `apps/connectshyft-api`, including route-level webhook progression, bridge-session persistence, and provider-event handling. `apps/connectshyft-api` production build also passed. Full GitHub-parity CI validation was run locally on the combined integration branch before the split, with the CI/backend-Jest wiring isolated into companion PR #217.

---

## Evidence

Provide proof that the bridge flow works as intended.

- [x] screenshots/log output showing session creation
- [x] screenshots/log output showing operator leg progression
- [x] screenshots/log output showing neighbor leg progression
- [x] screenshots/log output showing bridged state
- [x] screenshots/log output showing failure path behavior

Evidence summary:

Automated evidence is captured in `connectshyft.bridge-flow.test.ts`, `bridgeSessions.test.ts`, `handleProviderBridgeEvent.test.ts`, and the CS-004 `quickstart.md` runbook/validation notes. This PR does not include UI screenshots because the scope is backend/domain-only.

---

## Files Added / Modified

List the key files touched.

Expected examples:
- `/domains/communication/bridge/...`
- `/domains/communication/telephony/...`
- persistence files for bridge session / bridge leg
- application service wiring files

Files touched:

- `/domains/communication/bridge/bridgeSessionTypes.ts`
- `/domains/communication/bridge/bridgeStateMachine.ts`
- `/domains/communication/bridge/startBridgeSession.ts`
- `/domains/communication/bridge/handleProviderBridgeEvent.ts`
- `/domains/communication/telephony/index.ts`
- `/infrastructure/communications/telnyx/index.ts`
- `/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
- `/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
- `/apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts`
- `/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
- `/specs/connectshyft-recovery/issues/cs-004-call-bridge-flow/...`

---

## Out-of-Scope Confirmation

Confirm this PR does **not** attempt to fully solve:

- [x] full audit subsystem
- [x] full idempotency subsystem
- [x] UI redesign
- [x] provider failover design
- [x] unrelated repo cleanup

If any of the above were partially touched, explain why:

None.

---

## Final Definition of Done Check

- [x] operator leg can be initiated and persisted
- [x] neighbor leg can be initiated and persisted
- [x] bridge session state is authoritative outside the UI
- [x] bridge state transitions are validated through the state machine
- [x] provider integration remains behind the telephony interface
- [x] failure paths do not leave orphaned or ambiguous session state

---

## Final Statement

This change complies with ADR-00X Communication Infrastructure Contract, the Canonical Data Model Note, the CS-004 guardrailed issue spec, and the CS-004 bridge flow sequence diagram.
