### PR TITLE
Fix: CS-003a Telnyx adapter boundary remediation

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts
@@ -32,9 +32,24 @@ const startBridgeSessionMock = jest.fn(async (input: { bridgeSessionId: string }
   requestedAt: '2026-03-11T12:05:00.000Z',
 }))
 const verifyWebhookMock = jest.fn(() => ({ ok: true as const }))
+const endCallMock = jest.fn(async (input: { providerLegId: string }) => ({
+  providerKey: 'telnyx',
+  providerLegId: input.providerLegId,
+  ended: true as const,
+  providerRequestId: 'req-end-call-1001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:07:00.000Z',
+}))
 const translateProviderEventMock = jest.fn(({ rawEventType, payload }: { rawEventType: string; payload: unknown }) => ({
   eventType: rawEventType,
   payload: (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>,
+  correlation: {
+    providerLegId: null,
+    providerMessageId: null,
+    providerEventId: null,
+    providerNumber: null,
+  },
   providerNeutral: true as const,
   providerSpecificFieldsStripped: true as const,
   providerBranchingInDomain: false as const,
@@ -49,6 +64,7 @@ const providerAdapter: ConnectShyftProviderAdapter = {
   verifyWebhook: verifyWebhookMock,
   translateProviderEvent: translateProviderEventMock,
   startBridgeSession: startBridgeSessionMock,
+  endCall: endCallMock,
 }
 
 const baseInput = {
@@ -78,6 +94,7 @@ describe('connectshyft bridgeSessions', () => {
     startOutboundCallMock.mockReset()
     startBridgeOutboundCallMock.mockClear()
     startBridgeSessionMock.mockClear()
+    endCallMock.mockClear()
     verifyWebhookMock.mockClear()
     translateProviderEventMock.mockClear()
     resetConnectShyftBridgeSessionStateForTests()

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts
@@ -22,10 +22,10 @@ describe('connectshyft canonical event store', () => {
     const payload = sanitizeConnectShyftCanonicalPayload({
       threadState: 'UNCLAIMED',
       providerPayload: {
-        telnyxCallControlId: 'telnyx-123',
+        providerLegId: 'provider-leg-hidden',
       },
       nested: {
-        twilioCallSid: 'twilio-123',
+        providerMessageId: 'provider-message-hidden',
         keep: true,
       },
       providerLegId: 'provider-leg-1001',
@@ -59,7 +59,7 @@ describe('connectshyft canonical event store', () => {
       payload: {
         direction: 'inbound',
         channel: 'voice',
-        telnyxCallControlId: 'telnyx-hidden',
+        providerLegId: 'provider-leg-hidden',
       },
       occurredAtUtc: '2026-02-28T09:00:02.000Z',
     });

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts
@@ -412,8 +412,27 @@ describe('connectshyft provider registry', () => {
     ).toEqual({
       eventType: 'CallConnected',
       payload: {},
+      correlation: {
+        providerLegId: null,
+        providerMessageId: null,
+        providerEventId: null,
+        providerNumber: null,
+      },
       providerNeutral: true,
       providerSpecificFieldsStripped: true,
+      providerBranchingInDomain: false,
+    });
+
+    await expect(
+      result.adapter.endCall({
+        providerKey: 'mock-sandbox',
+        providerLegId: 'mock-sandbox-call-leg-thread-f1-unclaimed-1001',
+      }),
+    ).resolves.toMatchObject({
+      providerKey: 'mock-sandbox',
+      providerLegId: 'mock-sandbox-call-leg-thread-f1-unclaimed-1001',
+      ended: true,
+      adapterInvoked: true,
       providerBranchingInDomain: false,
     });
   });

--- a/apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts
@@ -46,16 +46,14 @@ export type ConnectShyftCanonicalEventListFilters = {
 };
 
 const CONNECTSHYFT_PROVIDER_SPECIFIC_KEYS = new Set([
-  'twilioCallSid',
-  'telnyxCallControlId',
   'providerLegId',
   'providerMessageId',
   'providerPayload',
   'providerName',
   'providerKey',
   'providerEventId',
+  'providerNumber',
   'providerNumberE164',
-  'twilioNumberE164',
 ]);
 
 const inMemoryCanonicalEvents: ConnectShyftStoredCanonicalEvent[] = [];
@@ -118,8 +116,7 @@ const sanitizePayloadValue = (value: unknown): unknown => {
   Object.entries(value as Record<string, unknown>).forEach(([key, entryValue]) => {
     if (
       CONNECTSHYFT_PROVIDER_SPECIFIC_KEYS.has(key)
-      || key.toLowerCase().startsWith('twilio')
-      || key.toLowerCase().startsWith('telnyx')
+      || key.toLowerCase().startsWith('provider')
     ) {
       return;
     }

--- a/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts
@@ -1,6 +1,8 @@
 import {
   assertValidCallDispatchResult,
+  assertValidEndCallResult,
   assertValidSmsDispatchResult,
+  type TelephonyEndCallResult,
   type TelephonyDispatchResult,
   type TelephonyOutboundCallPolicy,
   type TelephonyProviderAdapter,
@@ -8,7 +10,7 @@ import {
   type TelephonyWebhookVerificationInput,
   type TelephonyWebhookVerificationResult,
 } from '../../../../../domains/communication';
-import { createTelnyxAdapter } from '../../../../../infrastructure/communications/telnyx';
+import { resolveTelephonyProviderAdapter } from '../../../../../infrastructure/communications';
 import { isConnectShyftTestOverrideEnabled } from './featureFlags';
 
 const DEFAULT_ENABLED_PROVIDERS = ['telnyx'];
@@ -685,6 +687,15 @@ const buildMockSandboxAdapter = (
       providerBranchingInDomain: false,
     };
   },
+  async endCall(command): Promise<TelephonyEndCallResult> {
+    return assertValidEndCallResult({
+      providerKey,
+      providerLegId: command.providerLegId,
+      ended: true,
+      adapterInvoked: true,
+      providerBranchingInDomain: false,
+    });
+  },
   verifyWebhook(input) {
     if (input.verification?.enforceValidation === false) {
       return { ok: true };
@@ -695,6 +706,12 @@ const buildMockSandboxAdapter = (
     return {
       eventType: toCanonicalEventType(rawEventType),
       payload: payloadToRecord(payload),
+      correlation: {
+        providerLegId: null,
+        providerMessageId: null,
+        providerEventId: null,
+        providerNumber: null,
+      },
       providerNeutral: true,
       providerSpecificFieldsStripped: true,
       providerBranchingInDomain: false,
@@ -780,20 +797,20 @@ const createGuardrailedAdapter = (
 
     return baseAdapter.startBridgeSession(command);
   },
+  async endCall(command) {
+    return baseAdapter.endCall(command);
+  },
 });
 
 const resolveProviderAdapter = (
   providerKey: string,
 ): ConnectShyftProviderAdapter | null => {
-  if (providerKey === 'telnyx') {
-    return createGuardrailedAdapter(createTelnyxAdapter());
-  }
-
   if (providerKey === 'mock-sandbox') {
     return createGuardrailedAdapter(buildMockSandboxAdapter(providerKey));
   }
 
-  return null;
+  const baseAdapter = resolveTelephonyProviderAdapter(providerKey);
+  return baseAdapter ? createGuardrailedAdapter(baseAdapter) : null;
 };
 
 export const resolveConnectShyftRequestedProviderKey = (

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
@@ -8,6 +8,27 @@ const toCanonicalEventType = (rawEventType: string): string => rawEventType
   .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : ''))
   .join('')
 
+const toProviderCorrelation = (payload: unknown) => {
+  const source = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {}
+
+  return {
+    providerLegId: typeof source.provider_leg_id === 'string'
+      ? source.provider_leg_id
+      : (typeof source.providerLegId === 'string' ? source.providerLegId : null),
+    providerMessageId: typeof source.provider_message_id === 'string'
+      ? source.provider_message_id
+      : (typeof source.providerMessageId === 'string' ? source.providerMessageId : null),
+    providerEventId: typeof source.provider_event_id === 'string'
+      ? source.provider_event_id
+      : (typeof source.providerEventId === 'string' ? source.providerEventId : null),
+    providerNumber: typeof source.to === 'string'
+      ? source.to
+      : (typeof source.to_number === 'string' ? source.to_number : null),
+  }
+}
+
 const sendSmsMock = jest.fn()
 const startOutboundCallMock = jest.fn(async (command: { threadId: string; targetPhone?: string }) => ({
   providerKey: 'telnyx',
@@ -35,21 +56,32 @@ const startBridgeSessionMock = jest.fn(async (command: {
   requestedAt: '2026-03-11T12:06:00.000Z',
 }))
 const verifyWebhookMock = jest.fn(() => ({ ok: true as const }))
+const endCallMock = jest.fn(async (command: { providerLegId: string }) => ({
+  providerKey: 'telnyx',
+  providerLegId: command.providerLegId,
+  ended: true as const,
+  providerRequestId: 'req-end-call-4001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:07:00.000Z',
+}))
 const translateProviderEventMock = jest.fn(({ rawEventType, payload }: { rawEventType: string; payload: unknown }) => ({
   eventType: toCanonicalEventType(rawEventType),
   payload: (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>,
+  correlation: toProviderCorrelation(payload),
   providerNeutral: true as const,
   providerSpecificFieldsStripped: true as const,
   providerBranchingInDomain: false as const,
 }))
 
-jest.mock('../../../../../../../infrastructure/communications/telnyx', () => ({
-  createTelnyxAdapter: jest.fn(() => ({
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
     providerKey: 'telnyx',
     adapterInterfaceVersion: 'v1',
     sendSms: sendSmsMock,
     startOutboundCall: startOutboundCallMock,
     startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
     verifyWebhook: verifyWebhookMock,
     translateProviderEvent: translateProviderEventMock,
   })),
@@ -175,6 +207,7 @@ describe('connectshyft bridge webhook flow', () => {
     sendSmsMock.mockClear()
     startOutboundCallMock.mockClear()
     startBridgeSessionMock.mockClear()
+    endCallMock.mockClear()
     verifyWebhookMock.mockClear()
     translateProviderEventMock.mockClear()
     resetConnectShyftCanonicalEventsForTests()

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
@@ -1,4 +1,5 @@
 import connectShyftRouter, { resetConnectShyftOutboundDispatchReplayLedgerForTests } from '../connectshyft';
+import { TelephonyProviderFailure } from '../../../../../../../domains/communication';
 import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
 import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
 import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
@@ -7,6 +8,27 @@ const toCanonicalEventType = (rawEventType: string): string => rawEventType
   .split(/[._-]+/)
   .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : ''))
   .join('');
+
+const toProviderCorrelation = (payload: unknown) => {
+  const source = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {};
+
+  return {
+    providerLegId: typeof source.provider_leg_id === 'string'
+      ? source.provider_leg_id
+      : (typeof source.providerLegId === 'string' ? source.providerLegId : null),
+    providerMessageId: typeof source.provider_message_id === 'string'
+      ? source.provider_message_id
+      : (typeof source.providerMessageId === 'string' ? source.providerMessageId : null),
+    providerEventId: typeof source.provider_event_id === 'string'
+      ? source.provider_event_id
+      : (typeof source.providerEventId === 'string' ? source.providerEventId : null),
+    providerNumber: typeof source.to === 'string'
+      ? source.to
+      : (typeof source.to_number === 'string' ? source.to_number : null),
+  };
+};
 
 const sendSmsMock = jest.fn(async (command: { threadId: string }) => ({
   providerKey: 'telnyx',
@@ -42,21 +64,32 @@ const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string
 }));
 
 const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const endCallMock = jest.fn(async (command: { providerLegId: string }) => ({
+  providerKey: 'telnyx',
+  providerLegId: command.providerLegId,
+  ended: true as const,
+  providerRequestId: 'req-end-call-4001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:07:00.000Z',
+}));
 const translateProviderEventMock = jest.fn(({ rawEventType, payload }: { rawEventType: string; payload: unknown }) => ({
   eventType: toCanonicalEventType(rawEventType),
   payload: (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>,
+  correlation: toProviderCorrelation(payload),
   providerNeutral: true as const,
   providerSpecificFieldsStripped: true as const,
   providerBranchingInDomain: false as const,
 }));
 
-jest.mock('../../../../../../../infrastructure/communications/telnyx', () => ({
-  createTelnyxAdapter: jest.fn(() => ({
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
     providerKey: 'telnyx',
     adapterInterfaceVersion: 'v1',
     sendSms: sendSmsMock,
     startOutboundCall: startOutboundCallMock,
     startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
     verifyWebhook: verifyWebhookMock,
     translateProviderEvent: translateProviderEventMock,
   })),
@@ -183,6 +216,7 @@ describe('connectshyft outbound dispatch routes', () => {
     verifyWebhookMock.mockClear();
     translateProviderEventMock.mockClear();
     startBridgeSessionMock.mockClear();
+    endCallMock.mockClear();
     resetConnectShyftCanonicalEventsForTests();
     resetConnectShyftBridgeSessionStateForTests();
     resetConnectShyftProviderCorrelationStateForTests();
@@ -335,5 +369,43 @@ describe('connectshyft outbound dispatch routes', () => {
       code: 'CONNECTSHYFT_OPERATOR_CALLBACK_REQUIRED',
     });
     expect(startOutboundCallMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces normalized provider failure classification without changing the top-level refusal code', async () => {
+    sendSmsMock.mockRejectedValueOnce(new TelephonyProviderFailure({
+      message: 'Rate limited by provider',
+      classification: {
+        providerKey: 'telnyx',
+        category: 'temporary_provider_failure',
+        retryable: true,
+        httpStatus: 429,
+        providerCode: 'rate_limited',
+      },
+    }));
+
+    const response = await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/messages',
+      headers: buildHeaders(),
+      body: {
+        providerKey: 'telnyx',
+        body: 'Need assistance',
+        targetPhone: '+12605550111',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PROVIDER_DISPATCH_FAILED',
+      data: {
+        providerFailureClassification: {
+          providerKey: 'telnyx',
+          category: 'temporary_provider_failure',
+          retryable: true,
+          httpStatus: 429,
+          providerCode: 'rate_limited',
+        },
+      },
+    });
   });
 });

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -4,6 +4,7 @@ import type { Knex } from 'knex';
 import {
   InMemoryTelephonyDispatchLedger,
   buildTelephonyDispatchReplayKey,
+  isTelephonyProviderFailure,
 } from '../../../../../../domains/communication';
 import { refusal, success } from '../../../platform/envelopes/response';
 import { CAPABILITIES, hasCapability } from '../../../platform/rbac/capabilities';
@@ -1005,82 +1006,6 @@ const asRecord = (value: unknown): Record<string, unknown> | null => {
   return value as Record<string, unknown>;
 };
 
-const readWebhookIdentifierFromSources = (
-  sources: Array<Record<string, unknown> | null>,
-  candidates: string[],
-): string | null => {
-  for (const source of sources) {
-    if (!source) {
-      continue;
-    }
-    for (const candidate of candidates) {
-      const value = normalizeLifecycleString(source[candidate]);
-      if (value) {
-        return value;
-      }
-    }
-  }
-  return null;
-};
-
-const extractWebhookProviderIdentifiers = (body: unknown): {
-  providerLegId: string | null;
-  providerMessageId: string | null;
-  providerEventId: string | null;
-} => {
-  const payload = asRecord(body);
-  const providerPayload = asRecord(payload?.providerPayload);
-  const data = asRecord(payload?.data);
-  const dataPayload = asRecord(data?.payload);
-  const sources = [payload, providerPayload, dataPayload, data];
-
-  return {
-    providerLegId: readWebhookIdentifierFromSources(sources, [
-      'providerLegId',
-      'provider_leg_id',
-      'callControlId',
-      'call_control_id',
-      'telnyxCallControlId',
-    ]),
-    providerMessageId: readWebhookIdentifierFromSources(sources, [
-      'providerMessageId',
-      'provider_message_id',
-      'messageUuid',
-      'message_uuid',
-      'telnyxMessageId',
-      'telnyx_message_id',
-    ]),
-    providerEventId: readWebhookIdentifierFromSources(sources, [
-      'providerEventId',
-      'provider_event_id',
-      'eventId',
-      'event_id',
-      'id',
-    ]),
-  };
-};
-
-const extractWebhookProviderNumber = (body: unknown): string | null => {
-  const payload = asRecord(body);
-  const providerPayload = asRecord(payload?.providerPayload);
-  const data = asRecord(payload?.data);
-  const dataPayload = asRecord(data?.payload);
-  const sources = [payload, providerPayload, dataPayload, data];
-
-  return readWebhookIdentifierFromSources(sources, [
-    'providerNumberE164',
-    'provider_number_e164',
-    'to',
-    'toNumber',
-    'to_number',
-    'recipient',
-    'recipientNumber',
-    'recipient_number',
-    'twilioNumberE164',
-    'twilio_number_e164',
-  ]);
-};
-
 const normalizeRoutingSlug = (value: string): string => {
   const normalized = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   return normalized || 'unknown';
@@ -1184,14 +1109,24 @@ const resolveWebhookCorrelationFailure = (
 const resolveInboundWebhookCorrelation = async (input: {
   body: unknown;
   providerName: string;
+  providerCorrelation: {
+    providerLegId: string | null;
+    providerMessageId: string | null;
+    providerEventId: string | null;
+    providerNumber: string | null;
+  };
   tenantIdHint?: string | null;
 }): Promise<ConnectShyftResolvedWebhookCorrelation> => {
   const payload = asRecord(input.body);
   const tenantId = normalizeLifecycleString(payload?.tenantId);
   const orgUnitId = normalizeLifecycleString(payload?.orgUnitId);
   const threadId = normalizeLifecycleString(payload?.threadId);
-  const providerIdentifiers = extractWebhookProviderIdentifiers(input.body);
-  const providerNumberE164 = extractWebhookProviderNumber(input.body);
+  const providerIdentifiers = {
+    providerLegId: normalizeLifecycleString(input.providerCorrelation.providerLegId),
+    providerMessageId: normalizeLifecycleString(input.providerCorrelation.providerMessageId),
+    providerEventId: normalizeLifecycleString(input.providerCorrelation.providerEventId),
+  };
+  const providerNumberE164 = normalizeLifecycleString(input.providerCorrelation.providerNumber);
   const tenantScopeHint = normalizeLifecycleString(input.tenantIdHint || null);
   const numberMappingTenantScope = tenantId
     || (tenantScopeHint.toLowerCase() !== 'public' ? tenantScopeHint : '')
@@ -6646,6 +6581,9 @@ const performOutboundAction = async (
           lifecycleMutationApplied,
           auditPersisted: Boolean(persistedSmsOverride),
         },
+        providerFailureClassification: isTelephonyProviderFailure(error)
+          ? error.classification
+          : null,
         error: error instanceof Error ? error.message : 'unknown-provider-dispatch-error',
         ...buildReopenLifecycleData(),
       },
@@ -6999,6 +6937,7 @@ const handleInboundWebhook = async (
   const correlation = await resolveInboundWebhookCorrelation({
     body: req.body,
     providerName: providerSelection.providerResolution.resolvedProvider,
+    providerCorrelation: canonicalTranslation.correlation,
     tenantIdHint: req.tenantId || null,
   });
   if (!correlation.ok) {
@@ -7722,10 +7661,10 @@ const handleInboundWebhook = async (
         neighborId,
         actorUserId,
         lastInboundCsNumberId: `sms-inbound:${normalizeRoutingSlug(
-          correlation.providerNumberE164 || extractWebhookProviderNumber(req.body) || neighborId,
+          correlation.providerNumberE164 || canonicalTranslation.correlation.providerNumber || neighborId,
         )}`,
         preferredOutboundCsNumberId: `sms-outbound:${normalizeRoutingSlug(
-          extractWebhookProviderNumber(req.body) || neighborId,
+          canonicalTranslation.correlation.providerNumber || neighborId,
         )}`,
         eventType: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.inboundSmsAppended,
         buildCanonicalPayload: (threadState) => buildConnectShyftInboundSmsCanonicalPayload({

--- a/domains/communication/telephony/index.ts
+++ b/domains/communication/telephony/index.ts
@@ -58,6 +58,22 @@ export type TelephonyStartBridgeSessionResult = {
   requestedAt?: string
 }
 
+export type TelephonyEndCallCommand = {
+  providerKey: string
+  providerLegId: string
+  idempotencyKey?: string
+}
+
+export type TelephonyEndCallResult = {
+  providerKey: string
+  providerLegId: string
+  ended: true
+  providerRequestId?: string | null
+  adapterInvoked: true
+  providerBranchingInDomain: false
+  requestedAt?: string
+}
+
 export type TelephonyDispatchResult = {
   providerKey: string
   channel: TelephonyDispatchChannel
@@ -102,13 +118,52 @@ export type TelephonyProviderEventTranslationInput = {
   payload: unknown
 }
 
+export type TelephonyProviderEventCorrelation = {
+  providerLegId: string | null
+  providerMessageId: string | null
+  providerEventId: string | null
+  providerNumber: string | null
+}
+
 export type TelephonyProviderEvent = {
   eventType: string
   payload: Record<string, unknown>
+  correlation: TelephonyProviderEventCorrelation
   providerNeutral: true
   providerSpecificFieldsStripped: true
   providerBranchingInDomain: false
 }
+
+export type TelephonyProviderFailureCategory =
+  | 'auth_configuration'
+  | 'temporary_provider_failure'
+  | 'invalid_request'
+  | 'unknown_provider_failure'
+
+export type TelephonyProviderFailureClassification = {
+  providerKey: string
+  category: TelephonyProviderFailureCategory
+  retryable: boolean
+  httpStatus: number | null
+  providerCode: string | null
+}
+
+export class TelephonyProviderFailure extends Error {
+  readonly classification: TelephonyProviderFailureClassification
+
+  constructor(input: {
+    message: string
+    classification: TelephonyProviderFailureClassification
+  }) {
+    super(input.message)
+    this.name = 'TelephonyProviderFailure'
+    this.classification = input.classification
+  }
+}
+
+export const isTelephonyProviderFailure = (
+  error: unknown,
+): error is TelephonyProviderFailure => error instanceof TelephonyProviderFailure
 
 export interface TelephonyProviderAdapter {
   providerKey: string
@@ -123,7 +178,7 @@ export interface TelephonyProviderAdapter {
   startBridgeSession?: (
     command: TelephonyStartBridgeSessionCommand,
   ) => Promise<TelephonyStartBridgeSessionResult>
-  endCall?: (command: unknown) => Promise<unknown>
+  endCall(command: TelephonyEndCallCommand): Promise<TelephonyEndCallResult>
 }
 
 export type TelephonyDispatchReplayKeyInput = {
@@ -226,6 +281,18 @@ const normalizeDispatchResult = (
   requestedAt: normalizeString(result.requestedAt) || undefined,
 })
 
+const normalizeEndCallResult = (
+  result: TelephonyEndCallResult,
+): TelephonyEndCallResult => ({
+  providerKey: normalizeString(result.providerKey).toLowerCase(),
+  providerLegId: normalizeString(result.providerLegId),
+  ended: true,
+  providerRequestId: normalizeString(result.providerRequestId) || null,
+  adapterInvoked: true,
+  providerBranchingInDomain: false,
+  requestedAt: normalizeString(result.requestedAt) || undefined,
+})
+
 export const assertValidSmsDispatchResult = (
   result: TelephonyDispatchResult,
 ): TelephonyDispatchResult => {
@@ -267,6 +334,22 @@ export const assertValidCallDispatchResult = (
 
   if (normalized.providerMessageId) {
     throw new Error('Call dispatch results must not include providerMessageId.')
+  }
+
+  return normalized
+}
+
+export const assertValidEndCallResult = (
+  result: TelephonyEndCallResult,
+): TelephonyEndCallResult => {
+  const normalized = normalizeEndCallResult(result)
+
+  if (!normalized.providerKey) {
+    throw new Error('End-call results require providerKey.')
+  }
+
+  if (!normalized.providerLegId) {
+    throw new Error('End-call results require providerLegId.')
   }
 
   return normalized

--- a/infrastructure/communications/index.ts
+++ b/infrastructure/communications/index.ts
@@ -1,0 +1,12 @@
+import type { TelephonyProviderAdapter } from '../../domains/communication'
+import { createTelnyxAdapter } from './telnyx'
+
+export const resolveTelephonyProviderAdapter = (
+  providerKey: string,
+): TelephonyProviderAdapter | null => {
+  if (providerKey === 'telnyx') {
+    return createTelnyxAdapter()
+  }
+
+  return null
+}

--- a/infrastructure/communications/index.ts
+++ b/infrastructure/communications/index.ts
@@ -1,12 +1,36 @@
 import type { TelephonyProviderAdapter } from '../../domains/communication'
-import { createTelnyxAdapter } from './telnyx'
+
+type TelephonyProviderModule = {
+  createTelephonyProviderAdapter?: () => TelephonyProviderAdapter
+}
+
+const loadProviderModule = (providerKey: string): TelephonyProviderModule | null => {
+  try {
+    return require(`./${providerKey}`) as TelephonyProviderModule
+  } catch (error) {
+    if (
+      error
+      && typeof error === 'object'
+      && 'code' in error
+      && error.code === 'MODULE_NOT_FOUND'
+      && 'message' in error
+      && typeof error.message === 'string'
+      && error.message.includes(`'./${providerKey}'`)
+    ) {
+      return null
+    }
+
+    throw error
+  }
+}
 
 export const resolveTelephonyProviderAdapter = (
   providerKey: string,
 ): TelephonyProviderAdapter | null => {
-  if (providerKey === 'telnyx') {
-    return createTelnyxAdapter()
+  const providerModule = loadProviderModule(providerKey)
+  if (!providerModule || typeof providerModule.createTelephonyProviderAdapter !== 'function') {
+    return null
   }
 
-  return null
+  return providerModule.createTelephonyProviderAdapter()
 }

--- a/infrastructure/communications/telnyx/__tests__/index.test.ts
+++ b/infrastructure/communications/telnyx/__tests__/index.test.ts
@@ -191,6 +191,59 @@ describe('Telnyx adapter', () => {
     })
   })
 
+  it('ends active calls through the Telnyx hangup endpoint', async () => {
+    const fetchMock: jest.MockedFunction<typeof fetch> = jest.fn()
+    fetchMock.mockResolvedValue(
+      buildResponse(
+        {
+          data: {
+            result: 'ok',
+          },
+        },
+        {
+          headers: {
+            'x-request-id': 'req-hangup-4001',
+          },
+        },
+      ),
+    )
+
+    const adapter = createTelnyxAdapter({
+      apiKey: 'telnyx-test-key',
+      fetchImpl: fetchMock,
+      now: () => Date.parse('2026-03-11T12:07:00.000Z'),
+    })
+
+    const result = await adapter.endCall({
+      providerKey: 'telnyx',
+      providerLegId: 'telnyx-control-2001',
+      idempotencyKey: 'idem-hangup-001',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.telnyx.com/v2/calls/telnyx-control-2001/actions/hangup',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer telnyx-test-key',
+          'Idempotency-Key': 'idem-hangup-001',
+        }),
+      }),
+    )
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
+      command_id: 'idem-hangup-001',
+    })
+    expect(result).toEqual({
+      providerKey: 'telnyx',
+      providerLegId: 'telnyx-control-2001',
+      ended: true,
+      providerRequestId: 'req-hangup-4001',
+      adapterInvoked: true,
+      providerBranchingInDomain: false,
+      requestedAt: '2026-03-11T12:07:00.000Z',
+    })
+  })
+
   it('fails deterministically when TELNYX_API_KEY is missing', async () => {
     const adapter = createTelnyxAdapter({
       fromNumber: '+12605550199',
@@ -206,7 +259,16 @@ describe('Telnyx adapter', () => {
         body: 'Need assistance',
         targetPhone: '+12605550111',
       }),
-    ).rejects.toThrow('TELNYX_API_KEY is required for real Telnyx dispatch.')
+    ).rejects.toMatchObject({
+      message: 'TELNYX_API_KEY is required for real Telnyx dispatch.',
+      classification: {
+        providerKey: 'telnyx',
+        category: 'auth_configuration',
+        retryable: false,
+        httpStatus: null,
+        providerCode: null,
+      },
+    })
   })
 
   it('verifies Telnyx webhook signatures with Ed25519 public keys', () => {
@@ -272,6 +334,149 @@ describe('Telnyx adapter', () => {
     })
   })
 
+  it.each([
+    {
+      status: 400,
+      expectedCategory: 'invalid_request',
+      expectedRetryable: false,
+    },
+    {
+      status: 401,
+      expectedCategory: 'auth_configuration',
+      expectedRetryable: false,
+    },
+    {
+      status: 403,
+      expectedCategory: 'auth_configuration',
+      expectedRetryable: false,
+    },
+    {
+      status: 429,
+      expectedCategory: 'temporary_provider_failure',
+      expectedRetryable: true,
+    },
+    {
+      status: 503,
+      expectedCategory: 'temporary_provider_failure',
+      expectedRetryable: true,
+    },
+  ])(
+    'classifies Telnyx HTTP failures for status $status',
+    async ({ status, expectedCategory, expectedRetryable }) => {
+      const fetchMock: jest.MockedFunction<typeof fetch> = jest.fn()
+      fetchMock.mockResolvedValue(
+        buildResponse(
+          {
+            errors: [
+              {
+                code: `telnyx-${status}`,
+                detail: `failure-${status}`,
+              },
+            ],
+          },
+          {
+            status,
+          },
+        ),
+      )
+
+      const adapter = createTelnyxAdapter({
+        apiKey: 'telnyx-test-key',
+        fromNumber: '+12605550199',
+        fetchImpl: fetchMock,
+      })
+
+      await expect(
+        adapter.sendSms({
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          threadId: 'thread-f1-unclaimed-1001',
+          providerKey: 'telnyx',
+          body: 'Need assistance',
+          targetPhone: '+12605550111',
+        }),
+      ).rejects.toMatchObject({
+        message: `failure-${status}`,
+        classification: {
+          providerKey: 'telnyx',
+          category: expectedCategory,
+          retryable: expectedRetryable,
+          httpStatus: status,
+          providerCode: `telnyx-${status}`,
+        },
+      })
+    },
+  )
+
+  it('classifies transport failures as temporary provider failures', async () => {
+    const fetchMock: jest.MockedFunction<typeof fetch> = jest.fn()
+    fetchMock.mockRejectedValue(new Error('socket hang up'))
+
+    const adapter = createTelnyxAdapter({
+      apiKey: 'telnyx-test-key',
+      fromNumber: '+12605550199',
+      fetchImpl: fetchMock,
+    })
+
+    await expect(
+      adapter.sendSms({
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        providerKey: 'telnyx',
+        body: 'Need assistance',
+        targetPhone: '+12605550111',
+      }),
+    ).rejects.toMatchObject({
+      message: 'socket hang up',
+      classification: {
+        providerKey: 'telnyx',
+        category: 'temporary_provider_failure',
+        retryable: true,
+        httpStatus: null,
+        providerCode: null,
+      },
+    })
+  })
+
+  it('classifies invalid JSON responses as unknown provider failures', async () => {
+    const fetchMock: jest.MockedFunction<typeof fetch> = jest.fn()
+    fetchMock.mockResolvedValue(
+      new Response('not-json', {
+        status: 502,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    )
+
+    const adapter = createTelnyxAdapter({
+      apiKey: 'telnyx-test-key',
+      fromNumber: '+12605550199',
+      fetchImpl: fetchMock,
+    })
+
+    await expect(
+      adapter.sendSms({
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-f1-unclaimed-1001',
+        providerKey: 'telnyx',
+        body: 'Need assistance',
+        targetPhone: '+12605550111',
+      }),
+    ).rejects.toMatchObject({
+      message: 'Telnyx response was not valid JSON (status 502).',
+      classification: {
+        providerKey: 'telnyx',
+        category: 'unknown_provider_failure',
+        retryable: false,
+        httpStatus: 502,
+        providerCode: null,
+      },
+    })
+  })
+
   it('translates provider events into sanitized provider-neutral payloads', () => {
     const adapter = createTelnyxAdapter({
       apiKey: 'telnyx-test-key',
@@ -281,10 +486,12 @@ describe('Telnyx adapter', () => {
       adapter.translateProviderEvent({
         rawEventType: 'call.connected',
         payload: {
-          eventType: 'call.connected',
-          telnyxCallControlId: 'telnyx-raw-001',
-          providerPayload: {
-            call_control_id: 'telnyx-raw-001',
+          data: {
+            id: 'evt-1001',
+            payload: {
+              call_control_id: 'telnyx-raw-001',
+              to: '+12605550199',
+            },
           },
           delivery: {
             status: 'connected',
@@ -294,10 +501,15 @@ describe('Telnyx adapter', () => {
     ).toEqual({
       eventType: 'CallConnected',
       payload: {
-        eventType: 'call.connected',
         delivery: {
           status: 'connected',
         },
+      },
+      correlation: {
+        providerLegId: 'telnyx-raw-001',
+        providerMessageId: null,
+        providerEventId: 'evt-1001',
+        providerNumber: '+12605550199',
       },
       providerNeutral: true,
       providerSpecificFieldsStripped: true,
@@ -314,10 +526,14 @@ describe('Telnyx adapter', () => {
       adapter.translateProviderEvent({
         rawEventType: 'call.answered',
         payload: {
-          call_control_id: 'telnyx-control-operator-1001',
-          call_leg_id: 'telnyx-leg-operator-1001',
-          eventType: 'call.answered',
-          call_session_id: 'telnyx-session-1001',
+          data: {
+            id: 'evt-1002',
+            payload: {
+              call_control_id: 'telnyx-control-operator-1001',
+              call_leg_id: 'telnyx-leg-operator-1001',
+              call_session_id: 'telnyx-session-1001',
+            },
+          },
           occurrence: {
             leg: 'operator',
           },
@@ -326,10 +542,15 @@ describe('Telnyx adapter', () => {
     ).toEqual({
       eventType: 'CallAnswered',
       payload: {
-        eventType: 'call.answered',
         occurrence: {
           leg: 'operator',
         },
+      },
+      correlation: {
+        providerLegId: 'telnyx-control-operator-1001',
+        providerMessageId: null,
+        providerEventId: 'evt-1002',
+        providerNumber: null,
       },
       providerNeutral: true,
       providerSpecificFieldsStripped: true,

--- a/infrastructure/communications/telnyx/index.ts
+++ b/infrastructure/communications/telnyx/index.ts
@@ -1,11 +1,17 @@
 import { createPublicKey, verify } from 'node:crypto'
 import {
   assertValidCallDispatchResult,
+  assertValidEndCallResult,
   assertValidSmsDispatchResult,
   type TelephonyDispatchResult,
+  type TelephonyEndCallCommand,
+  type TelephonyEndCallResult,
+  type TelephonyProviderEventCorrelation,
   type TelephonyProviderAdapter,
+  type TelephonyProviderFailureCategory,
   type TelephonyProviderEvent,
   type TelephonyProviderEventTranslationInput,
+  TelephonyProviderFailure,
   type TelephonySendSmsCommand,
   type TelephonyStartBridgeOutboundCallCommand,
   type TelephonyStartBridgeSessionCommand,
@@ -21,6 +27,9 @@ const DEFAULT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS = 300
 const TELNYX_SIGNATURE_HEADER = 'telnyx-signature-ed25519'
 const TELNYX_TIMESTAMP_HEADER = 'telnyx-timestamp'
 const PROVIDER_SPECIFIC_KEYS = new Set([
+  'id',
+  'from',
+  'to',
   'providerKey',
   'providerName',
   'providerMessageId',
@@ -56,6 +65,11 @@ type TelnyxDispatchResponseBody = {
     call_leg_id?: unknown
     call_control_id?: unknown
   }
+  errors?: Array<{
+    code?: unknown
+    title?: unknown
+    detail?: unknown
+  }>
 }
 
 const normalizeString = (value: unknown): string => {
@@ -72,6 +86,22 @@ const normalizePayloadRecord = (payload: unknown): Record<string, unknown> => {
   }
 
   return payload as Record<string, unknown>
+}
+
+const readStringFromPayloadSources = (
+  sources: Array<Record<string, unknown>>,
+  candidates: string[],
+): string | null => {
+  for (const source of sources) {
+    for (const candidate of candidates) {
+      const value = normalizeString(source[candidate])
+      if (value) {
+        return value
+      }
+    }
+  }
+
+  return null
 }
 
 const sanitizePayloadValue = (value: unknown): unknown => {
@@ -95,7 +125,17 @@ const sanitizePayloadValue = (value: unknown): unknown => {
       return
     }
 
-    sanitized[key] = sanitizePayloadValue(entry)
+    const sanitizedEntry = sanitizePayloadValue(entry)
+    if (
+      sanitizedEntry
+      && typeof sanitizedEntry === 'object'
+      && !Array.isArray(sanitizedEntry)
+      && Object.keys(sanitizedEntry as Record<string, unknown>).length === 0
+    ) {
+      return
+    }
+
+    sanitized[key] = sanitizedEntry
   })
 
   return sanitized
@@ -238,7 +278,11 @@ const toCanonicalEventType = (rawEventType: string): string => {
 const resolveFetch = (fetchImpl?: typeof globalThis.fetch): typeof globalThis.fetch => {
   const resolved = fetchImpl ?? globalThis.fetch
   if (typeof resolved !== 'function') {
-    throw new Error('Global fetch is unavailable for the Telnyx adapter.')
+    throw buildTelnyxProviderFailure({
+      message: 'Global fetch is unavailable for the Telnyx adapter.',
+      category: 'auth_configuration',
+      retryable: false,
+    })
   }
 
   return resolved
@@ -281,14 +325,32 @@ const parseJsonResponse = async (response: Response): Promise<TelnyxDispatchResp
   try {
     return JSON.parse(bodyText) as TelnyxDispatchResponseBody
   } catch (_error) {
-    throw new Error(`Telnyx response was not valid JSON (status ${response.status}).`)
+    throw new TelephonyProviderFailure({
+      message: `Telnyx response was not valid JSON (status ${response.status}).`,
+      classification: {
+        providerKey: 'telnyx',
+        category: 'unknown_provider_failure',
+        retryable: false,
+        httpStatus: response.status,
+        providerCode: null,
+      },
+    })
   }
 }
 
 const assertConfiguredTargetPhone = (targetPhone: string | undefined): string => {
   const resolved = normalizeString(targetPhone)
   if (!resolved) {
-    throw new Error('Telnyx dispatch requires targetPhone for provider-backed delivery.')
+    throw new TelephonyProviderFailure({
+      message: 'Telnyx dispatch requires targetPhone for provider-backed delivery.',
+      classification: {
+        providerKey: 'telnyx',
+        category: 'invalid_request',
+        retryable: false,
+        httpStatus: null,
+        providerCode: null,
+      },
+    })
   }
 
   return resolved
@@ -300,7 +362,16 @@ const buildSmsPayload = (
 ): Record<string, unknown> => {
   const text = normalizeString(command.body)
   if (!text) {
-    throw new Error('Telnyx SMS dispatch requires a non-empty body.')
+    throw new TelephonyProviderFailure({
+      message: 'Telnyx SMS dispatch requires a non-empty body.',
+      classification: {
+        providerKey: 'telnyx',
+        category: 'invalid_request',
+        retryable: false,
+        httpStatus: null,
+        providerCode: null,
+      },
+    })
   }
 
   const payload: Record<string, unknown> = {
@@ -318,7 +389,16 @@ const buildSmsPayload = (
     return payload
   }
 
-  throw new Error('Set TELNYX_FROM_NUMBER or TELNYX_MESSAGING_PROFILE_ID for Telnyx SMS dispatch.')
+  throw new TelephonyProviderFailure({
+    message: 'Set TELNYX_FROM_NUMBER or TELNYX_MESSAGING_PROFILE_ID for Telnyx SMS dispatch.',
+    classification: {
+      providerKey: 'telnyx',
+      category: 'auth_configuration',
+      retryable: false,
+      httpStatus: null,
+      providerCode: null,
+    },
+  })
 }
 
 const buildOutboundCallPayload = (
@@ -326,11 +406,29 @@ const buildOutboundCallPayload = (
   command: TelephonyStartOutboundCallCommand | TelephonyStartBridgeOutboundCallCommand,
 ): Record<string, unknown> => {
   if (!config.connectionId) {
-    throw new Error('Set TELNYX_CONNECTION_ID for Telnyx outbound call initiation.')
+    throw new TelephonyProviderFailure({
+      message: 'Set TELNYX_CONNECTION_ID for Telnyx outbound call initiation.',
+      classification: {
+        providerKey: 'telnyx',
+        category: 'auth_configuration',
+        retryable: false,
+        httpStatus: null,
+        providerCode: null,
+      },
+    })
   }
 
   if (!config.fromNumber) {
-    throw new Error('Set TELNYX_FROM_NUMBER for Telnyx outbound call initiation.')
+    throw new TelephonyProviderFailure({
+      message: 'Set TELNYX_FROM_NUMBER for Telnyx outbound call initiation.',
+      classification: {
+        providerKey: 'telnyx',
+        category: 'auth_configuration',
+        retryable: false,
+        httpStatus: null,
+        providerCode: null,
+      },
+    })
   }
 
   return {
@@ -356,6 +454,83 @@ const buildBridgePayload = (
   return payload
 }
 
+const buildEndCallPayload = (
+  command: TelephonyEndCallCommand,
+): Record<string, unknown> => {
+  const idempotencyKey = normalizeString(command.idempotencyKey)
+  return idempotencyKey
+    ? { command_id: idempotencyKey }
+    : {}
+}
+
+const classifyTelnyxResponseFailure = (
+  response: Response,
+): {
+  category: TelephonyProviderFailureCategory
+  retryable: boolean
+} => {
+  if (response.status === 401 || response.status === 403) {
+    return {
+      category: 'auth_configuration',
+      retryable: false,
+    }
+  }
+
+  if (response.status === 429 || response.status >= 500) {
+    return {
+      category: 'temporary_provider_failure',
+      retryable: true,
+    }
+  }
+
+  if (response.status >= 400 && response.status < 500) {
+    return {
+      category: 'invalid_request',
+      retryable: false,
+    }
+  }
+
+  return {
+    category: 'unknown_provider_failure',
+    retryable: false,
+  }
+}
+
+const buildTelnyxProviderFailure = (input: {
+  message: string
+  category: TelephonyProviderFailureCategory
+  retryable: boolean
+  httpStatus?: number | null
+  providerCode?: string | null
+}): TelephonyProviderFailure => new TelephonyProviderFailure({
+  message: input.message,
+  classification: {
+    providerKey: 'telnyx',
+    category: input.category,
+    retryable: input.retryable,
+    httpStatus: input.httpStatus ?? null,
+    providerCode: normalizeString(input.providerCode) || null,
+  },
+})
+
+const extractTelnyxErrorMessage = (
+  response: Response,
+  data: TelnyxDispatchResponseBody,
+): {
+  message: string
+  providerCode: string | null
+} => {
+  const firstError = Array.isArray(data.errors) ? data.errors[0] : null
+  const providerCode = normalizeString(firstError?.code) || null
+  const detail = normalizeString(firstError?.detail)
+  const title = normalizeString(firstError?.title)
+
+  return {
+    message: detail || title || `Telnyx request failed with status ${response.status}.`,
+    providerCode,
+  }
+}
+
 const requestTelnyx = async (
   input: {
     options: TelnyxAdapterOptions
@@ -366,28 +541,77 @@ const requestTelnyx = async (
 ): Promise<{ response: Response; data: TelnyxDispatchResponseBody }> => {
   const config = resolveConfig(input.options)
   if (!config.apiKey) {
-    throw new Error('TELNYX_API_KEY is required for real Telnyx dispatch.')
+    throw buildTelnyxProviderFailure({
+      message: 'TELNYX_API_KEY is required for real Telnyx dispatch.',
+      category: 'auth_configuration',
+      retryable: false,
+    })
   }
 
   const fetchImpl = resolveFetch(input.options.fetchImpl)
-  const response = await fetchImpl(`${config.apiBaseUrl}${input.path}`, {
-    method: 'POST',
-    headers: buildRequestHeaders({
-      apiKey: config.apiKey,
-      idempotencyKey: input.idempotencyKey,
-    }),
-    body: JSON.stringify(input.body),
-  })
+  let response: Response
+  try {
+    response = await fetchImpl(`${config.apiBaseUrl}${input.path}`, {
+      method: 'POST',
+      headers: buildRequestHeaders({
+        apiKey: config.apiKey,
+        idempotencyKey: input.idempotencyKey,
+      }),
+      body: JSON.stringify(input.body),
+    })
+  } catch (error) {
+    throw buildTelnyxProviderFailure({
+      message: error instanceof Error
+        ? error.message
+        : 'Telnyx request failed before a response was received.',
+      category: 'temporary_provider_failure',
+      retryable: true,
+    })
+  }
 
   const data = await parseJsonResponse(response)
   if (!response.ok) {
-    const errorMessage =
-      normalizeString((data.data as Record<string, unknown> | undefined)?.id)
-      || `Telnyx request failed with status ${response.status}.`
-    throw new Error(errorMessage)
+    const failure = classifyTelnyxResponseFailure(response)
+    const errorDetails = extractTelnyxErrorMessage(response, data)
+    throw buildTelnyxProviderFailure({
+      message: errorDetails.message,
+      category: failure.category,
+      retryable: failure.retryable,
+      httpStatus: response.status,
+      providerCode: errorDetails.providerCode,
+    })
   }
 
   return { response, data }
+}
+
+const extractProviderEventCorrelation = (
+  payload: unknown,
+): TelephonyProviderEventCorrelation => {
+  const normalizedPayload = normalizePayloadRecord(payload)
+  const data = normalizePayloadRecord(normalizedPayload.data)
+  const dataPayload = normalizePayloadRecord(data.payload)
+  const sources = [normalizedPayload, dataPayload, data]
+
+  return {
+    providerLegId: readStringFromPayloadSources(sources, [
+      'call_control_id',
+      'call_leg_id',
+    ]),
+    providerMessageId: readStringFromPayloadSources(sources, [
+      'message_uuid',
+      'message_id',
+    ]),
+    providerEventId: readStringFromPayloadSources(sources, [
+      'event_id',
+      'id',
+    ]),
+    providerNumber: readStringFromPayloadSources(sources, [
+      'to',
+      'to_number',
+      'toNumber',
+    ]),
+  }
 }
 
 const buildProviderEvent = (
@@ -395,6 +619,7 @@ const buildProviderEvent = (
 ): TelephonyProviderEvent => ({
   eventType: toCanonicalEventType(input.rawEventType),
   payload: sanitizePayloadValue(normalizePayloadRecord(input.payload)) as Record<string, unknown>,
+  correlation: extractProviderEventCorrelation(input.payload),
   providerNeutral: true,
   providerSpecificFieldsStripped: true,
   providerBranchingInDomain: false,
@@ -592,6 +817,25 @@ export function createTelnyxAdapter(
         providerBranchingInDomain: false,
         requestedAt: requestStartedAt,
       }
+    },
+    async endCall(command): Promise<TelephonyEndCallResult> {
+      const requestStartedAt = new Date((options.now ?? Date.now)()).toISOString()
+      const { response } = await requestTelnyx({
+        options,
+        path: `/calls/${encodeURIComponent(command.providerLegId)}/actions/hangup`,
+        body: buildEndCallPayload(command),
+        idempotencyKey: command.idempotencyKey,
+      })
+
+      return assertValidEndCallResult({
+        providerKey: 'telnyx',
+        providerLegId: command.providerLegId,
+        ended: true,
+        providerRequestId: normalizeString(response.headers.get('x-request-id')),
+        adapterInvoked: true,
+        providerBranchingInDomain: false,
+        requestedAt: requestStartedAt,
+      })
     },
     verifyWebhook(input) {
       return verifyTelnyxWebhook(input, options)

--- a/infrastructure/communications/telnyx/index.ts
+++ b/infrastructure/communications/telnyx/index.ts
@@ -845,3 +845,7 @@ export function createTelnyxAdapter(
     },
   }
 }
+
+export const createTelephonyProviderAdapter = (
+  options: TelnyxAdapterOptions = {},
+): TelephonyProviderAdapter => createTelnyxAdapter(options)

--- a/specs/003-telnyx-outbound-adapter/contracts/telephony-provider-interface.md
+++ b/specs/003-telnyx-outbound-adapter/contracts/telephony-provider-interface.md
@@ -23,6 +23,11 @@ Define the shared telephony boundary used by app code and implemented by provide
 
 - `TelephonyProviderAdapter`
 - `TelephonyDispatchResult`
+- `TelephonyEndCallCommand`
+- `TelephonyEndCallResult`
+- `TelephonyProviderEventCorrelation`
+- `TelephonyProviderFailureClassification`
+- `TelephonyProviderFailure`
 - `TelephonySendSmsCommand`
 - `TelephonyStartOutboundCallCommand`
 - `TelephonyWebhookVerificationInput`
@@ -70,6 +75,22 @@ Define the shared telephony boundary used by app code and implemented by provide
 - `adapterInvoked = true`
 - `providerBranchingInDomain = false`
 
+### `endCall(command)`
+
+**Input**
+
+- `providerKey`
+- `providerLegId`
+- optional `idempotencyKey`
+
+**Output**
+
+- `providerKey`
+- `providerLegId`
+- `ended = true`
+- `adapterInvoked = true`
+- `providerBranchingInDomain = false`
+
 ### `verifyWebhook(input)`
 
 **Input**
@@ -98,10 +119,25 @@ Define the shared telephony boundary used by app code and implemented by provide
 
 - canonical event type
 - sanitized provider-neutral payload
+- normalized correlation metadata:
+  - `providerLegId`
+  - `providerMessageId`
+  - `providerEventId`
+  - `providerNumber`
 - `providerNeutral = true`
 - `providerSpecificFieldsStripped = true`
 - `providerBranchingInDomain = false`
 
+### Provider failure classification
+
+Provider-backed dispatch failures must surface normalized classifications rather than raw vendor errors.
+
+- `auth_configuration`
+- `temporary_provider_failure`
+- `invalid_request`
+- `unknown_provider_failure`
+- `retryable`
+
 ## Deferred Surface
 
-The contract may expose `startBridgeSession(command)` and `endCall(command)` as future-compatible methods, but CS-003 only needs real implementations for SMS and outbound call initiation.
+The contract may still expose `startBridgeSession(command)` as a future-compatible method, but `endCall(command)` is now part of the concrete shared adapter surface.

--- a/specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md
+++ b/specs/003-telnyx-outbound-adapter/evidence/architectural-integrity-verification.md
@@ -1,7 +1,7 @@
 # CS-003 Architectural Integrity Verification
 
 Date: March 12, 2026
-Verification target: merged implementation PR `#216` (`Feat: implement CS-003 Telnyx outbound adapter`)
+Verification target: CS-003a remediation of merged implementation PR `#216` (`Feat: implement CS-003 Telnyx outbound adapter`)
 
 ## Scope
 
@@ -31,7 +31,10 @@ node /Users/jeremiahotis/projects/connectshyft/node_modules/.pnpm/jest@29.7.0_@t
   --config jest.config.js \
   --runTestsByPath \
   src/modules/connectshyft/__tests__/providerRegistry.test.ts \
+  src/modules/connectshyft/__tests__/canonicalEvents.test.ts \
+  src/modules/connectshyft/__tests__/bridgeSessions.test.ts \
   src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
   ../../domains/communication/telephony/__tests__/index.test.ts \
   ../../infrastructure/communications/telnyx/__tests__/index.test.ts
 ```
@@ -42,13 +45,15 @@ node /Users/jeremiahotis/projects/connectshyft/node_modules/.pnpm/jest@29.7.0_@t
 |-------|--------|-------|
 | `apps/connectshyft-api` TypeScript build | PASS | `npm run build` succeeded |
 | Workspace boundary guard | PASS | `node scripts/enforce-workspace-boundaries.js` succeeded |
-| CS-003 target Jest suites | PASS | `4` suites passed, `31` tests passed |
+| CS-003a focused Jest suites | PASS | `7` suites passed, `54` tests passed |
 | Provider interface under `domains/communication/telephony` | PASS | See `/domains/communication/telephony/index.ts` |
 | Telnyx adapter under `infrastructure/communications/telnyx` | PASS | See `/infrastructure/communications/telnyx/index.ts` |
 | No Telnyx imports under `/domains/communication/bridge` | PASS | No matches found |
 | Provider events translated before entering shared domain contracts | PASS | Telnyx adapter exposes `translateProviderEvent(...)` and returns sanitized provider-neutral events |
-| No Telnyx imports under `/apps` | FAIL | `apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts` imports `createTelnyxAdapter` directly |
-| Telnyx request/payload handling exists only inside adapter | FAIL | app-layer webhook correlation and sanitization still reference Telnyx-specific field names |
+| No Telnyx imports under `/apps` | PASS | Provider registry resolves adapters through `/infrastructure/communications/index.ts` |
+| Telnyx request/payload handling exists only inside adapter | PASS | webhook correlation normalization and provider error classification now originate in infrastructure |
+| `endCall(command)` implemented on the shared adapter surface | PASS | typed contract exists in `/domains/communication/telephony/index.ts` and Telnyx implementation exists in `/infrastructure/communications/telnyx/index.ts` |
+| Provider failures normalized above infrastructure | PASS | dispatch errors expose provider-neutral classification and retryability |
 
 ## Verified Architecture Strengths
 
@@ -62,39 +67,46 @@ node /Users/jeremiahotis/projects/connectshyft/node_modules/.pnpm/jest@29.7.0_@t
 5. Provider event translation strips provider-specific fields before returning the event object to consumers.
 6. The focused CS-003 tests cover interface assertions, adapter request/response mapping, outbound dispatch behavior, and webhook verification/translation.
 
-## Architectural Deviations
+## Remediation Summary
 
-### 1. Direct Telnyx adapter import under `/apps`
+### 1. Provider construction is no longer app-owned
 
-File:
+Current state:
 
-- `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts`
-
-Current behavior:
-
-- `providerRegistry.ts` imports `createTelnyxAdapter` directly from `/infrastructure/communications/telnyx`.
-- This makes the application layer aware of the concrete provider implementation rather than resolving it through a provider-neutral composition boundary.
+- `providerRegistry.ts` no longer imports or constructs `createTelnyxAdapter` directly.
+- app-layer provider resolution now depends on `/infrastructure/communications/index.ts`, which owns the Telnyx composition seam.
 
 Impact:
 
-- The implementation still avoids raw Telnyx request execution in app code, but the strict "no Telnyx imports under `/apps`" boundary is not satisfied.
+- the strict "no Telnyx import under `/apps`" boundary is now satisfied without changing ConnectShyft rollout/policy behavior.
 
-### 2. App-layer references to Telnyx-specific webhook/correlation field names
+### 2. Webhook correlation is now provider-neutral above infrastructure
 
-Files:
+Current state:
 
-- `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
-- `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts`
-
-Current behavior:
-
-- app-layer logic still recognizes keys such as `telnyxCallControlId`, `telnyxMessageId`, and related provider-specific webhook identifiers.
-- This means some provider-shape awareness remains outside the infrastructure adapter.
+- Telnyx-specific correlation extraction moved into infrastructure translation.
+- route-level webhook handling now consumes normalized correlation metadata from translated provider events.
+- canonical event sanitization now strips generic provider metadata only and no longer knows provider brand names.
 
 Impact:
 
-- The route/domain-adjacent application layer is still partially coupled to Telnyx payload conventions.
-- The implementation is functionally correct, but it does not fully satisfy the strongest form of adapter isolation described in the PR template.
+- app services no longer interpret Telnyx-specific webhook field names directly.
+
+### 3. `endCall` is now part of the real shared adapter contract
+
+Current state:
+
+- `/domains/communication/telephony/index.ts` now defines typed `TelephonyEndCallCommand` and `TelephonyEndCallResult`.
+- `/infrastructure/communications/telnyx/index.ts` implements the Telnyx hangup command behind that provider-neutral surface.
+- registry/guardrail layers pass the capability through unchanged.
+
+### 4. Provider failures are now normalized above infrastructure
+
+Current state:
+
+- the shared telephony contract now defines normalized provider failure categories and retryability.
+- the Telnyx adapter throws classified provider-neutral failures for config, HTTP, network, and parse failures.
+- ConnectShyft outbound refusal payloads surface that normalized classification without changing the existing top-level refusal code.
 
 ## Out-of-Scope Checks
 
@@ -107,16 +119,20 @@ Impact:
 
 ## Conclusion
 
-CS-003 is functionally verified and mostly aligned with the ADR/provider-boundary intent, but it is not perfectly isolated at the application boundary.
+CS-003a resolves the four blocking architectural deviations identified during the original CS-003 verification.
 
 Current architectural status:
 
 - Shared provider contract: compliant
 - Infrastructure adapter placement: compliant
 - Event translation and webhook verification: compliant
-- Strict app-layer provider isolation: not fully compliant
+- Strict app-layer provider isolation: compliant
+- Typed `endCall` support: compliant
+- Normalized provider failure classification: compliant
 
-Recommended follow-up:
+Follow-up status:
 
-1. Remove the direct `createTelnyxAdapter` import from `/apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts` by introducing a provider-neutral adapter registry/composition seam outside app code.
-2. Move Telnyx-specific webhook identifier extraction and sanitization fully into infrastructure translation/correlation helpers so app code only consumes canonical provider-neutral fields.
+1. Direct Telnyx imports under `/apps` are removed.
+2. App-layer Telnyx-specific correlation handling is removed.
+3. `endCall` is implemented behind the provider-neutral interface.
+4. Provider failure classification is normalized for downstream CS-005 use.

--- a/specs/connectshyft-recovery/issues/CS-003a_Telnyx_Adapter_Boundary_Remediation_Guardrailed_Spec.md
+++ b/specs/connectshyft-recovery/issues/CS-003a_Telnyx_Adapter_Boundary_Remediation_Guardrailed_Spec.md
@@ -1,0 +1,164 @@
+# CS-003a Telnyx Adapter Boundary Remediation (Guardrailed Spec)
+
+## A. Outcome
+
+Telnyx is fully isolated behind the provider-neutral telephony interface, and no provider-specific imports, field handling, deferred lifecycle gaps, or missing provider error classification remain above the infrastructure boundary.
+
+This issue is a blocking remediation issue created from CS-003 architectural verification findings.
+
+## B. Scope
+
+This issue remediates the following verified deviations from CS-003:
+
+1. direct Telnyx import still exists in `providerRegistry.ts`
+2. app-layer Telnyx-specific field handling still exists in `connectshyft.ts`
+3. `endCall` is still deferred
+4. retryable vs non-retryable provider error classification is not implemented
+
+This issue includes:
+
+- refactoring provider registry to remove direct Telnyx dependency leakage
+- normalizing app-facing provider outputs so app services no longer handle Telnyx-specific fields
+- implementing `endCall` through the provider-neutral telephony interface
+- implementing provider error classification sufficient to distinguish retryable vs non-retryable failures without leaking raw Telnyx semantics above infrastructure
+
+## Governing Execution Contract
+
+This issue is governed by:
+
+- `/specs/connectshyft-recovery/developer_execution_packet.md`
+- `/specs/connectshyft-recovery/ADR-00X_Communication_Infrastructure_Contract.md`
+- `/specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md`
+
+This remediation also responds directly to:
+
+- CS-003 architectural verification findings
+- PR #219 verification results
+
+If implementation details conflict with the ADR or canonical data model note, those documents take precedence.
+
+## C. Non-Goals
+
+- no bridge orchestration redesign
+- no UI redesign
+- no reliability subsystem implementation beyond the provider classification hook required here
+- no audit subsystem redesign
+- no provider failover strategy
+- no unrelated repo cleanup
+
+## D. Implementation Guardrails
+
+1. No Telnyx import may remain outside `/infrastructure/communications/telnyx`.
+2. No app-layer service may interpret Telnyx-specific response fields directly.
+3. App and domain layers must consume normalized provider-neutral outputs only.
+4. `endCall` must be implemented through the telephony provider interface, not as a Telnyx-only app-layer call.
+5. Provider error classification must distinguish retryable vs non-retryable failures, but classification output must be normalized and provider-neutral above the infrastructure layer.
+6. This issue must not move domain boundaries or pull provider logic into `/apps`.
+7. All persistence and service behavior must conform to ADR-00X and the Canonical Data Model Note.
+8. No bridge-specific remediation should be bundled here unless required to remove direct fallout from these adapter leaks.
+
+## E. Verified Blocking Findings
+
+The following findings are blocking and must all be resolved before this issue is considered complete:
+
+### 1. Direct Telnyx import in provider registry
+
+Current state:
+
+- direct Telnyx import exists in `providerRegistry.ts`
+
+Required fix:
+
+- provider registry must depend on provider-neutral interface/factory boundaries only
+- Telnyx construction/wiring must remain isolated under infrastructure
+
+### 2. App-layer Telnyx-specific field handling
+
+Current state:
+
+- Telnyx-specific field handling exists in `connectshyft.ts`
+
+Required fix:
+
+- normalize provider response shape before app-layer consumption
+- app services must no longer know Telnyx-specific field names or payload semantics
+
+### 3. Deferred `endCall`
+
+Current state:
+
+- `endCall` is deferred
+
+Required fix:
+
+- implement `endCall` on the provider-neutral telephony contract
+- implement Telnyx-backed adapter support for it
+- ensure upstream code depends on the interface, not Telnyx directly
+
+### 4. Missing retryable/non-retryable provider error classification
+
+Current state:
+
+- provider errors are not yet classified
+
+Required fix:
+
+- introduce normalized provider error classification output
+- support at minimum:
+  - auth/configuration failure
+  - rate limiting / temporary provider failure
+  - invalid request / non-retryable failure
+  - unknown provider failure
+- classification must be usable by CS-005 without redesigning CS-003 again
+
+## F. Acceptance Criteria
+
+### Adapter Boundary
+
+- no Telnyx import remains outside `/infrastructure/communications/telnyx`
+- provider registry no longer depends directly on Telnyx
+
+### App Boundary
+
+- no Telnyx-specific field handling remains in app-layer services
+- app-layer services consume normalized provider-neutral result objects only
+
+### Lifecycle Completeness
+
+- `endCall` exists on the telephony provider interface
+- Telnyx adapter implements `endCall`
+- upstream callers can terminate calls without provider-specific logic
+
+### Error Classification
+
+- provider failures are classified into normalized internal categories
+- retryable vs non-retryable distinction exists
+- raw Telnyx error semantics do not leak above infrastructure
+
+### Regression Safety
+
+- existing CS-003 tests still pass
+- any affected CS-004 integrations still build and pass relevant focused tests
+
+## G. Evidence Required in PR
+
+- diff or proof showing removal of Telnyx imports outside infrastructure
+- proof that app-layer Telnyx field handling has been removed
+- tests covering `endCall`
+- tests covering provider error classification
+- updated architectural verification note or follow-up verification summary
+- explicit note of any downstream CS-004 impact discovered during remediation
+
+## H. Definition of Done
+
+This issue is done when all four verified deviations are resolved and the adapter boundary is clean enough that CS-004 can be re-verified against it without ambiguity.
+
+## I. ADR Compliance Check
+
+Before merging, confirm:
+
+- [ ] No Telnyx import exists outside infrastructure
+- [ ] No app-layer Telnyx field handling remains
+- [ ] `endCall` implemented via provider-neutral interface
+- [ ] Retryable vs non-retryable provider classification implemented
+- [ ] No new provider leakage introduced into bridge or app layers

--- a/tests/support/helpers/apiClient.ts
+++ b/tests/support/helpers/apiClient.ts
@@ -1,4 +1,5 @@
 import type { APIRequestContext, APIResponse } from '@playwright/test';
+import { ensureConnectShyftDbActorUser } from './connectShyftDbActor';
 
 type RequestOptions = {
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
@@ -8,6 +9,7 @@ type RequestOptions = {
 };
 
 const MAX_TRANSIENT_RETRIES = 2;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 const sleep = async (ms: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, ms));
@@ -24,6 +26,66 @@ const isTransientNetworkFailure = (error: unknown): boolean => {
   );
 };
 
+const decodeJwtPayload = (token: string): Record<string, unknown> | null => {
+  const segments = token.split('.');
+  if (segments.length < 2) {
+    return null;
+  }
+
+  try {
+    const payloadJson = Buffer.from(segments[1], 'base64url').toString('utf8');
+    const parsed = JSON.parse(payloadJson) as Record<string, unknown>;
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const readCookieValue = (cookieHeader: string | undefined, key: string): string | null => {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const cookie = cookieHeader
+    .split(';')
+    .map((segment) => segment.trim())
+    .find((segment) => segment.startsWith(`${key}=`));
+
+  if (!cookie) {
+    return null;
+  }
+
+  return cookie.slice(key.length + 1) || null;
+};
+
+const resolveConnectShyftActorUserId = (options: RequestOptions): string | null => {
+  const explicitUserId = options.headers?.['x-test-connectshyft-user-id']?.trim();
+  if (explicitUserId) {
+    return explicitUserId;
+  }
+
+  const accessToken = readCookieValue(options.headers?.cookie, 'access_token');
+  if (!accessToken) {
+    return null;
+  }
+
+  const payload = decodeJwtPayload(accessToken);
+  return typeof payload?.userId === 'string' ? payload.userId.trim() : null;
+};
+
+const primeConnectShyftActorUser = async (options: RequestOptions): Promise<void> => {
+  if (!options.path.startsWith('/api/v1/connectshyft/')) {
+    return;
+  }
+
+  const actorUserId = resolveConnectShyftActorUserId(options);
+  if (!actorUserId || !UUID_PATTERN.test(actorUserId)) {
+    return;
+  }
+
+  await ensureConnectShyftDbActorUser(actorUserId);
+};
+
 export async function apiRequest(
   request: APIRequestContext,
   options: RequestOptions,
@@ -33,6 +95,8 @@ export async function apiRequest(
   const requestUrl = options.path.startsWith('/api/')
     ? new URL(options.path, configuredApiBaseUrl).toString()
     : options.path;
+
+  await primeConnectShyftActorUser(options);
 
   for (let attempt = 0; ; attempt += 1) {
     try {

--- a/tests/support/helpers/connectShyftDbActor.ts
+++ b/tests/support/helpers/connectShyftDbActor.ts
@@ -1,7 +1,7 @@
 const resolveConnectShyftDbConnection = () => {
   const databaseUrl =
     process.env.MONEYSHYFT_TEST_DATABASE_URL
-    || (process.env.CI === 'true' ? process.env.DATABASE_URL : undefined);
+    || process.env.DATABASE_URL;
   if (databaseUrl) {
     return databaseUrl;
   }


### PR DESCRIPTION
# CS-003a Telnyx Adapter Boundary Remediation PR

Issue:
CS-003a Telnyx Adapter Boundary Remediation

Governing Documents:
- /specs/connectshyft-recovery/developer_execution_packet.md
- /specs/connectshyft-recovery/ADR-00X_Communication_Infrastructure_Contract.md
- /specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md
- /specs/connectshyft-recovery/issues/CS-003a_Telnyx_Adapter_Boundary_Remediation_Guardrailed_Spec.md

Verification Source:
- PR #219 architectural verification
- architectural-integrity-verification.md

---

## Summary

Remediates the four verified CS-003 architectural boundary leaks by removing direct Telnyx construction from the registry layer, normalizing provider correlation metadata before it reaches app services, implementing typed `endCall`, and adding normalized provider error classification with retryable vs non-retryable distinction.

---

## Scope Confirmation

This PR is limited to CS-003a remediation.

Confirm:

- [x] No bridge orchestration redesign
- [x] No UI changes
- [x] No schema changes
- [x] No retry subsystem implementation
- [x] No unrelated repo cleanup
- [x] No broad architecture rewrite

If any of the above were touched, explain why:

No scope deviations. The only non-runtime additions were two Playwright test-harness helper adjustments needed to make PR-parity runs deterministic against synthetic ConnectShyft actor IDs.

---

## Blocking Findings Remediated

Confirm all four verified deviations are addressed.

### 1. Direct Telnyx import in provider registry
- [x] direct Telnyx import removed from `providerRegistry.ts`
- [x] direct Telnyx construction removed from registry layer
- [x] registry now depends on provider-neutral resolver/factory only

Describe the registry change:

`providerRegistry.ts` now resolves adapters through `/infrastructure/communications/index.ts`. The generic infrastructure resolver loads provider modules by provider key and no longer hard-wires Telnyx construction in the app layer.

### 2. App-layer Telnyx-specific field handling
- [x] `connectshyft.ts` no longer reads Telnyx-specific webhook correlation keys directly
- [x] `canonicalEvents.ts` no longer contains vendor-specific sanitizer logic
- [x] app-layer services now consume provider-neutral correlation metadata only

Describe the normalization change:

`telephony/index.ts` now carries normalized correlation metadata (`providerLegId`, `providerMessageId`, `providerEventId`, `providerNumber`) on translated provider events. `telnyx/index.ts` populates those fields during translation, and `connectshyft.ts` / `canonicalEvents.ts` now operate only on the normalized provider-neutral shape.

### 3. Deferred `endCall`
- [x] `endCall` added to telephony contract
- [x] `TelephonyEndCallCommand` implemented
- [x] `TelephonyEndCallResult` implemented
- [x] Telnyx adapter implements `endCall`
- [x] registry / guardrailed adapter passes `endCall` through

Describe the `endCall` implementation:

The telephony contract now defines typed end-call command/result shapes. The Telnyx adapter implements `endCall` via the Telnyx hangup action, validates the normalized result, and the ConnectShyft guardrailed adapter passes the capability through unchanged.

### 4. Missing provider error classification
- [x] provider-neutral error classification type added
- [x] retryable vs non-retryable distinction implemented
- [x] Telnyx adapter maps provider failures into normalized categories
- [x] `connectshyft.ts` consumes normalized classification without Telnyx-specific logic

Describe the classification model:

The telephony contract now exposes normalized provider failure categories with `retryable: boolean`. Telnyx config, HTTP, parse, auth, invalid-request, throttling, and network failures are mapped into provider-neutral classifications, and outbound refusal payloads keep the existing top-level ConnectShyft refusal code while adding normalized `providerFailureClassification` details.

---

## Architecture Compliance

Confirm the remediation preserves the ADR boundary.

- [x] No Telnyx import exists outside `/infrastructure/communications/telnyx`
- [x] App-layer services consume provider-neutral outputs only
- [x] Provider-specific correlation extraction now happens inside infrastructure translation
- [x] No raw Telnyx payload semantics leak above infrastructure
- [x] No new provider-specific logic was introduced into `/apps`

If any deviation occurred, explain it here:

No deviations.

---

## Contract Surface Changes

List any changes to:

- `telephony/index.ts`
- provider interface types
- normalized event/correlation metadata
- normalized provider error classification

Files changed:

- `/domains/communication/telephony/index.ts`
- `/infrastructure/communications/index.ts`
- `/infrastructure/communications/telnyx/index.ts`

The contract now includes typed `endCall` support, normalized provider event correlation metadata, and normalized provider failure classification with retryability.

---

## Runtime Files Touched

Check all that apply:

- [x] `providerRegistry.ts`
- [x] `connectshyft.ts`
- [x] `canonicalEvents.ts`
- [x] `telephony/index.ts`
- [x] `telnyx/index.ts`

Additional files touched:

- `/infrastructure/communications/index.ts`
- `/tests/support/helpers/apiClient.ts`
- `/tests/support/helpers/connectShyftDbActor.ts`

---

## Test Updates

Confirm test coverage was updated to remove vendor-coupled assumptions.

- [x] `connectshyft.outbound-dispatch.test.ts` updated
- [x] `connectshyft.bridge-flow.test.ts` updated
- [x] `providerRegistry.test.ts` updated
- [x] `canonicalEvents.test.ts` updated
- [x] `telnyx/index.test.ts` updated

Additional tests added:

`bridgeSessions.test.ts` was also updated to keep provider-neutral bridge-state assertions aligned with the remediated event shape.

### Required assertions
- [x] no direct Telnyx mocking remains where generic provider mocking should be used
- [x] normalized correlation metadata is asserted
- [x] `endCall` behavior is covered
- [x] provider error classification mapping is covered
- [x] at least one route-level assertion verifies normalized classification output

Test notes:

Focused ConnectShyft runtime coverage passed after the remediation, and full PR-parity validation was rerun on the final branch head before opening this PR.

---

## Boundary / Verification Checks

Provide results for:

- [x] `node scripts/enforce-workspace-boundaries.js`
- [x] focused ConnectShyft API tests
- [x] targeted scan for Telnyx imports outside infrastructure
- [x] targeted scan for vendor-specific field handling in app layer

Paste or summarize the results:

- `node scripts/enforce-workspace-boundaries.js`: passed
- `apps/connectshyft-api`: `npm run build` passed
- `apps/connectshyft-api`: `npm run test:connectshyft` passed (`55` suites, `312` tests)
- Targeted Telnyx import scan outside `/infrastructure/communications/telnyx`: no matches
- Targeted Telnyx field-handling scan in `connectshyft.ts` and `canonicalEvents.ts`: no matches
- Full PR-parity local run passed:
  - `npm run policy:check`
  - `bash scripts/lint-or-discovery.sh`
  - `bash scripts/ci-run-playwright-stack.sh bash scripts/backend-jest-ci.sh`
  - Playwright shards `1/4` through `4/4`
  - `bash scripts/burn-in.sh 10 origin/codex/dev`
  - `bash scripts/quality-gates.sh`

---

## Docs Updated

- [x] `telephony-provider-interface.md` updated
- [x] `architectural-integrity-verification.md` updated or superseded
- [x] any new normalized contract behavior documented

Doc notes:

The provider interface contract now documents typed `endCall`, normalized correlation metadata, and provider failure classification. The architectural verification note now records the four PR #219 deviations as remediated.

---

## Out-of-Scope Confirmation

Confirm this PR does **not** attempt to solve:

- [x] CS-004 bridge redesign
- [x] CS-005 retry subsystem
- [x] provider failover strategy
- [x] persistence redesign beyond minimal typed normalization support

If anything above was partially touched, explain why:

No out-of-scope work was added.

---

## Final Definition of Done

- [x] no Telnyx import remains outside infrastructure
- [x] no app-layer Telnyx field handling remains
- [x] `endCall` is implemented and typed
- [x] provider error classification exists and is normalized
- [x] tests pass
- [x] boundary enforcement passes

---

## Final Statement

This change complies with ADR-00X Communication Infrastructure Contract, the Canonical Data Model Note, and the CS-003a guardrailed remediation spec. All four blocking findings from the CS-003 verification have been addressed.
