### PR TITLE
Feat: implement CS-005 communication reliability

### DIFF
--- a/.github/pull_request_template/cs-005-reliability-idempotency-audit.md
+++ b/.github/pull_request_template/cs-005-reliability-idempotency-audit.md
@@ -1,0 +1,50 @@
+# CS-005 Reliability / Idempotency / Audit PR
+
+Issue:
+CS-005 Reliability Idempotency Audit Guardrailed Spec
+
+Governing Documents:
+- /specs/connectshyft-recovery/developer_execution_packet.md
+- /specs/connectshyft-recovery/ADR-00X_Communication_Infrastructure_Contract.md
+- /specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md
+- /specs/connectshyft-recovery/issues/CS-005_Reliability_Idempotency_Audit_Guardrailed_Spec.md
+- /specs/connectshyft-recovery/architecture/CS-005_reliability_sequence_diagram.md
+- /specs/connectshyft-recovery/CS-005_Minimal_Internal_Event_Model_Note.md
+
+## Scope Confirmation
+- [ ] No redesign of bridge orchestration
+- [ ] No redesign of the Telnyx adapter
+- [ ] No UI redesign work included
+- [ ] No unrelated feature work included
+
+## Idempotency
+- [ ] duplicate outbound requests prevented
+- [ ] same key + same request returns authoritative result
+- [ ] same key + different request is rejected
+- [ ] idempotency record persists before side effects
+
+## Webhook Replay / Dedupe
+- [ ] duplicate webhook events detected
+- [ ] duplicate webhook events ignored safely
+- [ ] webhook receipt or equivalent checkpoint persists
+- [ ] replay-safe processing verified
+
+## Retry Strategy
+- [ ] retryable vs non-retryable failures distinguished
+- [ ] retry backoff implemented
+- [ ] retries stop after defined limit
+- [ ] retry exhaustion is recorded
+
+## Audit Logging
+- [ ] audit is append-only
+- [ ] command-side outcomes recorded
+- [ ] event-side outcomes recorded
+- [ ] duplicate-ignored actions recorded
+- [ ] failure reasons recorded
+
+## Final Definition of Done
+- [ ] duplicate sessions prevented
+- [ ] duplicate calls prevented
+- [ ] duplicate webhook events ignored safely
+- [ ] retries bounded
+- [ ] audit trail present

--- a/.github/pull_request_template/cs-005-reliability-verification.md
+++ b/.github/pull_request_template/cs-005-reliability-verification.md
@@ -1,0 +1,32 @@
+# CS-005 Reliability Verification PR
+
+Purpose:
+Architectural and behavioral verification of CS-005 after implementation.
+
+## Verification Checklist
+
+### Idempotency
+- [ ] idempotency happens before side effects
+- [ ] same key + same request returns authoritative result
+- [ ] same key + different request rejects with conflict
+
+### Webhook replay safety
+- [ ] duplicate provider events ignored safely
+- [ ] event application happens only after duplicate check
+- [ ] replay-safe processing verified
+
+### Retry
+- [ ] retryable vs non-retryable distinction exists
+- [ ] retry decisions are bounded
+- [ ] retry logic does not bypass domain state rules
+
+### Audit
+- [ ] audit is append-only
+- [ ] command-side outcomes recorded
+- [ ] event-side outcomes recorded
+- [ ] duplicate ignored actions recorded
+
+### Boundary integrity
+- [ ] provider payloads do not leak above infrastructure
+- [ ] bridge state machine remains authoritative
+- [ ] no reliability logic drift into UI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,8 @@ Docker:
 - Shared PostgreSQL; current ConnectShyft phone persistence in `connectshyft.cs_neighbor_phones` must evolve toward `communication_contact_point`-equivalent canonical fields (002-phone-identity)
 - TypeScript (ES2022) on Node.js >=20 + Jest, ts-jest, Express route test harnesses, shared communication domain modules under `domains/communication`, ConnectShyft module tests under `apps/connectshyft-api`, and repository boundary enforcement via `node scripts/enforce-workspace-boundaries.js` (004-bridge-test-fixture-normalization)
 - N/A for new behavior; existing shared PostgreSQL-backed bridge, correlation, and webhook models remain unchanged because CS-004b is test-only cleanup (004-bridge-test-fixture-normalization)
+- TypeScript (ES2022) on Node.js >=20 + Express, Knex, `pg`, Jest, ts-jest, shared communication domain modules under `domains/communication`, ConnectShyft route/module services under `apps/connectshyft-api`, and repository boundary enforcement via `node scripts/enforce-workspace-boundaries.js` (005-reliability-idempotency-audit)
+- Shared PostgreSQL using existing ConnectShyft bridge-session, message, provider-correlation, and webhook-receipt tables plus new durable `communication_idempotency_record` and `communication_audit_log`-equivalent persistence and minimal retry metadata on reliability-owned records where required (005-reliability-idempotency-audit)
 
 ## Recent Changes
 - 001-tighten-deployment-contracts: Added TypeScript (Node.js APIs), Vue 3 TypeScript frontends + Express APIs, host Nginx reverse proxy, Docker Compose

--- a/apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts
+++ b/apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts
@@ -1,0 +1,121 @@
+import type { Knex } from 'knex'
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft'
+const IDEMPOTENCY_TABLE = 'cs_communication_idempotency_records'
+const AUDIT_TABLE = 'cs_communication_audit_log'
+const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}`)
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${IDEMPOTENCY_TABLE} (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      operation_name TEXT NOT NULL,
+      actor_id TEXT NULL,
+      actor_scope_key TEXT NULL,
+      request_fingerprint TEXT NOT NULL,
+      request_summary TEXT NULL,
+      resource_type TEXT NULL,
+      resource_id TEXT NULL,
+      status TEXT NOT NULL,
+      response_snapshot_json JSONB NULL,
+      failure_classification_json JSONB NULL,
+      failure_message TEXT NULL,
+      attempt_count INTEGER NOT NULL DEFAULT 1,
+      first_seen_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_seen_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      completed_at_utc TIMESTAMPTZ NULL,
+      retry_eligible_at_utc TIMESTAMPTZ NULL,
+      expires_at_utc TIMESTAMPTZ NOT NULL,
+      CONSTRAINT cs_communication_idempotency_status_ck CHECK (
+        status IN ('in_progress', 'succeeded', 'failed')
+      ),
+      CONSTRAINT cs_communication_idempotency_scope_uq UNIQUE (
+        tenant_id,
+        idempotency_key,
+        operation_name
+      )
+    )
+  `)
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS connectshyft_cs_communication_idempotency_scope_idx
+    ON ${CONNECTSHYFT_SCHEMA}.${IDEMPOTENCY_TABLE} (
+      tenant_id,
+      operation_name,
+      idempotency_key,
+      last_seen_at_utc DESC,
+      id
+    )
+  `)
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${AUDIT_TABLE} (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      correlation_id TEXT NOT NULL,
+      actor_type TEXT NOT NULL,
+      actor_id TEXT NULL,
+      operation_name TEXT NOT NULL,
+      target_entity_type TEXT NOT NULL,
+      target_entity_id TEXT NULL,
+      channel TEXT NOT NULL,
+      result_state TEXT NOT NULL,
+      result_code TEXT NULL,
+      result_message TEXT NULL,
+      idempotency_key TEXT NULL,
+      request_fingerprint TEXT NULL,
+      provider_name TEXT NULL,
+      provider_reference_id TEXT NULL,
+      metadata_json JSONB NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT cs_communication_audit_actor_type_ck CHECK (
+        actor_type IN ('user', 'system', 'provider')
+      ),
+      CONSTRAINT cs_communication_audit_channel_ck CHECK (
+        channel IN ('sms', 'voice', 'bridge', 'webhook')
+      ),
+      CONSTRAINT cs_communication_audit_result_state_ck CHECK (
+        result_state IN ('succeeded', 'failed', 'ignored_duplicate', 'retrying', 'exhausted')
+      )
+    )
+  `)
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS connectshyft_cs_communication_audit_scope_idx
+    ON ${CONNECTSHYFT_SCHEMA}.${AUDIT_TABLE} (
+      tenant_id,
+      correlation_id,
+      created_at_utc DESC,
+      id
+    )
+  `)
+
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+    ADD COLUMN IF NOT EXISTS next_retry_at_utc TIMESTAMPTZ NULL
+  `)
+
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+    ADD COLUMN IF NOT EXISTS last_failure_classification JSONB NULL
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+    DROP COLUMN IF EXISTS last_failure_classification
+  `)
+
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+    DROP COLUMN IF EXISTS next_retry_at_utc
+  `)
+
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(AUDIT_TABLE)
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(IDEMPOTENCY_TABLE)
+}

--- a/apps/connectshyft-api/src/migrations/__tests__/connectShyftCommunicationReliabilityMigration.test.ts
+++ b/apps/connectshyft-api/src/migrations/__tests__/connectShyftCommunicationReliabilityMigration.test.ts
@@ -1,0 +1,57 @@
+import { down, up } from '../20260312120000_add_connectshyft_communication_reliability'
+
+function buildKnexMock() {
+  const dropped: string[] = []
+
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+    schema: {
+      withSchema: (schema: string) => ({
+        dropTableIfExists: async (tableName: string) => {
+          dropped.push(`${schema}.${tableName}`)
+        },
+      }),
+    },
+  }
+
+  return {
+    knex,
+    dropped,
+  }
+}
+
+describe('20260312120000_add_connectshyft_communication_reliability migration', () => {
+  it('creates durable idempotency and append-only audit persistence and extends webhook receipts', async () => {
+    const { knex } = buildKnexMock()
+
+    await up(knex)
+
+    const rawCalls = knex.raw.mock.calls.map((call: [string]) => call[0])
+
+    expect(rawCalls).toEqual(expect.arrayContaining([
+      'CREATE SCHEMA IF NOT EXISTS connectshyft',
+    ]))
+    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_communication_idempotency_records'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('CONSTRAINT cs_communication_idempotency_scope_uq UNIQUE'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('response_snapshot_json JSONB NULL'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_communication_audit_log'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes("result_state IN ('succeeded', 'failed', 'ignored_duplicate', 'retrying', 'exhausted')"))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('ADD COLUMN IF NOT EXISTS next_retry_at_utc TIMESTAMPTZ NULL'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('ADD COLUMN IF NOT EXISTS last_failure_classification JSONB NULL'))).toBe(true)
+  })
+
+  it('drops audit/idempotency persistence and removes webhook retry metadata in down migration', async () => {
+    const { knex, dropped } = buildKnexMock()
+
+    await down(knex)
+
+    const rawCalls = knex.raw.mock.calls.map((call: [string]) => call[0])
+
+    expect(rawCalls.some((sql: string) => sql.includes('DROP COLUMN IF EXISTS last_failure_classification'))).toBe(true)
+    expect(rawCalls.some((sql: string) => sql.includes('DROP COLUMN IF EXISTS next_retry_at_utc'))).toBe(true)
+    expect(dropped).toEqual([
+      'connectshyft.cs_communication_audit_log',
+      'connectshyft.cs_communication_idempotency_records',
+    ])
+  })
+})

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
@@ -373,6 +373,63 @@ describe('connectshyft provider correlation mappings', () => {
     });
   });
 
+  it('stores retry metadata for retryable receipt failures', async () => {
+    const started = await beginConnectShyftWebhookReceiptProcessing({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'provider-a',
+      canonicalEventType: 'CallConnected',
+      providerEventId: 'provider-event-f3-retry-2001',
+      providerLegId: 'provider-leg-f3-retry-2001',
+    });
+
+    const nextRetryAtUtc = '2026-03-12T12:05:00.000Z';
+    const markedRetryableFailure = await markConnectShyftWebhookReceiptProcessingResult({
+      tenantId: 'tenant-connectshyft-f3',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'provider-a',
+      dedupeKey: started.dedupeKey,
+      canonicalEventType: 'CallConnected',
+      providerEventId: 'provider-event-f3-retry-2001',
+      providerLegId: 'provider-leg-f3-retry-2001',
+      status: 'FAILED_RETRYABLE',
+      failureReason: 'temporary_provider_failure',
+      nextRetryAtUtc,
+      lastFailureClassification: {
+        category: 'temporary_provider_failure',
+        retryable: true,
+        httpStatus: 429,
+        providerCode: 'rate_limited',
+      },
+    });
+
+    expect(markedRetryableFailure.updated).toBe(true);
+
+    const retried = await beginConnectShyftWebhookReceiptProcessing({
+      tenantId: 'tenant-connectshyft-f3',
+      orgUnitId: 'org-connectshyft-f3-east',
+      threadId: 'thread-f3-unclaimed-1001',
+      providerName: 'provider-a',
+      canonicalEventType: 'CallConnected',
+      providerEventId: 'provider-event-f3-retry-2001',
+      providerLegId: 'provider-leg-f3-retry-2001',
+    });
+
+    expect(retried).toMatchObject({
+      previousStatus: 'FAILED_RETRYABLE',
+      status: 'RECEIVED',
+      attemptCount: 2,
+      nextRetryAtUtc,
+      lastFailureClassification: {
+        category: 'temporary_provider_failure',
+        retryable: true,
+        httpStatus: 429,
+        providerCode: 'rate_limited',
+      },
+    });
+  });
+
   it('allows duplicate provider identifiers across tenants and marks tenant-unspecified lookup as ambiguous', async () => {
     await recordConnectShyftProviderIdentifierMapping({
       tenantId: 'tenant-connectshyft-f3-a',

--- a/apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts
@@ -1,0 +1,81 @@
+import type { Knex } from 'knex'
+import db from '../../config/knex'
+import {
+  buildRecordCommunicationAudit,
+  type CommunicationAuditEntry,
+  type CommunicationAuditRepository,
+} from '../../../../../domains/communication'
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft'
+const AUDIT_TABLE = 'cs_communication_audit_log'
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+const inMemoryAuditEntries: CommunicationAuditEntry[] = []
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim()
+}
+
+const shouldUseDb = (tenantId: string, connection?: Knex): boolean =>
+  Boolean(connection && UUID_PATTERN.test(normalizeString(tenantId)))
+
+const buildRepository = (tenantId: string, connection?: Knex): CommunicationAuditRepository => {
+  if (!shouldUseDb(tenantId, connection)) {
+    return {
+      async append(entry) {
+        inMemoryAuditEntries.push(entry)
+      },
+    }
+  }
+
+  const knex = connection as Knex
+  return {
+    async append(entry) {
+      await knex
+        .withSchema(CONNECTSHYFT_SCHEMA)
+        .table(AUDIT_TABLE)
+        .insert({
+          id: entry.id,
+          tenant_id: entry.tenantId,
+          correlation_id: entry.correlationId,
+          actor_type: entry.actorType,
+          actor_id: entry.actorId ?? null,
+          operation_name: entry.operationName,
+          target_entity_type: entry.targetEntityType,
+          target_entity_id: entry.targetEntityId ?? null,
+          channel: entry.channel,
+          result_state: entry.resultState,
+          result_code: entry.resultCode ?? null,
+          result_message: entry.resultMessage ?? null,
+          idempotency_key: entry.idempotencyKey ?? null,
+          request_fingerprint: entry.requestFingerprint ?? null,
+          provider_name: entry.providerName ?? null,
+          provider_reference_id: entry.providerReferenceId ?? null,
+          metadata_json: entry.metadataJson ? JSON.parse(entry.metadataJson) : null,
+          created_at_utc: entry.createdAt.toISOString(),
+        })
+    },
+  }
+}
+
+export const appendConnectShyftCommunicationAuditEntry = async (
+  input: Omit<CommunicationAuditEntry, 'id' | 'createdAt'> & { db?: Knex },
+) => {
+  const repository = buildRepository(input.tenantId, input.db)
+  const recordAudit = buildRecordCommunicationAudit(repository)
+  return recordAudit(input)
+}
+
+export const listConnectShyftCommunicationAuditEntriesForTests = (): CommunicationAuditEntry[] => [
+  ...inMemoryAuditEntries,
+]
+
+export const resetConnectShyftCommunicationAuditLogForTests = (): void => {
+  inMemoryAuditEntries.splice(0, inMemoryAuditEntries.length)
+}
+
+export const loadConnectShyftCommunicationAuditDb = (): Knex => db

--- a/apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from 'node:crypto'
+import type { Knex } from 'knex'
+import db from '../../config/knex'
+import {
+  buildIdempotencyService,
+  type IdempotencyFailureSnapshot,
+  type IdempotencyOperationName,
+  type IdempotencyRecord,
+  type IdempotencyRepository,
+} from '../../../../../domains/communication'
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft'
+const IDEMPOTENCY_TABLE = 'cs_communication_idempotency_records'
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export type ConnectShyftIdempotencyResponseSnapshot = {
+  httpStatus: number
+  body: unknown
+}
+
+type DbIdempotencyRow = {
+  id: string
+  tenant_id: string
+  idempotency_key: string
+  operation_name: string
+  actor_id?: string | null
+  actor_scope_key?: string | null
+  request_fingerprint: string
+  request_summary?: string | null
+  resource_type?: string | null
+  resource_id?: string | null
+  status: string
+  response_snapshot_json?: unknown
+  failure_classification_json?: unknown
+  failure_message?: string | null
+  attempt_count?: unknown
+  first_seen_at_utc: string | Date
+  last_seen_at_utc: string | Date
+  completed_at_utc?: string | Date | null
+  retry_eligible_at_utc?: string | Date | null
+  expires_at_utc: string | Date
+}
+
+const inMemoryIdempotencyRecords = new Map<string, IdempotencyRecord>()
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim()
+}
+
+const toDate = (value: unknown): Date | null => {
+  if (!value) {
+    return null
+  }
+  if (value instanceof Date) {
+    return value
+  }
+  const normalized = normalizeString(value)
+  if (!normalized) {
+    return null
+  }
+  const parsed = new Date(normalized)
+  return Number.isNaN(parsed.valueOf()) ? null : parsed
+}
+
+const parseJsonValue = <T>(value: unknown): T | null => {
+  if (value == null) {
+    return null
+  }
+  if (typeof value === 'object') {
+    return value as T
+  }
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as T
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+const parseAttemptCount = (value: unknown): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(1, Math.trunc(value))
+  }
+  const normalized = normalizeString(value)
+  if (!normalized) {
+    return 1
+  }
+  const parsed = Number.parseInt(normalized, 10)
+  return Number.isFinite(parsed) ? Math.max(1, parsed) : 1
+}
+
+const buildInMemoryKey = (tenantId: string, idempotencyKey: string, operationName: IdempotencyOperationName): string =>
+  `${tenantId}|${operationName}|${idempotencyKey}`
+
+const shouldUseDb = (tenantId: string, connection?: Knex): boolean =>
+  Boolean(connection && UUID_PATTERN.test(normalizeString(tenantId)))
+
+const mapRow = (row: DbIdempotencyRow | undefined | null): IdempotencyRecord | null => {
+  if (!row) {
+    return null
+  }
+
+  return {
+    id: normalizeString(row.id),
+    tenantId: normalizeString(row.tenant_id),
+    idempotencyKey: normalizeString(row.idempotency_key),
+    operationName: normalizeString(row.operation_name) as IdempotencyOperationName,
+    actorId: normalizeString(row.actor_id) || null,
+    actorScopeKey: normalizeString(row.actor_scope_key) || null,
+    requestFingerprint: normalizeString(row.request_fingerprint),
+    requestSummary: normalizeString(row.request_summary) || null,
+    resourceType: normalizeString(row.resource_type) || null,
+    resourceId: normalizeString(row.resource_id) || null,
+    status: normalizeString(row.status) as IdempotencyRecord['status'],
+    responseSnapshot: typeof row.response_snapshot_json === 'string'
+      ? row.response_snapshot_json
+      : row.response_snapshot_json == null
+        ? null
+        : JSON.stringify(row.response_snapshot_json),
+    failureSnapshot: parseJsonValue<IdempotencyFailureSnapshot>(row.failure_classification_json),
+    failureMessage: normalizeString(row.failure_message) || null,
+    attemptCount: parseAttemptCount(row.attempt_count),
+    firstSeenAt: toDate(row.first_seen_at_utc) || new Date(),
+    lastSeenAt: toDate(row.last_seen_at_utc) || new Date(),
+    completedAt: toDate(row.completed_at_utc),
+    retryEligibleAt: toDate(row.retry_eligible_at_utc),
+    expiresAt: toDate(row.expires_at_utc) || new Date(),
+  }
+}
+
+const toRow = (record: IdempotencyRecord) => ({
+  id: record.id,
+  tenant_id: record.tenantId,
+  idempotency_key: record.idempotencyKey,
+  operation_name: record.operationName,
+  actor_id: record.actorId ?? null,
+  actor_scope_key: record.actorScopeKey ?? null,
+  request_fingerprint: record.requestFingerprint,
+  request_summary: record.requestSummary ?? null,
+  resource_type: record.resourceType ?? null,
+  resource_id: record.resourceId ?? null,
+  status: record.status,
+  response_snapshot_json: record.responseSnapshot ? JSON.parse(record.responseSnapshot) : null,
+  failure_classification_json: record.failureSnapshot ?? null,
+  failure_message: record.failureMessage ?? null,
+  attempt_count: record.attemptCount,
+  first_seen_at_utc: record.firstSeenAt.toISOString(),
+  last_seen_at_utc: record.lastSeenAt.toISOString(),
+  completed_at_utc: record.completedAt ? record.completedAt.toISOString() : null,
+  retry_eligible_at_utc: record.retryEligibleAt ? record.retryEligibleAt.toISOString() : null,
+  expires_at_utc: record.expiresAt.toISOString(),
+})
+
+const buildRepository = (tenantId: string, connection?: Knex): IdempotencyRepository => {
+  if (!shouldUseDb(tenantId, connection)) {
+    return {
+      async findByScope(input) {
+        return inMemoryIdempotencyRecords.get(
+          buildInMemoryKey(input.tenantId, input.idempotencyKey, input.operationName),
+        ) ?? null
+      },
+      async create(record) {
+        inMemoryIdempotencyRecords.set(
+          buildInMemoryKey(record.tenantId, record.idempotencyKey, record.operationName),
+          record,
+        )
+      },
+      async update(record) {
+        inMemoryIdempotencyRecords.set(
+          buildInMemoryKey(record.tenantId, record.idempotencyKey, record.operationName),
+          record,
+        )
+      },
+    }
+  }
+
+  const knex = connection as Knex
+  return {
+    async findByScope(input) {
+      const row = await knex
+        .withSchema(CONNECTSHYFT_SCHEMA)
+        .table(IDEMPOTENCY_TABLE)
+        .where({
+          tenant_id: input.tenantId,
+          idempotency_key: input.idempotencyKey,
+          operation_name: input.operationName,
+        })
+        .first()
+
+      return mapRow(row as DbIdempotencyRow | undefined)
+    },
+    async create(record) {
+      await knex.withSchema(CONNECTSHYFT_SCHEMA).table(IDEMPOTENCY_TABLE).insert(toRow(record))
+    },
+    async update(record) {
+      await knex
+        .withSchema(CONNECTSHYFT_SCHEMA)
+        .table(IDEMPOTENCY_TABLE)
+        .where({ id: record.id })
+        .update(toRow(record))
+    },
+  }
+}
+
+export const loadConnectShyftCommunicationDb = (): Knex => db
+
+export const beginConnectShyftCommunicationIdempotency = async (input: {
+  tenantId: string
+  idempotencyKey: string
+  operationName: IdempotencyOperationName
+  actorId?: string | null
+  actorScopeKey?: string | null
+  requestFingerprint: string
+  requestSummary?: string | null
+  expiresAt: Date
+  db?: Knex
+}) => {
+  const repository = buildRepository(input.tenantId, input.db)
+  const service = buildIdempotencyService(repository)
+
+  try {
+    return await service.beginOperation(input)
+  } catch (error) {
+    if (
+      shouldUseDb(input.tenantId, input.db)
+      && error
+      && typeof error === 'object'
+      && 'code' in error
+      && (error as { code?: string }).code === '23505'
+    ) {
+      return service.beginOperation(input)
+    }
+    throw error
+  }
+}
+
+export const completeConnectShyftCommunicationIdempotency = async (input: {
+  record: IdempotencyRecord
+  status: 'succeeded' | 'failed'
+  responseSnapshot?: ConnectShyftIdempotencyResponseSnapshot | null
+  resourceType?: string | null
+  resourceId?: string | null
+  failureSnapshot?: IdempotencyFailureSnapshot | null
+  failureMessage?: string | null
+  retryEligibleAt?: Date | null
+  db?: Knex
+}) => {
+  const repository = buildRepository(input.record.tenantId, input.db)
+  const service = buildIdempotencyService(repository)
+
+  return service.completeOperation({
+    record: input.record,
+    status: input.status,
+    responseSnapshot: input.responseSnapshot ? JSON.stringify(input.responseSnapshot) : null,
+    resourceType: input.resourceType ?? null,
+    resourceId: input.resourceId ?? null,
+    failureSnapshot: input.failureSnapshot ?? null,
+    failureMessage: input.failureMessage ?? null,
+    retryEligibleAt: input.retryEligibleAt ?? null,
+  })
+}
+
+export const parseConnectShyftIdempotencyResponseSnapshot = (
+  snapshot: string | null | undefined,
+): ConnectShyftIdempotencyResponseSnapshot | null => parseJsonValue<ConnectShyftIdempotencyResponseSnapshot>(snapshot)
+
+export const resetConnectShyftCommunicationReliabilityStateForTests = (): void => {
+  inMemoryIdempotencyRecords.clear()
+}
+
+export const buildConnectShyftCommunicationCorrelationId = (): string => randomUUID()

--- a/apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts
@@ -11,6 +11,12 @@ export type ConnectShyftWebhookReceiptProcessingStatus =
   | 'APPLIED'
   | 'FAILED_RETRYABLE'
   | 'FAILED_TERMINAL';
+export type ConnectShyftWebhookFailureClassification = {
+  category: string;
+  retryable: boolean;
+  httpStatus?: number | null;
+  providerCode?: string | null;
+};
 export type ConnectShyftProviderCorrelationRefusalReason =
   | 'missing-identifiers'
   | 'not-found'
@@ -89,6 +95,8 @@ const inMemoryWebhookReceiptStates = new Map<string, {
   attemptCount: number;
   correlationKeys: Record<string, unknown> | null;
   failureReason: string | null;
+  nextRetryAtUtc: string | null;
+  lastFailureClassification: ConnectShyftWebhookFailureClassification | null;
 }>();
 
 const normalizeString = (value: unknown): string => {
@@ -929,6 +937,8 @@ export const beginConnectShyftWebhookReceiptProcessing = async (input: {
   dedupeKey: string | null;
   status: ConnectShyftWebhookReceiptProcessingStatus;
   attemptCount: number;
+  nextRetryAtUtc?: string | null;
+  lastFailureClassification?: ConnectShyftWebhookFailureClassification | null;
   error?: {
     code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE';
     message: string;
@@ -1006,6 +1016,8 @@ export const beginConnectShyftWebhookReceiptProcessing = async (input: {
         attemptCount: 1,
         correlationKeys,
         failureReason: null,
+        nextRetryAtUtc: null,
+        lastFailureClassification: null,
       });
       return {
         deterministic: true,
@@ -1035,6 +1047,8 @@ export const beginConnectShyftWebhookReceiptProcessing = async (input: {
       attemptCount: nextAttemptCount,
       correlationKeys: correlationKeys || existing.correlationKeys,
       failureReason: nextStatus === 'APPLIED' ? existing.failureReason : null,
+      nextRetryAtUtc: nextStatus === 'APPLIED' ? null : existing.nextRetryAtUtc,
+      lastFailureClassification: nextStatus === 'APPLIED' ? null : existing.lastFailureClassification,
     });
 
     return {
@@ -1044,6 +1058,8 @@ export const beginConnectShyftWebhookReceiptProcessing = async (input: {
       dedupeKey,
       status: nextStatus,
       attemptCount: nextAttemptCount,
+      nextRetryAtUtc: existing.nextRetryAtUtc,
+      lastFailureClassification: existing.lastFailureClassification,
     };
   }
 
@@ -1081,6 +1097,8 @@ export const beginConnectShyftWebhookReceiptProcessing = async (input: {
         attempt_count: 1,
         correlation_keys: correlationKeys,
         failure_reason: null,
+        next_retry_at_utc: null,
+        last_failure_classification: null,
       })
       .onConflict(['tenant_id', 'provider_name', 'sid', 'event_type'])
       .ignore()
@@ -1138,6 +1156,8 @@ export const beginConnectShyftWebhookReceiptProcessing = async (input: {
         attempt_count: nextAttemptCount,
         correlation_keys: correlationKeys || null,
         failure_reason: null,
+        next_retry_at_utc: null,
+        last_failure_classification: null,
       });
 
     return {
@@ -1147,6 +1167,8 @@ export const beginConnectShyftWebhookReceiptProcessing = async (input: {
       dedupeKey,
       status: nextStatus,
       attemptCount: nextAttemptCount,
+      nextRetryAtUtc: null,
+      lastFailureClassification: null,
     };
   } catch (error) {
     return {
@@ -1177,6 +1199,8 @@ export const markConnectShyftWebhookReceiptProcessingResult = async (input: {
   providerMessageId?: string | null;
   status: ConnectShyftWebhookReceiptProcessingStatus;
   failureReason?: string | null;
+  nextRetryAtUtc?: string | null;
+  lastFailureClassification?: ConnectShyftWebhookFailureClassification | null;
   db?: Knex;
 }): Promise<{
   deterministic: true;
@@ -1202,6 +1226,8 @@ export const markConnectShyftWebhookReceiptProcessingResult = async (input: {
   });
   const status = normalizeWebhookReceiptProcessingStatus(input.status);
   const failureReason = normalizeString(input.failureReason || null) || null;
+  const nextRetryAtUtc = normalizeString(input.nextRetryAtUtc || null) || null;
+  const lastFailureClassification = input.lastFailureClassification || null;
   const now = new Date().toISOString();
 
   if (!tenantId || !providerName || (!dedupeKey && !receiptIdentity)) {
@@ -1234,6 +1260,10 @@ export const markConnectShyftWebhookReceiptProcessingResult = async (input: {
       lastSeenAtUtc: now,
       failureReason: status === 'FAILED_RETRYABLE' || status === 'FAILED_TERMINAL'
         ? failureReason
+        : null,
+      nextRetryAtUtc: status === 'FAILED_RETRYABLE' ? nextRetryAtUtc : null,
+      lastFailureClassification: status === 'FAILED_RETRYABLE' || status === 'FAILED_TERMINAL'
+        ? lastFailureClassification
         : null,
     });
     inMemoryUpdated = true;
@@ -1272,6 +1302,10 @@ export const markConnectShyftWebhookReceiptProcessingResult = async (input: {
       correlationKeys: null,
       failureReason: status === 'FAILED_RETRYABLE' || status === 'FAILED_TERMINAL'
         ? failureReason
+        : null,
+      nextRetryAtUtc: status === 'FAILED_RETRYABLE' ? nextRetryAtUtc : null,
+      lastFailureClassification: status === 'FAILED_RETRYABLE' || status === 'FAILED_TERMINAL'
+        ? lastFailureClassification
         : null,
     });
     inMemoryUpdated = true;
@@ -1315,6 +1349,10 @@ export const markConnectShyftWebhookReceiptProcessingResult = async (input: {
         processed_at_utc: now,
         failure_reason: status === 'FAILED_RETRYABLE' || status === 'FAILED_TERMINAL'
           ? failureReason
+          : null,
+        next_retry_at_utc: status === 'FAILED_RETRYABLE' ? nextRetryAtUtc : null,
+        last_failure_classification: status === 'FAILED_RETRYABLE' || status === 'FAILED_TERMINAL'
+          ? lastFailureClassification
           : null,
       });
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
@@ -51,7 +51,17 @@ const startBridgeSessionMock = jest.fn(async (command: {
   providerBranchingInDomain: false as const,
   requestedAt: '2026-03-11T12:06:00.000Z',
 }))
-const verifyWebhookMock = jest.fn(() => ({ ok: true as const }))
+const verifyWebhookMock = jest.fn(
+  (): { ok: true } | {
+    ok: false
+    refusal: {
+      code: 'WEBHOOK_SIGNATURE_NOT_CONFIGURED' | 'WEBHOOK_SIGNATURE_MISSING' | 'WEBHOOK_SIGNATURE_INVALID'
+      message: string
+      refusalType: 'business' | 'client'
+      httpStatus: 401 | 503
+    }
+  } => ({ ok: true as const }),
+)
 const endCallMock = jest.fn(async (command: { providerLegId: string }) => ({
   providerKey: 'telnyx',
   providerLegId: command.providerLegId,
@@ -261,6 +271,42 @@ describe('connectshyft bridge webhook flow', () => {
     expect(startOutboundCallMock).toHaveBeenCalledWith(expect.objectContaining({
       targetPhone: '+12605550155',
     }))
+  })
+
+  it('rejects unverified webhooks before receipt processing or bridge side effects', async () => {
+    verifyWebhookMock.mockReturnValueOnce({
+      ok: false as const,
+      refusal: {
+        code: 'WEBHOOK_SIGNATURE_INVALID' as const,
+        message: 'Signature invalid',
+        refusalType: 'business' as const,
+        httpStatus: 401 as const,
+      },
+    })
+
+    const response = await invokeRoute({
+      url: '/webhooks/inbound',
+      headers: buildHeaders(),
+      body: {
+        eventType: 'call.answered',
+        providerEventId: 'provider-event-webhook-invalid-1001',
+        providerLegId: 'provider-leg-webhook-invalid-1001',
+      },
+    })
+
+    expect(response.status).toBe(401)
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_WEBHOOK_SIGNATURE_INVALID',
+      data: {
+        signatureValidation: {
+          verified: false,
+        },
+      },
+    })
+    expect(translateProviderEventMock).not.toHaveBeenCalled()
+    expect(startOutboundCallMock).not.toHaveBeenCalled()
+    expect(startBridgeSessionMock).not.toHaveBeenCalled()
   })
 
   it('advances operator answered to neighbor dialing and bridges on neighbor answered', async () => {

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
@@ -349,6 +349,42 @@ describe('connectshyft outbound dispatch routes', () => {
     }));
   });
 
+  it('rejects conflicting reuse of the same idempotency key for a materially different payload', async () => {
+    const headers = buildHeaders({
+      'Idempotency-Key': 'idem-sms-conflict-1001',
+    });
+
+    const firstResponse = await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/messages',
+      headers,
+      body: {
+        providerKey: 'telnyx',
+        body: 'Need assistance',
+        targetPhone: '+12605550111',
+      },
+    });
+
+    expect(firstResponse.status).toBe(200);
+    expect((firstResponse.body as any).ok).toBe(true);
+
+    const conflictResponse = await invokeRoute({
+      url: '/threads/thread-f1-unclaimed-1001/messages',
+      headers,
+      body: {
+        providerKey: 'telnyx',
+        body: 'Different message body',
+        targetPhone: '+12605550111',
+      },
+    });
+
+    expect(conflictResponse.status).toBe(200);
+    expect(conflictResponse.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD',
+    });
+    expect(sendSmsMock).toHaveBeenCalledTimes(1);
+  });
+
   it('refuses outbound bridge calls when no operator callback number is provided', async () => {
     const response = await invokeRoute({
       url: '/threads/thread-f1-unclaimed-1001/call',

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -2,8 +2,8 @@ import { createHash, createHmac, randomBytes, randomUUID } from 'node:crypto';
 import { Request, Response, Router } from 'express';
 import type { Knex } from 'knex';
 import {
-  InMemoryTelephonyDispatchLedger,
   buildTelephonyDispatchReplayKey,
+  evaluateRetryPolicy,
   isTelephonyProviderFailure,
 } from '../../../../../../domains/communication';
 import { refusal, success } from '../../../platform/envelopes/response';
@@ -120,6 +120,16 @@ import {
   loadConnectShyftBridgeAggregateByThreadId,
   startConnectShyftBridgeSession,
 } from '../../../modules/connectshyft/bridgeSessions';
+import {
+  beginConnectShyftCommunicationIdempotency,
+  completeConnectShyftCommunicationIdempotency,
+  parseConnectShyftIdempotencyResponseSnapshot,
+  resetConnectShyftCommunicationReliabilityStateForTests,
+} from '../../../modules/connectshyft/communicationReliability';
+import {
+  appendConnectShyftCommunicationAuditEntry,
+  resetConnectShyftCommunicationAuditLogForTests,
+} from '../../../modules/connectshyft/communicationAuditLog';
 import { isStrictUtcIsoTimestamp } from '../../../platform/time/timezoneService';
 
 const router = Router();
@@ -195,12 +205,6 @@ const CONNECTSHYFT_LEGACY_ROLE_ALIASES: Record<string, string> = {
 
 type ConnectShyftOutboundAction = 'call' | 'message';
 type ConnectShyftNeighborMergeFailureStage = 'before-commit' | 'after-dependent-repoint';
-type ConnectShyftOutboundDispatchReplayRecord = {
-  code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED' | 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED';
-  message: 'ConnectShyft outbound call dispatched' | 'ConnectShyft outbound message dispatched';
-  data: Record<string, unknown>;
-};
-
 type ConnectShyftSyntheticThreadDescriptor = {
   tenantId: string;
   orgUnitId: string;
@@ -482,8 +486,10 @@ const CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS: Record<string, ConnectShyftSynth
 };
 const CONNECTSHYFT_DYNAMIC_C5_THREAD_PREFIX = 'thread-c5-unclaimed-';
 const CONNECTSHYFT_DYNAMIC_C5_THREAD_TEMPLATE_ID = 'thread-c5-unclaimed-1001';
-const connectShyftOutboundDispatchReplayLedger =
-  new InMemoryTelephonyDispatchLedger<ConnectShyftOutboundDispatchReplayRecord>();
+const CONNECTSHYFT_COMMUNICATION_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+const CONNECTSHYFT_WEBHOOK_RETRY_MAX_ATTEMPTS = 3;
+const CONNECTSHYFT_WEBHOOK_RETRY_BASE_DELAY_MS = 60 * 1000;
+const CONNECTSHYFT_WEBHOOK_RETRY_MAX_DELAY_MS = 15 * 60 * 1000;
 
 const loadPlatformDb = (): Knex => {
   const knexModule = require('../../../config/knex') as { default: Knex };
@@ -491,7 +497,8 @@ const loadPlatformDb = (): Knex => {
 };
 
 export const resetConnectShyftOutboundDispatchReplayLedgerForTests = (): void => {
-  connectShyftOutboundDispatchReplayLedger.clear();
+  resetConnectShyftCommunicationReliabilityStateForTests();
+  resetConnectShyftCommunicationAuditLogForTests();
 };
 
 const connectShyftEscalationConfigService = new ConnectShyftEscalationConfigService(
@@ -3375,6 +3382,73 @@ const parseOutboundDispatchIdempotencyKey = (req: Request): string | null => {
   return bodyIdempotencyKey || null;
 };
 
+const resolveOutboundIdempotencyOperationName = (
+  outboundAction: ConnectShyftOutboundAction,
+): 'send_sms' | 'start_bridge_session' => (
+  outboundAction === 'call' ? 'start_bridge_session' : 'send_sms'
+);
+
+const buildConnectShyftActorScopeKey = (
+  actorUserId: string | null,
+  actorRoles: readonly string[],
+): string => JSON.stringify({
+  actorUserId: normalizeLifecycleString(actorUserId),
+  actorRoles: [...actorRoles].sort(),
+});
+
+const appendConnectShyftCommunicationAudit = async (input: {
+  tenantId: string;
+  correlationId: string;
+  actorType: 'user' | 'system' | 'provider';
+  actorId?: string | null;
+  operationName: string;
+  targetEntityType: string;
+  targetEntityId?: string | null;
+  channel: 'sms' | 'voice' | 'bridge' | 'webhook';
+  resultState: 'succeeded' | 'failed' | 'ignored_duplicate' | 'retrying' | 'exhausted';
+  resultCode?: string | null;
+  resultMessage?: string | null;
+  idempotencyKey?: string | null;
+  requestFingerprint?: string | null;
+  providerName?: string | null;
+  providerReferenceId?: string | null;
+  metadata?: Record<string, unknown> | null;
+  db?: Knex;
+}): Promise<void> => {
+  await appendConnectShyftCommunicationAuditEntry({
+    tenantId: input.tenantId,
+    correlationId: input.correlationId,
+    actorType: input.actorType,
+    actorId: input.actorId ?? null,
+    operationName: input.operationName,
+    targetEntityType: input.targetEntityType,
+    targetEntityId: input.targetEntityId ?? null,
+    channel: input.channel,
+    resultState: input.resultState,
+    resultCode: input.resultCode ?? null,
+    resultMessage: input.resultMessage ?? null,
+    idempotencyKey: input.idempotencyKey ?? null,
+    requestFingerprint: input.requestFingerprint ?? null,
+    providerName: input.providerName ?? null,
+    providerReferenceId: input.providerReferenceId ?? null,
+    metadataJson: input.metadata ? JSON.stringify(input.metadata) : null,
+    db: input.db,
+  });
+};
+
+const resolveWebhookRetryDisposition = (input: {
+  attemptCount: number;
+  retryable: boolean;
+}) => {
+  return evaluateRetryPolicy({
+    attemptNumber: input.attemptCount,
+    maxAttempts: CONNECTSHYFT_WEBHOOK_RETRY_MAX_ATTEMPTS,
+    isRetryable: input.retryable,
+    baseDelayMs: CONNECTSHYFT_WEBHOOK_RETRY_BASE_DELAY_MS,
+    maxDelayMs: CONNECTSHYFT_WEBHOOK_RETRY_MAX_DELAY_MS,
+  });
+};
+
 const enforceOutboundCallPolicyRequest = (
   req: Request,
   res: Response,
@@ -6078,10 +6152,12 @@ const performOutboundAction = async (
 
   const actorRoles = resolveConnectShyftActorRoles(req, context);
   const actorUserId = resolveConnectShyftRequestedActorUserId(req);
+  const actorScopeKey = buildConnectShyftActorScopeKey(actorUserId, actorRoles);
   const outboundMessagePolicy = outboundAction === 'message'
     ? parseOutboundMessagePolicyRequest(req)
     : null;
   const outboundDispatchIdempotencyKey = parseOutboundDispatchIdempotencyKey(req);
+  const outboundIdempotencyOperation = resolveOutboundIdempotencyOperationName(outboundAction);
   const outboundCallDispatchPolicy: ConnectShyftOutboundCallDispatchPolicy | null = outboundAction === 'call'
     ? {
       transport: outboundCallPolicyRequest?.transport || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT,
@@ -6096,6 +6172,7 @@ const performOutboundAction = async (
     providerKey: providerSelection.providerResolution.resolvedProvider,
     action: outboundAction,
     idempotencyKey: outboundDispatchIdempotencyKey,
+    actorId: actorUserId,
     targetPhone: outboundAction === 'call'
       ? outboundCallPolicyRequest?.targetPhone || null
       : outboundMessagePolicy?.targetPhone || null,
@@ -6105,21 +6182,6 @@ const performOutboundAction = async (
     body: outboundMessagePolicy?.body || null,
     callPolicy: outboundCallDispatchPolicy,
   });
-  const replayedDispatch = connectShyftOutboundDispatchReplayLedger.get(outboundDispatchReplayKey);
-  if (replayedDispatch) {
-    success(res, {
-      code: replayedDispatch.code,
-      message: replayedDispatch.message,
-      data: {
-        ...replayedDispatch.data,
-        replaySafe: {
-          duplicate: true,
-          replayKey: outboundDispatchReplayKey,
-        },
-      },
-    });
-    return;
-  }
   const lifecycleContext = await resolveLifecycleContext({
     tenantId: context.tenantId,
     orgUnitId: context.orgUnitId,
@@ -6496,6 +6558,140 @@ const performOutboundAction = async (
     }
   }
 
+  const communicationReliabilityDb = isConnectShyftTestOverrideEnabled()
+    ? undefined
+    : loadPlatformDb();
+  const outboundIdempotencyRecord = (
+    outboundDispatchIdempotencyKey
+    && outboundDispatchReplayKey
+  )
+    ? await beginConnectShyftCommunicationIdempotency({
+      tenantId: context.tenantId,
+      idempotencyKey: outboundDispatchIdempotencyKey,
+      operationName: outboundIdempotencyOperation,
+      actorId: actorUserId,
+      actorScopeKey,
+      requestFingerprint: outboundDispatchReplayKey,
+      requestSummary: JSON.stringify({
+        outboundAction,
+        threadId,
+        providerKey: providerSelection.providerResolution.resolvedProvider,
+        targetPhone: outboundAction === 'call'
+          ? neighborContactPointId
+          : outboundMessagePolicy?.targetPhone || null,
+        operatorContactPointId,
+      }),
+      expiresAt: new Date(Date.now() + CONNECTSHYFT_COMMUNICATION_IDEMPOTENCY_TTL_MS),
+      db: communicationReliabilityDb,
+    })
+    : null;
+  if (outboundIdempotencyRecord?.decision === 'conflict') {
+    respondConnectShyftBusinessRefusal(res, {
+      code: 'CONNECTSHYFT_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD',
+      message: 'Idempotency key cannot be reused for a materially different outbound request.',
+      data: {
+        context,
+        threadId,
+        idempotency: {
+          duplicate: false,
+          conflict: true,
+          idempotencyKey: outboundDispatchIdempotencyKey,
+        },
+      },
+    });
+    return;
+  }
+  if (outboundIdempotencyRecord?.decision === 'in_progress') {
+    respondConnectShyftBusinessRefusal(res, {
+      code: 'CONNECTSHYFT_IDEMPOTENT_OPERATION_IN_PROGRESS',
+      message: 'An identical outbound request is already in progress.',
+      data: {
+        context,
+        threadId,
+        idempotency: {
+          duplicate: false,
+          conflict: false,
+          inProgress: true,
+          idempotencyKey: outboundDispatchIdempotencyKey,
+        },
+      },
+    });
+    return;
+  }
+  if (outboundIdempotencyRecord?.decision === 'return_existing') {
+    const replaySnapshot = parseConnectShyftIdempotencyResponseSnapshot(
+      outboundIdempotencyRecord.record.responseSnapshot,
+    );
+    if (replaySnapshot) {
+      const replayBody = (
+        replaySnapshot.body
+        && typeof replaySnapshot.body === 'object'
+        && !Array.isArray(replaySnapshot.body)
+      )
+        ? replaySnapshot.body as {
+          ok?: unknown;
+          code?: unknown;
+          message?: unknown;
+          data?: Record<string, unknown>;
+        }
+        : null;
+      const replayData = replayBody?.data && typeof replayBody.data === 'object'
+        ? replayBody.data
+        : {};
+      await appendConnectShyftCommunicationAudit({
+        tenantId: context.tenantId,
+        correlationId: outboundDispatchReplayKey || randomUUID(),
+        actorType: actorUserId ? 'user' : 'system',
+        actorId: actorUserId,
+        operationName: outboundIdempotencyOperation,
+        targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+        targetEntityId: threadId,
+        channel: outboundAction === 'call' ? 'bridge' : 'sms',
+        resultState: 'ignored_duplicate',
+        resultCode: 'CONNECTSHYFT_DUPLICATE_REQUEST_REPLAYED',
+        resultMessage: 'Duplicate outbound request replayed from durable idempotency state.',
+        idempotencyKey: outboundDispatchIdempotencyKey,
+        requestFingerprint: outboundDispatchReplayKey,
+        providerName: providerSelection.providerResolution.resolvedProvider,
+        metadata: {
+          duplicate: true,
+          threadId,
+        },
+        db: communicationReliabilityDb,
+      });
+      res.status(replaySnapshot.httpStatus).json(replayBody
+        ? {
+          ...replayBody,
+          data: {
+            ...replayData,
+            replaySafe: {
+              ...(replayData.replaySafe && typeof replayData.replaySafe === 'object'
+                ? replayData.replaySafe
+                : {}),
+              duplicate: true,
+              replayKey: outboundDispatchReplayKey,
+            },
+          },
+        }
+        : replaySnapshot.body);
+      return;
+    }
+    respondConnectShyftBusinessRefusal(res, {
+      code: 'CONNECTSHYFT_IDEMPOTENT_REPLAY_UNAVAILABLE',
+      message: 'Idempotent replay state is unavailable for this completed outbound request.',
+      data: {
+        context,
+        threadId,
+        idempotency: {
+          duplicate: true,
+          replayUnavailable: true,
+          idempotencyKey: outboundDispatchIdempotencyKey,
+        },
+      },
+    });
+    return;
+  }
+
   let providerDispatch: ConnectShyftProviderDispatchResult;
   try {
     providerDispatch = outboundAction === 'call'
@@ -6542,7 +6738,7 @@ const performOutboundAction = async (
     await rollbackPersistedSmsOverride();
 
     if (error instanceof ConnectShyftProviderDispatchPolicyError) {
-      respondConnectShyftBusinessRefusal(res, {
+      const refusalPayload = {
         code: error.code,
         message: error.message,
         data: {
@@ -6561,11 +6757,50 @@ const performOutboundAction = async (
           providerCallPolicy: error.data,
           ...buildReopenLifecycleData(),
         },
+      };
+      if (outboundIdempotencyRecord?.decision === 'proceed') {
+        await completeConnectShyftCommunicationIdempotency({
+          record: outboundIdempotencyRecord.record,
+          status: 'failed',
+          responseSnapshot: {
+            httpStatus: 200,
+            body: {
+              ok: false,
+              code: refusalPayload.code,
+              message: refusalPayload.message,
+              data: refusalPayload.data,
+            },
+          },
+          failureMessage: error.message,
+          db: communicationReliabilityDb,
+        });
+      }
+      await appendConnectShyftCommunicationAudit({
+        tenantId: context.tenantId,
+        correlationId: outboundDispatchReplayKey || randomUUID(),
+        actorType: actorUserId ? 'user' : 'system',
+        actorId: actorUserId,
+        operationName: outboundIdempotencyOperation,
+        targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+        targetEntityId: threadId,
+        channel: outboundAction === 'call' ? 'bridge' : 'sms',
+        resultState: 'failed',
+        resultCode: error.code,
+        resultMessage: error.message,
+        idempotencyKey: outboundDispatchIdempotencyKey,
+        requestFingerprint: outboundDispatchReplayKey,
+        providerName: providerSelection.providerResolution.resolvedProvider,
+        metadata: error.data,
+        db: communicationReliabilityDb,
       });
+      respondConnectShyftBusinessRefusal(res, refusalPayload);
       return;
     }
 
-    respondConnectShyftBusinessRefusal(res, {
+    const providerFailureClassification = isTelephonyProviderFailure(error)
+      ? error.classification
+      : null;
+    const refusalPayload = {
       code: 'CONNECTSHYFT_PROVIDER_DISPATCH_FAILED',
       message: 'Provider dispatch failed before persistence.',
       data: {
@@ -6581,13 +6816,52 @@ const performOutboundAction = async (
           lifecycleMutationApplied,
           auditPersisted: Boolean(persistedSmsOverride),
         },
-        providerFailureClassification: isTelephonyProviderFailure(error)
-          ? error.classification
-          : null,
+        providerFailureClassification,
         error: error instanceof Error ? error.message : 'unknown-provider-dispatch-error',
         ...buildReopenLifecycleData(),
       },
+    };
+    if (outboundIdempotencyRecord?.decision === 'proceed') {
+      await completeConnectShyftCommunicationIdempotency({
+        record: outboundIdempotencyRecord.record,
+        status: 'failed',
+        responseSnapshot: {
+          httpStatus: 200,
+          body: {
+            ok: false,
+            code: refusalPayload.code,
+            message: refusalPayload.message,
+            data: refusalPayload.data,
+          },
+        },
+        failureSnapshot: providerFailureClassification,
+        failureMessage: error instanceof Error ? error.message : 'unknown-provider-dispatch-error',
+        db: communicationReliabilityDb,
+      });
+    }
+    await appendConnectShyftCommunicationAudit({
+      tenantId: context.tenantId,
+      correlationId: outboundDispatchReplayKey || randomUUID(),
+      actorType: actorUserId ? 'user' : 'system',
+      actorId: actorUserId,
+      operationName: outboundIdempotencyOperation,
+      targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+      targetEntityId: threadId,
+      channel: outboundAction === 'call' ? 'bridge' : 'sms',
+      resultState: providerFailureClassification?.retryable ? 'retrying' : 'failed',
+      resultCode: refusalPayload.code,
+      resultMessage: refusalPayload.message,
+      idempotencyKey: outboundDispatchIdempotencyKey,
+      requestFingerprint: outboundDispatchReplayKey,
+      providerName: providerSelection.providerResolution.resolvedProvider,
+      providerReferenceId: providerFailureClassification?.providerCode || null,
+      metadata: {
+        providerFailureClassification,
+        error: error instanceof Error ? error.message : 'unknown-provider-dispatch-error',
+      },
+      db: communicationReliabilityDb,
     });
+    respondConnectShyftBusinessRefusal(res, refusalPayload);
     return;
   }
 
@@ -6838,11 +7112,51 @@ const performOutboundAction = async (
     ...(sideEffects || {}),
     ...(outboundDispatch ? { outboundDispatch } : {}),
   };
-
-  connectShyftOutboundDispatchReplayLedger.remember(outboundDispatchReplayKey, {
-    code: responseCode,
-    message: responseMessage,
-    data: responseData,
+  const bridgeSessionId = (
+    bridgeSessionState as ConnectShyftBridgeSessionStateContract | null
+  )?.bridgeSessionId || null;
+  if (outboundIdempotencyRecord?.decision === 'proceed') {
+    await completeConnectShyftCommunicationIdempotency({
+      record: outboundIdempotencyRecord.record,
+      status: 'succeeded',
+      responseSnapshot: {
+        httpStatus: 200,
+        body: {
+          ok: true,
+          code: responseCode,
+          message: responseMessage,
+          data: responseData,
+        },
+      },
+      resourceType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+      resourceId: outboundAction === 'call'
+        ? normalizeLifecycleString(bridgeSessionId)
+        : normalizeLifecycleString(canonicalEvent?.eventId),
+      db: communicationReliabilityDb,
+    });
+  }
+  await appendConnectShyftCommunicationAudit({
+    tenantId: context.tenantId,
+    correlationId: outboundDispatchReplayKey || randomUUID(),
+    actorType: actorUserId ? 'user' : 'system',
+    actorId: actorUserId,
+    operationName: outboundIdempotencyOperation,
+    targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+    targetEntityId: threadId,
+    channel: outboundAction === 'call' ? 'bridge' : 'sms',
+    resultState: 'succeeded',
+    resultCode: responseCode,
+    resultMessage: responseMessage,
+    idempotencyKey: outboundDispatchIdempotencyKey,
+    requestFingerprint: outboundDispatchReplayKey,
+    providerName: providerDispatch.providerKey,
+    providerReferenceId: providerDispatch.providerLegId || providerDispatch.providerMessageId || null,
+    metadata: {
+      threadId,
+      canonicalEventId: canonicalEvent?.eventId || null,
+      bridgeSessionId,
+    },
+    db: communicationReliabilityDb,
   });
 
   success(res, {
@@ -7458,7 +7772,44 @@ const handleInboundWebhook = async (
   const markWebhookReceipt = async (
     status: 'APPLIED' | 'FAILED_RETRYABLE' | 'FAILED_TERMINAL',
     failureReason?: string,
+    failureClassification?: {
+      category: string;
+      retryable: boolean;
+      httpStatus?: number | null;
+      providerCode?: string | null;
+    } | null,
   ): Promise<void> => {
+    const normalizedFailureClassification = failureClassification || (status === 'FAILED_RETRYABLE'
+      ? {
+        category: 'temporary_processing_failure',
+        retryable: true,
+        httpStatus: null,
+        providerCode: null,
+      }
+      : status === 'FAILED_TERMINAL'
+        ? {
+          category: 'terminal_processing_failure',
+          retryable: false,
+          httpStatus: null,
+          providerCode: null,
+        }
+        : null);
+    const retryDisposition = status === 'FAILED_RETRYABLE'
+      ? resolveWebhookRetryDisposition({
+        attemptCount: webhookReceipt.attemptCount,
+        retryable: normalizedFailureClassification?.retryable === true,
+      })
+      : null;
+    const persistedStatus = status === 'FAILED_RETRYABLE'
+      ? retryDisposition?.decision === 'retry'
+        ? 'FAILED_RETRYABLE'
+        : 'FAILED_TERMINAL'
+      : status;
+    const nextRetryAtUtc = persistedStatus === 'FAILED_RETRYABLE'
+      && retryDisposition?.decision === 'retry'
+      ? retryDisposition.nextAttemptAt.toISOString()
+      : null;
+
     await markConnectShyftWebhookReceiptProcessingResult({
       tenantId,
       threadId,
@@ -7468,8 +7819,38 @@ const handleInboundWebhook = async (
       providerEventId: correlation.providerEventId,
       providerLegId: correlation.providerLegId,
       providerMessageId: correlation.providerMessageId,
-      status,
+      status: persistedStatus,
       failureReason: failureReason || null,
+      nextRetryAtUtc,
+      lastFailureClassification: normalizedFailureClassification,
+      db: webhookPersistenceDb,
+    });
+    await appendConnectShyftCommunicationAudit({
+      tenantId,
+      correlationId: webhookReceipt.dedupeKey || correlation.providerEventId || randomUUID(),
+      actorType: 'provider',
+      operationName: 'apply_provider_event',
+      targetEntityType: 'webhook_receipt',
+      targetEntityId: webhookReceipt.dedupeKey,
+      channel: 'webhook',
+      resultState: persistedStatus === 'APPLIED'
+        ? 'succeeded'
+        : persistedStatus === 'FAILED_RETRYABLE'
+          ? 'retrying'
+          : retryDisposition?.decision === 'exhausted'
+            ? 'exhausted'
+            : 'failed',
+      resultCode: persistedStatus,
+      resultMessage: failureReason || null,
+      providerName: providerSelection.providerResolution.resolvedProvider,
+      providerReferenceId: correlation.providerEventId || correlation.providerLegId || correlation.providerMessageId || null,
+      metadata: {
+        threadId,
+        eventType,
+        attemptCount: webhookReceipt.attemptCount,
+        nextRetryAtUtc,
+        failureClassification: normalizedFailureClassification,
+      },
       db: webhookPersistenceDb,
     });
   };
@@ -7479,6 +7860,26 @@ const handleInboundWebhook = async (
     || webhookReceipt.previousStatus === 'FAILED_TERMINAL';
 
   if (shouldSuppressWebhookDuplicate) {
+    await appendConnectShyftCommunicationAudit({
+      tenantId,
+      correlationId: webhookReceipt.dedupeKey || correlation.providerEventId || randomUUID(),
+      actorType: 'provider',
+      operationName: 'apply_provider_event',
+      targetEntityType: 'webhook_receipt',
+      targetEntityId: webhookReceipt.dedupeKey,
+      channel: 'webhook',
+      resultState: 'ignored_duplicate',
+      resultCode: 'CONNECTSHYFT_WEBHOOK_DUPLICATE_SUPPRESSED',
+      resultMessage: 'Duplicate webhook suppressed before domain side effects.',
+      providerName: providerSelection.providerResolution.resolvedProvider,
+      providerReferenceId: correlation.providerEventId || correlation.providerLegId || correlation.providerMessageId || null,
+      metadata: {
+        threadId,
+        eventType,
+        attemptCount: webhookReceipt.attemptCount,
+      },
+      db: webhookPersistenceDb,
+    });
     success(res, {
       code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
       message: 'Inbound webhook accepted (duplicate suppressed)',

--- a/domains/communication/audit/__tests__/recordCommunicationAudit.test.ts
+++ b/domains/communication/audit/__tests__/recordCommunicationAudit.test.ts
@@ -1,0 +1,36 @@
+import { buildRecordCommunicationAudit } from '../recordCommunicationAudit'
+
+describe('communication audit recorder', () => {
+  it('appends immutable audit entries with generated ids and timestamps', async () => {
+    const appended: Array<Record<string, unknown>> = []
+    const recordAudit = buildRecordCommunicationAudit({
+      async append(entry) {
+        appended.push(entry)
+      },
+    })
+
+    const entry = await recordAudit({
+      tenantId: 'tenant-1',
+      correlationId: 'corr-1',
+      actorType: 'system',
+      operationName: 'send_sms',
+      targetEntityType: 'message_dispatch',
+      targetEntityId: 'message-1',
+      channel: 'sms',
+      resultState: 'succeeded',
+      resultCode: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+      requestFingerprint: 'fingerprint-1',
+      metadataJson: '{"ok":true}',
+    })
+
+    expect(entry.id).toBeTruthy()
+    expect(entry.createdAt).toBeInstanceOf(Date)
+    expect(appended).toHaveLength(1)
+    expect(appended[0]).toMatchObject({
+      tenantId: 'tenant-1',
+      correlationId: 'corr-1',
+      resultState: 'succeeded',
+      requestFingerprint: 'fingerprint-1',
+    })
+  })
+})

--- a/domains/communication/audit/auditTypes.ts
+++ b/domains/communication/audit/auditTypes.ts
@@ -1,0 +1,27 @@
+export type CommunicationAuditResultState =
+  | 'succeeded'
+  | 'failed'
+  | 'ignored_duplicate'
+  | 'retrying'
+  | 'exhausted'
+
+export type CommunicationAuditEntry = {
+  id: string
+  tenantId: string
+  correlationId: string
+  actorType: 'user' | 'system' | 'provider'
+  actorId?: string | null
+  operationName: string
+  targetEntityType: string
+  targetEntityId?: string | null
+  channel: 'sms' | 'voice' | 'bridge' | 'webhook'
+  resultState: CommunicationAuditResultState
+  resultCode?: string | null
+  resultMessage?: string | null
+  idempotencyKey?: string | null
+  requestFingerprint?: string | null
+  providerName?: string | null
+  providerReferenceId?: string | null
+  metadataJson?: string | null
+  createdAt: Date
+}

--- a/domains/communication/audit/index.ts
+++ b/domains/communication/audit/index.ts
@@ -1,0 +1,2 @@
+export * from './auditTypes'
+export * from './recordCommunicationAudit'

--- a/domains/communication/audit/recordCommunicationAudit.ts
+++ b/domains/communication/audit/recordCommunicationAudit.ts
@@ -1,0 +1,19 @@
+import { CommunicationAuditEntry } from './auditTypes'
+
+export type CommunicationAuditRepository = {
+  append(entry: CommunicationAuditEntry): Promise<void>
+}
+
+export function buildRecordCommunicationAudit(repository: CommunicationAuditRepository) {
+  return async function recordCommunicationAudit(
+    input: Omit<CommunicationAuditEntry, 'id' | 'createdAt'>,
+  ) {
+    const entry: CommunicationAuditEntry = {
+      id: crypto.randomUUID(),
+      createdAt: new Date(),
+      ...input,
+    }
+    await repository.append(entry)
+    return entry
+  }
+}

--- a/domains/communication/index.ts
+++ b/domains/communication/index.ts
@@ -4,3 +4,5 @@
 export * from './phone'
 export * from './telephony'
 export * from './bridge'
+export * from './reliability'
+export * from './audit'

--- a/domains/communication/reliability/__tests__/eventDeduper.test.ts
+++ b/domains/communication/reliability/__tests__/eventDeduper.test.ts
@@ -1,0 +1,51 @@
+import { dedupeWebhookEvent } from '../eventDeduper'
+
+describe('communication webhook event deduper', () => {
+  it('reprocesses retryable failures but suppresses processed and terminal duplicates', async () => {
+    const findDuplicate = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'receipt-1',
+        tenantId: 'tenant-1',
+        providerName: 'telnyx',
+        eventType: 'CallConnected',
+        providerEventId: 'event-1',
+        payloadHash: 'hash-1',
+        processingStatus: 'failed_retryable',
+        attemptCount: 2,
+      })
+      .mockResolvedValueOnce({
+        id: 'receipt-2',
+        tenantId: 'tenant-1',
+        providerName: 'telnyx',
+        eventType: 'CallConnected',
+        providerEventId: 'event-1',
+        payloadHash: 'hash-1',
+        processingStatus: 'processed',
+        attemptCount: 1,
+      })
+
+    const retryable = await dedupeWebhookEvent(
+      { findDuplicate },
+      {
+        tenantId: 'tenant-1',
+        providerName: 'telnyx',
+        providerEventId: 'event-1',
+        payloadHash: 'hash-1',
+      },
+    )
+
+    const processed = await dedupeWebhookEvent(
+      { findDuplicate },
+      {
+        tenantId: 'tenant-1',
+        providerName: 'telnyx',
+        providerEventId: 'event-1',
+        payloadHash: 'hash-1',
+      },
+    )
+
+    expect(retryable.decision).toBe('reprocess')
+    expect(processed.decision).toBe('ignore_duplicate')
+  })
+})

--- a/domains/communication/reliability/__tests__/idempotencyService.test.ts
+++ b/domains/communication/reliability/__tests__/idempotencyService.test.ts
@@ -1,0 +1,94 @@
+import { buildIdempotencyService } from '../idempotencyService'
+import type { IdempotencyRecord } from '../idempotencyTypes'
+
+describe('communication idempotency service', () => {
+  const records = new Map<string, IdempotencyRecord>()
+
+  const repository = {
+    async findByScope(input: {
+      tenantId: string
+      idempotencyKey: string
+      operationName: string
+    }) {
+      return records.get(`${input.tenantId}|${input.operationName}|${input.idempotencyKey}`) ?? null
+    },
+    async create(record: IdempotencyRecord) {
+      records.set(`${record.tenantId}|${record.operationName}|${record.idempotencyKey}`, record)
+    },
+    async update(record: IdempotencyRecord) {
+      records.set(`${record.tenantId}|${record.operationName}|${record.idempotencyKey}`, record)
+    },
+  }
+
+  beforeEach(() => {
+    records.clear()
+  })
+
+  it('proceeds once and replays the completed record for an identical fingerprint', async () => {
+    const service = buildIdempotencyService(repository)
+    const begun = await service.beginOperation({
+      tenantId: 'tenant-1',
+      idempotencyKey: 'idem-1',
+      operationName: 'send_sms',
+      actorId: 'user-1',
+      actorScopeKey: '{"actorUserId":"user-1"}',
+      requestFingerprint: 'fingerprint-1',
+      expiresAt: new Date('2026-03-13T00:00:00.000Z'),
+    })
+
+    expect(begun.decision).toBe('proceed')
+
+    const completed = await service.completeOperation({
+      record: begun.record,
+      status: 'succeeded',
+      responseSnapshot: '{"httpStatus":200,"body":{"ok":true}}',
+      resourceType: 'message_dispatch',
+      resourceId: 'message-1',
+    })
+
+    const replay = await service.beginOperation({
+      tenantId: 'tenant-1',
+      idempotencyKey: 'idem-1',
+      operationName: 'send_sms',
+      actorId: 'user-1',
+      actorScopeKey: '{"actorUserId":"user-1"}',
+      requestFingerprint: 'fingerprint-1',
+      expiresAt: new Date('2026-03-13T00:00:00.000Z'),
+    })
+
+    expect(completed.status).toBe('succeeded')
+    expect(replay.decision).toBe('return_existing')
+    expect(replay.record.responseSnapshot).toBe('{"httpStatus":200,"body":{"ok":true}}')
+  })
+
+  it('rejects conflicting reuse and reports in-progress duplicates before completion', async () => {
+    const service = buildIdempotencyService(repository)
+    const begun = await service.beginOperation({
+      tenantId: 'tenant-1',
+      idempotencyKey: 'idem-2',
+      operationName: 'start_bridge_session',
+      requestFingerprint: 'fingerprint-a',
+      expiresAt: new Date('2026-03-13T00:00:00.000Z'),
+    })
+
+    const inProgress = await service.beginOperation({
+      tenantId: 'tenant-1',
+      idempotencyKey: 'idem-2',
+      operationName: 'start_bridge_session',
+      requestFingerprint: 'fingerprint-a',
+      expiresAt: new Date('2026-03-13T00:00:00.000Z'),
+    })
+
+    const conflict = await service.beginOperation({
+      tenantId: 'tenant-1',
+      idempotencyKey: 'idem-2',
+      operationName: 'start_bridge_session',
+      requestFingerprint: 'fingerprint-b',
+      expiresAt: new Date('2026-03-13T00:00:00.000Z'),
+    })
+
+    expect(begun.decision).toBe('proceed')
+    expect(inProgress.decision).toBe('in_progress')
+    expect(conflict.decision).toBe('conflict')
+  })
+})

--- a/domains/communication/reliability/__tests__/retryPolicy.test.ts
+++ b/domains/communication/reliability/__tests__/retryPolicy.test.ts
@@ -1,0 +1,36 @@
+import { evaluateRetryPolicy } from '../retryPolicy'
+
+describe('communication retry policy', () => {
+  it('returns retry for retryable failures below the attempt cap and exhausts when capped', () => {
+    const retry = evaluateRetryPolicy({
+      attemptNumber: 1,
+      maxAttempts: 3,
+      isRetryable: true,
+      baseDelayMs: 1000,
+      maxDelayMs: 5000,
+      now: new Date('2026-03-12T12:00:00.000Z'),
+    })
+
+    const exhausted = evaluateRetryPolicy({
+      attemptNumber: 3,
+      maxAttempts: 3,
+      isRetryable: true,
+      baseDelayMs: 1000,
+      maxDelayMs: 5000,
+      now: new Date('2026-03-12T12:00:00.000Z'),
+    })
+
+    const doNotRetry = evaluateRetryPolicy({
+      attemptNumber: 1,
+      maxAttempts: 3,
+      isRetryable: false,
+      baseDelayMs: 1000,
+      maxDelayMs: 5000,
+      now: new Date('2026-03-12T12:00:00.000Z'),
+    })
+
+    expect(retry.decision).toBe('retry')
+    expect(exhausted).toEqual({ decision: 'exhausted' })
+    expect(doNotRetry).toEqual({ decision: 'do_not_retry' })
+  })
+})

--- a/domains/communication/reliability/eventDeduper.ts
+++ b/domains/communication/reliability/eventDeduper.ts
@@ -1,0 +1,47 @@
+export type WebhookReceiptRecord = {
+  id: string
+  tenantId: string
+  providerName: string
+  eventType: string
+  providerEventId?: string | null
+  payloadHash: string
+  processingStatus:
+    | 'received'
+    | 'processed'
+    | 'ignored_duplicate'
+    | 'failed_retryable'
+    | 'failed_terminal'
+  attemptCount: number
+  nextRetryAt?: Date | null
+  lastFailureClassification?: string | null
+}
+
+export type WebhookReceiptRepository = {
+  findDuplicate(input: {
+    tenantId: string
+    providerName: string
+    providerEventId?: string | null
+    payloadHash: string
+  }): Promise<WebhookReceiptRecord | null>
+}
+
+export async function dedupeWebhookEvent(
+  repository: WebhookReceiptRepository,
+  input: { tenantId: string; providerName: string; providerEventId?: string; payloadHash: string },
+) {
+  const duplicate = await repository.findDuplicate({
+    tenantId: input.tenantId,
+    providerName: input.providerName,
+    providerEventId: input.providerEventId ?? null,
+    payloadHash: input.payloadHash,
+  })
+  if (!duplicate) {
+    return { decision: 'proceed' as const }
+  }
+
+  if (duplicate.processingStatus === 'processed' || duplicate.processingStatus === 'failed_terminal') {
+    return { decision: 'ignore_duplicate' as const, duplicate }
+  }
+
+  return { decision: 'reprocess' as const, duplicate }
+}

--- a/domains/communication/reliability/idempotencyService.ts
+++ b/domains/communication/reliability/idempotencyService.ts
@@ -1,0 +1,90 @@
+import {
+  IdempotencyFailureSnapshot,
+  IdempotencyOperationName,
+  IdempotencyRecord,
+  IdempotencyRecordStatus,
+} from './idempotencyTypes'
+
+export type IdempotencyRepository = {
+  findByScope(input: {
+    tenantId: string
+    idempotencyKey: string
+    operationName: IdempotencyOperationName
+  }): Promise<IdempotencyRecord | null>
+  create(record: IdempotencyRecord): Promise<void>
+  update(record: IdempotencyRecord): Promise<void>
+}
+
+export type BeginIdempotencyOperationInput = {
+  tenantId: string
+  idempotencyKey: string
+  operationName: IdempotencyOperationName
+  actorId?: string | null
+  actorScopeKey?: string | null
+  requestFingerprint: string
+  requestSummary?: string | null
+  expiresAt: Date
+}
+
+export type CompleteIdempotencyOperationInput = {
+  record: IdempotencyRecord
+  status: Extract<IdempotencyRecordStatus, 'succeeded' | 'failed'>
+  responseSnapshot?: string | null
+  resourceType?: string | null
+  resourceId?: string | null
+  failureSnapshot?: IdempotencyFailureSnapshot | null
+  failureMessage?: string | null
+  retryEligibleAt?: Date | null
+}
+
+export function buildIdempotencyService(repository: IdempotencyRepository) {
+  return {
+    async beginOperation(input: BeginIdempotencyOperationInput) {
+      const existing = await repository.findByScope(input)
+      if (!existing) {
+        const now = new Date()
+        const record: IdempotencyRecord = {
+          id: crypto.randomUUID(),
+          tenantId: input.tenantId,
+          idempotencyKey: input.idempotencyKey,
+          operationName: input.operationName,
+          actorId: input.actorId ?? null,
+          actorScopeKey: input.actorScopeKey ?? null,
+          requestFingerprint: input.requestFingerprint,
+          requestSummary: input.requestSummary ?? null,
+          status: 'in_progress',
+          attemptCount: 1,
+          firstSeenAt: now,
+          lastSeenAt: now,
+          expiresAt: input.expiresAt,
+        }
+        await repository.create(record)
+        return { decision: 'proceed', record }
+      }
+      if (existing.requestFingerprint !== input.requestFingerprint) {
+        return { decision: 'conflict', record: existing }
+      }
+      if (existing.status === 'in_progress') {
+        return { decision: 'in_progress', record: existing }
+      }
+      return { decision: 'return_existing', record: existing }
+    },
+    async completeOperation(input: CompleteIdempotencyOperationInput) {
+      const now = new Date()
+      const updated: IdempotencyRecord = {
+        ...input.record,
+        status: input.status,
+        responseSnapshot: input.responseSnapshot ?? input.record.responseSnapshot ?? null,
+        resourceType: input.resourceType ?? input.record.resourceType ?? null,
+        resourceId: input.resourceId ?? input.record.resourceId ?? null,
+        failureSnapshot: input.failureSnapshot ?? null,
+        failureMessage: input.failureMessage ?? null,
+        completedAt: now,
+        retryEligibleAt: input.retryEligibleAt ?? null,
+        lastSeenAt: now,
+      }
+      await repository.update(updated)
+      return updated
+    },
+  }
+}

--- a/domains/communication/reliability/idempotencyTypes.ts
+++ b/domains/communication/reliability/idempotencyTypes.ts
@@ -1,0 +1,37 @@
+export type IdempotencyOperationName =
+  | 'send_sms'
+  | 'start_outbound_call'
+  | 'start_bridge_session'
+  | 'apply_provider_event'
+
+export type IdempotencyRecordStatus = 'in_progress' | 'succeeded' | 'failed'
+
+export type IdempotencyFailureSnapshot = {
+  category: string
+  retryable: boolean
+  httpStatus?: number | null
+  providerCode?: string | null
+}
+
+export type IdempotencyRecord = {
+  id: string
+  tenantId: string
+  idempotencyKey: string
+  operationName: IdempotencyOperationName
+  actorId?: string | null
+  actorScopeKey?: string | null
+  requestFingerprint: string
+  requestSummary?: string | null
+  resourceType?: string | null
+  resourceId?: string | null
+  status: IdempotencyRecordStatus
+  responseSnapshot?: string | null
+  failureSnapshot?: IdempotencyFailureSnapshot | null
+  failureMessage?: string | null
+  attemptCount: number
+  firstSeenAt: Date
+  lastSeenAt: Date
+  completedAt?: Date | null
+  retryEligibleAt?: Date | null
+  expiresAt: Date
+}

--- a/domains/communication/reliability/index.ts
+++ b/domains/communication/reliability/index.ts
@@ -1,0 +1,4 @@
+export * from './idempotencyTypes'
+export * from './idempotencyService'
+export * from './retryPolicy'
+export * from './eventDeduper'

--- a/domains/communication/reliability/retryPolicy.ts
+++ b/domains/communication/reliability/retryPolicy.ts
@@ -1,0 +1,21 @@
+export type RetryPolicyDecision =
+  | { decision: 'retry'; nextAttemptAt: Date }
+  | { decision: 'exhausted' }
+  | { decision: 'do_not_retry' }
+
+export function evaluateRetryPolicy(input: {
+  attemptNumber: number
+  maxAttempts: number
+  isRetryable: boolean
+  baseDelayMs: number
+  maxDelayMs: number
+  now?: Date
+}): RetryPolicyDecision {
+  if (!input.isRetryable) return { decision: 'do_not_retry' }
+  if (input.attemptNumber >= input.maxAttempts) return { decision: 'exhausted' }
+  const now = input.now ?? new Date()
+  const exponentialDelay = input.baseDelayMs * Math.pow(2, Math.max(input.attemptNumber - 1, 0))
+  const boundedDelay = Math.min(exponentialDelay, input.maxDelayMs)
+  const jitter = Math.floor(Math.random() * Math.max(Math.floor(boundedDelay * 0.2), 1))
+  return { decision: 'retry', nextAttemptAt: new Date(now.getTime() + boundedDelay + jitter) }
+}

--- a/domains/communication/telephony/__tests__/index.test.ts
+++ b/domains/communication/telephony/__tests__/index.test.ts
@@ -15,6 +15,7 @@ describe('communication telephony domain', () => {
       providerKey: 'telnyx',
       action: 'message',
       idempotencyKey: 'idem-001',
+      actorId: 'user-connectshyft-f1-primary-operator',
       body: 'Need assistance',
       targetPhone: '+12605550111',
     })
@@ -26,6 +27,7 @@ describe('communication telephony domain', () => {
       providerKey: 'telnyx',
       action: 'message',
       idempotencyKey: 'idem-001',
+      actorId: 'user-connectshyft-f1-primary-operator',
       body: 'Need assistance',
       targetPhone: '+12605550111',
     })
@@ -37,13 +39,27 @@ describe('communication telephony domain', () => {
       providerKey: 'telnyx',
       action: 'message',
       idempotencyKey: 'idem-001',
+      actorId: 'user-connectshyft-f1-primary-operator',
       body: 'Changed copy',
+      targetPhone: '+12605550111',
+    })
+
+    const changedActor = buildTelephonyDispatchReplayKey({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-f1-unclaimed-1001',
+      providerKey: 'telnyx',
+      action: 'message',
+      idempotencyKey: 'idem-001',
+      actorId: 'user-connectshyft-f1-secondary-operator',
+      body: 'Need assistance',
       targetPhone: '+12605550111',
     })
 
     expect(first).toBeTruthy()
     expect(first).toBe(duplicate)
     expect(changedPayload).not.toBe(first)
+    expect(changedActor).not.toBe(first)
   })
 
   it('stores and replays dispatch snapshots in the in-memory ledger', () => {

--- a/domains/communication/telephony/index.ts
+++ b/domains/communication/telephony/index.ts
@@ -188,6 +188,7 @@ export type TelephonyDispatchReplayKeyInput = {
   providerKey: string
   action: 'call' | 'message'
   idempotencyKey?: string | null
+  actorId?: string | null
   targetPhone?: string | null
   operatorContactPointId?: string | null
   body?: string | null
@@ -225,6 +226,7 @@ export const buildTelephonyDispatchReplayKey = (
   }
 
   const fingerprint = JSON.stringify({
+    actorId: normalizeString(input.actorId),
     targetPhone: normalizeString(input.targetPhone),
     operatorContactPointId: normalizeString(input.operatorContactPointId),
     body: normalizeString(input.body),

--- a/specs/005-reliability-idempotency-audit/contracts/communication-reliability-contract.md
+++ b/specs/005-reliability-idempotency-audit/contracts/communication-reliability-contract.md
@@ -1,0 +1,125 @@
+# Contract: CS-005 Communication Reliability
+
+## Purpose
+
+Define the external and internal contract changes required for ConnectShyft reliability hardening without introducing new feature surfaces or provider-specific leakage.
+
+## External HTTP Surfaces
+
+### Outbound mutation routes
+
+The existing lane-owned ConnectShyft mutation routes remain the relevant external surfaces:
+
+- `POST /api/v1/connectshyft/threads/:threadId/messages`
+- `POST /api/v1/connectshyft/threads/:threadId/call`
+
+Contract requirements:
+
+- Each route accepts `Idempotency-Key` in the request header.
+- An equivalent body-level `idempotencyKey` may still be normalized for backward compatibility where already supported, but the authoritative transport contract is the header.
+- The route must persist idempotency scope before invoking `sendSms`, `startOutboundCall`, or `startBridgeSession`.
+
+Duplicate behavior:
+
+- Same idempotency scope + same materially relevant fingerprint: return the original or current authoritative result, marked as replay-safe or existing.
+- Same idempotency scope + different materially relevant fingerprint: reject with conflict semantics and no new provider side effect.
+
+### Webhook ingress routes
+
+The existing ConnectShyft webhook ingress routes remain the relevant external provider-entry surfaces:
+
+- `POST /api/v1/connectshyft/webhooks/inbound`
+- `POST /api/v1/connectshyft/webhooks/sms`
+
+Contract requirements:
+
+- Verify provider signature before processing.
+- Persist or checkpoint receipt before event application when practical.
+- Perform duplicate detection before bridge/message domain application.
+- Translate raw provider payloads into provider-neutral internal events exactly once at the infrastructure edge.
+
+Duplicate behavior:
+
+- First valid receipt: process normally and mark processed.
+- Replay/duplicate receipt: suppress duplicate side effects, append duplicate audit evidence, and return a replay-safe success response.
+
+## Internal Contract Surfaces
+
+### Idempotency
+
+Shared domain contract under `domains/communication/reliability` must expose:
+
+- typed operation names
+- durable record status
+- `beginOperation(...)`
+- `completeOperation(...)`
+- conflict vs return-existing decisions
+
+Required semantics:
+
+- idempotency begins before side effects
+- conflict is based on request fingerprint mismatch
+- authoritative response snapshots may be stored for replay-safe return behavior
+
+Materially relevant request fingerprint inputs for CS-005 are:
+
+- `send_sms`: `threadId`, normalized destination contact point or phone, normalized message body, channel, actor scope
+- `start_outbound_call`: `threadId`, target participant or contact point, selected outbound number, channel, actor scope
+- `start_bridge_session`: `threadId`, operator participant, target participant or contact point, selected outbound number, channel, actor scope
+- `apply_provider_event`: `providerName`, normalized internal event type, provider event identity, and correlated internal bridge or message resource when already resolved
+
+### Retry
+
+Shared domain retry policy under `domains/communication/reliability/retryPolicy.ts` must remain:
+
+- bounded
+- classification-driven
+- incapable of bypassing domain state ownership
+
+Initial implementation contract:
+
+- only retryable classified failures may schedule retry intent
+- retry persistence records `attempt_count`, `next_retry_at`, and exhausted state
+- no standalone retry subsystem or provider-side workflow redesign is introduced
+- CS-005 persists retry intent only; execution of a future retry attempt is out of scope for this feature
+
+### Audit
+
+Shared domain audit contract under `domains/communication/audit` must remain append-only and capture:
+
+- `correlation_id`
+- actor identity
+- operation name
+- target entity
+- channel
+- result state
+- idempotency key
+- provider references when present
+
+Required audit result states:
+
+- `succeeded`
+- `failed`
+- `ignored_duplicate`
+- `retrying`
+- `exhausted`
+
+## Provider Boundary Rules
+
+- Provider adapters continue to expose only normalized provider-neutral results above infrastructure.
+- Provider-specific webhook shapes, signature semantics, and error payloads remain infrastructure-owned.
+- Reliability hardening may consume normalized provider failure classification, but must not introduce new raw provider coupling in routes, domain logic, or audit contracts.
+- Unverified webhook requests must be rejected before receipt persistence, translation, and downstream domain side effects.
+
+## Non-Goals
+
+- No new public reliability endpoints
+- No bridge orchestration redesign
+- No provider adapter redesign
+- No UI contract changes
+
+## Implementation Notes
+
+- Durable outbound idempotency is implemented in `apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts` and is invoked before provider side effects in `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`.
+- Append-only audit recording is implemented in `apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts` and records command success/failure/duplicate plus webhook applied/retrying/exhausted outcomes.
+- Webhook receipt persistence continues to use `cs_webhook_receipts`; CS-005 adds only minimal retry metadata (`next_retry_at_utc`, `last_failure_classification`) and does not introduce a worker or scheduler.

--- a/specs/005-reliability-idempotency-audit/data-model.md
+++ b/specs/005-reliability-idempotency-audit/data-model.md
@@ -1,0 +1,187 @@
+# Data Model: CS-005 Reliability / Idempotency / Audit
+
+## Scope
+
+CS-005 adds the minimum durable reliability persistence needed for outbound command safety, replay-safe webhook handling, bounded retry intent, and append-only audit evidence. It does not redesign bridge-session or provider-adapter ownership.
+
+## Entities
+
+### 1. Communication Idempotency Record
+
+Purpose: prevent duplicate outbound side effects before they happen and return the authoritative prior/current result for safe retries.
+
+Representative canonical fields:
+- `id`
+- `tenant_id`
+- `idempotency_key`
+- `operation_name`
+  - `send_sms`, `start_outbound_call`, `start_bridge_session`, `apply_provider_event`
+- `actor_id`
+  - nullable for system-originated work
+- `request_fingerprint`
+- `request_summary`
+  - serialized summary of materially relevant request fields
+- `resource_type`
+  - `communication_message`, `bridge_session`, or equivalent
+- `resource_id`
+  - nullable until authoritative resource exists
+- `status`
+  - `in_progress`, `succeeded`, `failed`
+- `response_snapshot`
+  - optional serialized authoritative response
+- `attempt_count`
+  - minimal bounded retry bookkeeping
+- `last_attempted_at`
+- `next_retry_at`
+  - nullable
+- `last_failure_classification`
+  - normalized provider/application failure category
+- `first_seen_at`
+- `last_seen_at`
+- `expires_at`
+
+Validation rules:
+- unique scope must include at least tenant + operation + idempotency key
+- same scope + different `request_fingerprint` is a conflict
+- idempotency record must exist before any outbound provider side effect
+- `response_snapshot` must only reflect authoritative application state
+
+State transitions:
+- `in_progress -> succeeded`
+- `in_progress -> failed`
+- `failed -> failed` with updated bounded retry metadata only; no mutation of prior audit rows
+
+### 2. Communication Audit Log
+
+Purpose: append-only operational history for outbound mutations, duplicate suppression, retry decisions, and webhook outcomes.
+
+Representative canonical fields:
+- `id`
+- `tenant_id`
+- `correlation_id`
+- `actor_type`
+  - `user`, `system`, `provider`
+- `actor_id`
+  - nullable
+- `operation_name`
+- `target_entity_type`
+- `target_entity_id`
+  - nullable
+- `channel`
+  - `sms`, `voice`, `bridge`, `webhook`
+- `result_state`
+  - `succeeded`, `failed`, `ignored_duplicate`, `retrying`, `exhausted`
+- `result_code`
+  - nullable
+- `result_message`
+  - nullable
+- `idempotency_key`
+  - nullable
+- `provider_name`
+  - nullable
+- `provider_reference_id`
+  - nullable
+- `metadata_json`
+- `created_at`
+
+Validation rules:
+- audit rows are append-only; updates and deletes are out of scope
+- command-side and webhook-side audit rows must be distinguishable by `operation_name`, `channel`, and metadata
+- duplicate suppression and retry decisions must create new audit rows rather than mutate old ones
+
+### 3. Communication Webhook Receipt
+
+Purpose: checkpoint provider ingress, support duplicate detection before application side effects, and persist bounded retry intent for webhook-processing failures.
+
+Representative fields:
+- `id`
+- `tenant_id`
+- `provider_name`
+- `event_type`
+- `provider_event_id`
+  - nullable when provider omits it
+- `signature_verified`
+- `payload_hash`
+- `received_at`
+- `processed_at`
+  - nullable
+- `processing_status`
+  - `received`, `processed`, `ignored_duplicate`, `failed`
+- `failure_message`
+  - nullable
+- `correlation_id`
+  - nullable
+- `retry_count`
+- `next_retry_at`
+  - nullable
+- `last_failure_classification`
+  - nullable
+- `raw_payload`
+  - raw or pointer depending on implementation
+- `headers_json`
+  - optional
+
+Validation rules:
+- duplicate detection occurs before event application
+- `signature_verified` must be preserved
+- replayed or duplicate receipts must not duplicate domain state changes
+- retry metadata must remain bounded and classification-driven
+
+State transitions:
+- `received -> processed`
+- `received -> ignored_duplicate`
+- `received -> failed`
+- `failed -> failed` with incremented retry metadata until exhausted
+
+### 4. Bridge Session
+
+Purpose: remain the authoritative persisted state machine for bridge calling while CS-005 adds surrounding reliability hardening.
+
+Relevant existing fields:
+- `id`
+- `thread_id`
+- `bridge_status`
+- `failure_code`
+- `failure_message`
+- `idempotency_key`
+- `audit_correlation_id`
+- timestamps
+
+Reliability rules:
+- bridge state remains domain-driven and authoritative
+- retry handling must not create or advance bridge states outside existing bridge-domain entry points
+- repeated provider events reconcile against existing bridge-session and bridge-leg state
+
+### 5. Communication Message
+
+Purpose: remain the authoritative message/timeline record while command-side idempotency and audit hardening prevent duplicate creation.
+
+Relevant existing fields:
+- `id`
+- `thread_id`
+- `direction`
+- `channel`
+- `message_status`
+- `provider_reference_id`
+- `idempotency_key`
+- timestamps
+
+Reliability rules:
+- duplicate outbound retries must not create duplicate message records
+- provider delivery/status events may update message state but duplicate webhooks must not create duplicate message rows
+
+## Relationships
+
+- One tenant can have many `communication_idempotency_record`
+- One outbound mutation can have one current idempotency record and many audit rows
+- One webhook receipt can have many related audit rows across receipt, duplicate, retry, and processed outcomes
+- One bridge session can be associated with an idempotency record and many audit rows
+- One communication message can be associated with an idempotency record and many audit rows
+
+## Invariants
+
+- Idempotency happens before outbound side effects
+- Duplicate webhook detection happens before domain event application
+- Retry decisions never bypass bridge/message domain ownership
+- Audit is append-only
+- Provider-native identifiers remain stored for reconciliation, but upstream logic operates on internal resource state first

--- a/specs/005-reliability-idempotency-audit/plan.md
+++ b/specs/005-reliability-idempotency-audit/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: CS-005 Reliability / Idempotency / Audit
+
+**Branch**: `005-reliability-idempotency-audit` | **Date**: 2026-03-12 | **Spec**: [spec.md](/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/spec.md)  
+**Input**: Feature specification from `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/spec.md`  
+**Source Input**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-005_Reliability_Idempotency_Audit_Guardrailed_Spec.md`
+
+## Summary
+
+Add the minimum durable reliability layer for ConnectShyft outbound SMS, outbound call initiation, bridge-session creation, and provider webhook ingestion by persisting idempotency records before side effects, appending audit history for command and webhook outcomes, and recording bounded retry intent without redesigning bridge orchestration or the provider adapter boundary. The implementation will reuse the existing shared communication reliability/audit primitives, existing bridge-session persistence, and existing webhook receipt flow inside `apps/connectshyft-api`, extending them only where durable request safety and append-only audit evidence are still missing.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022) on Node.js >=20  
+**Primary Dependencies**: Express, Knex, `pg`, Jest, ts-jest, shared communication domain modules under `domains/communication`, ConnectShyft route/module services under `apps/connectshyft-api`, and repository boundary enforcement via `node scripts/enforce-workspace-boundaries.js`  
+**Storage**: Shared PostgreSQL using existing ConnectShyft bridge-session, message, provider-correlation, and webhook-receipt tables plus new durable `communication_idempotency_record` and `communication_audit_log`-equivalent persistence and minimal retry metadata on reliability-owned records where required  
+**Testing**: Targeted ConnectShyft route/module Jest suites, shared domain reliability/audit unit tests, `apps/connectshyft-api` build, and workspace boundary enforcement  
+**Target Platform**: Linux-hosted Shyft Nx monorepo with ConnectShyft API running as a lane-specific Node/Express service behind host-managed Nginx  
+**Project Type**: Monolithic Nx web application with lane-specific APIs/frontends plus shared domain and infrastructure packages  
+**Performance Goals**: Exactly one outbound provider side effect occurs per idempotency scope for identical retries; duplicate webhook replays produce zero additional domain side effects; durability is achieved with indexed lookups and append-only writes rather than in-memory replay state  
+**Constraints**: Minimal reliability hardening only. No bridge redesign, no provider adapter redesign, no UI changes, no broad schema redesign beyond minimal durable reliability persistence, no retry subsystem redesign, and no runtime changes outside ConnectShyft communication reliability and audit integration. Idempotency must happen before side effects, duplicate protection must happen before event application, audit must remain append-only, and retry logic must not bypass bridge or message domain rules.  
+**Retry Execution Model**: CS-005 persists retry intent and exhausted state only. No worker, scheduler, automatic redial loop, or immediate provider re-dispatch cycle is introduced in this feature.  
+**Scale/Scope**: ConnectShyft outbound mutation endpoints (`/threads/:threadId/messages`, `/threads/:threadId/call`), bridge-session initiation flow, provider webhook ingress, shared communication reliability/audit domain primitives, ConnectShyft persistence adapters, targeted migrations, and verification docs only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Initial Gate Review**
+
+- Platform shell authority preserved: PASS. CS-005 changes ConnectShyft communication reliability only and does not alter `admin-web`/`admin-api` shell or auth authority.
+- Lane isolation preserved: PASS. Telephony, bridge, and reliability work remains inside shared communication domain plus `connectshyft-api`; no implicit cross-lane service coupling is added.
+- Routing delegation preserved: PASS. `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain delegated to `admin-api`; CS-005 only hardens lane-owned ConnectShyft communication routes and webhook ingress.
+- Deployment topology preserved: PASS. Host-managed Nginx, localhost-only API bindings, Docker-hosted APIs, and static frontend serving remain unchanged.
+- Database ownership preserved: PASS. Shared Postgres remains the storage model, and any new reliability migrations remain compatible with `admin-api` as the sole production migration owner.
+- Security boundaries preserved: PASS. No public port exposure or ingress changes are introduced; provider webhook verification remains at infrastructure ingress.
+- Workflow compliance: PASS. The numbered spec, plan, research, data model, contract, and quickstart artifacts derive directly from the CS-005 guardrailed spec and governing ADR/data model note.
+- Acceptance criteria present: PASS. The design includes explicit verification for routing delegation, canonical ports, shared Postgres compatibility, reproducible runbook behavior, targeted ConnectShyft tests, and boundary enforcement.
+
+**Post-Design Re-check**
+
+- Platform shell authority preserved: PASS. The design leaves shell and auth ownership untouched.
+- Lane isolation preserved: PASS. Domain/application/infrastructure responsibilities remain consistent with the ADR.
+- Routing delegation preserved: PASS. Quickstart includes explicit no-topology-change validation for auth/admin delegation and lane-owned ConnectShyft routes.
+- Deployment topology preserved: PASS. Quickstart includes explicit validation that canonical ports, localhost bindings, Docker topology, and static frontend serving remain unchanged.
+- Database ownership preserved: PASS. Data model and quickstart explicitly preserve shared Postgres compatibility and `admin-api` production migration ownership.
+- Security boundaries preserved: PASS. Webhook verification remains infrastructure-owned and no new public ingress is introduced.
+- Workflow compliance: PASS. Research resolves design decisions, Phase 1 artifacts are generated, and the plan remains traceable to the numbered spec.
+- Acceptance criteria present: PASS. The design defines measurable command-side, webhook-side, audit, build, and topology validation steps.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-reliability-idempotency-audit/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── contracts/
+    └── communication-reliability-contract.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/
+└── connectshyft-api/
+    └── src/
+        ├── migrations/
+        │   └── 20260312120000_add_connectshyft_communication_reliability.ts
+        ├── modules/
+        │   └── connectshyft/
+        │       ├── bridgeSessions.ts
+        │       ├── communicationAuditLog.ts
+        │       ├── communicationReliability.ts
+        │       ├── providerCorrelationMappings.ts
+        │       └── __tests__/
+        │           ├── bridgeSessions.test.ts
+        │           └── providerCorrelationMappings.test.ts
+        └── routes/
+            └── api/
+                └── v1/
+                    ├── connectshyft.ts
+                    └── __tests__/
+                        ├── connectshyft.bridge-flow.test.ts
+                        └── connectshyft.outbound-dispatch.test.ts
+
+domains/
+└── communication/
+    ├── audit/
+    │   ├── auditTypes.ts
+    │   ├── recordCommunicationAudit.ts
+    │   └── __tests__/
+    │       └── recordCommunicationAudit.test.ts
+    ├── bridge/
+    │   ├── handleProviderBridgeEvent.ts
+    │   └── startBridgeSession.ts
+    ├── reliability/
+    │   ├── eventDeduper.ts
+    │   ├── idempotencyService.ts
+    │   ├── idempotencyTypes.ts
+    │   ├── retryPolicy.ts
+    │   └── __tests__/
+    │       ├── eventDeduper.test.ts
+    │       ├── idempotencyService.test.ts
+    │       └── retryPolicy.test.ts
+    └── telephony/
+        └── __tests__/
+            └── index.test.ts
+
+infrastructure/
+└── communications/
+    ├── telnyx/
+    │   └── index.ts
+    └── webhooks/
+```
+
+**Structure Decision**: Keep reliability contracts and pure decision logic in `domains/communication`, keep provider translation and verification in `infrastructure/communications`, and wire durable persistence plus route/application orchestration in `apps/connectshyft-api`. This preserves provider neutrality and existing bridge state-machine ownership while limiting CS-005 to the minimum persistence and integration surfaces required for idempotency, replay safety, retry intent, and append-only audit.
+
+**Boundary Validation Rule**: CS-005 route and module reliability code may consume only provider-neutral telephony results and provider-neutral webhook translation outputs. Any raw provider-field handling outside infrastructure is out of scope and invalid for this feature.
+
+## Complexity Tracking
+
+No constitution violations are required for CS-005. This section is intentionally empty.

--- a/specs/005-reliability-idempotency-audit/quickstart.md
+++ b/specs/005-reliability-idempotency-audit/quickstart.md
@@ -1,0 +1,215 @@
+# Quickstart: CS-005 Reliability / Idempotency / Audit
+
+## Goal
+
+Validate durable idempotency, replay-safe webhook handling, bounded retry persistence, append-only audit recording, and unchanged platform routing/topology boundaries for ConnectShyft communication operations.
+
+## Prerequisites
+
+- Repository root: `/Users/jeremiahotis/projects/connectshyft`
+- Branch: `005-reliability-idempotency-audit`
+- Local test database available
+- ConnectShyft API test dependencies installed
+
+## Primary Validation Flow
+
+### 1. Run targeted reliability and bridge-related Jest coverage
+
+```sh
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+env NODE_ENV=test \
+  DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  ENABLE_TEST_CONNECTSHYFT_FLAGS=true \
+  npx jest --runInBand --runTestsByPath \
+    src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+    src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+    src/modules/connectshyft/__tests__/bridgeSessions.test.ts \
+    src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+```
+
+Expected result:
+- outbound duplicate replay tests pass
+- same-key/different-payload conflict tests pass
+- duplicate webhook suppression tests pass
+- retry-state/audit assertions pass without changing bridge ownership
+
+### 2. Run shared domain reliability and audit tests
+
+```sh
+cd /Users/jeremiahotis/projects/connectshyft
+env NODE_ENV=test \
+  MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  ENABLE_TEST_CONNECTSHYFT_FLAGS=true \
+  npx jest --runInBand --runTestsByPath \
+    domains/communication/reliability/__tests__/idempotencyService.test.ts \
+    domains/communication/reliability/__tests__/eventDeduper.test.ts \
+    domains/communication/reliability/__tests__/retryPolicy.test.ts \
+    domains/communication/audit/__tests__/recordCommunicationAudit.test.ts \
+    domains/communication/telephony/__tests__/index.test.ts
+```
+
+Expected result:
+- idempotency decision logic passes
+- bounded retry decisions pass
+- normalized provider failure classification remains intact
+
+### 3. Build the ConnectShyft API
+
+```sh
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+npm run build
+```
+
+Expected result:
+- TypeScript build passes with the new reliability persistence and route integration
+
+### 4. Run workspace boundary enforcement
+
+```sh
+cd /Users/jeremiahotis/projects/connectshyft
+node scripts/enforce-workspace-boundaries.js
+```
+
+Expected result:
+- no provider-boundary or workspace-boundary violations
+
+## Reliability Evidence To Capture
+
+- proof that materially relevant request fingerprint fields are stable across safe retries and reject conflicting payload reuse
+- proof that the first outbound request creates a durable idempotency record before provider dispatch
+- proof that same-key/same-payload replay returns the authoritative prior/current result with no duplicate side effect
+- proof that same-key/different-payload replay fails loudly
+- proof that unverified webhook requests are rejected before receipt persistence and event application
+- proof that duplicate webhook receipts are ignored before domain re-application
+- proof that retryable failures record bounded retry intent and exhausted outcomes
+- proof that audit rows are append-only across success, duplicate, retrying, exhausted, and failure outcomes
+- proof that persisted idempotency and webhook-receipt state survives in-memory reset by re-reading durable records
+
+## Compatibility / Constitution Validation
+
+### 5. Validate routing delegation remains unchanged
+
+```sh
+git diff --name-only -- \
+  nginx \
+  apps/admin-api/src/routes \
+  apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/moneyshyft-api/src/routes
+```
+
+Expected result:
+- no changes that alter `/api/v1/auth/*` or `/api/v1/platform/admin/*` delegation to `admin-api`
+- `/api/v1/connectshyft/*` remains lane-owned
+
+### 5a. Validate unverified webhooks are rejected before receipt persistence
+
+```sh
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+env NODE_ENV=test \
+  DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  ENABLE_TEST_CONNECTSHYFT_FLAGS=true \
+  npx jest --runInBand --runTestsByPath \
+    src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
+```
+
+Expected result:
+- coverage proves failed signature verification rejects the request before receipt persistence, translation, and downstream domain side effects
+
+### 6. Validate canonical API ports and localhost binding remain unchanged
+
+```sh
+git diff --name-only -- \
+  apps/admin-api/src/server.ts \
+  apps/moneyshyft-api/src/server.ts \
+  apps/connectshyft-api/src/server.ts \
+  docker-compose.example.yml \
+  docker-compose.production.example.yml
+```
+
+Expected result:
+- no changes to localhost binding or canonical ports for `admin-api`, `money-api`, or `connect-api`
+
+### 7. Validate shared Postgres compatibility and migration ownership
+
+```sh
+git diff --name-only -- \
+  apps/admin-api/src/migrations \
+  apps/moneyshyft-api/src/migrations \
+  apps/connectshyft-api/src/migrations \
+  apps/admin-api/src/config/database.ts \
+  apps/moneyshyft-api/src/config/database.ts \
+  apps/connectshyft-api/src/config/database.ts
+```
+
+Expected result:
+- reliability migrations are compatible with shared Postgres
+- no change to `admin-api` as sole production migration owner
+
+### 8. Validate deployment runbook reproducibility remains intact
+
+```sh
+git diff --name-only -- \
+  SETUP.md \
+  PRODUCTION_DEPLOYMENT_GUIDE.md \
+  nginx \
+  docker-compose.example.yml \
+  docker-compose.production.example.yml \
+  apps/*/Dockerfile.production
+```
+
+Expected result:
+- no extra manual deployment adjustments are introduced by CS-005
+
+### 9. Validate provider-boundary scans remain clean outside infrastructure
+
+```sh
+cd /Users/jeremiahotis/projects/connectshyft
+rg -n "from '/Users/jeremiahotis/projects/connectshyft/infrastructure/communications/telnyx|telnyx[A-Z]|call_control_id|message_id|event_id" \
+  apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/connectshyft-api/src/modules/connectshyft \
+  domains/communication
+```
+
+Expected result:
+- no raw provider imports or raw provider payload field handling appear outside infrastructure-owned surfaces
+- generic provider correlation fields such as `provider_event_id` may remain in canonical metadata and receipt persistence, but no Telnyx-specific imports or payload fields appear in the CS-005 route/audit/reliability surfaces
+
+### 10. Validate persisted durability by re-reading state after initial write
+
+```sh
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+env NODE_ENV=test \
+  DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  ENABLE_TEST_CONNECTSHYFT_FLAGS=true \
+  npx jest --runInBand --runTestsByPath \
+    src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+    src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+```
+
+Expected result:
+- tests prove replay-safe behavior still works after re-reading persisted idempotency or webhook receipt state rather than relying on in-memory replay state
+
+## Retry Model Note
+
+CS-005 persists retry intent only.
+
+- No worker or scheduler is introduced.
+- No immediate automatic redial or provider re-dispatch loop is introduced.
+- Retryable failures only update durable retry metadata and append audit evidence.
+
+## Recorded Results
+
+- targeted ConnectShyft reliability suites: passed via `env NODE_ENV=test MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci ENABLE_TEST_CONNECTSHYFT_FLAGS=true npm run test:connectshyft` in `apps/connectshyft-api` with `60` suites and `322` tests passing
+- shared domain reliability suites: passed within the same run, including `idempotencyService.test.ts`, `eventDeduper.test.ts`, `retryPolicy.test.ts`, `recordCommunicationAudit.test.ts`, and `telephony/index.test.ts`
+- ConnectShyft API build: passed via `npm run build` in `apps/connectshyft-api`
+- workspace boundary enforcement: passed via `node scripts/enforce-workspace-boundaries.js`
+- targeted provider-boundary scan: passed; `rg -n "telnyx" apps/connectshyft-api/src/routes/api/v1/connectshyft.ts apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts` returned no matches
+- routing delegation validation: unchanged; `git diff --name-only` across nginx/admin/connect routes only showed `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- unverified webhook rejection validation: passed in `src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- canonical port / localhost binding validation: unchanged; targeted `git diff --name-only` over server and compose files returned no matches
+- shared Postgres / migration ownership validation: unchanged except for lane-local ConnectShyft migration additions; targeted `git diff --name-only` returned only `apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts`
+- runbook reproducibility validation: unchanged; targeted `git diff --name-only` over deployment/runbook files returned no matches
+- persisted durability re-read validation: passed via route replay coverage in `src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`, receipt retry metadata coverage in `src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`, and domain idempotency coverage in `domains/communication/reliability/__tests__/idempotencyService.test.ts`

--- a/specs/005-reliability-idempotency-audit/research.md
+++ b/specs/005-reliability-idempotency-audit/research.md
@@ -1,0 +1,41 @@
+# Research: CS-005 Reliability / Idempotency / Audit
+
+## Decision 1: Use durable idempotency records in ConnectShyft persistence before outbound side effects
+
+- **Decision**: Implement command-side idempotency with a durable `communication_idempotency_record`-equivalent persistence adapter in `apps/connectshyft-api`, backed by the shared domain service in `domains/communication/reliability/idempotencyService.ts`.
+- **Rationale**: The current route-level replay ledger in `connectshyft.ts` is in-memory and cannot survive process restarts or realistic client retry windows. The ADR and execution packet require idempotency before side effects and durable request safety.
+- **Alternatives considered**:
+  - Keep the existing in-memory replay ledger: rejected because it is not durable and cannot satisfy CS-005.
+  - Push idempotency into the provider adapter: rejected because idempotency scope includes actor, operation, and authoritative application result, which belongs above infrastructure.
+
+## Decision 2: Keep audit append-only and separate from the volunteer-facing timeline
+
+- **Decision**: Persist a dedicated `communication_audit_log`-equivalent append-only record for command outcomes, duplicate suppression outcomes, retry decisions, and webhook processing outcomes using the shared audit contract in `domains/communication/audit`.
+- **Rationale**: The ADR and internal event note require durable audit evidence that is distinct from the user-facing timeline and captures result states such as `ignored_duplicate`, `retrying`, and `exhausted`.
+- **Alternatives considered**:
+  - Reuse thread timeline records as audit evidence: rejected because timeline content is user-facing and not append-only operational history.
+  - Store audit metadata only inside existing message or bridge rows: rejected because it would overwrite history and fail the append-only requirement.
+
+## Decision 3: Use bounded retry metadata on reliability-owned records, not a new retry subsystem
+
+- **Decision**: Persist bounded retry intent and exhaustion state on reliability-owned records already involved in the operation path, primarily idempotency records and webhook receipts, and use `domains/communication/reliability/retryPolicy.ts` for classification-driven retry decisions.
+- **Rationale**: CS-005 requires bounded retry only and explicitly forbids a broad retry subsystem redesign. Storing minimal retry metadata next to existing reliability records keeps the scope surgical while preserving replay safety.
+- **Alternatives considered**:
+  - Introduce a standalone retry jobs/work queue subsystem: rejected as broader than CS-005 allows.
+  - Avoid persisting retry intent at all: rejected because retry scheduling/exhaustion must be durable and auditable.
+
+## Decision 4: Reuse existing bridge-session ownership and webhook receipt flow
+
+- **Decision**: Keep bridge lifecycle authority in the existing bridge domain and `bridgeSessions.ts`, and keep provider ingress dedupe centered on `cs_webhook_receipts` / provider-correlation mapping flow while extending it for clearer duplicate, retryable failure, and exhausted outcomes.
+- **Rationale**: The ADR requires persisted bridge-session state and replay-safe webhook processing, but CS-005 must not redesign bridge orchestration or move provider logic upward.
+- **Alternatives considered**:
+  - Redesign the bridge state machine to absorb retry orchestration: rejected because CS-005 is hardening, not bridge redesign.
+  - Move webhook duplicate suppression into raw provider adapter code only: rejected because authoritative processing state must remain visible to application persistence.
+
+## Decision 5: Treat existing ConnectShyft HTTP routes as the external contract surface
+
+- **Decision**: Define CS-005 around the existing ConnectShyft lane-owned mutation and webhook routes, specifically outbound message/call initiation and provider webhook ingress, rather than introducing new reliability-specific endpoints.
+- **Rationale**: The repo already exposes these route surfaces, and CS-005 is meant to harden them in place while preserving routing delegation and lane boundaries.
+- **Alternatives considered**:
+  - Introduce separate reliability endpoints: rejected because that would expand scope and risk route-boundary drift.
+  - Restrict reliability handling to internal services only with no HTTP contract updates: rejected because the execution packet explicitly requires `Idempotency-Key` support on outbound communication endpoints.

--- a/specs/005-reliability-idempotency-audit/spec.md
+++ b/specs/005-reliability-idempotency-audit/spec.md
@@ -1,0 +1,159 @@
+# Feature Specification: CS-005 Reliability / Idempotency / Audit
+
+**Feature Branch**: `005-reliability-idempotency-audit`  
+**Created**: 2026-03-12  
+**Status**: Draft  
+**Input**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-005_Reliability_Idempotency_Audit_Guardrailed_Spec.md`  
+**Source Input**: `/Users/jeremiahotis/projects/connectshyft/specs/connectshyft-recovery/issues/CS-005_Reliability_Idempotency_Audit_Guardrailed_Spec.md`
+
+## Overview
+
+CS-005 adds the minimum durable reliability layer required for ConnectShyft outbound SMS, outbound call initiation, persisted bridge-session creation, and provider webhook handling. The feature must prevent duplicate side effects before they occur, keep webhook processing replay-safe, record append-only audit history, and persist bounded retry intent without redesigning bridge orchestration, provider adapters, UI, or broader schema ownership.
+
+This feature is governed by the execution packet, the Communication Infrastructure ADR, the canonical data model note, the CS-005 reliability sequence diagram, and the minimal internal event model note. Where the issue spec is terse, those governing documents define the non-negotiable behavior and boundaries.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Prevent Duplicate Outbound Side Effects (Priority: P1)
+
+As a ConnectShyft operator, I can retry an outbound message or call request with the same `Idempotency-Key` without creating duplicate provider side effects.
+
+**Why this priority**: Idempotency before side effects is the main safety requirement for CS-005 and blocks safe production use of outbound communication.
+
+**Independent Test**: Submit the same outbound message or outbound call request twice with the same effective payload and verify only one provider action occurs while the second response returns the authoritative existing result. Submit the same key with a different payload and verify the request is rejected with no new side effect.
+
+**Acceptance Scenarios**:
+
+1. **Given** an outbound SMS or call request with a new `Idempotency-Key`, **When** the request begins, **Then** a durable idempotency record is created before any provider side effect is attempted.
+2. **Given** a second outbound request with the same `Idempotency-Key` and materially identical payload, **When** it is received, **Then** the system returns the original or current authoritative result and does not create a second provider side effect.
+3. **Given** a second outbound request with the same `Idempotency-Key` and a materially different payload, **When** it is received, **Then** the system rejects the request loudly and does not create any new provider side effect.
+
+---
+
+### User Story 2 - Keep Webhook Processing Replay-Safe (Priority: P1)
+
+As a system maintainer, I can replay or receive duplicate provider webhooks without causing duplicate bridge transitions, duplicate messages, or duplicate audit side effects.
+
+**Why this priority**: Duplicate or replayed provider events are the main operational failure mode after outbound initiation succeeds.
+
+**Independent Test**: Deliver the same verified provider event multiple times and confirm the receipt is checkpointed, the first event is applied once, and later duplicates are marked ignored without duplicating domain state changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a verified provider webhook that has not yet been applied, **When** it is received, **Then** the receipt is persisted before domain side effects and the event is translated once into provider-neutral internal event language.
+2. **Given** a verified provider webhook that matches a previously processed receipt, **When** it is received again, **Then** the system suppresses duplicate side effects, records the duplicate outcome, and returns a replay-safe response.
+3. **Given** a retryable webhook-processing failure, **When** bounded retry policy allows another attempt, **Then** retry intent is persisted without bypassing bridge or message domain state rules.
+
+---
+
+### User Story 3 - Produce Append-Only Reliability Audit Evidence (Priority: P2)
+
+As a maintainer or auditor, I can inspect a durable append-only communication audit trail showing outbound mutations, duplicate suppression, retry decisions, and provider event outcomes.
+
+**Why this priority**: The ADR and execution packet require auditable evidence for communication mutations and reliability behavior.
+
+**Independent Test**: Trigger a successful outbound mutation, a duplicate replay, a retryable failure, and a terminal failure, then verify append-only audit rows exist for each outcome with correlation, actor, operation, target, and result state.
+
+**Acceptance Scenarios**:
+
+1. **Given** an outbound communication mutation, **When** it succeeds or fails, **Then** an append-only audit row records actor, operation, target entity, result state, timestamp, idempotency key, and provider references if present.
+2. **Given** a duplicate or replay-safe suppression outcome, **When** the system returns the existing authoritative result or ignores a duplicate webhook, **Then** audit history records the duplicate outcome without mutating prior audit rows.
+3. **Given** a bounded retry decision, **When** a retry is scheduled or exhausted, **Then** audit history records the retrying or exhausted result state with normalized failure evidence.
+
+### Edge Cases
+
+- A client retries while the original outbound request is still `in_progress`.
+- The same `Idempotency-Key` is reused across materially different request fingerprints.
+- A provider webhook arrives after the authoritative bridge or message state is already terminal.
+- A provider webhook is replayed after its receipt is already marked `processed` or `ignored_duplicate`.
+- A retryable provider failure is followed by a terminal failure before the next retry window.
+- Background retry state must not create a new bridge session or call leg outside existing bridge-domain entry points.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: All outbound ConnectShyft communication mutation endpoints that create or advance SMS, outbound calls, or bridge sessions MUST accept `Idempotency-Key`.
+- **FR-002**: The system MUST persist a durable idempotency record before performing any outbound provider side effect.
+- **FR-003**: A repeated request with the same idempotency scope and materially identical request fingerprint MUST return the original or current authoritative result and MUST NOT create duplicate provider side effects.
+- **FR-004**: A repeated request with the same idempotency scope and materially different request fingerprint MUST fail loudly and MUST NOT create provider side effects.
+- **FR-005**: Provider webhooks MUST be signature-verified before receipt application. Unverified webhook requests MUST be rejected before receipt persistence, event translation, and downstream domain side effects.
+- **FR-006**: Duplicate or replayed provider events MUST NOT create duplicate bridge transitions, duplicate message records, duplicate audit rows, or duplicate provider side effects.
+- **FR-007**: Retry handling MUST be bounded, persist retry intent and exhaustion state, and MUST NOT bypass bridge or message domain state rules.
+- **FR-008**: Communication audit history MUST be append-only and MUST record actor, operation, target entity, channel, result state, timestamp, idempotency key, and provider references when present.
+- **FR-009**: Provider-specific request, webhook, and error semantics MUST remain confined to infrastructure. ConnectShyft route and module reliability code MUST NOT import provider adapters directly or read raw provider payload fields.
+- **FR-010**: Bridge-session lifecycle ownership MUST remain in the existing bridge domain/application flow; CS-005 MUST harden reliability around that flow without redesigning it.
+- **FR-011**: System MUST preserve lane boundaries and deployment compatibility by keeping `/api/v1/auth/*` and `/api/v1/platform/admin/*` delegated to `admin-api`, keeping all other lane `/api` routes lane-owned, and keeping shared-Postgres migration ownership with `admin-api`.
+
+### Idempotency Fingerprint Rules
+
+Materially relevant request fingerprint fields for CS-005 are:
+
+- `send_sms`
+  - `threadId`
+  - normalized destination contact point or destination phone
+  - normalized message body
+  - channel = `sms`
+  - actor scope
+- `start_outbound_call`
+  - `threadId`
+  - target participant or contact point
+  - selected outbound number
+  - actor scope
+  - channel = `voice`
+- `start_bridge_session`
+  - `threadId`
+  - operator participant
+  - target participant or contact point
+  - selected outbound number
+  - actor scope
+  - channel = `bridge`
+- `apply_provider_event`
+  - `providerName`
+  - normalized internal event type
+  - provider event identity (`providerEventId` if available, otherwise verified `payloadHash`)
+  - correlated internal bridge or message resource when already resolved
+
+Fields such as trace IDs, request timestamps, header ordering, and raw provider payload formatting are not materially relevant fingerprint inputs.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Reliability hardening MUST be minimal and surgical; it MUST NOT introduce bridge redesign, provider adapter redesign, UI changes, or unrelated architecture changes.
+- **NFR-002**: Idempotency and webhook replay protection MUST remain durable across process restarts by relying on persisted records rather than in-memory replay state.
+- **NFR-003**: Retry policy MUST remain bounded and classification-driven; the initial implementation MUST avoid a broad retry subsystem or background orchestration redesign.
+- **NFR-004**: Audit persistence MUST be append-only and distinct from volunteer-facing thread timeline rendering.
+- **NFR-005**: Production deployment topology, localhost-only API bindings, host-managed Nginx routing, and shared Postgres ownership MUST remain unchanged.
+
+### Initial Retry Execution Model
+
+CS-005 persists retry intent only.
+
+- No background worker or scheduler is introduced in CS-005.
+- No immediate automatic redial or provider re-dispatch loop is introduced in CS-005.
+- Retryable failures may update durable retry metadata (`attemptCount`, `nextRetryAt`, `lastFailureClassification`) and append audit evidence only.
+- A later issue may consume persisted retry intent, but CS-005 itself stops at durable recording plus replay-safe suppression.
+
+## Compatibility Acceptance Scenarios
+
+1. **Given** CS-005 adds reliability persistence and route/application wiring, **When** routing ownership is reviewed, **Then** `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain delegated to `admin-api` and `/api/v1/connectshyft/*` remains lane-owned.
+2. **Given** CS-005 introduces reliability state persistence only inside the existing ConnectShyft and shared communication boundaries, **When** deployment topology is reviewed, **Then** host Nginx routing, localhost-only API bindings, Docker-hosted APIs, and static frontend serving remain unchanged.
+3. **Given** CS-005 adds minimal durable reliability tables or columns, **When** database ownership is reviewed, **Then** shared Postgres compatibility remains intact and `admin-api` remains the sole production migration owner.
+
+### Key Entities *(include if feature involves data)*
+
+- **Communication Idempotency Record**: Durable request-safety record keyed by tenant, operation scope, actor scope, idempotency key, and request fingerprint.
+- **Communication Audit Log**: Append-only reliability and mutation history recording actor, operation, target, channel, result, correlation, provider references, and timestamps.
+- **Communication Webhook Receipt**: Verified provider ingress checkpoint used for duplicate suppression, processing status, and bounded retry bookkeeping.
+- **Bridge Session**: Existing authoritative bridge lifecycle record that continues to own bridge state while gaining reliability metadata integration.
+- **Communication Message**: Existing authoritative outbound/inbound message record that remains the user-facing timeline entity while idempotency and audit hardening are added around it.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Repeating the same outbound message or call request with the same `Idempotency-Key` and effective payload results in exactly one provider side effect and one authoritative application result.
+- **SC-002**: Reusing the same `Idempotency-Key` with a materially different payload is rejected without creating a new side effect.
+- **SC-003**: Replaying a verified provider webhook does not create duplicate bridge transitions, duplicate message records, or duplicate audit rows.
+- **SC-004**: Append-only audit rows exist for successful outbound operations, duplicate suppressions, retry scheduling or exhaustion, and terminal failures.
+- **SC-005**: Targeted ConnectShyft reliability tests, `apps/connectshyft-api` build, and `node scripts/enforce-workspace-boundaries.js` all pass after implementation.
+- **SC-006**: Routing delegation, canonical API ports, shared Postgres compatibility, and deployment runbook reproducibility remain unchanged and are explicitly re-verified.

--- a/specs/005-reliability-idempotency-audit/tasks.md
+++ b/specs/005-reliability-idempotency-audit/tasks.md
@@ -1,0 +1,227 @@
+# Tasks: CS-005 Reliability / Idempotency / Audit
+
+**Input**: Design documents from `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/`  
+**Prerequisites**: [plan.md](/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/plan.md), [spec.md](/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/spec.md), [research.md](/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/research.md), [data-model.md](/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/data-model.md), [contracts/communication-reliability-contract.md](/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/contracts/communication-reliability-contract.md), [quickstart.md](/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md)
+
+**Tests**: Tests are required for this feature because the specification defines independent test criteria and measurable reliability outcomes for each user story.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and validated independently while preserving provider boundaries and bridge state-machine ownership.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the concrete CS-005 persistence and integration file surfaces required for the rest of the work.
+
+- [X] T001 Create the CS-005 reliability migration scaffold in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts`
+- [X] T002 [P] Create the ConnectShyft reliability persistence module scaffold in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts`
+- [X] T003 [P] Create the ConnectShyft audit persistence module scaffold in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts`
+- [X] T004 Capture the CS-005 route, webhook, and evidence matrix in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/contracts/communication-reliability-contract.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Extend shared reliability and audit primitives plus durable persistence foundations before story-specific route integration.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T005 Extend idempotency record types and decisions for durable replay, response snapshots, and retry metadata in `/Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/idempotencyTypes.ts`
+- [X] T006 Extend the shared idempotency service for conflict handling, in-progress handling, and authoritative replay completion in `/Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/idempotencyService.ts`
+- [X] T007 [P] Extend bounded retry decision inputs for persisted retry intent and exhaustion bookkeeping in `/Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/retryPolicy.ts`
+- [X] T008 [P] Extend webhook dedupe contracts for duplicate, retryable-failure, and exhausted receipt handling in `/Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/eventDeduper.ts`
+- [X] T009 [P] Extend append-only audit entry types for duplicate and retry result evidence in `/Users/jeremiahotis/projects/connectshyft/domains/communication/audit/auditTypes.ts`
+- [X] T010 Extend audit recording helpers for CS-005 append-only command and webhook entries in `/Users/jeremiahotis/projects/connectshyft/domains/communication/audit/recordCommunicationAudit.ts`
+- [X] T011 Implement durable idempotency repository operations in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts`
+- [X] T012 [P] Implement append-only communication audit repository operations in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts`
+- [X] T013 Update shared reliability and audit exports in `/Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/index.ts` and `/Users/jeremiahotis/projects/connectshyft/domains/communication/audit/index.ts`
+- [X] T014 Implement shared Postgres persistence for communication idempotency, communication audit log, and minimal webhook retry metadata in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts`
+
+**Checkpoint**: Shared reliability primitives, durable repositories, and migration scaffolding are ready for story implementation.
+
+---
+
+## Phase 3: User Story 1 - Prevent Duplicate Outbound Side Effects (Priority: P1) 🎯 MVP
+
+**Goal**: Make outbound message, outbound call, and bridge-start requests durable and idempotent before provider side effects happen.
+
+**Independent Test**: Submit the same outbound request twice with the same effective payload and `Idempotency-Key` and verify only one provider action occurs while the second response returns the authoritative existing result. Reuse the same key with a different payload and verify the request is rejected without creating a new side effect.
+
+### Tests for User Story 1 ⚠️
+
+- [X] T015 [P] [US1] Add shared idempotency decision coverage in `/Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/__tests__/idempotencyService.test.ts`
+- [X] T016 [P] [US1] Add outbound replay and conflict route coverage in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
+- [X] T017 [P] [US1] Add bridge-session idempotency integration coverage in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T018 [US1] Replace the in-memory outbound replay ledger with durable idempotency orchestration in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T019 [US1] Persist idempotency scope, resource bindings, response snapshots, and failure metadata for outbound operations in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts`
+- [X] T020 [US1] Integrate bridge-session start and outbound call/message authority with durable idempotency correlation in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
+- [X] T021 [US1] Align the communication reliability contract and command-side validation notes with the implemented outbound idempotency behavior and materially relevant request fingerprint rules in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/contracts/communication-reliability-contract.md` and `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+
+**Checkpoint**: Outbound message/call/bridge-start requests are durable and replay-safe without duplicate provider side effects.
+
+---
+
+## Phase 4: User Story 2 - Keep Webhook Processing Replay-Safe (Priority: P1)
+
+**Goal**: Checkpoint verified provider webhooks, suppress duplicates before event application, and persist bounded retry intent without bypassing bridge or message domain rules.
+
+**Independent Test**: Deliver the same verified provider event multiple times and confirm the first receipt is applied once, later duplicates are ignored without duplicate state changes, and retryable failures persist bounded retry intent and exhaustion evidence.
+
+### Tests for User Story 2 ⚠️
+
+- [X] T022 [P] [US2] Add webhook duplicate, retry-state, and signature-verification rejection route coverage in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- [X] T023 [P] [US2] Add webhook receipt replay and retry bookkeeping coverage in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+- [X] T024 [P] [US2] Add shared dedupe and retry-policy unit coverage in `/Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/__tests__/eventDeduper.test.ts` and `/Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/__tests__/retryPolicy.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T025 [US2] Extend webhook receipt persistence for duplicate suppression, retry counts, next-attempt timestamps, and exhausted outcomes in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts`
+- [X] T026 [US2] Integrate receipt checkpointing, duplicate suppression, and bounded retry decisions into webhook ingress in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T027 [US2] Preserve bridge-domain ownership while reapplying provider-neutral events against authoritative session state in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
+- [X] T028 [US2] Document the replay-safe webhook flow, bounded retry evidence, and retry-intent-only execution model in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+
+**Checkpoint**: Duplicate or replayed provider webhooks are ignored safely, and retry intent is bounded and durable without bypassing bridge/message domain rules.
+
+---
+
+## Phase 5: User Story 3 - Produce Append-Only Reliability Audit Evidence (Priority: P2)
+
+**Goal**: Append durable audit history for outbound mutations, duplicate suppressions, retry decisions, and webhook outcomes without changing volunteer-facing timeline behavior.
+
+**Independent Test**: Trigger successful, duplicate, retrying, exhausted, and failed communication outcomes and verify append-only audit rows capture actor, operation, target, channel, result state, correlation, idempotency key, and provider references.
+
+### Tests for User Story 3 ⚠️
+
+- [X] T029 [P] [US3] Add shared audit recorder coverage in `/Users/jeremiahotis/projects/connectshyft/domains/communication/audit/__tests__/recordCommunicationAudit.test.ts`
+- [X] T030 [P] [US3] Add outbound and duplicate-audit route assertions in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
+- [X] T031 [P] [US3] Add webhook and bridge-audit assertions in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts`
+
+### Implementation for User Story 3
+
+- [X] T032 [US3] Implement append-only command and webhook audit persistence in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts`
+- [X] T033 [US3] Integrate audit appends for command success, failure, duplicate, retrying, and exhausted outcomes in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T034 [US3] Persist bridge and webhook audit correlation/resource evidence without changing bridge state ownership in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts`
+- [X] T035 [US3] Update the audit contract and recorded evidence expectations in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/contracts/communication-reliability-contract.md` and `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+
+**Checkpoint**: Append-only reliability audit evidence exists for command-side and webhook-side communication outcomes.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Run end-to-end validation, record constitution evidence, and close documentation for the implemented feature.
+
+- [X] T036 [P] Run the targeted ConnectShyft reliability Jest suites and record the results in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+- [X] T037 [P] Run the shared domain reliability and audit Jest suites and record the results in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+- [X] T038 Run the ConnectShyft API build, workspace boundary enforcement, and targeted provider-boundary scans, then record the results in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+- [X] T039 [P] Record Nginx routing delegation validation for `/api/v1/auth/*`, `/api/v1/platform/admin/*`, and `/api/v1/connectshyft/*` in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+- [X] T040 [P] Record localhost binding and canonical port validation for `admin-api`, `money-api`, and `connect-api` in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+- [X] T041 [P] Record shared Postgres compatibility and `admin-api` production migration ownership validation in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+- [X] T042 Record reproducible deployment runbook validation, persisted durability re-read validation, and final CS-005 evidence summary in `/Users/jeremiahotis/projects/connectshyft/specs/005-reliability-idempotency-audit/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup**: No dependencies; can start immediately.
+- **Phase 2: Foundational**: Depends on Setup completion and blocks all user stories.
+- **Phase 3: User Story 1**: Depends on Foundational completion.
+- **Phase 4: User Story 2**: Depends on Foundational completion and can proceed in parallel with User Story 1 once the shared persistence foundation exists.
+- **Phase 5: User Story 3**: Depends on User Story 1 and User Story 2 because audit evidence must cover both outbound and webhook outcomes.
+- **Phase 6: Polish**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependency on other stories after Foundational; this is the MVP.
+- **User Story 2 (P1)**: No dependency on User Story 1 after Foundational, but shares the same reliability persistence and migration groundwork.
+- **User Story 3 (P2)**: Depends on User Story 1 and User Story 2 because append-only audit verification must cover both command-side and webhook-side flows.
+
+### Within Each User Story
+
+- Tests MUST be written and fail before implementation changes for that story.
+- Shared domain contracts and repository wiring precede route/application integration.
+- Route/application integration precedes documentation evidence capture.
+- Story-specific validation must pass before moving to the next dependent story.
+
+### Parallel Opportunities
+
+- Setup tasks marked `[P]` can run in parallel.
+- Foundational domain contract tasks `T007` through `T010` and repository task `T012` can run in parallel after `T005` and `T006` establish the shared idempotency shape.
+- User Story 1 test tasks `T015` through `T017` can run in parallel.
+- User Story 2 test tasks `T022` through `T024` can run in parallel.
+- User Story 3 test tasks `T029` through `T031` can run in parallel.
+- Final validation tasks `T036`, `T037`, `T039`, `T040`, and `T041` can run in parallel once implementation is complete.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch User Story 1 tests together:
+Task: "Add shared idempotency decision coverage in /Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/__tests__/idempotencyService.test.ts"
+Task: "Add outbound replay and conflict route coverage in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts"
+Task: "Add bridge-session idempotency integration coverage in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts"
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch User Story 2 tests together:
+Task: "Add webhook duplicate and retry-state route coverage in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts"
+Task: "Add webhook receipt replay and retry bookkeeping coverage in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts"
+Task: "Add shared dedupe and retry-policy unit coverage in /Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/__tests__/eventDeduper.test.ts and /Users/jeremiahotis/projects/connectshyft/domains/communication/reliability/__tests__/retryPolicy.test.ts"
+```
+
+---
+
+## Parallel Example: User Story 3
+
+```bash
+# Launch User Story 3 tests together:
+Task: "Add shared audit recorder coverage in /Users/jeremiahotis/projects/connectshyft/domains/communication/audit/__tests__/recordCommunicationAudit.test.ts"
+Task: "Add outbound and duplicate-audit route assertions in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts"
+Task: "Add webhook and bridge-audit assertions in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts and /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. **Stop and validate** the duplicate outbound prevention flow independently.
+5. Demo or ship the durable outbound idempotency slice if partial delivery is required.
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational so durable reliability primitives and persistence are in place.
+2. Deliver User Story 1 for outbound idempotency.
+3. Deliver User Story 2 for replay-safe webhook processing and bounded retry intent.
+4. Deliver User Story 3 for append-only audit evidence across both flows.
+5. Finish Polish by recording full validation and constitution evidence in `quickstart.md`.
+
+### Parallel Team Strategy
+
+1. One developer completes Setup + Foundational.
+2. After Foundational:
+   - Developer A: User Story 1 outbound idempotency integration
+   - Developer B: User Story 2 webhook replay-safety integration
+3. Once both P1 stories stabilize, Developer C or either lane finishes User Story 3 audit integration and the final validation pass.
+
+---
+
+## Notes
+
+- `[P]` tasks touch different files and can proceed in parallel once their prerequisites are met.
+- Each user story remains independently testable and maps directly to the CS-005 spec.
+- Idempotency must be persisted before side effects in every implementation task that touches outbound commands.
+- Retry logic must remain bounded and must not bypass bridge or message domain ownership.
+- Constitution-mandated routing, port, shared Postgres, and runbook validation tasks are explicit in the final phase.

--- a/specs/connectshyft-recovery/CS-005_Minimal_Internal_Event_Model_Note.md
+++ b/specs/connectshyft-recovery/CS-005_Minimal_Internal_Event_Model_Note.md
@@ -1,0 +1,36 @@
+# CS-005 Minimal Internal Event Model Note
+
+Provider-native names must not become internal event language above infrastructure.
+
+Minimum internal events:
+- outbound_sms_requested
+- outbound_sms_accepted
+- outbound_sms_failed
+- outbound_call_requested
+- outbound_call_accepted
+- outbound_call_failed
+- bridge_session_requested
+- bridge_session_created
+- bridge_session_failed
+- operator_call_created
+- neighbor_call_created
+- operator_answered
+- neighbor_answered
+- bridge_connected
+- bridge_failed
+- call_completed
+- idempotency_duplicate_returned
+- idempotency_conflict_rejected
+- webhook_received
+- webhook_duplicate_ignored
+- webhook_processed
+- webhook_failed
+- retry_scheduled
+- retry_exhausted
+
+Audit-facing result states:
+- succeeded
+- failed
+- ignored_duplicate
+- retrying
+- exhausted

--- a/specs/connectshyft-recovery/architecture/CS-005_reliability_sequence_diagram.md
+++ b/specs/connectshyft-recovery/architecture/CS-005_reliability_sequence_diagram.md
@@ -1,0 +1,54 @@
+# CS-005 Reliability Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / Client
+    participant APP as Application Service
+    participant IDEMP as Idempotency Service
+    participant DOMAIN as Bridge / Message Domain
+    participant TELE as Telephony Provider Interface
+    participant INFRA as Provider Adapter
+    participant WEBHOOK as Webhook Ingestion
+    participant DEDUPE as Event Deduper
+    participant AUDIT as Audit Service
+    participant DB as Persistence
+
+    UI->>APP: startBridgeSession / sendSms / startOutboundCall
+    APP->>IDEMP: beginOperation(idempotencyKey, fingerprint)
+
+    alt duplicate same request
+        IDEMP-->>APP: return_existing
+        APP-->>UI: authoritative prior result
+    else new request
+        IDEMP->>DB: create in_progress idempotency record
+        APP->>DOMAIN: perform domain operation
+        DOMAIN->>TELE: provider-neutral command
+        TELE->>INFRA: adapter call
+        INFRA-->>TELE: normalized success/failure
+        TELE-->>DOMAIN: normalized result
+        APP->>AUDIT: append audit
+        APP->>IDEMP: complete operation
+    end
+
+    INFRA-->>WEBHOOK: raw provider webhook
+    WEBHOOK->>DB: store/checkpoint receipt
+    WEBHOOK->>DEDUPE: check duplicate/replay
+
+    alt duplicate
+        DEDUPE-->>WEBHOOK: ignore_duplicate
+        WEBHOOK->>AUDIT: append duplicate-ignored audit
+    else first-seen
+        WEBHOOK->>INFRA: translate provider event
+        INFRA-->>APP: normalized internal event
+        APP->>DOMAIN: apply event
+        DOMAIN->>DB: persist authoritative state transition
+        APP->>AUDIT: append event audit
+        WEBHOOK->>DB: mark receipt processed
+    end
+```
+
+Non-negotiable:
+- idempotency before side effects
+- duplicate detection before event application
+- audit append-only
+- retry logic cannot bypass domain rules

--- a/specs/connectshyft-recovery/issues/CS-005_Reliability_Idempotency_Audit_Guardrailed_Spec.md
+++ b/specs/connectshyft-recovery/issues/CS-005_Reliability_Idempotency_Audit_Guardrailed_Spec.md
@@ -6,9 +6,14 @@ This issue is governed by the ConnectShyft Recovery Execution Packet:
 
 PRs must use the ConnectShyft Recovery template:
 
-.github/pull_request_template/connectshyft_recovery.md
+.github/pull_request_template/cs-005-reliability-idempotency-audit.md
 
 PRs that do not reference the Execution Packet will not be accepted.
+
+# CS-005 Verification PR Template
+
+Use:
+/.github/pull_request_template/cs-005-reliability-verification.md
 
 ## A. Outcome
 Messaging and calling operations become retry‑safe and auditable.


### PR DESCRIPTION
# CS-005 Reliability / Idempotency / Audit PR

Issue:
CS-005 Reliability Idempotency Audit Guardrailed Spec

Governing Documents:
- /specs/connectshyft-recovery/developer_execution_packet.md
- /specs/connectshyft-recovery/ADR-00X_Communication_Infrastructure_Contract.md
- /specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md
- /specs/connectshyft-recovery/issues/CS-005_Reliability_Idempotency_Audit_Guardrailed_Spec.md
- /specs/connectshyft-recovery/architecture/CS-005_reliability_sequence_diagram.md
- /specs/connectshyft-recovery/CS-005_Minimal_Internal_Event_Model_Note.md

## Summary
Implements durable communication reliability hardening for ConnectShyft outbound SMS/call and provider-webhook flows by persisting idempotency before side effects, suppressing duplicate webhook application, recording bounded retry intent and exhaustion, and appending audit evidence without redesigning bridge orchestration or the provider adapter.

## Scope Confirmation
- [x] No redesign of bridge orchestration
- [x] No redesign of the Telnyx adapter
- [x] No UI redesign work included
- [x] No unrelated feature work included

## Idempotency
- [x] duplicate outbound requests prevented
- [x] same key + same request returns authoritative result
- [x] same key + different request is rejected
- [x] idempotency record persists before side effects

Notes:
- outbound request fingerprint materiality is defined for SMS, outbound call, bridge start, and provider-event apply flows
- route integration now writes durable idempotency records before provider dispatch and replays the authoritative result on identical retries

## Webhook Replay / Dedupe
- [x] duplicate webhook events detected
- [x] duplicate webhook events ignored safely
- [x] webhook receipt or equivalent checkpoint persists
- [x] replay-safe processing verified

Notes:
- unverified webhooks are rejected before receipt persistence or downstream side effects
- duplicate and out-of-order provider events are suppressed through persisted receipt/checkpoint state plus replay-safe domain application

## Retry Strategy
- [x] retryable vs non-retryable failures distinguished
- [x] retry backoff implemented
- [x] retries stop after defined limit
- [x] retry exhaustion is recorded

Notes:
- CS-005 persists bounded retry intent only
- no worker, scheduler, automatic redial loop, or provider re-dispatch loop is introduced in this PR

## Audit Logging
- [x] audit is append-only
- [x] command-side outcomes recorded
- [x] event-side outcomes recorded
- [x] duplicate-ignored actions recorded
- [x] failure reasons recorded

Notes:
- audit rows are stored separately from the canonical timeline/session state and include actor, operation, target, channel, correlation, idempotency key, and provider references

## Validation
- [x] `npm run policy:check`
- [x] `bash scripts/lint-or-discovery.sh`
- [x] `node scripts/enforce-workspace-boundaries.js`
- [x] `env NODE_ENV=test MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci ENABLE_TEST_CONNECTSHYFT_FLAGS=true npm run test:connectshyft` in `apps/connectshyft-api`
- [x] `npm run build` in `apps/connectshyft-api`
- [x] `env NODE_ENV=test DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci TEST_ENV=local ENABLE_TEST_AUTH_HARNESS=true ENABLE_TEST_CONNECTSHYFT_FLAGS=true TEST_EMAIL=test@example.com TEST_PASSWORD=test1234 BASE_URL=http://localhost:5174 API_URL=http://localhost:3000 API_BASE_URL=http://localhost:3000 FRONTEND_URL=http://localhost:5174 VITE_API_PROXY_TARGET=http://localhost:3000 PLAYWRIGHT_FRONTEND_APP_DIR=apps/connectshyft-web JWT_SECRET=test-jwt-secret JWT_REFRESH_SECRET=test-jwt-refresh-secret bash scripts/ci-run-playwright-stack.sh bash scripts/backend-jest-ci.sh`

Validation summary:
- ConnectShyft focused suite: 60 suites passed, 322 tests passed
- repo-level backend jest wrapper: workspace Nx tests plus admin/money/connect ConnectShyft suites passed
- build and boundary checks passed

## Key Files
- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
- `apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts`
- `apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts`
- `apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts`
- `apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts`
- `domains/communication/reliability/*`
- `domains/communication/audit/*`
- `domains/communication/telephony/index.ts`
- `specs/005-reliability-idempotency-audit/*`

## Final Definition of Done
- [x] duplicate sessions prevented
- [x] duplicate calls prevented
- [x] duplicate webhook events ignored safely
- [x] retries bounded
- [x] audit trail present
