### PR TITLE
Docs: verify CS-005 reliability implementation

### DIFF
--- a/specs/005-reliability-idempotency-audit/evidence/reliability-verification.md
+++ b/specs/005-reliability-idempotency-audit/evidence/reliability-verification.md
@@ -1,0 +1,205 @@
+# CS-005 Reliability Verification
+
+Status: Verified
+Date: 2026-03-12
+Verification Scope: CS-005 reliability, idempotency, webhook replay safety, bounded retry intent, append-only audit, and boundary integrity
+
+## Governing Documents
+
+- `/specs/connectshyft-recovery/developer_execution_packet.md`
+- `/specs/connectshyft-recovery/ADR-00X_Communication_Infrastructure_Contract.md`
+- `/specs/connectshyft-recovery/Canonical_Data_Model_Note_Communication_Infrastructure.md`
+- `/specs/connectshyft-recovery/issues/CS-005_Reliability_Idempotency_Audit_Guardrailed_Spec.md`
+- `/specs/connectshyft-recovery/architecture/CS-005_reliability_sequence_diagram.md`
+- `/specs/connectshyft-recovery/CS-005_Minimal_Internal_Event_Model_Note.md`
+
+## Verification Summary
+
+CS-005 is behaviorally and architecturally compatible with the Communication Infrastructure ADR.
+
+Verified outcomes:
+
+- outbound idempotency is persisted before provider side effects
+- identical retries return authoritative prior/current results
+- conflicting reuse of the same idempotency key is rejected
+- duplicate provider webhooks are checkpointed and ignored safely after first application
+- retry handling is bounded and persists retry intent without introducing a worker or bypassing domain state rules
+- communication audit recording is append-only and separate from authoritative bridge/session state
+- provider-specific payload handling remains below infrastructure-owned boundaries
+- bridge state transitions remain owned by the bridge domain and persistence layer
+
+## Verification Checklist
+
+### Idempotency
+
+Status: Pass
+
+Evidence:
+
+- outbound route handling writes durable idempotency records before `sendSms`, `startOutboundCall`, or bridge-start side effects
+- same-key/same-payload replay returns the stored authoritative result
+- same-key/different-payload replay returns a deterministic conflict refusal
+- materially relevant fingerprint fields are defined for SMS, outbound call, bridge start, and provider-event apply flows
+
+Relevant files:
+
+- `/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `/apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts`
+- `/domains/communication/reliability/idempotencyTypes.ts`
+- `/domains/communication/reliability/idempotencyService.ts`
+
+### Webhook Replay Safety
+
+Status: Pass
+
+Evidence:
+
+- unverified webhooks are rejected before receipt persistence and domain application
+- verified provider events are checkpointed using durable receipt state before downstream handling
+- duplicate events are ignored safely and do not reapply bridge/message side effects
+- replay safety remains durable after re-reading persisted receipt and idempotency state
+
+Relevant files:
+
+- `/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `/apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts`
+- `/domains/communication/reliability/eventDeduper.ts`
+
+### Retry
+
+Status: Pass
+
+Evidence:
+
+- normalized provider failures distinguish retryable from non-retryable outcomes
+- retry decisions are bounded by policy and persisted attempt metadata
+- exhaustion is recorded explicitly
+- CS-005 persists retry intent only and does not add a worker, scheduler, or automatic provider re-dispatch loop
+- retry handling updates durable reliability state and audit evidence without bypassing bridge domain transitions
+
+Relevant files:
+
+- `/domains/communication/reliability/retryPolicy.ts`
+- `/domains/communication/telephony/index.ts`
+- `/apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts`
+- `/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+
+### Audit
+
+Status: Pass
+
+Evidence:
+
+- communication audit records are append-only
+- command-side outcomes are recorded for initial dispatch, replay, conflict, retrying, exhausted, and failure outcomes
+- event-side outcomes are recorded for verified webhook receipt, duplicate ignore, processed application, retry intent, and exhaustion
+- duplicate-ignored actions are recorded explicitly and audit storage remains separate from the canonical thread/session timeline
+
+Relevant files:
+
+- `/domains/communication/audit/auditTypes.ts`
+- `/domains/communication/audit/recordCommunicationAudit.ts`
+- `/apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts`
+
+### Boundary Integrity
+
+Status: Pass
+
+Evidence:
+
+- no provider-specific payload handling appears in CS-005 route, reliability, or audit surfaces
+- provider failures enter the app layer as normalized provider-neutral classifications
+- bridge state machine ownership remains in the bridge domain and bridge session persistence surfaces
+- no UI files are touched
+- unrelated legacy `twilioNumberE164` fields still exist elsewhere in the large `connectshyft.ts` route file, but they are outside the CS-005 reliability hunks verified here
+
+Relevant files:
+
+- `/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `/apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts`
+- `/apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts`
+- `/domains/communication/bridge/bridgeStateMachine.ts`
+- `/domains/communication/bridge/handleProviderBridgeEvent.ts`
+
+## Commands Run
+
+Executed locally on 2026-03-12:
+
+```bash
+cd /Users/jeremiahotis/projects/connectshyft
+npm run policy:check
+bash scripts/lint-or-discovery.sh
+node scripts/enforce-workspace-boundaries.js
+
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api
+env NODE_ENV=test \
+  MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  ENABLE_TEST_CONNECTSHYFT_FLAGS=true \
+  npm run test:connectshyft
+npm run build
+
+cd /Users/jeremiahotis/projects/connectshyft
+env NODE_ENV=test \
+  DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci \
+  TEST_ENV=local \
+  ENABLE_TEST_AUTH_HARNESS=true \
+  ENABLE_TEST_CONNECTSHYFT_FLAGS=true \
+  TEST_EMAIL=test@example.com \
+  TEST_PASSWORD=test1234 \
+  BASE_URL=http://localhost:5174 \
+  API_URL=http://localhost:3000 \
+  API_BASE_URL=http://localhost:3000 \
+  FRONTEND_URL=http://localhost:5174 \
+  VITE_API_PROXY_TARGET=http://localhost:3000 \
+  PLAYWRIGHT_FRONTEND_APP_DIR=apps/connectshyft-web \
+  JWT_SECRET=test-jwt-secret \
+  JWT_REFRESH_SECRET=test-jwt-refresh-secret \
+  bash scripts/ci-run-playwright-stack.sh bash scripts/backend-jest-ci.sh
+
+git diff --unified=0 9bb3fde45dad34cc512cbfd3dd9cbcf10af40bf2 8f16a79c -- \
+  apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  | rg -n "telnyx|twilio|call_control_id|message_uuid"
+
+rg -n "telnyx|twilio|call_control_id|message_uuid|telnyx[A-Z]|twilio[A-Z]" \
+  apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts \
+  apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts \
+  domains/communication \
+  -g '!infrastructure/communications/**'
+```
+
+## Validation Results
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| Git policy | PASS | `npm run policy:check` passed |
+| Lint/discovery guard | PASS | `bash scripts/lint-or-discovery.sh` passed via Playwright discovery fallback |
+| Workspace boundary guard | PASS | `node scripts/enforce-workspace-boundaries.js` passed |
+| Focused ConnectShyft API suite | PASS | `60` suites passed, `322` tests passed |
+| ConnectShyft API build | PASS | `npm run build` passed |
+| Repo-level backend Jest wrapper | PASS | workspace Nx tests plus admin, money, and connect ConnectShyft Jest lanes passed |
+| CS-005 hunk provider-boundary scan | PASS | `git diff ... | rg ...` returned no provider-specific matches in the CS-005 route hunks |
+| Broader provider-boundary scan | PASS with follow-up note | no vendor-specific matches in `communicationReliability.ts`, `communicationAuditLog.ts`, or shared communication domain runtime files; unrelated legacy `twilioNumberE164` matches still exist elsewhere in `connectshyft.ts`, and provider-key fixtures remain in shared tests |
+
+## Out-of-Scope Confirmation
+
+Verified as unchanged in this implementation:
+
+- no bridge redesign
+- no Telnyx adapter redesign
+- no UI changes
+- no broad schema redesign beyond minimal reliability persistence
+- no worker-based retry subsystem
+
+## Conclusion
+
+CS-005 satisfies the intended reliability hardening scope without violating the Communication Infrastructure ADR.
+
+Final verification outcome:
+
+1. Idempotency occurs before outbound side effects and returns authoritative replay results.
+2. Duplicate webhook processing is suppressed durably and safely.
+3. Retry handling is bounded, classification-driven, and persists intent only.
+4. Audit recording is append-only and separate from canonical state.
+5. Provider and bridge boundaries remain intact.


### PR DESCRIPTION
# CS-005 Reliability Verification PR

Purpose:
Architectural and behavioral verification of CS-005 after implementation.

Verification target:
Implementation branch `005-reliability-idempotency-audit` / PR #223.

Scope note:
This is a stacked verification PR with base `005-reliability-idempotency-audit` so the diff remains verification-only.

## Verification Checklist

### Idempotency
- [x] idempotency happens before side effects
- [x] same key + same request returns authoritative result
- [x] same key + different request rejects with conflict

Evidence:
- durable idempotency persistence is wired ahead of outbound provider dispatch in `connectshyft.ts`
- local ConnectShyft reliability suite passes replay and conflict assertions

### Webhook replay safety
- [x] duplicate provider events ignored safely
- [x] event application happens only after duplicate check
- [x] replay-safe processing verified

Evidence:
- unverified webhook rejection and duplicate suppression are covered in the route/module reliability tests
- persisted receipt and replay-state re-read behavior is verified by the focused ConnectShyft suite

### Retry
- [x] retryable vs non-retryable distinction exists
- [x] retry decisions are bounded
- [x] retry logic does not bypass domain state rules

Evidence:
- normalized provider failure classification remains intact
- CS-005 persists retry intent only; no worker or auto-redial loop is introduced

### Audit
- [x] audit is append-only
- [x] command-side outcomes recorded
- [x] event-side outcomes recorded
- [x] duplicate ignored actions recorded

Evidence:
- append-only audit recording is implemented and covered in `recordCommunicationAudit.test.ts` and the ConnectShyft route/module suites

### Boundary integrity
- [x] provider payloads do not leak above infrastructure
- [x] bridge state machine remains authoritative
- [x] no reliability logic drift into UI

Evidence:
- no provider-specific matches were found in the CS-005 route hunks added by the implementation commit
- no vendor-specific matches were found in `communicationReliability.ts`, `communicationAuditLog.ts`, or shared communication domain runtime files
- broader route scan still shows unrelated legacy `twilioNumberE164` fields elsewhere in `connectshyft.ts`; those are outside the CS-005 reliability hunks and are documented in the verification artifact

## Local Verification
- [x] `npm run policy:check`
- [x] `bash scripts/lint-or-discovery.sh`
- [x] `node scripts/enforce-workspace-boundaries.js`
- [x] `env NODE_ENV=test MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci ENABLE_TEST_CONNECTSHYFT_FLAGS=true npm run test:connectshyft` in `apps/connectshyft-api`
- [x] `npm run build` in `apps/connectshyft-api`
- [x] `env NODE_ENV=test DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci TEST_ENV=local ENABLE_TEST_AUTH_HARNESS=true ENABLE_TEST_CONNECTSHYFT_FLAGS=true TEST_EMAIL=test@example.com TEST_PASSWORD=test1234 BASE_URL=http://localhost:5174 API_URL=http://localhost:3000 API_BASE_URL=http://localhost:3000 FRONTEND_URL=http://localhost:5174 VITE_API_PROXY_TARGET=http://localhost:3000 PLAYWRIGHT_FRONTEND_APP_DIR=apps/connectshyft-web JWT_SECRET=test-jwt-secret JWT_REFRESH_SECRET=test-jwt-refresh-secret bash scripts/ci-run-playwright-stack.sh bash scripts/backend-jest-ci.sh`

Results:
- ConnectShyft focused suite: 60 suites passed, 322 tests passed
- repo-level backend jest wrapper: workspace Nx tests plus admin/money/connect ConnectShyft lanes passed
- boundary guard and build passed

## Verification Artifact
- `specs/005-reliability-idempotency-audit/evidence/reliability-verification.md`
