### PR TITLE
Fix: persist ConnectShyft texting preference

### DIFF
--- a/.github/pull_request_template/connectshyft-texting-preference.md
+++ b/.github/pull_request_template/connectshyft-texting-preference.md
@@ -1,0 +1,29 @@
+# ConnectShyft Texting Preference PR
+
+## Summary
+Describe the texting preference persistence/display fix.
+
+## Scope Confirmation
+- [ ] Scoped to current ConnectShyft runtime host in `apps/moneyshyft-api`
+- [ ] No lane-convergence refactor
+- [ ] No SMS target-resolution changes
+- [ ] No provider adapter redesign
+- [ ] No port, ingress, or route-ownership changes outside the current ConnectShyft runtime host
+
+## Persistence
+- [ ] create omission defaults to `YES`
+- [ ] explicit `YES | NO | UNKNOWN` values persist unchanged
+- [ ] invalid request values behave like omission
+- [ ] update omission preserves the existing canonical enum
+
+## API / UI
+- [ ] API returns `prefersTexting` with the persisted canonical enum
+- [ ] UI label mapping verified against the contract copy
+- [ ] `YES` never displays `Texting Preference Unknown`
+- [ ] labels match exactly: `Prefers Texting`, `Prefers Calls Only`, `Texting Preference Unknown`
+
+## Verification
+- [ ] backend module tests updated
+- [ ] backend route tests updated
+- [ ] quickstart manual verification path documented
+- [ ] deployment/routing validation reviewed against host-managed docs

--- a/apps/connectshyft-web/src/features/connectshyft/neighbors.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/neighbors.ts
@@ -18,13 +18,15 @@ export type ConnectShyftNeighborPhone = {
   verificationStatus: 'verified' | 'unverified';
 };
 
+export type ConnectShyftTextingPreference = 'UNKNOWN' | 'YES' | 'NO';
+
 export type ConnectShyftNeighbor = {
   neighborId: string;
   tenantId: string;
   orgUnitId: string;
   firstName: string;
   lastName: string;
-  prefersTexting: 'UNKNOWN' | 'YES' | 'NO';
+  prefersTexting: ConnectShyftTextingPreference;
   phones: ConnectShyftNeighborPhone[];
   createdAtUtc?: string;
   updatedAtUtc?: string;
@@ -110,6 +112,7 @@ type ConnectShyftEnvelope = {
 export type ConnectShyftNeighborCreateInput = {
   firstName: string;
   lastName: string;
+  prefersTexting?: ConnectShyftTextingPreference;
   phones: ConnectShyftNeighborPhoneInput[];
 };
 
@@ -147,6 +150,7 @@ export type ConnectShyftNeighborUpdateInput = {
   orgUnitId?: string;
   firstName: string;
   lastName: string;
+  prefersTexting?: ConnectShyftTextingPreference;
   phones: ConnectShyftNeighborPhoneInput[];
 };
 
@@ -503,6 +507,7 @@ export const createConnectShyftNeighbor = async (
   const payload = {
     firstName: input.firstName,
     lastName: input.lastName,
+    prefersTexting: input.prefersTexting,
     phones: input.phones,
   };
 
@@ -625,6 +630,7 @@ export const updateConnectShyftNeighborProfile = async (
         orgUnitId: input.orgUnitId,
         firstName: input.firstName,
         lastName: input.lastName,
+        prefersTexting: input.prefersTexting,
         phones: input.phones,
       },
       {

--- a/apps/connectshyft-web/src/features/connectshyft/presentation.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/presentation.ts
@@ -152,18 +152,18 @@ export const resolveConnectShyftPreferenceChip = (
   neighbor?: Pick<ConnectShyftNeighbor, 'prefersTexting'> | null,
 ): string => {
   if (!neighbor) {
-    return 'Texting preference unknown';
+    return 'Texting Preference Unknown';
   }
 
   if (neighbor.prefersTexting === 'YES') {
-    return 'Prefers texting';
+    return 'Prefers Texting';
   }
 
   if (neighbor.prefersTexting === 'NO') {
-    return 'Prefers calls';
+    return 'Prefers Calls Only';
   }
 
-  return 'Texting preference unknown';
+  return 'Texting Preference Unknown';
 };
 
 export const formatConnectShyftTimestamp = (value: string): string => {

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborCreateView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborCreateView.vue
@@ -251,6 +251,7 @@ import {
   fetchConnectShyftNeighborScope,
   type ConnectShyftNeighborScope,
   type ConnectShyftNeighbor,
+  type ConnectShyftTextingPreference,
 } from '@/features/connectshyft/neighbors';
 import { CONNECTSHYFT_RESPONSIVE_BREAKPOINTS } from '@/features/connectshyft/uiContracts';
 
@@ -264,7 +265,7 @@ const addressLine1 = ref('');
 const addressCity = ref('');
 const addressState = ref('');
 const addressPostalCode = ref('');
-const prefersTexting = ref<'YES' | 'NO' | 'UNKNOWN'>('YES');
+const prefersTexting = ref<ConnectShyftTextingPreference>('YES');
 const additionalPhoneShared = ref(false);
 const notes = ref('');
 const isSubmitting = ref(false);
@@ -334,6 +335,7 @@ const handleCreate = async (): Promise<void> => {
   const result = await createConnectShyftNeighbor({
     firstName: firstName.value,
     lastName: lastName.value,
+    prefersTexting: prefersTexting.value,
     phones: [
       {
         label: phoneLabel.value,

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborProfileView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborProfileView.vue
@@ -90,6 +90,22 @@
           </label>
         </div>
 
+        <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+          <label class="flex flex-col gap-1 text-sm text-slate-700">
+            Prefers texting
+            <select
+              data-testid="connectshyft-neighbor-prefers-texting-select"
+              v-model="prefersTexting"
+              :disabled="isSubmitting"
+              class="rounded border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+            >
+              <option value="YES">Yes</option>
+              <option value="NO">No</option>
+              <option value="UNKNOWN">Unknown</option>
+            </select>
+          </label>
+        </div>
+
         <section class="mt-4 space-y-3">
           <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Phone indicators</h2>
 
@@ -301,6 +317,7 @@ import {
   type ConnectShyftNeighbor,
   type ConnectShyftNeighborPhone,
   type ConnectShyftNeighborScope,
+  type ConnectShyftTextingPreference,
   updateConnectShyftNeighborProfile,
 } from '@/features/connectshyft/neighbors';
 
@@ -317,6 +334,7 @@ const scope = ref<ConnectShyftNeighborScope | null>(null);
 const profile = ref<ConnectShyftNeighbor | null>(null);
 const firstName = ref('');
 const lastName = ref('');
+const prefersTexting = ref<ConnectShyftTextingPreference>('YES');
 const phones = ref<ConnectShyftNeighborPhone[]>([]);
 const refusalState = ref<{ code: string; message: string } | null>(null);
 const editPolicyIndicator = ref<string | null>(null);
@@ -405,6 +423,7 @@ const hydrateProfileState = (neighbor: ConnectShyftNeighbor): void => {
   profile.value = neighbor;
   firstName.value = neighbor.firstName;
   lastName.value = neighbor.lastName;
+  prefersTexting.value = neighbor.prefersTexting;
   phones.value = neighbor.phones.map((phone) => ({ ...phone }));
 };
 
@@ -480,6 +499,7 @@ const handleSave = async (): Promise<void> => {
     orgUnitId: scope.value?.orgUnitId,
     firstName: firstName.value,
     lastName: lastName.value,
+    prefersTexting: prefersTexting.value,
     phones: phones.value.map((phone) => ({
       label: phone.label,
       value: phone.value,

--- a/apps/moneyshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts
+++ b/apps/moneyshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts
@@ -61,6 +61,106 @@ describe('connectshyft neighbor service', () => {
     expect(scopedNeighbors[0].neighborId).toBe(result.data.neighbor.neighborId);
   });
 
+  it('defaults create-time prefersTexting to YES when omitted', () => {
+    const result = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550199',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          prefersTexting: 'YES',
+        },
+      },
+    });
+  });
+
+  it('persists explicit canonical create-time prefersTexting values unchanged', () => {
+    const noPreference = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Ari',
+      lastName: 'Quinn',
+      prefersTexting: 'NO',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550199',
+        },
+      ],
+    });
+
+    const unknownPreference = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Jules',
+      lastName: 'North',
+      prefersTexting: 'UNKNOWN',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550200',
+        },
+      ],
+    });
+
+    expect(noPreference).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          prefersTexting: 'NO',
+        },
+      },
+    });
+    expect(unknownPreference).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          prefersTexting: 'UNKNOWN',
+        },
+      },
+    });
+  });
+
+  it('treats invalid create-time prefersTexting values as omitted and still defaults to YES', () => {
+    const result = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Ari',
+      lastName: 'Quinn',
+      prefersTexting: 'INVALID' as never,
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550199',
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          prefersTexting: 'YES',
+        },
+      },
+    });
+  });
+
   it('refuses create requests that omit phone entries', () => {
     const result = service.createNeighbor({
       actorRoles: ['ORGUNIT_MEMBER'],
@@ -304,6 +404,7 @@ describe('connectshyft neighbor service', () => {
         neighbor: {
           firstName: 'Mina Shared',
           lastName: 'Lopez Shared',
+          prefersTexting: 'YES',
           phones: [
             expect.objectContaining({
               label: 'mobile',
@@ -314,6 +415,99 @@ describe('connectshyft neighbor service', () => {
               isShared: true,
             }),
           ],
+        },
+      },
+    });
+  });
+
+  it('persists explicit update-time prefersTexting changes and preserves the existing value on omission or invalid input', () => {
+    const created = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      prefersTexting: 'YES',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550199',
+        },
+      ],
+    });
+
+    if (!created.ok) {
+      throw new Error('Expected neighbor create to succeed');
+    }
+
+    const updatedToNo = service.updateNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: created.data.neighbor.neighborId,
+      relationshipValidated: true,
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      prefersTexting: 'NO',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550199',
+        },
+      ],
+    });
+
+    const updatedOmitted = service.updateNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: created.data.neighbor.neighborId,
+      relationshipValidated: true,
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550199',
+        },
+      ],
+    });
+
+    const updatedInvalid = service.updateNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: created.data.neighbor.neighborId,
+      relationshipValidated: true,
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      prefersTexting: 'INVALID' as never,
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550199',
+        },
+      ],
+    });
+
+    expect(updatedToNo).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          prefersTexting: 'NO',
+        },
+      },
+    });
+    expect(updatedOmitted).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          prefersTexting: 'NO',
+        },
+      },
+    });
+    expect(updatedInvalid).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          prefersTexting: 'NO',
         },
       },
     });

--- a/apps/moneyshyft-api/src/modules/connectshyft/neighbors.ts
+++ b/apps/moneyshyft-api/src/modules/connectshyft/neighbors.ts
@@ -96,6 +96,7 @@ export type ConnectShyftCreateNeighborCommand = NeighborActorContext & {
   orgUnitId: string;
   firstName: string;
   lastName: string;
+  prefersTexting?: ConnectShyftCanonicalTextingPreference;
   phones: ConnectShyftNeighborPhoneInput[];
   neighborId?: string;
 };
@@ -114,6 +115,7 @@ export type ConnectShyftUpdateNeighborCommand = NeighborActorContext & {
   neighborId: string;
   firstName: string;
   lastName: string;
+  prefersTexting?: ConnectShyftCanonicalTextingPreference;
   phones: ConnectShyftNeighborPhoneInput[];
   relationshipValidated?: boolean;
 };
@@ -329,6 +331,16 @@ const normalizeTextingPreference = (
   }
 
   return 'UNKNOWN';
+};
+
+const normalizeOptionalTextingPreference = (
+  value: unknown,
+): ConnectShyftCanonicalTextingPreference | undefined => {
+  if (value === 'YES' || value === 'NO' || value === 'UNKNOWN') {
+    return value;
+  }
+
+  return undefined;
 };
 
 const buildPhoneRequiredRefusal = (): NeighborRefusalResult => ({
@@ -654,6 +666,7 @@ type NeighborStoreCreateInput = {
   orgUnitId: string;
   firstName: string;
   lastName: string;
+  prefersTexting?: ConnectShyftCanonicalTextingPreference;
   phones: NormalizedConnectShyftNeighborPhoneInput[];
   neighborId?: string;
 };
@@ -663,6 +676,7 @@ type NeighborStoreUpdateInput = {
   neighborId: string;
   firstName: string;
   lastName: string;
+  prefersTexting?: ConnectShyftCanonicalTextingPreference;
   phones: NormalizedConnectShyftNeighborPhoneInput[];
 };
 
@@ -695,7 +709,7 @@ export class InMemoryConnectShyftNeighborStore {
       orgUnitId: input.orgUnitId,
       firstName: input.firstName,
       lastName: input.lastName,
-      prefersTexting: 'UNKNOWN',
+      prefersTexting: input.prefersTexting || 'YES',
       phones: input.phones.map((phone) => ({
         phoneId: randomUUID(),
         label: phone.label,
@@ -742,7 +756,7 @@ export class InMemoryConnectShyftNeighborStore {
       ...existing,
       firstName: input.firstName,
       lastName: input.lastName,
-      prefersTexting: existing.prefersTexting || 'UNKNOWN',
+      prefersTexting: input.prefersTexting || existing.prefersTexting || 'UNKNOWN',
       updatedAtUtc: now,
       phones: input.phones.map((phone) => ({
         phoneId: randomUUID(),
@@ -967,7 +981,7 @@ export class KnexConnectShyftNeighborStore {
             org_unit_id: input.orgUnitId,
             first_name: input.firstName,
             last_name: input.lastName,
-            prefers_texting: 'UNKNOWN',
+            prefers_texting: input.prefersTexting || 'YES',
             created_at_utc: trx.fn.now(),
             updated_at_utc: trx.fn.now(),
           })
@@ -1169,6 +1183,7 @@ export class KnexConnectShyftNeighborStore {
           .update({
             first_name: input.firstName,
             last_name: input.lastName,
+            prefers_texting: input.prefersTexting,
             updated_at_utc: trx.fn.now(),
           })
           .returning<DbNeighborRow[]>([
@@ -1414,6 +1429,7 @@ export class ConnectShyftNeighborService {
       orgUnitId: input.orgUnitId,
       firstName: normalizeNonEmptyString(input.firstName),
       lastName: normalizeNonEmptyString(input.lastName),
+      prefersTexting: normalizeOptionalTextingPreference(input.prefersTexting) || 'YES',
       phones: normalizedPhones.phones,
       neighborId: input.neighborId,
     });
@@ -1485,6 +1501,7 @@ export class ConnectShyftNeighborService {
       neighborId: input.neighborId,
       firstName: normalizeNonEmptyString(input.firstName),
       lastName: normalizeNonEmptyString(input.lastName),
+      prefersTexting: normalizeOptionalTextingPreference(input.prefersTexting),
       phones: normalizedPhones.phones,
     });
 
@@ -1590,6 +1607,7 @@ export class AsyncConnectShyftNeighborService {
         orgUnitId: input.orgUnitId,
         firstName: normalizeNonEmptyString(input.firstName),
         lastName: normalizeNonEmptyString(input.lastName),
+        prefersTexting: normalizeOptionalTextingPreference(input.prefersTexting) || 'YES',
         phones: normalizedPhones.phones,
         neighborId: input.neighborId,
       });
@@ -1686,6 +1704,7 @@ export class AsyncConnectShyftNeighborService {
         neighborId: input.neighborId,
         firstName: normalizeNonEmptyString(input.firstName),
         lastName: normalizeNonEmptyString(input.lastName),
+        prefersTexting: normalizeOptionalTextingPreference(input.prefersTexting),
         phones: normalizedPhones.phones,
       });
 

--- a/apps/moneyshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts
+++ b/apps/moneyshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts
@@ -1,0 +1,313 @@
+import express from 'express';
+import request from 'supertest';
+import * as PlatformAdminService from '../../../../services/PlatformAdminService';
+import { connectShyftNeighborServiceAsync } from '../../../../modules/connectshyft/neighbors';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import connectShyftRouter from '../connectshyft';
+
+const TEST_TENANT_ID = 'tenant-connectshyft-alpha';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-alpha-east';
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(responseEnvelope);
+
+  app.use((req, _res, next) => {
+    const tenantId = req.header('x-test-connectshyft-tenant-id') || TEST_TENANT_ID;
+    const orgUnitId = req.header('x-test-connectshyft-orgunit-id') || TEST_ORG_UNIT_ID;
+    const role = req.header('x-test-connectshyft-role') || 'ORGUNIT_MEMBER';
+    const userId = req.header('x-test-connectshyft-user-id') || 'user-connectshyft-neighbors';
+
+    req.user = {
+      userId,
+      email: `${userId}@connectshyft.test`,
+      householdId: tenantId,
+      activeTenantId: tenantId,
+      activeOrgUnitId: orgUnitId,
+      role,
+    };
+    req.tenantId = tenantId;
+    req.orgUnitId = orgUnitId;
+    req.tenantContext = {
+      tenantId,
+      orgUnitId,
+      scopeMode: 'ORG_UNIT',
+      source: 'auth',
+    };
+
+    next();
+  });
+
+  app.use('/api/v1/connectshyft', connectShyftRouter);
+  return app;
+};
+
+const buildHeaders = (overrides: Record<string, string> = {}): Record<string, string> => ({
+  'x-correlation-id': 'corr-connectshyft-neighbors',
+  'x-test-connectshyft-flags': JSON.stringify({
+    connectshyft_enabled: true,
+    connectshyft_inbox_enabled: true,
+    connectshyft_escalation_enabled: true,
+    connectshyft_webhooks_enabled: true,
+  }),
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-neighbors',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  ...overrides,
+});
+
+describe('connectshyft neighbor routes', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+    process.env.CONNECTSHYFT_ENABLED = 'true';
+    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+  });
+
+  beforeEach(() => {
+    jest.spyOn(PlatformAdminService, 'evaluateActorTenantModuleEntitlement').mockResolvedValue({
+      tenantId: TEST_TENANT_ID,
+      moduleKey: 'connectshyft',
+      enabled: true,
+      reason: 'enabled',
+      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+      message: 'ConnectShyft entitlement enabled for tests.',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+  });
+
+  it('passes explicit create-time prefersTexting values through and returns the canonical enum', async () => {
+    const createSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor').mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+      httpStatus: 201,
+      data: {
+        neighbor: {
+          neighborId: 'neighbor-create-yes',
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          firstName: 'Mina',
+          lastName: 'Lopez',
+          prefersTexting: 'NO',
+          phones: [],
+          createdAtUtc: '2026-03-14T00:00:00.000Z',
+          updatedAtUtc: '2026-03-14T00:00:00.000Z',
+        },
+      },
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/neighbors')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: TEST_ORG_UNIT_ID,
+        firstName: 'Mina',
+        lastName: 'Lopez',
+        prefersTexting: 'NO',
+        phones: [
+          {
+            label: 'mobile',
+            value: '+12605550199',
+          },
+        ],
+      });
+
+    expect(response.status).toBe(201);
+    expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      prefersTexting: 'NO',
+    }));
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+      data: {
+        neighbor: {
+          neighborId: 'neighbor-create-yes',
+          prefersTexting: 'NO',
+        },
+      },
+    });
+  });
+
+  it('treats invalid create-time prefersTexting values as omitted', async () => {
+    const createSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor').mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+      httpStatus: 201,
+      data: {
+        neighbor: {
+          neighborId: 'neighbor-create-default',
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          firstName: 'Ari',
+          lastName: 'Quinn',
+          prefersTexting: 'YES',
+          phones: [],
+          createdAtUtc: '2026-03-14T00:00:00.000Z',
+          updatedAtUtc: '2026-03-14T00:00:00.000Z',
+        },
+      },
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/neighbors')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: TEST_ORG_UNIT_ID,
+        firstName: 'Ari',
+        lastName: 'Quinn',
+        prefersTexting: 'MAYBE',
+        phones: [
+          {
+            label: 'mobile',
+            value: '+12605550199',
+          },
+        ],
+      });
+
+    expect(response.status).toBe(201);
+    expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({
+      prefersTexting: undefined,
+    }));
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          prefersTexting: 'YES',
+        },
+      },
+    });
+  });
+
+  it('passes update-time prefers_texting alias values through and returns the canonical enum', async () => {
+    const updateSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'updateNeighbor').mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+      httpStatus: 200,
+      data: {
+        neighbor: {
+          neighborId: 'neighbor-update-unknown',
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          firstName: 'Jules',
+          lastName: 'North',
+          prefersTexting: 'UNKNOWN',
+          phones: [],
+          createdAtUtc: '2026-03-14T00:00:00.000Z',
+          updatedAtUtc: '2026-03-14T00:00:00.000Z',
+        },
+      },
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .put('/api/v1/connectshyft/neighbors/neighbor-update-unknown')
+      .set(buildHeaders({ 'x-test-connectshyft-role': 'TENANT_ADMIN' }))
+      .send({
+        orgUnitId: TEST_ORG_UNIT_ID,
+        firstName: 'Jules',
+        lastName: 'North',
+        prefers_texting: 'UNKNOWN',
+        phones: [
+          {
+            label: 'mobile',
+            value: '+12605550200',
+          },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: TEST_TENANT_ID,
+      neighborId: 'neighbor-update-unknown',
+      prefersTexting: 'UNKNOWN',
+    }));
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+      data: {
+        neighbor: {
+          prefersTexting: 'UNKNOWN',
+        },
+      },
+    });
+  });
+
+  it('treats invalid update-time prefersTexting values as omitted so existing values can be preserved', async () => {
+    const updateSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'updateNeighbor').mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+      httpStatus: 200,
+      data: {
+        neighbor: {
+          neighborId: 'neighbor-update-preserve',
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          firstName: 'Mina',
+          lastName: 'Shared',
+          prefersTexting: 'YES',
+          phones: [],
+          createdAtUtc: '2026-03-14T00:00:00.000Z',
+          updatedAtUtc: '2026-03-14T00:00:00.000Z',
+        },
+      },
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .put('/api/v1/connectshyft/neighbors/neighbor-update-preserve')
+      .set(buildHeaders({ 'x-test-connectshyft-role': 'TENANT_ADMIN' }))
+      .send({
+        orgUnitId: TEST_ORG_UNIT_ID,
+        firstName: 'Mina',
+        lastName: 'Shared',
+        prefersTexting: 'INVALID',
+        phones: [
+          {
+            label: 'mobile',
+            value: '+12605550199',
+          },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      prefersTexting: undefined,
+    }));
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          prefersTexting: 'YES',
+        },
+      },
+    });
+  });
+});

--- a/apps/moneyshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/moneyshyft-api/src/routes/api/v1/connectshyft.ts
@@ -20,6 +20,7 @@ import {
   AsyncConnectShyftNeighborService,
   KnexConnectShyftNeighborStore,
   connectShyftNeighborServiceAsync,
+  type ConnectShyftCanonicalTextingPreference,
   type ConnectShyftIdentityMatchDecision,
   type ConnectShyftNeighborPhoneInput,
 } from '../../../modules/connectshyft/neighbors';
@@ -3567,11 +3568,28 @@ const parseNeighborPhones = (req: Request): ConnectShyftNeighborPhoneInput[] => 
   });
 };
 
+const parseNeighborTextingPreference = (
+  req: Request,
+): ConnectShyftCanonicalTextingPreference | undefined => {
+  const candidates = [req.body?.prefersTexting, req.body?.prefers_texting];
+
+  for (const candidate of candidates) {
+    if (candidate === 'YES' || candidate === 'NO' || candidate === 'UNKNOWN') {
+      return candidate;
+    }
+  }
+
+  return undefined;
+};
+
 const parseNeighborCreateBody = (req: Request) => {
+  const prefersTexting = parseNeighborTextingPreference(req);
+
   return {
     orgUnitId: parseOrgUnitIdFromBody(req),
     firstName: typeof req.body?.firstName === 'string' ? req.body.firstName : '',
     lastName: typeof req.body?.lastName === 'string' ? req.body.lastName : '',
+    prefersTexting,
     phones: parseNeighborPhones(req),
   };
 };
@@ -3580,6 +3598,7 @@ const parseNeighborUpdateBody = (req: Request) => ({
   orgUnitId: parseOrgUnitIdFromBody(req),
   firstName: typeof req.body?.firstName === 'string' ? req.body.firstName : '',
   lastName: typeof req.body?.lastName === 'string' ? req.body.lastName : '',
+  prefersTexting: parseNeighborTextingPreference(req),
   phones: parseNeighborPhones(req),
 });
 
@@ -3888,6 +3907,7 @@ const updateNeighborWithSideEffects = async (input: {
   actorUserId: string | null;
   firstName: string;
   lastName: string;
+  prefersTexting?: ConnectShyftCanonicalTextingPreference;
   phones: ConnectShyftNeighborPhoneInput[];
   policy: Extract<ConnectShyftNeighborEditPolicyDecision, { ok: true }>;
   provenance: NeighborEditProvenancePayload;
@@ -3914,6 +3934,7 @@ const updateNeighborWithSideEffects = async (input: {
     neighborId: input.neighborId,
     firstName: input.firstName,
     lastName: input.lastName,
+    prefersTexting: input.prefersTexting,
     phones: input.phones,
     relationshipValidated: input.policy.relationshipValidated,
   };
@@ -4703,6 +4724,7 @@ router.post('/neighbors', async (req: Request, res: Response) => {
     orgUnitId: context.orgUnitId,
     firstName: payload.firstName,
     lastName: payload.lastName,
+    prefersTexting: payload.prefersTexting,
     phones: payload.phones,
   });
 
@@ -4909,6 +4931,7 @@ router.put('/neighbors/:neighborId', async (req: Request, res: Response) => {
     actorUserId,
     firstName: payload.firstName,
     lastName: payload.lastName,
+    prefersTexting: payload.prefersTexting,
     phones: payload.phones,
     policy: policyDecision,
     provenance,

--- a/specs/008-connectshyft-texting-preference/contracts/neighbor-texting-preference.md
+++ b/specs/008-connectshyft-texting-preference/contracts/neighbor-texting-preference.md
@@ -1,0 +1,118 @@
+# Neighbor Texting Preference Contract
+
+## Scope
+
+Current ConnectShyft runtime host only:
+- `apps/moneyshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/moneyshyft-api/src/modules/connectshyft/neighbors.ts`
+
+Current UI submission and display surfaces only:
+- `apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborCreateView.vue`
+- `apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborProfileView.vue`
+- `apps/connectshyft-web/src/features/connectshyft/presentation.ts`
+
+## Canonical Enum
+
+Canonical API/UI field: `prefersTexting`
+
+Compatibility request alias at the current route boundary: `prefers_texting`
+
+Accepted values for either request field are:
+- `YES`
+- `NO`
+- `UNKNOWN`
+
+## Request Contracts
+
+### POST `/api/v1/connectshyft/neighbors`
+
+**Accepted request body**
+
+```json
+{
+  "orgUnitId": "22222222-2222-4222-8222-222222222222",
+  "firstName": "Mina",
+  "lastName": "Lopez",
+  "phones": [
+    {
+      "label": "mobile",
+      "value": "+12605550199"
+    }
+  ],
+  "prefersTexting": "YES"
+}
+```
+
+**Behavior**
+- If `prefersTexting` is omitted, runtime persists `YES`
+- If `prefersTexting` is provided as a canonical enum, runtime persists that exact value
+- If an incoming value is not canonical, the current runtime surface treats it as omitted
+- The route may accept `prefers_texting` as a compatibility alias, but the canonical response field remains `prefersTexting`
+
+### PUT `/api/v1/connectshyft/neighbors/:neighborId`
+
+**Accepted request body**
+
+```json
+{
+  "orgUnitId": "22222222-2222-4222-8222-222222222222",
+  "firstName": "Mina",
+  "lastName": "Lopez",
+  "phones": [
+    {
+      "label": "mobile",
+      "value": "+12605550199",
+      "isShared": false
+    }
+  ],
+  "prefersTexting": "NO"
+}
+```
+
+**Behavior**
+- If `prefersTexting` is provided, runtime persists the canonical value
+- If omitted, runtime preserves the existing stored value
+- If an incoming value is not canonical, the current runtime surface treats it as omitted and preserves the existing stored value
+
+## Response Contract
+
+### Neighbor envelope payload
+
+```json
+{
+  "ok": true,
+  "code": "CONNECTSHYFT_NEIGHBOR_RESOLVED",
+  "data": {
+    "neighbor": {
+      "neighborId": "neighbor-123",
+      "tenantId": "tenant-123",
+      "orgUnitId": "org-123",
+      "firstName": "Mina",
+      "lastName": "Lopez",
+      "prefersTexting": "YES",
+      "phones": []
+    }
+  }
+}
+```
+
+**Rules**
+- API responses MUST return the persisted canonical enum
+- Responses MUST NOT degrade `YES` to `UNKNOWN`
+- Any fallback to `UNKNOWN` is allowed only when the stored value is truly absent or invalid
+
+## UI Display Contract
+
+**Display labels**
+- `YES` -> `Prefers Texting`
+- `NO` -> `Prefers Calls Only`
+- `UNKNOWN` -> `Texting Preference Unknown`
+
+**Display surfaces**
+- Inbox snapshot
+- Thread detail snapshot
+- Any future current-lane neighbor preference chip or badge
+
+**Rules**
+- UI labels must be derived from canonical enum values only
+- UI copy must match the contract strings exactly

--- a/specs/008-connectshyft-texting-preference/data-model.md
+++ b/specs/008-connectshyft-texting-preference/data-model.md
@@ -1,0 +1,93 @@
+# Data Model
+
+## Entity: ConnectShyftNeighbor
+
+**Source of truth**: `connectshyft.cs_neighbors`
+
+**Fields**
+- `neighborId`: canonical neighbor identifier
+- `tenantId`: tenant scope
+- `orgUnitId`: orgUnit scope
+- `firstName`: normalized trimmed string
+- `lastName`: normalized trimmed string
+- `prefersTexting`: canonical enum exposed by runtime and UI
+- `createdAtUtc`: persistence timestamp
+- `updatedAtUtc`: persistence timestamp
+
+**Validation rules**
+- `prefersTexting` MUST be one of `YES`, `NO`, `UNKNOWN`
+- Create defaults to `YES` when the request omits the field or provides an invalid value
+- Update persists only canonical values; if omitted or invalid, the existing persisted value is preserved
+- Read paths normalize any non-canonical stored value to `UNKNOWN` as a defensive fallback only
+
+**Relationships**
+- One neighbor has many `ConnectShyftNeighborPhone` records
+- One neighbor may be referenced by current thread and SMS preference resolution flows
+
+## Entity: ConnectShyftNeighborPhone
+
+**Source of truth**: `connectshyft.cs_neighbor_phones`
+
+**Fields**
+- `phoneId`
+- `neighborId`
+- `label`
+- `value`
+- `sortOrder`
+- `isPrimary`
+- `isShared`
+- `verificationStatus`
+
+**Validation rules**
+- At least one phone is required for create and update
+- Phone values are normalized to E.164 before persistence
+
+## Entity: ConnectShyftNeighborFormPayload
+
+**Used by**
+- `apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborCreateView.vue`
+- `apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborProfileView.vue`
+- `apps/connectshyft-web/src/features/connectshyft/neighbors.ts`
+- `apps/moneyshyft-api/src/routes/api/v1/connectshyft.ts`
+
+**Fields**
+- `orgUnitId` on update/create route bodies where currently required
+- `firstName`
+- `lastName`
+- `phones`
+- `prefersTexting`
+
+**Validation rules**
+- `prefersTexting` must map to the canonical enum before reaching persistence
+- The frontend selector must round-trip the canonical enum without introducing a label-derived value
+
+## Derived Display Model: Texting Preference Chip
+
+**Used by**
+- Inbox snapshot
+- Thread detail snapshot
+
+**Mapping**
+- `YES` -> `Prefers Texting`
+- `NO` -> `Prefers Calls Only`
+- `UNKNOWN` -> `Texting Preference Unknown`
+
+**Invariant**
+- Display uses only the canonical enum value returned from the API; it does not infer from null-like or ad hoc shapes.
+
+## State Transitions
+
+### Create
+- Input omits preference -> persist `YES`
+- Input explicitly sets `YES` -> persist `YES`
+- Input explicitly sets `NO` -> persist `NO`
+- Input explicitly sets `UNKNOWN` -> persist `UNKNOWN`
+
+### Update
+- Input explicitly changes preference -> persist new canonical value
+- Input omits preference -> preserve existing stored canonical value
+- Input provides invalid preference -> preserve existing stored canonical value
+
+### Read
+- Stored canonical value -> returned unchanged as `prefersTexting`
+- Stored absent/invalid value -> returned as `UNKNOWN` only as a defensive fallback

--- a/specs/008-connectshyft-texting-preference/plan.md
+++ b/specs/008-connectshyft-texting-preference/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: ConnectShyft Texting Preference Persistence and Display
+
+**Branch**: `008-connectshyft-texting-preference` | **Date**: 2026-03-14 | **Spec**: [/Users/jeremiahotis/projects/connectshyft/specs/008-connectshyft-texting-preference/spec.md](/Users/jeremiahotis/projects/connectshyft/specs/008-connectshyft-texting-preference/spec.md)
+**Input**: Feature specification from `/specs/008-connectshyft-texting-preference/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Patch the current ConnectShyft runtime host in `apps/moneyshyft-api` so neighbor create/update flows preserve canonical `prefers_texting` values, treat omitted or invalid incoming preference values according to the current runtime contract, default new-neighbor create behavior to `YES` at the runtime write path, return the stored enum unchanged through existing neighbor responses, and render the exact contract labels in the current `apps/connectshyft-web` display surfaces without any lane-convergence or module-relocation work.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022) on Node.js >=20, Vue 3 SFCs with TypeScript  
+**Primary Dependencies**: Express, Knex, pg, Jest, Supertest, Vue 3, Axios-based API client  
+**Storage**: Shared PostgreSQL, primarily `connectshyft.cs_neighbors` and `connectshyft.cs_neighbor_phones`  
+**Testing**: Jest module tests, Supertest route tests, manual ConnectShyft web verification  
+**Target Platform**: Dockerized Node API behind host-managed Nginx plus ConnectShyft Vue SPA  
+**Project Type**: Full-stack web application with lane-specific frontend and backend  
+**Performance Goals**: Preserve existing neighbor CRUD latency and query shape; no additional cross-service hops  
+**Constraints**: Surgical patch in `apps/moneyshyft-api`, no lane-convergence refactor, no code movement into `apps/connectshyft-api`, canonical enum limited to `YES | NO | UNKNOWN`, UI labels must match contract text exactly  
+**Scale/Scope**: One neighbor preference field across current create/update/read/display flows in the existing ConnectShyft runtime and web UI
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Platform shell authority preserved: PASS. No auth, shell, or platform-admin ownership changes are introduced.
+- Lane isolation preserved: PASS. The fix stays inside the existing MoneyShyft-hosted ConnectShyft runtime plus the current ConnectShyft web UI surface; no new cross-lane service coupling is added.
+- Routing delegation preserved: PASS. No route ownership or delegation behavior changes are required outside the existing `/api/v1/connectshyft/*` lane surface.
+- Deployment topology preserved: PASS. No Docker, Nginx, port, or binding changes are involved.
+- Database ownership preserved: PASS. The design keeps the existing shared Postgres schema compatible and avoids migration-authority expansion; the runtime will write explicit canonical values without requiring lane-convergence work.
+- Security boundaries preserved: PASS. No public ingress, cookie, or session-boundary behavior changes are introduced.
+- Workflow compliance: PASS. This plan derives directly from the copied feature spec and produces research, data model, contracts, and quickstart artifacts for later task generation.
+- Acceptance criteria present: PASS. The plan covers create defaulting, update omission behavior, API response integrity, exact UI labels, routing ownership, shared-database compatibility, and regression checks in automated backend tests plus manual UI verification.
+
+Post-design constitution re-check: PASS. Phase 1 design remains within the current runtime host, preserves shared-database compatibility, and introduces no routing, topology, or shell-authority changes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-connectshyft-texting-preference/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── neighbor-texting-preference.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/
+├── moneyshyft-api/
+│   └── src/
+│       ├── routes/api/v1/connectshyft.ts
+│       ├── modules/connectshyft/neighbors.ts
+│       ├── modules/connectshyft/__tests__/neighbors.test.ts
+│       └── routes/api/v1/__tests__/
+└── connectshyft-web/
+    └── src/
+        ├── features/connectshyft/neighbors.ts
+        ├── features/connectshyft/presentation.ts
+        ├── views/ConnectShyft/ConnectShyftNeighborCreateView.vue
+        ├── views/ConnectShyft/ConnectShyftNeighborProfileView.vue
+        ├── views/ConnectShyft/ConnectShyftInboxView.vue
+        ├── views/ConnectShyft/ConnectShyftThreadDetailView.vue
+        └── components/connectshyft/ConnectShyftNeighborSnapshot.vue
+
+architecture/
+├── connectshyft/runtime-host-reality-contract.md
+└── connectshyft/neighbor-texting-preference-contract.md
+```
+
+**Structure Decision**: Keep the runtime fix in `apps/moneyshyft-api` per the governing runtime-host contract, update only the current ConnectShyft web surfaces that submit or render the field, and avoid any work in `apps/connectshyft-api`.
+
+## Implementation Phases
+
+1. Establish shared request/DTO boundaries for canonical `prefersTexting` handling across the current frontend and runtime route surface.
+2. Implement and test backend persistence and API round-trip behavior for create/update defaulting, omission handling, and canonical enum reads.
+3. Implement current ConnectShyft UI submission and exact-label display behavior on the existing create, profile, inbox, and thread-detail surfaces.
+4. Validate constitution-required routing, topology, shared-database, and runbook regression checks alongside feature-specific quickstart verification.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |

--- a/specs/008-connectshyft-texting-preference/quickstart.md
+++ b/specs/008-connectshyft-texting-preference/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart
+
+## Goal
+
+Verify that the current ConnectShyft runtime host persists, returns, and displays canonical texting preferences without degrading `YES` to `UNKNOWN`.
+
+## Automated Checks
+
+### Backend module tests
+
+From repo root:
+
+```bash
+cd apps/moneyshyft-api && npm test -- --runInBand src/modules/connectshyft/__tests__/neighbors.test.ts
+```
+
+### Backend route tests
+
+From repo root:
+
+```bash
+cd apps/moneyshyft-api && npm test -- --runInBand src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts
+```
+
+## Manual Verification
+
+### 1. Create default path
+
+1. Open the ConnectShyft add-neighbor view.
+2. Leave the texting-preference selector at its default.
+3. Create a neighbor with a valid phone number.
+4. Confirm the API response returns `prefersTexting: "YES"`.
+5. Confirm inbox or thread-detail snapshot displays `Prefers Texting`.
+
+### 2. Explicit `NO`
+
+1. Create a neighbor with texting preference set to `NO`.
+2. Confirm the API response returns `prefersTexting: "NO"`.
+3. Confirm the snapshot displays `Prefers Calls Only`.
+
+### 3. Explicit `UNKNOWN`
+
+1. Create or update a neighbor with texting preference set to `UNKNOWN`.
+2. Confirm the API response returns `prefersTexting: "UNKNOWN"`.
+3. Confirm the snapshot displays `Texting Preference Unknown`.
+
+### 4. Update round-trip
+
+1. Open an existing neighbor profile.
+2. Change the texting preference from `UNKNOWN` to `YES`.
+3. Save the profile.
+4. Confirm the update response returns `prefersTexting: "YES"`.
+5. Confirm the inbox/thread snapshot now displays `Prefers Texting`.
+
+## Regression Notes
+
+- No route ownership, deployment topology, or lane isolation behavior should change.
+- SMS preference resolution should continue reading the stored canonical enum from the same neighbor record.

--- a/specs/008-connectshyft-texting-preference/research.md
+++ b/specs/008-connectshyft-texting-preference/research.md
@@ -1,0 +1,63 @@
+# Phase 0 Research
+
+## Decision 1: Default new neighbors to `YES` in the runtime write path instead of adding a schema migration in this feature
+
+**Decision**: Update the current create flow in `apps/moneyshyft-api/src/modules/connectshyft/neighbors.ts` so the runtime explicitly writes `YES` when no valid preference is provided.
+
+**Rationale**: The bug exists in the current runtime host, and the minimal surgical fix is to make the runtime write the correct canonical value without expanding migration-authority scope. The existing database constraint already allows `YES`, `NO`, and `UNKNOWN`, so no schema shape change is required for this feature.
+
+**Alternatives considered**:
+- Alter the column default in a new migration: more invasive and not required to fix the runtime bug.
+- Edit the existing migration file: unsafe for already-applied migrations.
+- Backfill historical `UNKNOWN` rows to `YES`: rejected because prior intent is ambiguous.
+
+## Decision 2: Extend the existing create/update DTOs and route parsers instead of introducing a new serializer layer
+
+**Decision**: Add `prefersTexting` to the existing frontend input types, API body parsers, and backend command/store inputs, using the current route and service surfaces.
+
+**Rationale**: The current bug is caused by dropped request fields and a hardcoded `UNKNOWN` write. The existing response mapping already carries the stored enum correctly once persistence is fixed. Reusing current DTOs keeps the change bounded to the affected lane surfaces.
+
+**Alternatives considered**:
+- Introduce a new ConnectShyft neighbor serializer module: unnecessary indirection for a single-field fix.
+- Move logic into `apps/connectshyft-api`: explicitly prohibited by the runtime-host contract.
+
+## Decision 3: Keep API responses canonical and tolerate `prefers_texting` as an input/output compatibility alias only where already needed
+
+**Decision**: The canonical API/UI field remains `prefersTexting`, while frontend parsing continues to tolerate `prefers_texting` and route parsing may accept `prefers_texting` as a compatibility alias.
+
+**Rationale**: Current consumers already parse both shapes. Preserving that tolerance avoids accidental breakage while keeping the canonical field stable and aligned with the contract.
+
+**Alternatives considered**:
+- Require camelCase only everywhere immediately: higher regression risk for little gain.
+- Standardize on snake_case in frontend state: inconsistent with existing UI code.
+
+## Decision 4: Treat invalid incoming preference values as omission in the current runtime surface
+
+**Decision**: Non-canonical incoming preference values are treated as omitted at the current route/runtime boundary.
+Create behavior therefore defaults to `YES`, while update behavior preserves the existing stored canonical value.
+
+**Rationale**: This preserves the minimal surgical fix already designed in the current runtime host, avoids introducing a larger validation/refusal path for this feature, and keeps `UNKNOWN` fallback limited to truly absent or invalid stored data.
+
+**Alternatives considered**:
+- Reject invalid incoming values with a new business/client error: more explicit, but larger in surface area than required for this fix.
+- Coerce invalid incoming values directly to `UNKNOWN`: rejected because it would violate the canonical preference contract.
+
+## Decision 5: Fix the current UI display at the shared presentation function
+
+**Decision**: Update `resolveConnectShyftPreferenceChip()` in `apps/connectshyft-web/src/features/connectshyft/presentation.ts` to emit exact contract strings.
+
+**Rationale**: The snapshot component used by inbox and thread detail already delegates label rendering to this single function. One change updates the current display surfaces consistently.
+
+**Alternatives considered**:
+- Change strings separately in each view or component: duplicates logic and risks drift.
+- Leave current lowercase labels in place: violates the governing UI label contract.
+
+## Decision 6: Cover persistence with backend tests and UI behavior with manual verification
+
+**Decision**: Add Jest module tests in `neighbors.test.ts`, add Supertest route coverage under `apps/moneyshyft-api/src/routes/api/v1/__tests__`, and rely on manual verification for `apps/connectshyft-web`.
+
+**Rationale**: The repository already has backend unit and route harnesses, but no established frontend test runner. This provides strong automated coverage for the failure point without adding new test infrastructure.
+
+**Alternatives considered**:
+- Introduce a new frontend test runner: out of scope for a minimal patch.
+- Rely on manual testing only: insufficient for a persistence regression.

--- a/specs/008-connectshyft-texting-preference/spec.md
+++ b/specs/008-connectshyft-texting-preference/spec.md
@@ -1,0 +1,156 @@
+# Spec - ConnectShyft Neighbor Texting Preference Persistence and Display
+
+Status: Ready for SpecKit
+
+## Governing contracts
+
+- `architecture/connectshyft/runtime-host-reality-contract.md`
+- `architecture/connectshyft/neighbor-texting-preference-contract.md`
+
+## Supporting files required
+
+These supporting files remain shared reference artifacts outside the numbered feature folder:
+
+- `specs/connectshyft-texting-preference/bootstrap-prompts.md`
+- `specs/connectshyft-texting-preference/implementation-checklist.md`
+- `.github/pull_request_template/connectshyft-texting-preference.md`
+
+## Problem statement
+
+When a neighbor is saved with texting preference set to Yes, the interface still displays `Texting Preference Unknown`.
+
+This indicates a mismatch somewhere in:
+- persistence
+- API serialization
+- response mapping
+- UI display mapping
+
+## Runtime host reality
+
+The current runtime host is:
+
+- `apps/moneyshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/moneyshyft-api/src/modules/connectshyft/...`
+
+This issue must patch the current runtime host surgically.
+
+## Outcome
+
+Ensure the system behaves consistently so that:
+
+- new-neighbor create behavior defaults `prefers_texting` to `YES`
+- create/update persistence stores the intended enum
+- API responses return the correct enum
+- UI renders the correct label
+- `YES` does not degrade to `UNKNOWN`
+
+## Naming conventions
+
+- Database column name: `prefers_texting`
+- API response field: `prefersTexting`
+- UI state field: `prefersTexting`
+- Current route bodies may accept either `prefersTexting` or `prefers_texting`, but the canonical response field remains `prefersTexting`
+
+## Scope
+
+In scope:
+- current ConnectShyft runtime under `apps/moneyshyft-api`
+- DB/API/UI enum mapping path
+- create/update behavior
+- response serialization
+- display mapping
+- tests
+- PR guardrails
+
+Out of scope:
+- lane-convergence refactor
+- moving runtime into `apps/connectshyft-api`
+- SMS target resolution logic
+- provider adapter redesign
+- unrelated UI redesign
+
+## Functional requirements
+
+### FR-1 Canonical enum
+`prefers_texting` must remain one of:
+- `YES`
+- `NO`
+- `UNKNOWN`
+
+### FR-2 Default behavior
+New-neighbor create behavior defaults to `YES` when no explicit texting preference is provided.
+This requirement does not require changing historical records or database-column defaults unless separately specified.
+
+### FR-3 Persistence integrity
+Create/update paths must persist the intended enum and must not silently coerce `YES` to `UNKNOWN`.
+
+### FR-4 API response integrity
+API responses must return the persisted canonical enum.
+
+### FR-5 UI mapping integrity
+The UI must display labels from canonical enum values only and must not display `Texting Preference Unknown` when the stored value is `YES`.
+
+### FR-6 Route field compatibility
+The current runtime surface must preserve the canonical API/UI field `prefersTexting` and may accept `prefers_texting` as a compatibility alias at the route boundary.
+
+### FR-7 Create omission behavior
+When a create request omits texting preference, the runtime must persist `YES`.
+
+### FR-8 Update omission behavior
+When an update request omits texting preference, the runtime must preserve the existing stored canonical value.
+
+### FR-9 Invalid incoming value behavior
+Invalid incoming texting preference values must be treated as omitted by the current runtime surface.
+This means create behavior defaults to `YES`, update behavior preserves the existing stored canonical value, and only stored absent or invalid data may fall back to `UNKNOWN` on read.
+
+## User stories
+
+### US1 - Persist the selected texting preference (Priority: P1)
+As a ConnectShyft operator
+I want neighbor create/update flows to persist the intended texting preference
+So that API responses reflect the actual stored canonical enum.
+
+Acceptance notes:
+- Create without an explicit preference returns `YES`
+- Create with `YES`, `NO`, or `UNKNOWN` returns the same canonical enum
+- Update preserves or changes the stored canonical enum as requested
+- `YES` must not degrade to `UNKNOWN`
+
+### US2 - Display the correct texting preference label (Priority: P2)
+As a ConnectShyft operator
+I want the UI to display the correct texting preference label
+So that saved neighbor preferences are visible and understandable.
+
+Acceptance notes:
+- `YES` displays `Prefers Texting`
+- `NO` displays `Prefers Calls Only`
+- `UNKNOWN` displays `Texting Preference Unknown`
+- Inbox and thread-detail snapshot surfaces use the canonical enum only
+
+## Acceptance scenarios
+
+### AS-1 Routing ownership unchanged
+Given the current ConnectShyft runtime host under `apps/moneyshyft-api`
+When this issue is implemented
+Then `/api/v1/connectshyft/*` behavior remains owned by the existing lane runtime surface
+And no auth or platform-admin route delegation behavior changes
+
+### AS-2 Shared Postgres compatibility preserved
+Given the shared PostgreSQL deployment model
+When neighbor texting preference create/update paths are exercised
+Then the feature persists canonical values using the existing shared schema
+And no lane-specific migration authority or schema split is introduced
+
+### AS-3 No deployment-topology regression
+Given the current host Nginx and Dockerized API topology
+When this feature is deployed
+Then no port, ingress, or binding behavior changes are required for the fix
+
+## Acceptance criteria
+
+- a new neighbor saved without explicit override persists `YES`
+- a neighbor saved as `YES` returns `YES` in API response
+- update without explicit override preserves the existing stored canonical value
+- invalid incoming request values behave like omission for the current runtime surface
+- UI displays the expected label for `YES`
+- no runtime path in current ConnectShyft host degrades `YES` to `UNKNOWN`

--- a/specs/008-connectshyft-texting-preference/tasks.md
+++ b/specs/008-connectshyft-texting-preference/tasks.md
@@ -1,0 +1,187 @@
+# Tasks: ConnectShyft Texting Preference Persistence and Display
+
+**Input**: Design documents from `/specs/008-connectshyft-texting-preference/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Backend Jest and Supertest coverage are required by the feature spec; manual ConnectShyft web verification is required by quickstart.md.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- Backend runtime host: `apps/moneyshyft-api/src/`
+- Current ConnectShyft web UI: `apps/connectshyft-web/src/`
+- Feature docs: `specs/008-connectshyft-texting-preference/`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the route-test surface and task-specific verification targets before changing runtime behavior.
+
+- [X] T001 Create the neighbor route regression test file in `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared request/DTO boundaries needed by both backend persistence and frontend submission work.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T002 [P] Extend shared frontend neighbor create/update input types for `prefersTexting` in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-web/src/features/connectshyft/neighbors.ts`
+- [X] T003 [P] Add canonical `prefersTexting` input support to backend neighbor command and store types in `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T004 Add route body parsing support for `prefersTexting` and `prefers_texting`, including invalid-as-omitted behavior, in `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/routes/api/v1/connectshyft.ts`
+
+**Checkpoint**: Shared DTO and parser boundaries are ready for story implementation.
+
+---
+
+## Phase 3: User Story 1 - Persist Canonical Texting Preference Through the Current Neighbor API (Priority: P1) 🎯 MVP
+
+**Goal**: Ensure create/update requests persist canonical texting preferences, default new neighbors to `YES`, and return the stored enum unchanged in the current runtime host.
+
+**Independent Test**: Creating a neighbor without an explicit preference returns `prefersTexting: "YES"`, creating with explicit `YES|NO|UNKNOWN` returns the same enum, invalid incoming values behave like omission, and updating a neighbor changes or preserves the persisted enum without degrading `YES` to `UNKNOWN`.
+
+### Tests for User Story 1
+
+- [X] T005 [P] [US1] Add create-default, explicit-enum, and invalid-as-omitted persistence regression tests in `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts`
+- [X] T006 [P] [US1] Add create/update route response and invalid-input regression tests in `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Persist default `YES` and explicit canonical create values in `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T008 [US1] Persist update-time texting preference changes and omission-preserve behavior in `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T009 [US1] Pass canonical texting preference through create and update route handlers in `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/routes/api/v1/connectshyft.ts`
+
+**Checkpoint**: The current ConnectShyft runtime host persists and returns canonical texting preferences correctly without any UI work.
+
+---
+
+## Phase 4: User Story 2 - Submit and Display Exact Contract Labels in the Current ConnectShyft UI (Priority: P2)
+
+**Goal**: Ensure the current ConnectShyft web UI sends the chosen preference on create/update and renders exact contract labels in inbox and thread-detail snapshot chips.
+
+**Independent Test**: Using the current create or profile UI to save `YES`, `NO`, or `UNKNOWN` results in the snapshot chip showing exactly `Prefers Texting`, `Prefers Calls Only`, or `Texting Preference Unknown`.
+
+### Implementation for User Story 2
+
+- [X] T010 [US2] Send `prefersTexting` in create and update API payloads in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-web/src/features/connectshyft/neighbors.ts`
+- [X] T011 [P] [US2] Submit the create-view texting preference selector in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborCreateView.vue`
+- [X] T012 [P] [US2] Add profile-view texting preference selector load/save wiring in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborProfileView.vue`
+- [X] T013 [US2] Update exact contract label mapping for preference chips in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-web/src/features/connectshyft/presentation.ts`
+
+**Checkpoint**: The current ConnectShyft UI round-trips canonical texting preferences and shows exact contract copy on existing snapshot surfaces.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, verification notes, and PR guardrails across the implemented stories.
+
+- [X] T014 [P] Execute and confirm the manual UI verification scenarios documented in `/Users/jeremiahotis/projects/connectshyft/specs/008-connectshyft-texting-preference/quickstart.md`
+- [X] T015 [P] Create or update PR validation guidance for this feature in `/Users/jeremiahotis/projects/connectshyft/.github/pull_request_template/connectshyft-texting-preference.md`
+- [X] T016 [P] Run the backend neighbor module regression suite defined by `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/package.json`
+- [X] T017 [P] Run the backend neighbor route regression suite defined by `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/package.json`
+- [X] T018 [P] Validate ConnectShyft lane route ownership remains confined to `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T019 [P] Verify no API binding or port configuration changes were introduced for this feature using `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api` and deployment documentation
+- [X] T020 [P] Confirm shared Postgres compatibility for texting-preference persistence against `/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T021 [P] Verify reproducible validation steps for this feature are captured in `/Users/jeremiahotis/projects/connectshyft/specs/008-connectshyft-texting-preference/quickstart.md`
+- [X] T022 [P] Validate host Nginx routing remains correct for ConnectShyft lane traffic using `/Users/jeremiahotis/projects/connectshyft/nginx/nginx.conf` and deployment routing documentation
+- [X] T023 [P] Verify reproducible deployment runbook coverage for this feature using `/Users/jeremiahotis/projects/connectshyft/docs/PRODUCTION_DEPLOYMENT_GUIDE.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks both user stories.
+- **User Story 1 (Phase 3)**: Depends on Phase 2; delivers the MVP backend fix.
+- **User Story 2 (Phase 4)**: Depends on Phase 2 and should follow User Story 1 so UI verification runs against the corrected backend behavior.
+- **Polish (Phase 5)**: Depends on completion of the stories being shipped and closes constitution-required validation tasks.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other stories after Phase 2; this is the suggested MVP scope.
+- **US2 (P2)**: Depends on US1 for backend round-trip behavior, but remains independently testable once US1 is complete.
+
+### Within Each User Story
+
+- Backend tests for US1 should be written first and fail before implementation.
+- Backend persistence changes in `neighbors.ts` must land before route wiring is finalized.
+- Shared frontend payload support in `features/connectshyft/neighbors.ts` should land before the create/profile views are wired.
+- Exact label mapping should be updated after payload round-trip wiring is in place.
+
+### Dependency Graph
+
+```text
+Phase 1 Setup
+  -> Phase 2 Foundational
+    -> US1 (P1 backend persistence + API round-trip)
+      -> US2 (P2 UI submission + exact label display)
+        -> Phase 5 Polish
+```
+
+---
+
+## Parallel Opportunities
+
+- **Phase 2**: T002 and T003 can run in parallel because they touch separate frontend and backend files.
+- **US1**: T005 and T006 can run in parallel as separate backend test files.
+- **US2**: After T010, T011 and T012 can run in parallel because they touch different Vue views.
+- **Polish**: T014 through T023 can run in parallel once implementation is complete.
+
+## Parallel Example: User Story 1
+
+```bash
+# Backend regression tests for US1 in parallel:
+Task: "Add create-default, explicit-enum, and invalid-as-omitted persistence regression tests in /Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts"
+Task: "Add create/update route response and invalid-input regression tests in /Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# UI view wiring for US2 in parallel after payload support exists:
+Task: "Submit the create-view texting preference selector in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborCreateView.vue"
+Task: "Add profile-view texting preference selector load/save wiring in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNeighborProfileView.vue"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate the backend create/update API independently using the new Jest and Supertest coverage
+5. Stop here if only the runtime persistence/API fix is needed for the MVP
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational
+2. Deliver US1 and validate backend persistence/API round-trip
+3. Deliver US2 and validate UI submission/display against the corrected backend
+4. Finish Polish tasks and PR validation notes
+
+### Parallel Team Strategy
+
+1. One developer handles backend shared typing/parser work while another handles frontend DTO work in Phase 2.
+2. In US1, one developer can author module tests while another authors route tests before backend implementation closes the failures.
+3. In US2, create and profile view wiring can proceed in parallel once shared frontend payload support is merged.
+
+---
+
+## Notes
+
+- All tasks follow the required checklist format with task ID, optional `[P]`, required story labels for story phases, and exact file paths.
+- No task moves code into `apps/connectshyft-api` or performs lane-convergence refactors.
+- The task plan assumes the runtime fix remains centered on `apps/moneyshyft-api` and the current ConnectShyft web UI surfaces only.


### PR DESCRIPTION
# ConnectShyft Texting Preference PR

## Summary
Persist ConnectShyft neighbor texting preferences through the current `apps/moneyshyft-api` runtime host, round-trip the canonical enum on create and update, and align the current ConnectShyft UI with the exact contract labels.

## Scope Confirmation
- [x] Scoped to current ConnectShyft runtime host in `apps/moneyshyft-api`
- [x] No lane-convergence refactor
- [x] No SMS target-resolution changes
- [x] No provider adapter redesign
- [x] No port, ingress, or route-ownership changes outside the current ConnectShyft runtime host

## Persistence
- [x] create omission defaults to `YES`
- [x] explicit `YES | NO | UNKNOWN` values persist unchanged
- [x] invalid request values behave like omission
- [x] update omission preserves the existing canonical enum

## API / UI
- [x] API returns `prefersTexting` with the persisted canonical enum
- [x] UI label mapping verified against the contract copy
- [x] `YES` never displays `Texting Preference Unknown`
- [x] labels match exactly: `Prefers Texting`, `Prefers Calls Only`, `Texting Preference Unknown`

## Verification
- [x] backend module tests updated
- [x] backend route tests updated
- [x] quickstart manual verification path documented
- [x] deployment/routing validation reviewed against host-managed docs

## Local Validation
- `npm run policy:check`
- `npm run boundary:check`
- `cd apps/moneyshyft-api && env NODE_ENV=test MONEYSHYFT_TEST_DATABASE_URL=postgresql://jeremiahotis@127.0.0.1:5432/moneyshyft_ci ENABLE_TEST_CONNECTSHYFT_FLAGS=true npm run test:connectshyft`
- `cd apps/moneyshyft-api && npm run build`
- `cd apps/connectshyft-web && npm run build`
- `bash scripts/verify-connectshyft-route-ownership.sh`

## Notes
- Manual browser walkthrough from `specs/008-connectshyft-texting-preference/quickstart.md` is documented but was not executed in this terminal-only run.
