### PR TITLE
Docs: verify CS-003 Telnyx adapter architecture

### DIFF
--- a/specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md
+++ b/specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md
@@ -1,0 +1,120 @@
+# CS-003 Architectural Integrity Verification
+
+Date: March 12, 2026
+Verification target: merged implementation PR `#216` (`Feat: implement CS-003 Telnyx outbound adapter`)
+
+## Scope
+
+This document verifies the current CS-003 Telnyx outbound adapter implementation against:
+
+- `/specs/connectshyft-recovery/developer_execution_packet.md`
+- `/specs/connectshyft-recovery/ADR-00X_Communication_Infrastructure_Contract.md`
+- `/specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md`
+- `/specs/connectshyft-recovery/issues/CS-003_Telnyx_Adapter_Guardrailed_Spec.md`
+
+## Commands Executed
+
+Executed locally on March 12, 2026:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+npm run build
+
+cd /Users/jeremiahotis/projects/connectshyft
+node scripts/enforce-workspace-boundaries.js
+
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+node /Users/jeremiahotis/projects/connectshyft/node_modules/.pnpm/jest@29.7.0_@types+node@20.19.37_babel-plugin-macros@3.1.0_ts-node@10.9.2_@types+node@20.19.37_typescript@5.9.3_/node_modules/jest/bin/jest.js \
+  --runInBand \
+  --config jest.config.js \
+  --runTestsByPath \
+  src/modules/connectshyft/__tests__/providerRegistry.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+  ../../domains/communication/telephony/__tests__/index.test.ts \
+  ../../infrastructure/communications/telnyx/__tests__/index.test.ts
+```
+
+## Validation Results
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| `apps/connectshyft-api` TypeScript build | PASS | `npm run build` succeeded |
+| Workspace boundary guard | PASS | `node scripts/enforce-workspace-boundaries.js` succeeded |
+| CS-003 target Jest suites | PASS | `4` suites passed, `31` tests passed |
+| Provider interface under `domains/communication/telephony` | PASS | See `/domains/communication/telephony/index.ts` |
+| Telnyx adapter under `infrastructure/communications/telnyx` | PASS | See `/infrastructure/communications/telnyx/index.ts` |
+| No Telnyx imports under `/domains/communication/bridge` | PASS | No matches found |
+| Provider events translated before entering shared domain contracts | PASS | Telnyx adapter exposes `translateProviderEvent(...)` and returns sanitized provider-neutral events |
+| No Telnyx imports under `/apps` | FAIL | `apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts` imports `createTelnyxAdapter` directly |
+| Telnyx request/payload handling exists only inside adapter | FAIL | app-layer webhook correlation and sanitization still reference Telnyx-specific field names |
+
+## Verified Architecture Strengths
+
+1. The provider-neutral contract exists and is exported from `/domains/communication/telephony/index.ts` and `/domains/communication/index.ts`.
+2. The Telnyx implementation is concentrated in `/infrastructure/communications/telnyx/index.ts` with dedicated infrastructure tests in `/infrastructure/communications/telnyx/__tests__/index.test.ts`.
+3. The adapter implements real `sendSms`, `startOutboundCall`, `startBridgeSession`, `verifyWebhook`, and `translateProviderEvent` entrypoints.
+4. Webhook signature verification fails closed with provider-neutral refusal codes:
+   - `WEBHOOK_SIGNATURE_NOT_CONFIGURED`
+   - `WEBHOOK_SIGNATURE_MISSING`
+   - `WEBHOOK_SIGNATURE_INVALID`
+5. Provider event translation strips provider-specific fields before returning the event object to consumers.
+6. The focused CS-003 tests cover interface assertions, adapter request/response mapping, outbound dispatch behavior, and webhook verification/translation.
+
+## Architectural Deviations
+
+### 1. Direct Telnyx adapter import under `/apps`
+
+File:
+
+- `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts`
+
+Current behavior:
+
+- `providerRegistry.ts` imports `createTelnyxAdapter` directly from `/infrastructure/communications/telnyx`.
+- This makes the application layer aware of the concrete provider implementation rather than resolving it through a provider-neutral composition boundary.
+
+Impact:
+
+- The implementation still avoids raw Telnyx request execution in app code, but the strict "no Telnyx imports under `/apps`" boundary is not satisfied.
+
+### 2. App-layer references to Telnyx-specific webhook/correlation field names
+
+Files:
+
+- `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts`
+
+Current behavior:
+
+- app-layer logic still recognizes keys such as `telnyxCallControlId`, `telnyxMessageId`, and related provider-specific webhook identifiers.
+- This means some provider-shape awareness remains outside the infrastructure adapter.
+
+Impact:
+
+- The route/domain-adjacent application layer is still partially coupled to Telnyx payload conventions.
+- The implementation is functionally correct, but it does not fully satisfy the strongest form of adapter isolation described in the PR template.
+
+## Out-of-Scope Checks
+
+| Constraint | Result | Notes |
+|-----------|--------|-------|
+| No bridge orchestration implemented as part of CS-003 | PASS | CS-003 limits itself to outbound SMS/call initiation and future-compatible bridge hooks |
+| No UI changes included | PASS | merged implementation PR `#216` touched no `apps/connectshyft-web` files |
+| No unrelated persistence schema work | PASS | merged implementation PR `#216` introduced no new migrations |
+| No full reliability/retry subsystem | PASS | no retry worker or audit/idempotency subsystem was introduced; only minimal dispatch replay helpers required for outbound request safety exist |
+
+## Conclusion
+
+CS-003 is functionally verified and mostly aligned with the ADR/provider-boundary intent, but it is not perfectly isolated at the application boundary.
+
+Current architectural status:
+
+- Shared provider contract: compliant
+- Infrastructure adapter placement: compliant
+- Event translation and webhook verification: compliant
+- Strict app-layer provider isolation: not fully compliant
+
+Recommended follow-up:
+
+1. Remove the direct `createTelnyxAdapter` import from `/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts` by introducing a provider-neutral adapter registry/composition seam outside app code.
+2. Move Telnyx-specific webhook identifier extraction and sanitization fully into infrastructure translation/correlation helpers so app code only consumes canonical provider-neutral fields.

--- a/specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md
+++ b/specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md
@@ -12,6 +12,8 @@ This document verifies the current CS-003 Telnyx outbound adapter implementation
 - `/specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md`
 - `/specs/connectshyft-recovery/issues/CS-003_Telnyx_Adapter_Guardrailed_Spec.md`
 
+Scope-sensitive checks in this document are evaluated against merged PR `#216`'s file set, because the current repository state also contains later CS-004 bridge-flow work that intentionally extends the adapter surface beyond original CS-003 scope.
+
 ## Commands Executed
 
 Executed locally on March 12, 2026:


### PR DESCRIPTION
# CS-003 Telnyx Adapter PR

Issue:
CS-003 Telnyx Adapter Guardrailed Spec

Governing Documents:
- /specs/connectshyft-recovery/developer_execution_packet.md
- /specs/connectshyft-recovery/ADR-00X_Communication_Infrastructure_Contract.md
- /specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md
- /specs/connectshyft-recovery/issues/CS-003_Telnyx_Adapter_Guardrailed_Spec.md

Verification Artifact:
- /specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md

---

# Summary

Adds a docs-only verification artifact for merged PR #216 (`Feat: implement CS-003 Telnyx outbound adapter`) and records current architectural-integrity findings against the ADR/spec. This PR does not re-implement CS-003; it verifies the adapter surface, reruns the focused CS-003 validation commands, and documents the remaining app-layer Telnyx coupling points.

---

# Scope Confirmation

This PR is limited to CS-003 verification.

Note: scope-sensitive checks below are evaluated against merged PR #216's file set because current `codex/dev` also contains later CS-004 bridge-flow work.

Confirm:

- [x] No bridge orchestration implemented
- [x] No UI changes included
- [x] No persistence schema changes unrelated to provider calls
- [ ] No reliability/idempotency system implemented

Scope note:
Merged PR #216 introduced minimal outbound replay-key / replay-ledger support for request safety, so the implementation is not purely free of idempotency mechanics even though it did not introduce the full CS-005 subsystem.

---

# Architecture Compliance

Confirm the provider adapter respects the ADR boundaries.

- [x] Provider interface lives under `/domains/communication/telephony`
- [x] Telnyx adapter lives under `/infrastructure/communications/telnyx`
- [ ] No Telnyx imports appear under `/apps`
- [x] No Telnyx imports appear under `/domains/communication/bridge`
- [x] Provider events are translated before entering the domain

If any deviation occurred explain it here.

Deviations recorded in the verification artifact:
- `apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts` imports `createTelnyxAdapter` directly from infrastructure.
- app-layer webhook/correlation handling still references Telnyx-specific field names in `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` and `apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts`.

---

# Provider Interface Contract

Confirm the adapter implements the provider contract.

- [x] startOutboundCall implemented
- [x] startBridgeSession implemented
- [ ] endCall implemented (if part of spec)
- [x] call status mapping implemented
- [x] error mapping implemented

Describe the provider interface:

The shared contract is defined in `domains/communication/telephony/index.ts` and exported through `domains/communication/index.ts`. The Telnyx adapter implements `sendSms`, `startOutboundCall`, `startBridgeSession`, `verifyWebhook`, and `translateProviderEvent`. `endCall` remains deferred because CS-003 did not require live hangup support.

---

# Provider Event Translation

Provider webhooks or events must be translated into domain events.

Confirm:

- [x] Telnyx webhook/event parsing implemented
- [x] provider payload translated to internal event types
- [x] raw provider payloads do not leak into domain logic

Example translated events:

- `CallAttemptStarted`
- `CallAnswered`
- `CallConnected`
- `MessageDelivered`

Describe the translation layer:

`infrastructure/communications/telnyx/index.ts` verifies Telnyx Ed25519 webhook signatures, enforces a replay window, normalizes raw event names into internal event types, and strips provider-specific keys from translated payloads before returning provider-neutral events.

---

# Adapter Isolation

Confirm Telnyx logic is isolated.

- [ ] Telnyx request shapes exist only inside adapter
- [x] Domain logic does not depend on Telnyx SDK types
- [x] Adapter depends on domain interface, not the reverse

Files touched:

Verification artifact added by this PR:
- `specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md`

Key CS-003 implementation files assessed:
- `domains/communication/telephony/index.ts`
- `domains/communication/telephony/__tests__/index.test.ts`
- `domains/communication/index.ts`
- `infrastructure/communications/telnyx/index.ts`
- `infrastructure/communications/telnyx/__tests__/index.test.ts`
- `apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts`
- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`

---

# Error Handling

Confirm provider errors are normalized.

- [x] provider errors mapped to internal failure codes
- [ ] retryable vs non-retryable errors identified
- [x] adapter does not throw raw Telnyx errors upstream

Describe error handling strategy:

The adapter converts configuration, HTTP, JSON, and webhook-signature failures into normalized adapter-level errors or provider-neutral refusal codes. Application routes then normalize provider dispatch failures into internal codes such as `CONNECTSHYFT_PROVIDER_DISPATCH_FAILED`, while policy violations surface as `ConnectShyftProviderDispatchPolicyError`. The current implementation does not classify retryable vs non-retryable provider failures.

---

# Tests

- [x] adapter unit tests
- [x] provider payload translation tests
- [x] error mapping tests
- [x] interface contract tests

Test notes:

Executed on March 12, 2026:
- `apps/connectshyft-api`: `npm run build` passed
- repo root: `node scripts/enforce-workspace-boundaries.js` passed
- focused CS-003 Jest validation passed: `4` suites, `31` tests

Focused Jest command used:

```bash
cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
node /Users/jeremiahotis/projects/connectshyft/node_modules/.pnpm/jest@29.7.0_@types+node@20.19.37_babel-plugin-macros@3.1.0_ts-node@10.9.2_@types+node@20.19.37_typescript@5.9.3_/node_modules/jest/bin/jest.js \
  --runInBand \
  --config jest.config.js \
  --runTestsByPath \
  src/modules/connectshyft/__tests__/providerRegistry.test.ts \
  src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
  ../../domains/communication/telephony/__tests__/index.test.ts \
  ../../infrastructure/communications/telnyx/__tests__/index.test.ts
```

---

# Evidence

Provide logs or examples of:

- outbound call creation
- webhook event translation
- provider error mapping

Evidence summary:

Automated evidence captured on March 12, 2026:
- outbound dispatch route coverage asserts real provider results such as `providerMessageId = telnyx-message-thread-f1-unclaimed-1001` and `providerLegId = telnyx-leg-operator-thread-f1-unclaimed-1001`
- Telnyx adapter tests assert webhook translation examples including `call.connected -> CallConnected` and `call.answered -> CallAnswered`
- webhook verification tests assert normalized refusals such as `WEBHOOK_SIGNATURE_MISSING` and `WEBHOOK_SIGNATURE_INVALID`
- route-level error normalization remains provider-neutral (`CONNECTSHYFT_PROVIDER_DISPATCH_FAILED`)

Live Telnyx sandbox calls were not rerun in this workspace because credentials/network access were not available here.

---

# Files Added / Modified

Expected examples:

- `/domains/communication/telephony/provider.ts`
- `/infrastructure/communications/telnyx/telnyxAdapter.ts`
- `/infrastructure/communications/telnyx/eventTranslator.ts`

Files touched:

This verification PR adds:
- `specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md`

The merged CS-003 implementation assessed in this PR touched:
- `apps/connectshyft-api/.env.example`
- `apps/connectshyft-api/Dockerfile.production`
- `apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts`
- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
- `domains/communication/index.ts`
- `domains/communication/telephony/index.ts`
- `domains/communication/telephony/__tests__/index.test.ts`
- `infrastructure/communications/telnyx/index.ts`
- `infrastructure/communications/telnyx/__tests__/index.test.ts`
- `specs/003-telnyx-outbound-adapter/contracts/connectshyft-outbound-dispatch.md`
- `specs/003-telnyx-outbound-adapter/contracts/telephony-provider-interface.md`
- `specs/003-telnyx-outbound-adapter/quickstart.md`

---

# Out-of-Scope Confirmation

Confirm this PR does NOT include:

- [x] bridge orchestration
- [x] session persistence logic
- [x] reliability retry systems
- [x] UI changes

Out-of-scope note:
These checks refer to merged PR #216's diff. Current `codex/dev` includes later CS-004 bridge/session work outside this verification target.

---

# Final Definition of Done

- [x] provider adapter implements telephony interface
- [x] provider events translate into internal events
- [ ] Telnyx is isolated under infrastructure
- [x] no provider coupling exists in domain or UI layers

---

# Final Statement

This verification change evaluates CS-003 against ADR-00X Communication Infrastructure Contract and the CS-003 Guardrailed Spec, and records the remaining app-layer Telnyx coupling deviations in `/specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md`.
