### PR TITLE
Fix: normalize CS-004b bridge test fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ Docker:
 - Shared host-managed PostgreSQL (single instance) (001-tighten-deployment-contracts)
 - TypeScript (ES2022) on Node.js >=20 + Express, Knex, pg, Jest/ts-jest, root-level shared communication domain source under `domains/communication` (002-phone-identity)
 - Shared PostgreSQL; current ConnectShyft phone persistence in `connectshyft.cs_neighbor_phones` must evolve toward `communication_contact_point`-equivalent canonical fields (002-phone-identity)
+- TypeScript (ES2022) on Node.js >=20 + Jest, ts-jest, Express route test harnesses, shared communication domain modules under `domains/communication`, ConnectShyft module tests under `apps/connectshyft-api`, and repository boundary enforcement via `node scripts/enforce-workspace-boundaries.js` (004-bridge-test-fixture-normalization)
+- N/A for new behavior; existing shared PostgreSQL-backed bridge, correlation, and webhook models remain unchanged because CS-004b is test-only cleanup (004-bridge-test-fixture-normalization)
 
 ## Recent Changes
 - 001-tighten-deployment-contracts: Added TypeScript (Node.js APIs), Vue 3 TypeScript frontends + Express APIs, host Nginx reverse proxy, Docker Compose

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts
@@ -11,11 +11,11 @@ import type { ConnectShyftProviderAdapter } from '../providerRegistry'
 const sendSmsMock = jest.fn()
 const startOutboundCallMock = jest.fn()
 const startBridgeOutboundCallMock = jest.fn(async (input: { legRole: string; threadId: string }) => ({
-  providerKey: 'telnyx',
+  providerKey: 'provider-a',
   channel: 'call' as const,
   providerLegId: input.legRole === 'operator'
-    ? `telnyx-leg-operator-${input.threadId}`
-    : `telnyx-leg-neighbor-${input.threadId}`,
+    ? `provider-leg-operator-${input.threadId}`
+    : `provider-leg-neighbor-${input.threadId}`,
   providerMessageId: null,
   providerRequestId: `req-${input.legRole}-${input.threadId}`,
   adapterInvoked: true as const,
@@ -23,7 +23,7 @@ const startBridgeOutboundCallMock = jest.fn(async (input: { legRole: string; thr
   requestedAt: '2026-03-11T12:00:00.000Z',
 }))
 const startBridgeSessionMock = jest.fn(async (input: { bridgeSessionId: string }) => ({
-  providerKey: 'telnyx',
+  providerKey: 'provider-a',
   bridgeSessionId: input.bridgeSessionId,
   bridgeEstablished: true as const,
   providerRequestId: 'req-bridge-1001',
@@ -33,7 +33,7 @@ const startBridgeSessionMock = jest.fn(async (input: { bridgeSessionId: string }
 }))
 const verifyWebhookMock = jest.fn(() => ({ ok: true as const }))
 const endCallMock = jest.fn(async (input: { providerLegId: string }) => ({
-  providerKey: 'telnyx',
+  providerKey: 'provider-a',
   providerLegId: input.providerLegId,
   ended: true as const,
   providerRequestId: 'req-end-call-1001',
@@ -56,7 +56,7 @@ const translateProviderEventMock = jest.fn(({ rawEventType, payload }: { rawEven
 }))
 
 const providerAdapter: ConnectShyftProviderAdapter = {
-  providerKey: 'telnyx',
+  providerKey: 'provider-a',
   adapterInterfaceVersion: 'v1',
   sendSms: sendSmsMock,
   startOutboundCall: startOutboundCallMock,
@@ -76,7 +76,7 @@ const baseInput = {
   operatorContactPointId: '+12605550155',
   neighborContactPointId: '+12605550111',
   selectedOutboundContactPointId: 'cs-number-501',
-  providerKey: 'telnyx',
+  providerKey: 'provider-a',
   providerAdapter,
 } as const
 
@@ -151,7 +151,7 @@ describe('connectshyft bridgeSessions', () => {
       tenantId: baseInput.tenantId,
       orgUnitId: baseInput.orgUnitId,
       threadId: baseInput.threadId,
-      providerKey: 'telnyx',
+  providerKey: 'provider-a',
       providerAdapter,
       providerLegId: started.aggregate.operatorLeg.providerCallId || null,
       eventType: 'CallAnswered',
@@ -191,7 +191,7 @@ describe('connectshyft bridgeSessions', () => {
         status: 'neighbor_dialing',
       },
       neighborLeg: {
-        providerCallId: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        providerCallId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
         status: 'ringing',
       },
     })
@@ -209,7 +209,7 @@ describe('connectshyft bridgeSessions', () => {
       tenantId: baseInput.tenantId,
       orgUnitId: baseInput.orgUnitId,
       threadId: baseInput.threadId,
-      providerKey: 'telnyx',
+      providerKey: 'provider-a',
       providerAdapter,
       providerLegId: started.aggregate.operatorLeg.providerCallId || null,
       eventType: 'CallAnswered',
@@ -219,7 +219,7 @@ describe('connectshyft bridgeSessions', () => {
       tenantId: baseInput.tenantId,
       orgUnitId: baseInput.orgUnitId,
       threadId: baseInput.threadId,
-      providerKey: 'telnyx',
+      providerKey: 'provider-a',
       providerAdapter,
       providerLegId: afterOperatorAnswer.aggregate?.neighborLeg.providerCallId || null,
       eventType: 'CallAnswered',
@@ -229,7 +229,7 @@ describe('connectshyft bridgeSessions', () => {
       tenantId: baseInput.tenantId,
       orgUnitId: baseInput.orgUnitId,
       threadId: baseInput.threadId,
-      providerKey: 'telnyx',
+      providerKey: 'provider-a',
       providerAdapter,
       providerLegId: afterNeighborAnswer.aggregate?.neighborLeg.providerCallId || null,
       eventType: 'CallCompleted',
@@ -267,7 +267,7 @@ describe('connectshyft bridgeSessions', () => {
       tenantId: baseInput.tenantId,
       orgUnitId: baseInput.orgUnitId,
       threadId: baseInput.threadId,
-      providerKey: 'telnyx',
+      providerKey: 'provider-a',
       providerAdapter,
       providerLegId: started.aggregate.operatorLeg.providerCallId || null,
       eventType: 'CallAnswered',
@@ -277,7 +277,7 @@ describe('connectshyft bridgeSessions', () => {
       tenantId: baseInput.tenantId,
       orgUnitId: baseInput.orgUnitId,
       threadId: baseInput.threadId,
-      providerKey: 'telnyx',
+      providerKey: 'provider-a',
       providerAdapter,
       providerLegId: afterOperatorAnswer.aggregate?.neighborLeg.providerCallId || null,
       eventType: 'CallFailed',

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
@@ -20,17 +20,17 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'call_leg',
-      providerIdentifier: 'telnyx-leg-f3-1001',
+      providerIdentifier: 'provider-leg-f3-1001',
       internalReferenceId: 'canonical-call-f3-1001',
     });
 
     expect(callRecord.status).toBe('created');
     expect(callRecord.mapping).toMatchObject({
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'call_leg',
-      providerIdentifier: 'telnyx-leg-f3-1001',
+      providerIdentifier: 'provider-leg-f3-1001',
       threadId: 'thread-f3-unclaimed-1001',
       internalReferenceId: 'canonical-call-f3-1001',
     });
@@ -39,9 +39,9 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'call_leg',
-      providerIdentifier: 'telnyx-leg-f3-1001',
+      providerIdentifier: 'provider-leg-f3-1001',
       internalReferenceId: 'canonical-call-f3-duplicate',
     });
 
@@ -52,17 +52,17 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'message',
-      providerIdentifier: 'telnyx-msg-f3-1001',
+      providerIdentifier: 'provider-message-f3-1001',
       internalReferenceId: 'canonical-message-f3-1001',
     });
 
     expect(messageRecord.status).toBe('created');
     expect(messageRecord.mapping).toMatchObject({
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'message',
-      providerIdentifier: 'telnyx-msg-f3-1001',
+      providerIdentifier: 'provider-message-f3-1001',
       threadId: 'thread-f3-unclaimed-1001',
       internalReferenceId: 'canonical-message-f3-1001',
     });
@@ -73,24 +73,24 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
-      providerIdentifier: 'telnyx-leg-bridge-f3-1001',
+      providerName: 'provider-a',
+      providerIdentifier: 'provider-leg-bridge-f3-1001',
       bridgeLegId: 'bridge-leg-neighbor-f3-1001',
     });
 
     expect(mapping).toMatchObject({
       status: 'created',
       mapping: {
-        providerName: 'telnyx',
+        providerName: 'provider-a',
         identifierKind: 'call_leg',
-        providerIdentifier: 'telnyx-leg-bridge-f3-1001',
+        providerIdentifier: 'provider-leg-bridge-f3-1001',
         internalReferenceId: 'bridge-leg-neighbor-f3-1001',
       },
     });
 
     const resolved = await resolveConnectShyftProviderCorrelationByIdentifiers({
-      providerName: 'telnyx',
-      providerLegId: 'telnyx-leg-bridge-f3-1001',
+      providerName: 'provider-a',
+      providerLegId: 'provider-leg-bridge-f3-1001',
     });
 
     expect(resolved).toMatchObject({
@@ -107,15 +107,15 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'call_leg',
-      providerIdentifier: 'telnyx-leg-f3-1001',
+      providerIdentifier: 'provider-leg-f3-1001',
       internalReferenceId: 'canonical-call-f3-1001',
     });
 
     const resolvedByCallLeg = await resolveConnectShyftProviderCorrelationByIdentifiers({
-      providerName: 'telnyx',
-      providerLegId: 'telnyx-leg-f3-1001',
+      providerName: 'provider-a',
+      providerLegId: 'provider-leg-f3-1001',
     });
 
     expect(resolvedByCallLeg).toMatchObject({
@@ -132,15 +132,15 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'message',
-      providerIdentifier: 'telnyx-msg-f3-1001',
+      providerIdentifier: 'provider-message-f3-1001',
       internalReferenceId: 'canonical-message-f3-1001',
     });
 
     const resolvedByMessage = await resolveConnectShyftProviderCorrelationByIdentifiers({
-      providerName: 'telnyx',
-      providerMessageId: 'telnyx-msg-f3-1001',
+      providerName: 'provider-a',
+      providerMessageId: 'provider-message-f3-1001',
     });
 
     expect(resolvedByMessage).toMatchObject({
@@ -159,9 +159,9 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'call_leg',
-      providerIdentifier: 'telnyx-leg-f3-1001',
+      providerIdentifier: 'provider-leg-f3-1001',
       internalReferenceId: 'canonical-call-f3-1001',
     });
 
@@ -169,16 +169,16 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-claimed-1002',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'message',
-      providerIdentifier: 'telnyx-msg-f3-1002',
+      providerIdentifier: 'provider-message-f3-1002',
       internalReferenceId: 'canonical-message-f3-1002',
     });
 
     const resolution = await resolveConnectShyftProviderCorrelationByIdentifiers({
-      providerName: 'telnyx',
-      providerLegId: 'telnyx-leg-f3-1001',
-      providerMessageId: 'telnyx-msg-f3-1002',
+      providerName: 'provider-a',
+      providerLegId: 'provider-leg-f3-1001',
+      providerMessageId: 'provider-message-f3-1002',
     });
 
     expect(resolution).toEqual({
@@ -189,7 +189,7 @@ describe('connectshyft provider correlation mappings', () => {
 
   it('returns deterministic refusal reasons when fallback cannot resolve', async () => {
     const missingIdentifiers = await resolveConnectShyftProviderCorrelationByIdentifiers({
-      providerName: 'telnyx',
+      providerName: 'provider-a',
     });
     expect(missingIdentifiers).toEqual({
       ok: false,
@@ -197,8 +197,8 @@ describe('connectshyft provider correlation mappings', () => {
     });
 
     const notFound = await resolveConnectShyftProviderCorrelationByIdentifiers({
-      providerName: 'telnyx',
-      providerLegId: 'telnyx-leg-f3-unknown',
+      providerName: 'provider-a',
+      providerLegId: 'provider-leg-f3-unknown',
     });
     expect(notFound).toEqual({
       ok: false,
@@ -211,10 +211,10 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'CallConnected',
       providerEventId: 'provider-event-f3-1001',
-      providerLegId: 'telnyx-leg-f3-1001',
+      providerLegId: 'provider-leg-f3-1001',
     });
 
     expect(first).toEqual({
@@ -227,10 +227,10 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'CallConnected',
       providerEventId: 'provider-event-f3-1001',
-      providerLegId: 'telnyx-leg-f3-1001',
+      providerLegId: 'provider-leg-f3-1001',
     });
 
     expect(duplicate).toEqual({
@@ -245,30 +245,30 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'MessageDelivered',
       providerEventId: 'provider-event-f3-shared-by-type',
-      providerMessageId: 'telnyx-msg-f3-shared-by-type',
+      providerMessageId: 'provider-message-f3-shared-by-type',
     });
 
     const firstVoice = await recordConnectShyftWebhookReceipt({
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'CallConnected',
       providerEventId: 'provider-event-f3-shared-by-type',
-      providerLegId: 'telnyx-leg-f3-shared-by-type',
+      providerLegId: 'provider-leg-f3-shared-by-type',
     });
 
     const duplicateMessage = await recordConnectShyftWebhookReceipt({
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'MessageDelivered',
       providerEventId: 'provider-event-f3-shared-by-type',
-      providerMessageId: 'telnyx-msg-f3-shared-by-type',
+      providerMessageId: 'provider-message-f3-shared-by-type',
     });
 
     expect(firstMessage.duplicate).toBe(false);
@@ -284,10 +284,10 @@ describe('connectshyft provider correlation mappings', () => {
           tenantId: 'tenant-connectshyft-f3',
           orgUnitId: 'org-connectshyft-f3-east',
           threadId: 'thread-f3-unclaimed-1001',
-          providerName: 'telnyx',
+          providerName: 'provider-a',
           canonicalEventType: 'MessageDelivered',
           providerEventId: 'provider-event-f3-concurrent-burst',
-          providerMessageId: 'telnyx-msg-f3-concurrent-burst',
+          providerMessageId: 'provider-message-f3-concurrent-burst',
         }),
       ),
     );
@@ -305,10 +305,10 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'VoiceTranscriptionCompleted',
       providerEventId: 'provider-event-f3-transcription-1001',
-      providerLegId: 'telnyx-leg-f3-1001',
+      providerLegId: 'provider-leg-f3-1001',
     });
 
     expect(first).toMatchObject({
@@ -321,7 +321,7 @@ describe('connectshyft provider correlation mappings', () => {
 
     const markedRetryableFailure = await markConnectShyftWebhookReceiptProcessingResult({
       tenantId: 'tenant-connectshyft-f3',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       dedupeKey: first.dedupeKey,
       status: 'FAILED_RETRYABLE',
       failureReason: 'canonical_event_persistence_error',
@@ -332,10 +332,10 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'VoiceTranscriptionCompleted',
       providerEventId: 'provider-event-f3-transcription-1001',
-      providerLegId: 'telnyx-leg-f3-1001',
+      providerLegId: 'provider-leg-f3-1001',
     });
 
     expect(second).toMatchObject({
@@ -348,7 +348,7 @@ describe('connectshyft provider correlation mappings', () => {
 
     const markedApplied = await markConnectShyftWebhookReceiptProcessingResult({
       tenantId: 'tenant-connectshyft-f3',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       dedupeKey: first.dedupeKey,
       status: 'APPLIED',
     });
@@ -358,10 +358,10 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'VoiceTranscriptionCompleted',
       providerEventId: 'provider-event-f3-transcription-1001',
-      providerLegId: 'telnyx-leg-f3-1001',
+      providerLegId: 'provider-leg-f3-1001',
     });
 
     expect(duplicateAfterApplied).toMatchObject({
@@ -378,9 +378,9 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3-a',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'call_leg',
-      providerIdentifier: 'telnyx-leg-f3-shared',
+      providerIdentifier: 'provider-leg-f3-shared',
       internalReferenceId: 'canonical-call-f3-tenant-a',
     });
 
@@ -388,17 +388,17 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3-b',
       orgUnitId: 'org-connectshyft-f3-west',
       threadId: 'thread-f3-claimed-1002',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'call_leg',
-      providerIdentifier: 'telnyx-leg-f3-shared',
+      providerIdentifier: 'provider-leg-f3-shared',
       internalReferenceId: 'canonical-call-f3-tenant-b',
     });
 
     expect(otherTenantRecord.status).toBe('created');
 
     const ambiguousLookup = await resolveConnectShyftProviderCorrelationByIdentifiers({
-      providerName: 'telnyx',
-      providerLegId: 'telnyx-leg-f3-shared',
+      providerName: 'provider-a',
+      providerLegId: 'provider-leg-f3-shared',
     });
 
     expect(ambiguousLookup).toEqual({
@@ -407,8 +407,8 @@ describe('connectshyft provider correlation mappings', () => {
     });
 
     const tenantScopedLookup = await resolveConnectShyftProviderCorrelationByIdentifiers({
-      providerName: 'telnyx',
-      providerLegId: 'telnyx-leg-f3-shared',
+      providerName: 'provider-a',
+      providerLegId: 'provider-leg-f3-shared',
       tenantId: 'tenant-connectshyft-f3-a',
     });
 
@@ -427,10 +427,10 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3-a',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'MessageDelivered',
       providerEventId: 'provider-event-f3-shared-2001',
-      providerMessageId: 'telnyx-msg-f3-shared-2001',
+      providerMessageId: 'provider-message-f3-shared-2001',
     });
     expect(tenantAFirst.duplicate).toBe(false);
 
@@ -438,10 +438,10 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3-b',
       orgUnitId: 'org-connectshyft-f3-west',
       threadId: 'thread-f3-unclaimed-9001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'MessageDelivered',
       providerEventId: 'provider-event-f3-shared-2001',
-      providerMessageId: 'telnyx-msg-f3-shared-2001',
+      providerMessageId: 'provider-message-f3-shared-2001',
     });
     expect(tenantBFirst.duplicate).toBe(false);
 
@@ -449,10 +449,10 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3-a',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'MessageDelivered',
       providerEventId: 'provider-event-f3-shared-2001',
-      providerMessageId: 'telnyx-msg-f3-shared-2001',
+      providerMessageId: 'provider-message-f3-shared-2001',
     });
     expect(tenantASecond.duplicate).toBe(true);
   });
@@ -477,9 +477,9 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: '11111111-1111-4111-8111-111111111111',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: '22222222-2222-4222-8222-222222222222',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       identifierKind: 'call_leg',
-      providerIdentifier: 'telnyx-leg-f3-db-failure',
+      providerIdentifier: 'provider-leg-f3-db-failure',
       internalReferenceId: 'canonical-call-f3-db-failure',
       db: failingDb,
     });
@@ -491,10 +491,10 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: '11111111-1111-4111-8111-111111111111',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: '22222222-2222-4222-8222-222222222222',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'CallConnected',
       providerEventId: 'provider-event-f3-db-failure',
-      providerLegId: 'telnyx-leg-f3-db-failure',
+      providerLegId: 'provider-leg-f3-db-failure',
       db: failingDb,
     });
 
@@ -513,19 +513,19 @@ describe('connectshyft provider correlation mappings', () => {
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'MessageDelivered',
       providerEventId: 'provider-event-f3-retention-1',
-      providerMessageId: 'telnyx-msg-f3-retention-1',
+      providerMessageId: 'provider-message-f3-retention-1',
     });
     await recordConnectShyftWebhookReceipt({
       tenantId: 'tenant-connectshyft-f3',
       orgUnitId: 'org-connectshyft-f3-east',
       threadId: 'thread-f3-unclaimed-1001',
-      providerName: 'telnyx',
+      providerName: 'provider-a',
       canonicalEventType: 'MessageDelivered',
       providerEventId: 'provider-event-f3-retention-2',
-      providerMessageId: 'telnyx-msg-f3-retention-2',
+      providerMessageId: 'provider-message-f3-retention-2',
     });
 
     const asOfUtc = '2100-01-10T00:00:00.000Z';

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
@@ -14,18 +14,14 @@ const toProviderCorrelation = (payload: unknown) => {
     : {}
 
   return {
-    providerLegId: typeof source.provider_leg_id === 'string'
-      ? source.provider_leg_id
-      : (typeof source.providerLegId === 'string' ? source.providerLegId : null),
-    providerMessageId: typeof source.provider_message_id === 'string'
-      ? source.provider_message_id
-      : (typeof source.providerMessageId === 'string' ? source.providerMessageId : null),
-    providerEventId: typeof source.provider_event_id === 'string'
-      ? source.provider_event_id
-      : (typeof source.providerEventId === 'string' ? source.providerEventId : null),
-    providerNumber: typeof source.to === 'string'
-      ? source.to
-      : (typeof source.to_number === 'string' ? source.to_number : null),
+    providerLegId: typeof source.providerLegId === 'string' ? source.providerLegId : null,
+    providerMessageId: typeof source.providerMessageId === 'string' ? source.providerMessageId : null,
+    providerEventId: typeof source.providerEventId === 'string' ? source.providerEventId : null,
+    providerNumber: typeof source.providerNumber === 'string'
+      ? source.providerNumber
+      : (typeof source.to === 'string'
+        ? source.to
+        : (typeof source.to_number === 'string' ? source.to_number : null)),
   }
 }
 
@@ -34,8 +30,8 @@ const startOutboundCallMock = jest.fn(async (command: { threadId: string; target
   providerKey: 'telnyx',
   channel: 'call' as const,
   providerLegId: command.targetPhone === '+12605550155'
-    ? `telnyx-leg-operator-${command.threadId}`
-    : `telnyx-leg-neighbor-${command.threadId}`,
+    ? `provider-leg-operator-${command.threadId}`
+    : `provider-leg-neighbor-${command.threadId}`,
   providerMessageId: null,
   providerRequestId: 'req-call-2001',
   adapterInvoked: true as const,
@@ -238,7 +234,7 @@ describe('connectshyft bridge webhook flow', () => {
       data: {
         dispatch: {
           providerKey: 'telnyx',
-          providerLegId: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+          providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001',
         },
         bridgeSession: {
           bridgeSessionId: expect.any(String),
@@ -289,7 +285,7 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.answered',
-        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+        providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001',
       },
     })
 
@@ -330,7 +326,7 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.answered',
-        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        providerLegId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
       },
     })
 
@@ -360,8 +356,8 @@ describe('connectshyft bridge webhook flow', () => {
     })
     expect(startBridgeSessionMock).toHaveBeenCalledTimes(1)
     expect(startBridgeSessionMock).toHaveBeenCalledWith(expect.objectContaining({
-      operatorProviderCallId: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
-      neighborProviderCallId: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+      operatorProviderCallId: 'provider-leg-operator-thread-f1-unclaimed-1001',
+      neighborProviderCallId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
     }))
   })
 
@@ -384,8 +380,8 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.answered',
-        provider_event_id: 'bridge-operator-answered-1001',
-        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+        providerEventId: 'provider-event-operator-answered-1001',
+        providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001',
       },
     })
     const operatorAnsweredDuplicate = await invokeRoute({
@@ -396,8 +392,8 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.answered',
-        provider_event_id: 'bridge-operator-answered-1001',
-        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+        providerEventId: 'provider-event-operator-answered-1001',
+        providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001',
       },
     })
 
@@ -434,7 +430,7 @@ describe('connectshyft bridge webhook flow', () => {
       },
     })
     expect((operatorAnsweredDuplicate.body as any).data.replaySafe.dedupeKey)
-      .toContain('bridge-operator-answered-1001')
+      .toContain('provider-event-operator-answered-1001')
     expect(startOutboundCallMock).toHaveBeenCalledTimes(2)
     expect(startBridgeSessionMock).toHaveBeenCalledTimes(0)
   })
@@ -458,7 +454,7 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.answered',
-        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+        providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001',
       },
     })
     await invokeRoute({
@@ -469,7 +465,7 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.answered',
-        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        providerLegId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
       },
     })
 
@@ -481,8 +477,8 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.completed',
-        provider_event_id: 'bridge-completed-1001',
-        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        providerEventId: 'provider-event-completed-1001',
+        providerLegId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
       },
     })
     const completedReplay = await invokeRoute({
@@ -493,8 +489,8 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.completed',
-        provider_event_id: 'bridge-completed-1001',
-        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        providerEventId: 'provider-event-completed-1001',
+        providerLegId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
       },
     })
 
@@ -555,7 +551,7 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.answered',
-        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+        providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001',
       },
     })
 
@@ -567,7 +563,7 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.failed',
-        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        providerLegId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
         reason: 'neighbor_declined',
       },
     })
@@ -617,7 +613,7 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.answered',
-        provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+        providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001',
       },
     })
     await invokeRoute({
@@ -628,7 +624,7 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.answered',
-        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        providerLegId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
       },
     })
     await invokeRoute({
@@ -639,8 +635,8 @@ describe('connectshyft bridge webhook flow', () => {
         orgUnitId: 'org-connectshyft-f1-east',
         threadId: 'thread-f1-unclaimed-1001',
         eventType: 'call.completed',
-        provider_event_id: 'bridge-completed-refresh-1001',
-        provider_leg_id: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001',
+        providerEventId: 'provider-event-completed-refresh-1001',
+        providerLegId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
       },
     })
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
@@ -15,18 +15,14 @@ const toProviderCorrelation = (payload: unknown) => {
     : {};
 
   return {
-    providerLegId: typeof source.provider_leg_id === 'string'
-      ? source.provider_leg_id
-      : (typeof source.providerLegId === 'string' ? source.providerLegId : null),
-    providerMessageId: typeof source.provider_message_id === 'string'
-      ? source.provider_message_id
-      : (typeof source.providerMessageId === 'string' ? source.providerMessageId : null),
-    providerEventId: typeof source.provider_event_id === 'string'
-      ? source.provider_event_id
-      : (typeof source.providerEventId === 'string' ? source.providerEventId : null),
-    providerNumber: typeof source.to === 'string'
-      ? source.to
-      : (typeof source.to_number === 'string' ? source.to_number : null),
+    providerLegId: typeof source.providerLegId === 'string' ? source.providerLegId : null,
+    providerMessageId: typeof source.providerMessageId === 'string' ? source.providerMessageId : null,
+    providerEventId: typeof source.providerEventId === 'string' ? source.providerEventId : null,
+    providerNumber: typeof source.providerNumber === 'string'
+      ? source.providerNumber
+      : (typeof source.to === 'string'
+        ? source.to
+        : (typeof source.to_number === 'string' ? source.to_number : null)),
   };
 };
 
@@ -34,7 +30,7 @@ const sendSmsMock = jest.fn(async (command: { threadId: string }) => ({
   providerKey: 'telnyx',
   channel: 'message' as const,
   providerLegId: null,
-  providerMessageId: `telnyx-message-${command.threadId}`,
+  providerMessageId: `provider-message-${command.threadId}`,
   providerRequestId: 'req-sms-1001',
   adapterInvoked: true as const,
   providerBranchingInDomain: false as const,
@@ -45,8 +41,8 @@ const startOutboundCallMock = jest.fn(async (command: { threadId: string; target
   providerKey: 'telnyx',
   channel: 'call' as const,
   providerLegId: command.targetPhone === '+12605550155'
-    ? `telnyx-leg-operator-${command.threadId}`
-    : `telnyx-leg-neighbor-${command.threadId}`,
+    ? `provider-leg-operator-${command.threadId}`
+    : `provider-leg-neighbor-${command.threadId}`,
   providerMessageId: null,
   providerRequestId: 'req-call-2001',
   adapterInvoked: true as const,
@@ -251,7 +247,7 @@ describe('connectshyft outbound dispatch routes', () => {
       data: {
         dispatch: {
           providerKey: 'telnyx',
-          providerMessageId: 'telnyx-message-thread-f1-unclaimed-1001',
+          providerMessageId: 'provider-message-thread-f1-unclaimed-1001',
           providerLegId: null,
         },
         correlationMapping: {
@@ -277,7 +273,7 @@ describe('connectshyft outbound dispatch routes', () => {
       data: {
         dispatch: {
           providerKey: 'telnyx',
-          providerMessageId: 'telnyx-message-thread-f1-unclaimed-1001',
+          providerMessageId: 'provider-message-thread-f1-unclaimed-1001',
         },
         replaySafe: {
           duplicate: true,
@@ -313,7 +309,7 @@ describe('connectshyft outbound dispatch routes', () => {
       data: {
         dispatch: {
           providerKey: 'telnyx',
-          providerLegId: 'telnyx-leg-operator-thread-f1-unclaimed-1001',
+          providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001',
           providerMessageId: null,
         },
         call: {

--- a/specs/004-bridge-test-fixture-normalization/contracts/bridge-test-fixture-contract.md
+++ b/specs/004-bridge-test-fixture-normalization/contracts/bridge-test-fixture-contract.md
@@ -1,0 +1,54 @@
+# Contract: CS-004b Normalized Bridge Test Fixtures
+
+## Purpose
+
+Define the allowed fixture shapes for bridge-related tests so app-layer and bridge-domain coverage remains provider-neutral after CS-003a remediation.
+
+## In-Scope Test Surfaces
+
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+
+## Required Normalized Fields
+
+Bridge-facing tests must prefer these names:
+
+- `providerLegId`
+- `providerMessageId`
+- `providerEventId`
+- `providerNumber`
+- `providerCallId` where the underlying test surface expects call-level identifiers
+
+## Required Fixture Naming
+
+Where the provider itself is not the behavior under test, fixture values should use neutral identifiers such as:
+
+- `provider-leg-operator-*`
+- `provider-leg-neighbor-*`
+- `provider-message-*`
+- `provider-event-*`
+- `provider-a`
+- `provider-b`
+
+Where provider selection is required by the route or mapping surface, a concrete supported provider key may still appear in request setup, but bridge-facing fixture identifiers and correlation fields must remain neutral.
+
+## Disallowed In Bridge/App Test Fixtures
+
+- Vendor-prefixed field names such as `telnyxCallControlId`, `telnyxMessageId`, or `telnyxEventId`
+- Legacy snake_case correlation keys in bridge-facing app tests when normalized camelCase fields can be used instead
+- Direct Telnyx module mocking
+- Vendor-labeled fixture identifier values when the provider itself is not under test
+
+## Allowed Exception
+
+Provider-native payloads and headers may remain only in infrastructure translation or webhook-signature tests and helpers where provider translation or signature verification is the explicit behavior under test.
+
+Allowed exception surface for CS-004b:
+
+- `tests/support/helpers/connectShyftWebhookTestHelpers.ts`
+
+## Runtime Contract
+
+This contract does not change runtime behavior. It only constrains the naming and shape of bridge-related test fixtures so they reflect the existing provider-neutral runtime contract.

--- a/specs/004-bridge-test-fixture-normalization/data-model.md
+++ b/specs/004-bridge-test-fixture-normalization/data-model.md
@@ -1,0 +1,123 @@
+# Data Model: CS-004b Bridge Test Fixture Normalization
+
+## Overview
+
+CS-004b does not add or change runtime persistence. The relevant entities are test-side fixture models that must mirror the existing provider-neutral bridge contract without implying vendor coupling above infrastructure.
+
+## Entities
+
+### 1. Normalized Bridge Route Fixture
+
+**Purpose**: Represents the request/response and adapter-mock data used by bridge route tests.
+
+**Fields**
+- `providerKey`
+- `threadId`
+- `tenantId`
+- `orgUnitId`
+- `eventType`
+- `providerLegId`
+- `providerMessageId`
+- `providerEventId`
+- `providerNumber`
+- `bridgeSessionId`
+- `sessionState`
+- `operatorLegState`
+- `neighborLegState`
+- `failureCode`
+- `failureMessage`
+
+**Validation Rules**
+- Must use normalized camelCase provider correlation fields in bridge and app-layer tests.
+- Vendor-prefixed field names are not allowed in these fixtures.
+- Identifier values should be provider-neutral unless the provider itself is the behavior under test.
+
+**Relationships**
+- Consumed by `connectshyft.bridge-flow.test.ts`
+- Consumed by `connectshyft.outbound-dispatch.test.ts`
+
+### 2. Normalized Bridge Session Fixture
+
+**Purpose**: Represents the provider adapter return values and persisted-state expectations used by bridge session application tests.
+
+**Fields**
+- `providerKey`
+- `channel`
+- `bridgeSessionId`
+- `providerLegId`
+- `providerRequestId`
+- `requestedAt`
+- `status`
+- `operatorLegStatus`
+- `neighborLegStatus`
+- `failureCode`
+- `failureMessage`
+
+**Validation Rules**
+- Must retain existing state expectations from CS-004.
+- Must use neutral provider leg/message identifier values.
+- Must not imply raw provider payload semantics.
+
+**Relationships**
+- Consumed by `bridgeSessions.test.ts`
+- Mirrors the existing runtime bridge aggregate without changing it
+
+### 3. Provider Correlation Fixture
+
+**Purpose**: Represents the bridge-adjacent provider identifier mapping records used in provider-correlation tests.
+
+**Fields**
+- `providerName`
+- `identifierKind`
+- `providerIdentifier`
+- `internalReferenceId`
+- `tenantId`
+- `orgUnitId`
+- `threadId`
+
+**Validation Rules**
+- Provider names may be neutral labels such as `provider-a` and `provider-b`.
+- Identifier values should be neutralized to `provider-leg-*` or `provider-message-*` when the test is not about a specific vendor.
+- Existing uniqueness, ambiguity, and replay-safety semantics must remain unchanged.
+
+**Relationships**
+- Consumed by `providerCorrelationMappings.test.ts`
+- Supports bridge leg correlation without changing runtime mapping behavior
+
+### 4. Provider Translation Exception Fixture
+
+**Purpose**: Documents the allowed exception for provider-native payloads in infrastructure-edge tests and helpers.
+
+**Fields**
+- `providerNativeHeaders`
+- `providerNativePayload`
+- `signatureMaterial`
+- `translationExpectation`
+
+**Validation Rules**
+- May remain provider-native only when translation or signature verification is the explicit behavior under test.
+- Must not be imported into bridge-domain or app-layer bridge tests.
+
+**Relationships**
+- Applies to infrastructure translation/signature tests and helpers only
+- Explicitly excluded from the CS-004b bridge-fixture cleanup set
+
+## State Considerations
+
+Runtime bridge state transitions do not change in CS-004b. Test fixtures must continue to represent the existing bridge lifecycle accurately:
+
+- `created`
+- `operator_dialing`
+- `operator_answered`
+- `neighbor_dialing`
+- `neighbor_answered`
+- `bridged`
+- `completed`
+- `failed`
+
+## Non-Changes
+
+- No schema changes
+- No migration changes
+- No provider adapter contract changes
+- No bridge runtime model changes

--- a/specs/004-bridge-test-fixture-normalization/plan.md
+++ b/specs/004-bridge-test-fixture-normalization/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: CS-004b Bridge Test Fixture Normalization
+
+**Branch**: `004-bridge-test-fixture-normalization` | **Date**: 2026-03-12 | **Spec**: [spec.md](/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/spec.md)  
+**Input**: Feature specification from `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/spec.md`  
+**Source Input**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-004b_Bridge_Test_Fixture_Normalization_Guardrailed_Spec.md`
+
+## Summary
+
+Normalize the remaining bridge-related test fixtures to provider-neutral names and correlation shapes so ConnectShyft bridge tests reinforce the CS-003a/CS-004 architecture boundary without changing runtime behavior. The implementation is limited to targeted Jest files, bridge-adjacent test-support assets if needed, and documentation proving that provider-native payloads remain confined to infrastructure translation tests.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022) on Node.js >=20  
+**Primary Dependencies**: Jest, ts-jest, Express route test harnesses, shared communication domain modules under `domains/communication`, ConnectShyft module tests under `apps/connectshyft-api`, and repository boundary enforcement via `node scripts/enforce-workspace-boundaries.js`  
+**Storage**: N/A for new behavior; existing shared PostgreSQL-backed bridge, correlation, and webhook models remain unchanged because CS-004b is test-only cleanup  
+**Testing**: Targeted Jest suites for bridge routes, bridge sessions, and bridge-adjacent provider correlation tests; targeted repository scans for vendor-labeled fixtures; boundary enforcement validation  
+**Target Platform**: Linux-hosted Shyft Nx monorepo with ConnectShyft API tests executing inside the existing repository toolchain  
+**Project Type**: Monolithic Nx web application with shared domain/infrastructure code and lane-specific API test suites  
+**Performance Goals**: Zero runtime behavior delta; no production code-path changes; no reduction in existing bridge test coverage  
+**Constraints**: Test-only cleanup. Direct edit targets are limited to the four bridge-facing Jest files and `specs/004-bridge-test-fixture-normalization/*`. Allowed support-surface edits are limited to `tests/support/helpers/connectShyftWebhookTestHelpers.ts` and any test-support file directly imported by the four target Jest files. Runtime production files are out of scope except for a minimal type-only alignment change that does not alter runtime branching, persistence, routing, provider behavior, UI behavior, or deployment behavior. No bridge redesign, provider adapter redesign, UI changes, schema changes, or retry subsystem work are allowed.  
+**Runtime Exception Rule**: If a non-test runtime file must change, the change must be limited to type-only alignment or exported test-facing typings. Any logic change requires replanning because CS-004b is not authorized to change runtime behavior.  
+**Scale/Scope**: One normalized feature directory, four targeted bridge-related Jest files, one allowed infrastructure-edge helper exception surface, one internal test-fixture contract, and planning evidence only  
+**Explicit Out-of-Scope Support Surfaces**: Provider registry tests and broader story fixture families (`F1`, `F2`, `F3`, `E4`, `G6`) remain out of scope unless a direct import dependency from the four in-scope bridge-facing Jest files requires adjustment.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Initial Gate Review**
+
+- Platform shell authority preserved: PASS. CS-004b changes only tests, test-support assets, and planning docs; `admin-web` and `admin-api` remain untouched as shell/auth authorities.
+- Lane isolation preserved: PASS. No runtime lane coupling or cross-lane service calls are introduced.
+- Routing delegation preserved: PASS. No route ownership, Nginx delegation, or `/api/v1/auth/*` / `/api/v1/platform/admin/*` behavior changes are proposed.
+- Deployment topology preserved: PASS. No deployment, port, Docker, or static-build topology changes are in scope.
+- Database ownership preserved: PASS. No migrations or schema ownership changes are proposed.
+- Security boundaries preserved: PASS. No ingress, cookie, secret, or public-port behavior changes are proposed.
+- Workflow compliance: PASS. The normalized feature spec, plan, research, data model, contract, and quickstart remain traceable to the CS-004b guardrailed issue spec.
+- Acceptance criteria present: PASS. This plan includes verifiable no-runtime-change checks, targeted bridge suite validation, boundary enforcement, and touched-file checks proving Admin, MoneyShyft, and ConnectShyft routing/deploy/database behavior remains unchanged.
+
+**Post-Design Re-check**
+
+- Platform shell authority preserved: PASS. Design remains docs/tests only.
+- Lane isolation preserved: PASS. Design keeps all runtime boundaries unchanged.
+- Routing delegation preserved: PASS. Quickstart explicitly verifies no routing or lane runtime files are modified.
+- Deployment topology preserved: PASS. Quickstart explicitly verifies no deploy topology files are modified.
+- Database ownership preserved: PASS. Quickstart explicitly verifies no migration or schema files are modified.
+- Security boundaries preserved: PASS. No runtime security surfaces are altered.
+- Workflow compliance: PASS. Planning artifacts are complete and remain spec-driven.
+- Acceptance criteria present: PASS. The design defines measurable scan, test, boundary, and touched-file validation steps.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-bridge-test-fixture-normalization/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── contracts/
+    └── bridge-test-fixture-contract.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/
+└── connectshyft-api/
+    └── src/
+        ├── routes/
+        │   └── api/
+        │       └── v1/
+        │           └── __tests__/
+        │               ├── connectshyft.bridge-flow.test.ts
+        │               └── connectshyft.outbound-dispatch.test.ts
+        └── modules/
+            └── connectshyft/
+                └── __tests__/
+                    ├── bridgeSessions.test.ts
+                    └── providerCorrelationMappings.test.ts
+
+domains/
+└── communication/
+    └── bridge/
+        └── __tests__/
+            ├── bridgeStateMachine.test.ts
+            └── handleProviderBridgeEvent.test.ts
+
+tests/
+└── support/
+    └── helpers/
+        └── connectShyftWebhookTestHelpers.ts
+```
+
+**Structure Decision**: Keep CS-004b confined to bridge-facing test files under `apps/connectshyft-api` plus any strictly necessary test-support assets. Bridge domain tests that are already provider-neutral remain unchanged, and infrastructure translation helpers remain provider-native only where translation behavior is the subject under test.
+
+## Complexity Tracking
+
+No constitution violations are required for CS-004b. This section is intentionally empty.

--- a/specs/004-bridge-test-fixture-normalization/quickstart.md
+++ b/specs/004-bridge-test-fixture-normalization/quickstart.md
@@ -1,0 +1,348 @@
+# Quickstart: CS-004b Bridge Test Fixture Normalization
+
+## Goal
+
+Validate that bridge-related test fixtures were normalized to provider-neutral names and shapes without changing runtime behavior, routing, deployment topology, or shared-database ownership.
+
+## Prerequisites
+
+- Repository root: `/Users/jeremiahotis/projects/connectshyft`
+- Branch: `004-bridge-test-fixture-normalization`
+- ConnectShyft API test dependencies installed
+
+## Baseline Evidence Placeholders
+
+### Before normalization
+
+- `connectshyft.bridge-flow.test.ts`: vendor-labeled bridge leg fixture values and legacy snake_case correlation keys were present in webhook payload fixtures.
+- `connectshyft.outbound-dispatch.test.ts`: vendor-labeled message and leg fixture values were present, and the local correlation helper still accepted legacy snake_case bridge-facing payload keys.
+- `bridgeSessions.test.ts`: provider call fixture values were vendor-labeled even though the assertions were bridge-session focused.
+- `providerCorrelationMappings.test.ts`: provider identifier fixtures used vendor-labeled call/message IDs throughout the bridge-adjacent mapping coverage.
+
+### After normalization target
+
+- Bridge-facing app and module tests use neutral fixture identifiers such as `provider-leg-*`, `provider-message-*`, and camelCase correlation fields.
+- Provider-native payload/header shapes remain only in explicit signature-verification or translation-edge helper coverage.
+- No runtime behavior, routing, deployment, UI, adapter, or schema files are changed.
+
+## In-Scope Inventory
+
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+
+## Reviewed Exception / Verification Surfaces
+
+- `tests/support/helpers/connectShyftWebhookTestHelpers.ts`: allowed provider-native webhook signature headers and raw provider payload examples when signature verification or translation-edge behavior is under test.
+- `domains/communication/bridge/__tests__/bridgeStateMachine.test.ts`: reviewed as provider-neutral baseline coverage.
+- `domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts`: reviewed as provider-neutral baseline coverage.
+
+## Validation Steps
+
+### 1. Confirm the touched-file set stays within tests and feature docs
+
+```sh
+git diff --name-only
+```
+
+Expected result:
+- only bridge-related test files, optional test-support files, and files under `specs/004-bridge-test-fixture-normalization/` are changed
+- no files under `nginx/`, `docker-compose*`, `apps/*/src/migrations/`, or runtime provider adapter sources are changed
+
+### 2. Verify bridge-facing tests no longer carry vendor-labeled fixtures
+
+```sh
+rg -n "telnyx-|twilio-|provider_leg_id:|provider_message_id:|provider_event_id:" \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+  apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts \
+  apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts \
+  domains/communication/bridge/__tests__/bridgeStateMachine.test.ts \
+  domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts \
+  tests/support/helpers/connectShyftWebhookTestHelpers.ts
+```
+
+Expected result:
+- no matches in bridge-facing app and domain tests
+- any remaining matches are explicitly documented provider-native exception surfaces in `tests/support/helpers/connectShyftWebhookTestHelpers.ts`
+
+### 3. Run targeted bridge-related Jest suites
+
+```sh
+cd apps/connectshyft-api
+npx jest --runInBand --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+  src/modules/connectshyft/__tests__/bridgeSessions.test.ts \
+  src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+```
+
+Expected result:
+- all targeted suites pass
+
+### 4. Run repository boundary enforcement
+
+```sh
+cd /Users/jeremiahotis/projects/connectshyft
+node scripts/enforce-workspace-boundaries.js
+```
+
+Expected result:
+- boundary enforcement passes
+
+### 5. Confirm deployment, routing, and database invariants remain unchanged
+
+```sh
+git diff --name-only -- \
+  nginx \
+  docker-compose.example.yml \
+  docker-compose.production.example.yml \
+  apps/admin-api/src \
+  apps/moneyshyft-api/src \
+  apps/connectshyft-api/src/migrations
+```
+
+Expected result:
+- no relevant runtime deploy/routing/database files changed for Admin, MoneyShyft, or ConnectShyft
+
+### 6. Record no-op Nginx routing delegation validation
+
+```sh
+git diff --name-only -- \
+  nginx \
+  apps/admin-api/src/routes \
+  apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/moneyshyft-api/src/routes
+```
+
+Expected result:
+- no changes that affect `/api/v1/auth/*` or `/api/v1/platform/admin/*` delegation to `admin-api`
+- no changes that affect `/api/v1/connectshyft/*` lane ownership
+
+### 7. Record no-op localhost binding and canonical port validation
+
+```sh
+git diff --name-only -- \
+  apps/admin-api/src/server.ts \
+  apps/moneyshyft-api/src/server.ts \
+  apps/connectshyft-api/src/server.ts \
+  docker-compose.example.yml \
+  docker-compose.production.example.yml
+```
+
+Expected result:
+- no changes to API bind behavior or canonical ports for `admin-api`, `money-api`, or `connect-api`
+
+### 8. Record shared Postgres compatibility and migration ownership validation
+
+```sh
+git diff --name-only -- \
+  apps/admin-api/src/migrations \
+  apps/moneyshyft-api/src/migrations \
+  apps/connectshyft-api/src/migrations \
+  apps/admin-api/src/config/database.ts \
+  apps/moneyshyft-api/src/config/database.ts \
+  apps/connectshyft-api/src/config/database.ts
+```
+
+Expected result:
+- no schema or database connectivity changes
+- `admin-api` remains the only production migration owner
+
+### 9. Record reproducible runbook validation
+
+```sh
+git diff --name-only -- \
+  SETUP.md \
+  PRODUCTION_DEPLOYMENT_GUIDE.md \
+  nginx \
+  docker-compose.example.yml \
+  docker-compose.production.example.yml \
+  apps/*/Dockerfile.production
+```
+
+Expected result:
+- no deployment runbook or production topology changes are required for CS-004b because the issue is test-only cleanup
+
+## Evidence To Capture
+
+- list of updated bridge test files
+- before/after examples of normalized fixture names
+- targeted Jest pass output
+- boundary enforcement pass output
+- confirmation that runtime behavior and deploy/routing/database surfaces were unchanged
+- confirmation that routing delegation, API binding/ports, shared Postgres ownership, and runbook reproducibility remained unchanged
+
+## Recorded Results
+
+### Updated file set
+
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+- `specs/004-bridge-test-fixture-normalization/contracts/bridge-test-fixture-contract.md`
+- `specs/004-bridge-test-fixture-normalization/quickstart.md`
+- `specs/004-bridge-test-fixture-normalization/tasks.md`
+
+### Before / after fixture examples
+
+- `connectshyft.bridge-flow.test.ts`
+  - before: `provider_leg_id: 'telnyx-leg-operator-thread-f1-unclaimed-1001'`
+  - after: `providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001'`
+- `connectshyft.outbound-dispatch.test.ts`
+  - before: `providerMessageId: 'telnyx-message-thread-f1-unclaimed-1001'`
+  - after: `providerMessageId: 'provider-message-thread-f1-unclaimed-1001'`
+- `bridgeSessions.test.ts`
+  - before: `providerCallId: 'telnyx-leg-neighbor-thread-f1-unclaimed-1001'`
+  - after: `providerCallId: 'provider-leg-neighbor-thread-f1-unclaimed-1001'`
+- `providerCorrelationMappings.test.ts`
+  - before: `providerName: 'telnyx', providerIdentifier: 'telnyx-leg-f3-1001'`
+  - after: `providerName: 'provider-a', providerIdentifier: 'provider-leg-f3-1001'`
+
+### Targeted Jest result
+
+Command:
+
+```sh
+cd apps/connectshyft-api
+env NODE_ENV=test \
+  MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  ENABLE_TEST_CONNECTSHYFT_FLAGS=true \
+  npx jest --runInBand --runTestsByPath \
+    src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+    src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+    src/modules/connectshyft/__tests__/bridgeSessions.test.ts \
+    src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+```
+
+Result:
+
+- `4` suites passed
+- `27` tests passed
+
+### Vendor-label scan result
+
+Command:
+
+```sh
+rg -n "telnyx-|twilio-|provider_leg_id:|provider_message_id:|provider_event_id:" \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+  apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts \
+  apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts \
+  domains/communication/bridge/__tests__/bridgeStateMachine.test.ts \
+  domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts \
+  tests/support/helpers/connectShyftWebhookTestHelpers.ts
+```
+
+Result:
+
+- no matches in the four bridge-facing app/module tests
+- no matches in `bridgeStateMachine.test.ts`
+- no matches in `handleProviderBridgeEvent.test.ts`
+- remaining matches are limited to `tests/support/helpers/connectShyftWebhookTestHelpers.ts` and are allowed provider-native signature/header fields:
+  - `x-test-connectshyft-telnyx-public-key`
+  - `telnyx-timestamp`
+  - `telnyx-signature-ed25519`
+
+### Boundary enforcement result
+
+Command:
+
+```sh
+node scripts/enforce-workspace-boundaries.js
+```
+
+Result:
+
+- `Workspace boundary guard passed (projects=8, sharedProjects=1)`
+
+### Touched-file guard result
+
+Command:
+
+```sh
+git diff --name-only
+```
+
+Result:
+
+- only the four in-scope bridge-facing test files and feature-doc files changed
+- no runtime deploy, routing, database, UI, or adapter files changed
+
+### No-op routing delegation validation
+
+Command:
+
+```sh
+git diff --name-only -- \
+  nginx \
+  apps/admin-api/src/routes \
+  apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/moneyshyft-api/src/routes
+```
+
+Result:
+
+- no diffs
+- `/api/v1/auth/*` and `/api/v1/platform/admin/*` delegation to `admin-api` remains unchanged
+- `/api/v1/connectshyft/*` lane ownership remains unchanged
+
+### No-op localhost binding / canonical port validation
+
+Command:
+
+```sh
+git diff --name-only -- \
+  apps/admin-api/src/server.ts \
+  apps/moneyshyft-api/src/server.ts \
+  apps/connectshyft-api/src/server.ts \
+  docker-compose.example.yml \
+  docker-compose.production.example.yml
+```
+
+Result:
+
+- no diffs
+- `admin-api`, `money-api`, and `connect-api` localhost binding / canonical ports remain unchanged
+
+### Shared Postgres / migration ownership validation
+
+Command:
+
+```sh
+git diff --name-only -- \
+  apps/admin-api/src/migrations \
+  apps/moneyshyft-api/src/migrations \
+  apps/connectshyft-api/src/migrations \
+  apps/admin-api/src/config/database.ts \
+  apps/moneyshyft-api/src/config/database.ts \
+  apps/connectshyft-api/src/config/database.ts
+```
+
+Result:
+
+- no diffs
+- no schema or database connectivity changes were introduced
+- `admin-api` remains the production migration owner
+
+### Runbook reproducibility validation
+
+Command:
+
+```sh
+git diff --name-only -- \
+  SETUP.md \
+  PRODUCTION_DEPLOYMENT_GUIDE.md \
+  nginx \
+  docker-compose.example.yml \
+  docker-compose.production.example.yml \
+  apps/*/Dockerfile.production
+```
+
+Result:
+
+- no diffs
+- no deployment or runbook changes are required because CS-004b is test-only cleanup

--- a/specs/004-bridge-test-fixture-normalization/research.md
+++ b/specs/004-bridge-test-fixture-normalization/research.md
@@ -1,0 +1,31 @@
+# Research: CS-004b Bridge Test Fixture Normalization
+
+## Decision 1
+
+- **Decision**: Limit CS-004b fixture cleanup to the bridge-related Jest files that still carry vendor-labeled data: `connectshyft.bridge-flow.test.ts`, `connectshyft.outbound-dispatch.test.ts`, `bridgeSessions.test.ts`, and `providerCorrelationMappings.test.ts`.
+- **Rationale**: Repository scans show the bridge-domain unit tests are already provider-neutral, while the remaining leakage is concentrated in those four bridge-facing route and module tests. This keeps the cleanup surgical and aligned with the issue guardrails.
+- **Alternatives considered**: Sweep all ConnectShyft tests for `telnyx` and `twilio` strings. Rejected because it broadens scope beyond bridge-related coverage and would pull in provider registry, translation, and voicemail scenario tests that intentionally exercise provider-specific behavior.
+
+## Decision 2
+
+- **Decision**: Normalize bridge-facing fixture shapes to the existing CS-003a contract vocabulary: `providerLegId`, `providerMessageId`, `providerEventId`, and `providerNumber`, with neutral identifier values such as `provider-leg-*` and `provider-message-*`.
+- **Rationale**: CS-003a already established the normalized telephony contract. Bridge tests should reflect that contract rather than implying vendor-specific semantics or legacy snake_case payload shapes in app-layer tests.
+- **Alternatives considered**: Keep legacy snake_case fields such as `provider_leg_id` in bridge route tests or rename fixtures ad hoc per file. Rejected because both approaches dilute the normalized contract and make the test surface inconsistent.
+
+## Decision 3
+
+- **Decision**: Preserve provider-native payloads and headers only in infrastructure translation or signature-verification helpers and tests.
+- **Rationale**: The ADR allows provider-native handling at the infrastructure edge. Helpers such as webhook signature builders are still correctly provider-specific because their job is to exercise translation and verification behavior, not bridge-domain neutrality.
+- **Alternatives considered**: Remove all provider-native payloads from the repository. Rejected because it would damage valid adapter-edge coverage and exceed the issue scope.
+
+## Decision 4
+
+- **Decision**: Avoid runtime production code changes and validate success through targeted bridge Jest suites, targeted vendor-string scans, touched-file checks, and boundary enforcement.
+- **Rationale**: CS-004b is explicitly test-only cleanup. The safest implementation path is to keep production code unchanged and prove that only tests and docs moved.
+- **Alternatives considered**: Introduce runtime aliasing or compatibility shims to accommodate old fixture names. Rejected because runtime changes are unnecessary for the intended cleanup.
+
+## Decision 5
+
+- **Decision**: Prefer file-local fixture normalization instead of introducing new shared bridge test helper abstractions.
+- **Rationale**: The remaining leakage is limited and localized. Updating the existing file-local mock builders and fixture literals keeps the change easy to review and avoids an unnecessary test-helper refactor.
+- **Alternatives considered**: Extract a new shared bridge-fixture builder library under `tests/support`. Rejected because it adds abstraction without reducing enough duplication to justify the extra surface area.

--- a/specs/004-bridge-test-fixture-normalization/spec.md
+++ b/specs/004-bridge-test-fixture-normalization/spec.md
@@ -1,0 +1,93 @@
+# Feature Specification: CS-004b Bridge Test Fixture Normalization
+
+**Feature Branch**: `004-bridge-test-fixture-normalization`  
+**Created**: 2026-03-12  
+**Status**: Draft  
+**Input**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-004b_Bridge_Test_Fixture_Normalization_Guardrailed_Spec.md`  
+**Source Input**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-004b_Bridge_Test_Fixture_Normalization_Guardrailed_Spec.md`
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Normalize Bridge Route and Module Fixtures (Priority: P1)
+
+As a maintainer, I can read bridge-related route and module tests without seeing vendor-labeled fixture names that imply app-layer or bridge-layer provider coupling.
+
+**Why this priority**: The CS-004 architecture verification already passed, so the remaining risk is misleading test data that contradicts the normalized provider boundary established by CS-003a.
+
+**Independent Test**: Run the targeted bridge Jest suites and confirm the bridge route, bridge session, and provider-correlation tests still pass while their fixtures use provider-neutral names and normalized correlation shapes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bridge route or bridge-session test currently using vendor-labeled fixture identifiers, **When** the fixture data is normalized, **Then** the test asserts the same runtime behavior through provider-neutral names such as `providerLegId`, `providerMessageId`, and `providerEventId`.
+2. **Given** bridge-adjacent provider-correlation tests, **When** provider identifiers are rewritten to neutral fixture values, **Then** the tests still prove the same uniqueness, replay-safety, and mapping behavior.
+
+---
+
+### User Story 2 - Preserve Allowed Provider-Native Translation Coverage (Priority: P2)
+
+As a maintainer, I can keep provider-native payloads only in infrastructure translation and webhook-signature tests so bridge-domain and app-layer tests stay architecturally neutral.
+
+**Why this priority**: CS-004b must clean up bridge-facing tests without overreaching into adapter translation tests where provider-native payloads are still the correct test surface.
+
+**Independent Test**: Scan the updated bridge-related test files for vendor-labeled fields and confirm any remaining provider-native payloads live only in infrastructure translation or signature-verification tests.
+
+**Acceptance Scenarios**:
+
+1. **Given** a bridge-domain or app-layer test, **When** fixture cleanup is complete, **Then** it no longer depends on vendor-prefixed field names or vendor-labeled identifier values.
+2. **Given** an infrastructure translation or signature-verification test, **When** the cleanup is complete, **Then** provider-native payloads may remain only where translation behavior is the explicit subject under test.
+
+### Edge Cases
+
+- Bridge tests that assert normalized provider failure classification may still carry a concrete `providerKey` value when the provider classification itself is the behavior under test.
+- Infrastructure translation and signature helpers may retain provider-native headers or payload keys when they are explicitly testing adapter-edge behavior.
+- No runtime behavior or production contract may change as a side effect of fixture renaming.
+- Bridge route tests must prefer normalized camelCase correlation fields instead of legacy snake_case webhook fixture keys unless the test is explicitly about translation compatibility at the infrastructure edge.
+
+## Scope Guardrails
+
+In scope:
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+- `tests/support/helpers/connectShyftWebhookTestHelpers.ts` only if needed to document the allowed provider-native exception surface
+
+Out of scope unless a direct import dependency forces a change:
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts`
+- story fixtures and factories under `tests/support/fixtures/` and `tests/support/factories/` for `F1`, `F2`, `F3`, `E4`, and `G6`
+- runtime bridge, adapter, UI, schema, routing, or migration files
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Bridge-related route, module, and domain-adjacent tests MUST replace vendor-labeled fixture identifier values with provider-neutral values where provider choice is not the behavior under test.
+- **FR-002**: Bridge and app-layer tests MUST prefer normalized correlation field names such as `providerLegId`, `providerMessageId`, `providerEventId`, and `providerNumber`.
+- **FR-003**: Bridge-related tests MUST NOT reintroduce direct Telnyx module mocking.
+- **FR-004**: Bridge-domain and app-layer tests MUST consume provider-neutral shapes only.
+- **FR-005**: Provider-native headers or payloads MAY remain only in infrastructure translation or webhook-signature tests where translation behavior is the explicit subject under test.
+- **FR-006**: Runtime production code MUST remain unchanged unless a minimal type-alignment adjustment is strictly required to keep tests compiling.
+- **FR-007**: Bridge-related Jest suites and boundary enforcement MUST continue to pass after fixture normalization.
+- **FR-008**: System MUST preserve lane boundaries and deployment compatibility by keeping `/api/v1/auth/*` and `/api/v1/platform/admin/*` delegated to `admin-api`, keeping all other lane `/api` routes lane-owned, and keeping shared-Postgres migration ownership with `admin-api`.
+
+## Compatibility Acceptance Scenarios
+
+1. **Given** CS-004b is implemented as test-only cleanup, **When** route ownership is reviewed, **Then** `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain delegated to `admin-api` and `/api/v1/connectshyft/*` remains lane-owned.
+2. **Given** CS-004b changes no runtime deployment files, **When** deployment topology is reviewed, **Then** host Nginx routing, localhost-only API bindings, and static frontend serving remain unchanged.
+3. **Given** CS-004b changes no schema or migration code, **When** database ownership is reviewed, **Then** shared Postgres compatibility remains intact and `admin-api` remains the sole production migration owner.
+
+### Key Entities *(include if feature involves data)*
+
+- **Normalized Bridge Route Fixture**: The request/response and resolver-mock data used by bridge route tests, carrying provider-neutral identifiers and normalized correlation fields.
+- **Normalized Bridge Session Fixture**: The provider adapter return values and persisted-state expectations used by bridge session application tests.
+- **Provider Correlation Fixture**: The provider identifier mapping data used in bridge-adjacent correlation tests, expressed with neutral provider and identifier names.
+- **Provider Translation Exception Fixture**: The explicitly allowed provider-native payloads that remain in infrastructure translation or signature-verification tests only.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Targeted bridge-related Jest suites pass with no runtime production file changes required beyond any minimal test-compilation type alignment.
+- **SC-002**: A targeted repository scan finds no vendor-labeled fixture values or vendor-prefixed correlation keys in bridge-related app-layer or bridge-domain tests after cleanup.
+- **SC-003**: `node scripts/enforce-workspace-boundaries.js` passes after the cleanup.
+- **SC-004**: All touched source files for CS-004b are limited to tests, test-support assets, and planning documentation; no schema, UI, provider adapter, or bridge runtime behavior changes are introduced.

--- a/specs/004-bridge-test-fixture-normalization/tasks.md
+++ b/specs/004-bridge-test-fixture-normalization/tasks.md
@@ -1,0 +1,170 @@
+# Tasks: CS-004b Bridge Test Fixture Normalization
+
+**Input**: Design documents from `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/`  
+**Prerequisites**: `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/plan.md`, `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/spec.md`, `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/research.md`, `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/data-model.md`, `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/contracts/`, `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+
+**Tests**: Targeted Jest validation and repository scans are required because the feature spec explicitly requires bridge-related suites to pass, vendor-labeled bridge fixtures to be removed, and boundary enforcement to remain green.
+
+**Organization**: Tasks are grouped by user story so the bridge-facing fixture cleanup can be delivered as one independently testable normalization slice followed by one independently testable exception-preservation slice.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Lock the normalization contract and evidence workflow before editing bridge-related tests.
+
+- [X] T001 Capture baseline before/after evidence placeholders and validation command targets in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+- [X] T002 Align the normalized field set, neutral identifier examples, and allowed exception notes in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/contracts/bridge-test-fixture-contract.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Confirm the exact in-scope bridge-facing test files and current vendor-labeled fixture surfaces before any cleanup begins.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [X] T003 [P] Review the current vendor-labeled bridge route fixture inventory in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- [X] T004 [P] Review the current vendor-labeled outbound dispatch fixture inventory in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
+- [X] T005 [P] Review the current vendor-labeled bridge-session fixture inventory in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- [X] T006 [P] Review the current vendor-labeled provider-correlation fixture inventory in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+
+**Checkpoint**: The in-scope bridge-facing files and exception boundaries are confirmed and ready for targeted normalization.
+
+---
+
+## Phase 3: User Story 1 - Normalize Bridge Route and Module Fixtures (Priority: P1) 🎯 MVP
+
+**Goal**: Replace vendor-labeled bridge-facing fixture names and shapes with provider-neutral values while preserving existing route, bridge-session, and provider-correlation test intent.
+
+**Independent Test**: Run the targeted bridge Jest suites and confirm the bridge route, bridge session, and provider-correlation tests still pass while using provider-neutral identifiers and normalized correlation fields.
+
+### Tests for User Story 1
+
+- [X] T007 [P] [US1] Normalize bridge route fixture identifiers and correlation field names in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- [X] T008 [P] [US1] Normalize outbound dispatch fixture identifiers and correlation field names in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
+- [X] T009 [P] [US1] Normalize bridge-session adapter fixture values and persisted-state expectations in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+- [X] T010 [P] [US1] Normalize provider-correlation fixture identifiers and neutral provider labels in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Run the targeted bridge Jest suites documented in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md` against `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`, and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+
+**Checkpoint**: User Story 1 is complete when the four bridge-facing Jest files use provider-neutral fixture names and all targeted suites still pass.
+
+---
+
+## Phase 4: User Story 2 - Preserve Allowed Provider-Native Translation Coverage (Priority: P2)
+
+**Goal**: Keep provider-native payloads only where translation or signature verification is the thing being tested, while confirming bridge-domain and app-layer tests remain provider-neutral.
+
+**Independent Test**: Run the targeted vendor-label scans and confirm any remaining provider-native payloads live only in infrastructure translation or signature-verification coverage, not in bridge-facing app or domain tests.
+
+### Tests for User Story 2
+
+- [X] T012 [P] [US2] Verify and, if needed, clarify the allowed provider-native webhook-signature exception in `/Users/jeremiahotis/projects/connectshyft/tests/support/helpers/connectShyftWebhookTestHelpers.ts`
+- [X] T013 [P] [US2] Verify bridge-domain state-machine coverage remains provider-neutral in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts`
+- [X] T014 [P] [US2] Verify bridge-domain event-handling coverage remains provider-neutral in `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Run vendor-label scans across `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`, `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts`, `/Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts`, and `/Users/jeremiahotis/projects/connectshyft/tests/support/helpers/connectShyftWebhookTestHelpers.ts`, then record which remaining provider-native fields are allowed exception surfaces in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+
+**Checkpoint**: User Story 2 is complete when bridge-facing tests are clean and any remaining provider-native payloads are confined to explicit infrastructure-edge exception surfaces.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Capture final evidence and no-regression validation for the test-only cleanup.
+
+- [X] T016 [P] Capture the final updated file list and before/after fixture naming examples in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+- [X] T017 [P] Run `node scripts/enforce-workspace-boundaries.js` and record the result in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+- [X] T018 Run the touched-file guard checks from `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md` and confirm no runtime deploy, routing, database, UI, or adapter files changed in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+- [X] T019 [P] Record no-op Nginx routing delegation validation for `/api/v1/auth/*`, `/api/v1/platform/admin/*`, and `/api/v1/connectshyft/*` in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+- [X] T020 [P] Record no-op localhost binding and canonical port validation for `admin-api`, `money-api`, and `connect-api` in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+- [X] T021 [P] Record shared Postgres compatibility and `admin-api` production migration ownership validation in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+- [X] T022 Record reproducible runbook validation for CS-004b as a no-runtime-change cleanup in `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup** has no dependencies and can begin immediately.
+- **Phase 2: Foundational** depends on Phase 1 and blocks all story work.
+- **Phase 3: User Story 1** depends on Phase 2 and delivers the MVP bridge-facing fixture cleanup.
+- **Phase 4: User Story 2** depends on Phase 3 because exception-surface validation assumes the bridge-facing normalization is already complete.
+- **Phase 5: Polish** depends on the completion of both user stories and captures final evidence plus constitution-mandated no-op deployment validations.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start immediately after Foundational and is the MVP slice.
+- **US2 (P2)**: Depends on US1 because the exception scan only makes sense after bridge-facing fixture cleanup lands.
+
+### Within Each User Story
+
+- Review the in-scope file inventory before editing any bridge-facing test.
+- Normalize bridge-facing fixture values and field names before running validation.
+- Keep provider-specific `providerKey` values only where classification or provider selection itself is the behavior under test.
+- Do not modify runtime production files unless a minimal type-alignment fix is strictly required.
+
+### Recommended Completion Order
+
+1. Phase 1: Setup
+2. Phase 2: Foundational
+3. Phase 3: US1
+4. Phase 4: US2
+5. Phase 5: Polish
+
+---
+
+## Parallel Execution Examples
+
+### User Story 1
+
+```bash
+Task: "T007 [US1] Normalize bridge route fixture identifiers and correlation field names in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts"
+Task: "T008 [US1] Normalize outbound dispatch fixture identifiers and correlation field names in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts"
+Task: "T009 [US1] Normalize bridge-session adapter fixture values and persisted-state expectations in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts"
+Task: "T010 [US1] Normalize provider-correlation fixture identifiers and neutral provider labels in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts"
+```
+
+### User Story 2
+
+```bash
+Task: "T012 [US2] Verify and, if needed, clarify the allowed provider-native webhook-signature exception in /Users/jeremiahotis/projects/connectshyft/tests/support/helpers/connectShyftWebhookTestHelpers.ts"
+Task: "T013 [US2] Verify bridge-domain state-machine coverage remains provider-neutral in /Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/bridgeStateMachine.test.ts"
+Task: "T014 [US2] Verify bridge-domain event-handling coverage remains provider-neutral in /Users/jeremiahotis/projects/connectshyft/domains/communication/bridge/__tests__/handleProviderBridgeEvent.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. Validate the US1 independent test before advancing to exception-surface verification.
+
+### Incremental Delivery
+
+1. Deliver US1 to clean the four bridge-facing Jest files and keep them passing.
+2. Add US2 to confirm the remaining provider-native payloads are limited to allowed infrastructure-edge coverage.
+3. Finish with Phase 5 evidence capture, constitution no-op validation, and no-regression validation.
+
+### Parallel Team Strategy
+
+1. One developer can handle the two route test files while another handles the module test files in US1.
+2. After US1 is complete, one developer can verify infrastructure-edge exceptions while another records evidence and boundary-validation output.
+3. Serialize any repeated edits to `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/quickstart.md` and `/Users/jeremiahotis/projects/connectshyft/specs/004-bridge-test-fixture-normalization/contracts/bridge-test-fixture-contract.md` to avoid conflicts.
+
+---
+
+## Notes
+
+- `[P]` means the task is parallelizable because it targets a separate file or independent validation surface with no incomplete upstream dependency.
+- This task list is intentionally test-centric because CS-004b is a test-only normalization issue.
+- The suggested MVP scope is **User Story 1 only**.
+- No tasks modify UI files, schema files, runtime bridge orchestration code, or provider adapter implementation files.

--- a/specs/connectshyft-recovery/issues/CS-004b_Bridge_Test_Fixture_Normalization_Guardrailed_Spec.md
+++ b/specs/connectshyft-recovery/issues/CS-004b_Bridge_Test_Fixture_Normalization_Guardrailed_Spec.md
@@ -1,0 +1,96 @@
+# CS-004b Bridge Test Fixture Normalization (Guardrailed Spec)
+
+## A. Outcome
+
+Bridge-related tests use provider-neutral fixture names and payload shapes so the test suite reinforces the Communication Infrastructure ADR instead of implying vendor-specific coupling inside bridge or app-domain logic.
+
+## B. Scope
+
+This issue is limited to test and test-support cleanup for CS-004 bridge-related coverage after CS-004 architectural verification.
+
+In scope:
+- replace vendor-labeled fixture keys in bridge-related tests with provider-neutral names
+- update test helpers, factories, mocks, and fixture builders accordingly
+- keep runtime behavior unchanged
+- preserve current test intent and coverage
+
+Expected focus areas:
+- `connectshyft.bridge-flow.test.ts`
+- `connectshyft.outbound-dispatch.test.ts`
+- any bridge-adjacent test helpers or fixture builders
+- any additional bridge-related tests still carrying vendor-labeled payload fields
+
+## Governing Execution Contract
+
+This issue is governed by:
+
+- `/specs/connectshyft-recovery/developer_execution_packet.md`
+- `/specs/connectshyft-recovery/ADR-00X_Communication_Infrastructure_Contract.md`
+- `/specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md`
+
+This issue is informed by the CS-004 architecture verification result:
+- bridge orchestration remains architecturally compatible
+- bridge test fixtures still contain some vendor-labeled data even though direct Telnyx module mocking is gone
+
+If implementation details conflict with the ADR or canonical data model note, those documents take precedence.
+
+## C. Non-Goals
+
+- no runtime code changes unless strictly required to keep tests compiling after fixture renaming
+- no bridge orchestration redesign
+- no provider adapter changes
+- no UI changes
+- no schema changes
+- no retry/idempotency work
+- no broad test refactor outside fixture normalization
+
+## D. Implementation Guardrails
+
+1. Runtime behavior must not change.
+2. Provider-neutral test names must reflect the normalized contract already established by CS-003a.
+3. Tests must not reintroduce direct Telnyx module mocking.
+4. Test fixtures must prefer normalized names such as:
+   - `providerCallId`
+   - `providerMessageId`
+   - `providerEventId`
+   - `providerLegId`
+   - `providerNumber`
+5. No vendor-prefixed field names should remain in bridge-related tests unless they are explicitly testing infrastructure translation behavior inside the Telnyx adapter.
+6. Bridge-domain and app-layer tests must consume provider-neutral shapes only.
+7. Infrastructure adapter tests may still contain provider-native payloads where the purpose of the test is provider translation.
+
+## E. Acceptance Criteria
+
+### Fixture Neutrality
+- bridge-related tests no longer use vendor-labeled fixture names where provider-neutral names are appropriate
+- bridge and route-level tests use normalized correlation metadata
+
+### Boundary Clarity
+- no direct Telnyx module mocking in bridge-related tests
+- bridge-domain tests do not imply provider-native event semantics above infrastructure
+
+### Regression Safety
+- bridge-related Jest suites still pass
+- no runtime production files are modified unless strictly required for type alignment
+- boundary enforcement still passes
+
+## F. Evidence Required in PR
+
+- list of tests updated
+- example before/after fixture naming changes
+- proof that bridge-related tests still pass
+- statement confirming runtime behavior unchanged
+
+## G. Definition of Done
+
+This issue is done when bridge-related tests reinforce provider-neutral architecture and no vendor-labeled fixture naming remains outside provider adapter translation tests.
+
+## H. Suggested Fixture Name Conversions
+
+Examples:
+- `telnyxCallControlId` -> `providerCallId`
+- `telnyxMessageId` -> `providerMessageId`
+- `telnyxEventId` -> `providerEventId`
+- `telnyxTo` / `telnyxFrom` -> `providerNumber` or normalized correlation metadata fields as appropriate
+
+Use normalized names that match the current telephony contract, not ad hoc replacements.


### PR DESCRIPTION
# CS-004b Bridge Test Fixture Normalization PR

Issue:
CS-004b Bridge Test Fixture Normalization

Governing Documents:
- /specs/connectshyft-recovery/developer_execution_packet.md
- /specs/connectshyft-recovery/ADR-00X_Communication_Infrastructure_Contract.md
- /specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md
- /specs/connectshyft-recovery/issues/CS-004b_Bridge_Test_Fixture_Normalization_Guardrailed_Spec.md

Verification Source:
- CS-004 architecture verification result noting vendor-labeled bridge test fixtures

---

## Summary

Normalizes bridge-related test fixtures and assertions from vendor-labeled identifiers to provider-neutral names so the bridge-facing test surface reinforces the Communication Infrastructure ADR without changing runtime behavior.

---

## Scope Confirmation

This PR is limited to test cleanup.

Confirm:

- [x] No runtime behavior changes
- [x] No bridge orchestration redesign
- [x] No provider adapter redesign
- [x] No telephony contract redesign
- [x] No UI changes
- [x] No schema changes
- [x] No retry/idempotency work
- [x] No unrelated repo cleanup

If any runtime file changed, explain why it was strictly necessary for compile or type alignment:

No runtime files changed.

---

## Fixture Normalization

Confirm bridge-related tests now use provider-neutral fixture names.

- [x] vendor-labeled bridge fixture keys replaced with normalized names
- [x] route-level bridge tests consume provider-neutral correlation metadata
- [x] bridge-domain tests consume provider-neutral fixture shapes
- [x] direct Telnyx module mocking is not used in bridge-related tests
- [x] infrastructure adapter translation tests remain vendor-native only where appropriate

Describe the main fixture changes:

The bridge-facing route and module tests now use neutral `provider-*` identifiers and camelCase provider-neutral correlation fields instead of vendor-labeled fixture data. Remaining provider-native payloads are limited to the documented webhook-signature/translation helper exception surface where raw provider payload shape is the thing under test.

---

## Files Updated

Check all that apply:

- [x] `connectshyft.bridge-flow.test.ts`
- [x] `connectshyft.outbound-dispatch.test.ts`
- [ ] shared fixture builders/helpers
- [x] additional bridge-adjacent tests

List files touched:

- `/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
- `/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
- `/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
- `/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
- `/specs/connectshyft-recovery/issues/CS-004b_Bridge_Test_Fixture_Normalization_Guardrailed_Spec.md`
- `/specs/004-bridge-test-fixture-normalization/spec.md`
- `/specs/004-bridge-test-fixture-normalization/plan.md`
- `/specs/004-bridge-test-fixture-normalization/research.md`
- `/specs/004-bridge-test-fixture-normalization/data-model.md`
- `/specs/004-bridge-test-fixture-normalization/contracts/bridge-test-fixture-contract.md`
- `/specs/004-bridge-test-fixture-normalization/quickstart.md`
- `/specs/004-bridge-test-fixture-normalization/tasks.md`
- `/AGENTS.md`

---

## Before / After Examples

Provide at least 2 concrete examples.

Examples from this PR:

- `telnyx-leg-operator-*` → `provider-leg-operator-*`
- `telnyx-message-*` → `provider-message-*`
- `provider_leg_id` fixture input → `providerLegId`
- `provider_event_id` fixture input → `providerEventId`

---

## Boundary Compliance

Confirm the test layer now matches the provider-neutral architecture.

- [x] bridge-domain and app-layer tests use provider-neutral shapes
- [x] no vendor-specific fixture naming remains outside provider translation tests
- [x] no direct Telnyx mocking remains in bridge-related tests
- [x] runtime files remain unchanged or only minimally aligned for type safety

Evidence:

Focused scans across the bridge-facing app/module/domain test files are clean. The only remaining Telnyx-labeled surface is the documented webhook helper used for provider-native signature and translation scenarios.

---

## Test Results

- [x] focused bridge-related Jest suites passed
- [x] outbound dispatch tests passed
- [x] boundary enforcement script passed

Paste or summarize results:

- Focused bridge Jest: `4 suites`, `27 tests` passed
- `node scripts/enforce-workspace-boundaries.js`: passed
- Targeted vendor-label scan: only the allowed provider-native webhook helper matches remain
- Full local PR-parity sweep also passed:
  - `npm run policy:check`
  - `bash scripts/lint-or-discovery.sh`
  - `bash scripts/ci-run-playwright-stack.sh bash scripts/backend-jest-ci.sh`
  - Playwright shards `1/4` through `4/4`
  - `bash scripts/quality-gates.sh`
  - `bash scripts/ci-run-playwright-stack.sh bash scripts/burn-in.sh 10 origin/codex/dev`

---

## Runtime Integrity Confirmation

- [x] runtime production behavior unchanged
- [x] no bridge runtime logic modified
- [x] no provider adapter runtime behavior modified

If any runtime code changed, explain the exact reason and why it was minimal:

No runtime code changed.

---

## Out-of-Scope Confirmation

Confirm this PR does NOT attempt to solve:

- [x] CS-003a adapter remediation
- [x] CS-004 bridge redesign
- [x] CS-005 reliability work
- [x] provider failover strategy
- [x] unrelated test modernization

If anything above was partially touched, explain why:

No out-of-scope behavior was touched.

---

## Final Definition of Done

- [x] bridge-related tests reinforce provider-neutral architecture
- [x] no unnecessary runtime changes introduced
- [x] focused tests pass
- [x] no vendor-labeled fixture naming remains outside infrastructure translation tests

---

## Final Statement

This change complies with ADR-00X Communication Infrastructure Contract and the Canonical Data Model Note. It normalizes bridge-related test fixtures without changing runtime behavior.
