### PR TITLE
Fix: enforce duplicate phone handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,8 @@ Docker:
 - Shared PostgreSQL plus in-memory ConnectShyft thread and number-mapping fixtures in tests (021-connectshyft-sms-sender-architecture)
 - TypeScript (ES2022) on Node.js >=20 + Express, Jest/ts-jest, Supertest, shared `domains/communication` phone normalization and telephony contracts, ConnectShyft provider registry, ConnectShyft identity boundary, existing communication audit log (022-inbound-sms-identity-resolution-and-raw-body-capture)
 - Shared PostgreSQL `connectshyft` schema, existing communication audit log persistence, in-memory ConnectShyft fixtures in tests, and shared migration authority if a narrow neighbor lifecycle marker is required for deleted-record exclusion (022-inbound-sms-identity-resolution-and-raw-body-capture)
+- TypeScript (ES2022) on Node.js >=20 + Express, Knex, `pg`, Jest/ts-jest, shared `domains/communication` phone normalization, ConnectShyft neighbor service/store modules, existing `identityBoundary.ts` and `identityResolver.ts` (023-duplicate-handling-and-phone-uniqueness-enforcement)
+- Shared PostgreSQL `connectshyft` schema with canonical phone columns in `cs_neighbor_phones`, canonical production migration authority under `shared/database/migrations`, and lane-local migration mirrors for local build/test compatibility (023-duplicate-handling-and-phone-uniqueness-enforcement)
 
 ## Recent Changes
 - 001-tighten-deployment-contracts: Added TypeScript (Node.js APIs), Vue 3 TypeScript frontends + Express APIs, host Nginx reverse proxy, Docker Compose

--- a/apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts
+++ b/apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts
@@ -1,0 +1,104 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const NEIGHBOR_PHONES_TABLE = 'cs_neighbor_phones';
+const NEIGHBORS_TABLE = 'cs_neighbors';
+const UNIQUENESS_STATE_COLUMN = 'uniqueness_enforcement_state';
+const UNIQUENESS_STATE_CHECK = 'cs_neighbor_phones_uniqueness_enforcement_state_ck';
+const CURRENT_UNIQUE_E164_INDEX = 'connectshyft_cs_neighbor_phones_current_unique_e164_uq';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS ${UNIQUENESS_STATE_COLUMN} TEXT NOT NULL DEFAULT 'ENFORCED'
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${UNIQUENESS_STATE_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+          ADD CONSTRAINT ${UNIQUENESS_STATE_CHECK}
+          CHECK (${UNIQUENESS_STATE_COLUMN} IN ('ENFORCED', 'LEGACY_EXEMPT'));
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+    SET ${UNIQUENESS_STATE_COLUMN} = 'LEGACY_EXEMPT'
+    WHERE phones.is_active = FALSE
+       OR EXISTS (
+         SELECT 1
+         FROM ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+         WHERE neighbors.tenant_id = phones.tenant_id
+           AND neighbors.id = phones.neighbor_id
+           AND neighbors.is_deleted = TRUE
+       )
+  `);
+
+  await knex.raw(`
+    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+    SET ${UNIQUENESS_STATE_COLUMN} = 'LEGACY_EXEMPT'
+    FROM (
+      SELECT
+        phones.tenant_id,
+        phones.normalized_e164
+      FROM ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+      JOIN ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+        ON neighbors.tenant_id = phones.tenant_id
+       AND neighbors.id = phones.neighbor_id
+      WHERE phones.is_active = TRUE
+        AND neighbors.is_deleted = FALSE
+        AND phones.normalized_e164 IS NOT NULL
+      GROUP BY phones.tenant_id, phones.normalized_e164
+      HAVING COUNT(DISTINCT phones.neighbor_id) > 1
+    ) AS duplicate_current_claims
+    JOIN ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+      ON neighbors.tenant_id = phones.tenant_id
+     AND neighbors.id = phones.neighbor_id
+    WHERE phones.tenant_id = duplicate_current_claims.tenant_id
+      AND phones.normalized_e164 = duplicate_current_claims.normalized_e164
+      AND phones.is_active = TRUE
+      AND neighbors.is_deleted = FALSE
+  `);
+
+  await knex.raw(`
+    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+    SET ${UNIQUENESS_STATE_COLUMN} = 'ENFORCED'
+    FROM ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+    WHERE neighbors.tenant_id = phones.tenant_id
+      AND neighbors.id = phones.neighbor_id
+      AND phones.is_active = TRUE
+      AND neighbors.is_deleted = FALSE
+      AND phones.normalized_e164 IS NOT NULL
+      AND phones.${UNIQUENESS_STATE_COLUMN} <> 'LEGACY_EXEMPT'
+  `);
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS ${CURRENT_UNIQUE_E164_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} (tenant_id, normalized_e164)
+    WHERE is_active = TRUE AND ${UNIQUENESS_STATE_COLUMN} = 'ENFORCED' AND normalized_e164 IS NOT NULL
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${CURRENT_UNIQUE_E164_INDEX}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP CONSTRAINT IF EXISTS ${UNIQUENESS_STATE_CHECK}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS ${UNIQUENESS_STATE_COLUMN}
+  `);
+}

--- a/apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts
+++ b/apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts
@@ -59,11 +59,11 @@ export async function up(knex: Knex): Promise<void> {
       GROUP BY phones.tenant_id, phones.normalized_e164
       HAVING COUNT(DISTINCT phones.neighbor_id) > 1
     ) AS duplicate_current_claims
-    JOIN ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
-      ON neighbors.tenant_id = phones.tenant_id
-     AND neighbors.id = phones.neighbor_id
+    , ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
     WHERE phones.tenant_id = duplicate_current_claims.tenant_id
       AND phones.normalized_e164 = duplicate_current_claims.normalized_e164
+      AND neighbors.tenant_id = phones.tenant_id
+      AND neighbors.id = phones.neighbor_id
       AND phones.is_active = TRUE
       AND neighbors.is_deleted = FALSE
   `);

--- a/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts
+++ b/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts
@@ -1,0 +1,41 @@
+import {
+  down,
+  up,
+} from '../20260318143000_add_connectshyft_neighbor_phone_uniqueness';
+
+function buildKnexMock() {
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+  };
+
+  return { knex };
+}
+
+describe('20260318143000_add_connectshyft_neighbor_phone_uniqueness migration', () => {
+  it('adds uniqueness-enforcement columns, grandfathering backfill, and partial unique index idempotently', async () => {
+    const { knex } = buildKnexMock();
+
+    await up(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS uniqueness_enforcement_state');
+    expect(rawSql).toContain("DEFAULT 'ENFORCED'");
+    expect(rawSql).toContain('cs_neighbor_phones_uniqueness_enforcement_state_ck');
+    expect(rawSql).toContain("SET uniqueness_enforcement_state = 'LEGACY_EXEMPT'");
+    expect(rawSql).toContain("SET uniqueness_enforcement_state = 'ENFORCED'");
+    expect(rawSql).toContain('connectshyft_cs_neighbor_phones_current_unique_e164_uq');
+    expect(rawSql).toContain('(tenant_id, normalized_e164)');
+    expect(rawSql).toContain("WHERE is_active = TRUE AND uniqueness_enforcement_state = 'ENFORCED'");
+  });
+
+  it('drops the partial unique index and grandfathering column on down migration', async () => {
+    const { knex } = buildKnexMock();
+
+    await down(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+    expect(rawSql).toContain('DROP INDEX IF EXISTS connectshyft.connectshyft_cs_neighbor_phones_current_unique_e164_uq');
+    expect(rawSql).toContain('DROP CONSTRAINT IF EXISTS cs_neighbor_phones_uniqueness_enforcement_state_ck');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS uniqueness_enforcement_state');
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts
@@ -21,11 +21,13 @@ const buildNeighbor = (
 
 const buildResolver = (
   neighborsByTenant: Record<string, ConnectShyftIdentityBoundaryNeighbor[]>,
+  lookupByTenantAndPhone: Record<string, Record<string, ConnectShyftIdentityBoundaryNeighbor[]>> = {},
 ): ConnectShyftSubjectResolver => {
   const adapter = new AsyncInProcessConnectShyftIdentityBoundaryAdapter(
     async (tenantId) => neighborsByTenant[tenantId] || [],
     async (tenantId, normalizedContactPointValue) =>
-      (neighborsByTenant[tenantId] || []).filter((neighbor) =>
+      lookupByTenantAndPhone[tenantId]?.[normalizedContactPointValue]
+      || (neighborsByTenant[tenantId] || []).filter((neighbor) =>
         neighbor.phones.some((phone) => phone.value === normalizedContactPointValue)),
   );
 
@@ -44,6 +46,24 @@ describe('connectshyft identity resolver', () => {
       tenantId: 'tenant-a',
       orgUnitId: 'org-a',
       contactPoint: '+12605551212',
+    })).resolves.toEqual({
+      type: 'single_match',
+      neighborId: 'neighbor-1',
+      normalizedContactPoint: '+12605551212',
+    });
+  });
+
+  it('normalizes canonical formatting variants before resolving a unique phone match', async () => {
+    const resolver = buildResolver({
+      'tenant-a': [
+        buildNeighbor('neighbor-1', '+12605551212'),
+      ],
+    });
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '(260) 555-1212',
     })).resolves.toEqual({
       type: 'single_match',
       neighborId: 'neighbor-1',
@@ -84,6 +104,58 @@ describe('connectshyft identity resolver', () => {
       type: 'multiple_matches',
       candidateNeighborIds: ['neighbor-1', 'neighbor-2'],
       normalizedContactPoint: '+12605551212',
+    });
+  });
+
+  it('returns no_match when deleted-only phone rows are excluded from active lookup', async () => {
+    const resolver = buildResolver(
+      {
+        'tenant-a': [
+          buildNeighbor('neighbor-deleted-shadow', '+12605551213'),
+        ],
+      },
+      {
+        'tenant-a': {
+          '+12605551213': [],
+        },
+      },
+    );
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '+1 (260) 555-1213',
+    })).resolves.toEqual({
+      type: 'no_match',
+      normalizedContactPoint: '+12605551213',
+    });
+  });
+
+  it('returns single_match when active lookup excludes deleted duplicates and keeps the current owner', async () => {
+    const currentOwner = buildNeighbor('neighbor-current', '+12605551214');
+    const deletedShadow = buildNeighbor('neighbor-deleted-shadow', '+12605551214');
+    const resolver = buildResolver(
+      {
+        'tenant-a': [
+          currentOwner,
+          deletedShadow,
+        ],
+      },
+      {
+        'tenant-a': {
+          '+12605551214': [currentOwner],
+        },
+      },
+    );
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '260.555.1214',
+    })).resolves.toEqual({
+      type: 'single_match',
+      neighborId: 'neighbor-current',
+      normalizedContactPoint: '+12605551214',
     });
   });
 

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts
@@ -3,6 +3,7 @@ import {
   ConnectShyftNeighborService,
   InMemoryConnectShyftNeighborStore,
 } from '../neighbors';
+import { InProcessConnectShyftIdentityBoundaryAdapter } from '../identityBoundary';
 
 describe('connectshyft neighbor service', () => {
   const originalEnv = process.env;
@@ -178,6 +179,417 @@ describe('connectshyft neighbor service', () => {
               isActive: true,
             }),
           ],
+        },
+      },
+    });
+  });
+
+  it('refuses inbound-create requests when another current neighbor already owns the canonical phone', () => {
+    const existing = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550181',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    if (!existing.ok) {
+      throw new Error('Expected seed neighbor create to succeed');
+    }
+
+    const inboundDuplicate = service.createNeighborFromInbound({
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      phone: '(260) 555-0181',
+    });
+
+    expect(inboundDuplicate).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+      data: {
+        reason: 'duplicate_phone',
+        fieldErrors: [
+          expect.objectContaining({
+            field: 'phones',
+            reason: 'duplicate_phone',
+          }),
+        ],
+      },
+    });
+  });
+
+  it('refuses duplicate create requests when another current neighbor already owns the canonical phone', () => {
+    const existing = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+1 (260) 555-0199',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    if (!existing.ok) {
+      throw new Error('Expected seed neighbor create to succeed');
+    }
+
+    const duplicate = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Jules',
+      lastName: 'North',
+      phones: [
+        {
+          label: 'mobile',
+          value: '2605550199',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    expect(duplicate).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+      data: {
+        reason: 'duplicate_phone',
+        fieldErrors: [
+          expect.objectContaining({
+            field: 'phones',
+            reason: 'duplicate_phone',
+          }),
+        ],
+      },
+    });
+
+    const listed = service.listNeighbors({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+    });
+
+    expect(listed).toMatchObject({
+      ok: true,
+      data: {
+        neighbors: [
+          expect.objectContaining({
+            neighborId: existing.data.neighbor.neighborId,
+            phones: [
+              expect.objectContaining({
+                value: '+12605550199',
+              }),
+            ],
+          }),
+        ],
+      },
+    });
+    if (!listed.ok) {
+      throw new Error('Expected neighbor list to succeed');
+    }
+    expect(listed.data.neighbors).toHaveLength(1);
+  });
+
+  it('refuses duplicate update and replacement requests without changing the current owner', () => {
+    const currentOwner = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Owner',
+      lastName: 'Current',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550155',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+    const candidate = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Candidate',
+      lastName: 'Replacement',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550156',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    if (!currentOwner.ok || !candidate.ok) {
+      throw new Error('Expected seed neighbors to be created');
+    }
+
+    const duplicateUpdate = service.updateNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: candidate.data.neighbor.neighborId,
+      relationshipValidated: true,
+      firstName: 'Candidate',
+      lastName: 'Replacement',
+      phones: [
+        {
+          label: 'mobile',
+          value: '(260) 555-0155',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    expect(duplicateUpdate).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+      data: {
+        reason: 'duplicate_phone',
+        fieldErrors: [
+          expect.objectContaining({
+            field: 'phones',
+            reason: 'duplicate_phone',
+          }),
+        ],
+      },
+    });
+
+    const ownerAfter = service.resolveNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: currentOwner.data.neighbor.neighborId,
+    });
+    const candidateAfter = service.resolveNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: candidate.data.neighbor.neighborId,
+    });
+
+    expect(ownerAfter).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          phones: [
+            expect.objectContaining({
+              value: '+12605550155',
+            }),
+          ],
+        },
+      },
+    });
+    expect(candidateAfter).toMatchObject({
+      ok: true,
+      data: {
+        neighbor: {
+          phones: [
+            expect.objectContaining({
+              value: '+12605550156',
+            }),
+          ],
+        },
+      },
+    });
+  });
+
+  it('allows self-retaining updates when the same canonical phone stays on the same neighbor', () => {
+    const created = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550177',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    if (!created.ok) {
+      throw new Error('Expected seed neighbor to be created');
+    }
+
+    const updated = service.updateNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: created.data.neighbor.neighborId,
+      relationshipValidated: true,
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      phones: [
+        {
+          label: 'mobile',
+          value: '260-555-0177',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    expect(updated).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+      data: {
+        neighbor: {
+          neighborId: created.data.neighbor.neighborId,
+          phones: [
+            expect.objectContaining({
+              value: '+12605550177',
+            }),
+          ],
+        },
+      },
+    });
+  });
+
+  it('allows phone reuse when the only prior owner is soft-deleted and keeps the new current owner resolvable', () => {
+    const deletedOriginal = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Legacy',
+      lastName: 'Deleted',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550166',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    if (!deletedOriginal.ok) {
+      throw new Error('Expected deleted-owner seed neighbor to be created');
+    }
+
+    store.setNeighborDeletedStateForTests({
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: deletedOriginal.data.neighbor.neighborId,
+      isDeleted: true,
+    });
+
+    const reused = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Current',
+      lastName: 'Owner',
+      phones: [
+        {
+          label: 'mobile',
+          value: '(260) 555-0166',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    expect(reused).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+      data: {
+        neighbor: {
+          phones: [
+            expect.objectContaining({
+              value: '+12605550166',
+            }),
+          ],
+        },
+      },
+    });
+
+    if (!reused.ok) {
+      throw new Error('Expected soft-deleted phone reuse to succeed');
+    }
+
+    const evaluated = service.evaluateIdentityMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      contactPoint: {
+        label: 'mobile',
+        value: '260-555-0166',
+        isShared: false,
+        verificationStatus: 'verified',
+      },
+    });
+
+    expect(evaluated).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+      data: {
+        identityMatch: {
+          decision: 'AUTO_MERGE_ALLOWED',
+          matchedNeighborId: reused.data.neighbor.neighborId,
+          candidateCount: 1,
+          candidateNeighborIds: [reused.data.neighbor.neighborId],
+          contactPoint: {
+            value: '+12605550166',
+          },
+        },
+      },
+    });
+  });
+
+  it('returns no_match when a phone is owned only by a soft-deleted neighbor', () => {
+    const deletedOnly = service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Deleted',
+      lastName: 'Only',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550167',
+          verificationStatus: 'verified',
+        },
+      ],
+    });
+
+    if (!deletedOnly.ok) {
+      throw new Error('Expected deleted-only seed neighbor to be created');
+    }
+
+    store.setNeighborDeletedStateForTests({
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: deletedOnly.data.neighbor.neighborId,
+      isDeleted: true,
+    });
+
+    const evaluated = service.evaluateIdentityMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      contactPoint: {
+        label: 'mobile',
+        value: '+1 (260) 555-0167',
+        isShared: false,
+        verificationStatus: 'verified',
+      },
+    });
+
+    expect(evaluated).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+      data: {
+        identityMatch: {
+          decision: 'NO_AUTO_MERGE',
+          reason: 'NO_EXACT_CONTACT_POINT_MATCH',
+          matchedNeighborId: null,
+          candidateCount: 0,
+          candidateNeighborIds: [],
+          contactPoint: {
+            value: '+12605550167',
+          },
         },
       },
     });
@@ -949,43 +1361,38 @@ describe('connectshyft neighbor service', () => {
   });
 
   it('returns deterministic ambiguous refusal with manual-resolution context for multi-match contacts', () => {
-    const first = service.createNeighbor({
-      actorRoles: ['ORGUNIT_MEMBER'],
-      tenantId: 'tenant-connectshyft-alpha',
-      orgUnitId: 'org-connectshyft-alpha-east',
-      firstName: 'First',
-      lastName: 'Match',
-      phones: [
-        {
-          label: 'mobile',
-          value: '+12605550303',
-          isShared: false,
-          verificationStatus: 'verified',
-        },
-      ],
-    });
+    const ambiguousService = new ConnectShyftNeighborService(
+      new InMemoryConnectShyftNeighborStore(),
+      new InProcessConnectShyftIdentityBoundaryAdapter(
+        () => [],
+        (_tenantId, normalizedContactPointValue) => [
+          {
+            neighborId: 'neighbor-first-ambiguous',
+            phones: [
+              {
+                phoneId: 'phone-first-ambiguous',
+                value: normalizedContactPointValue,
+                isShared: false,
+                verificationStatus: 'verified',
+              },
+            ],
+          },
+          {
+            neighborId: 'neighbor-second-ambiguous',
+            phones: [
+              {
+                phoneId: 'phone-second-ambiguous',
+                value: normalizedContactPointValue,
+                isShared: false,
+                verificationStatus: 'verified',
+              },
+            ],
+          },
+        ],
+      ),
+    );
 
-    const second = service.createNeighbor({
-      actorRoles: ['ORGUNIT_MEMBER'],
-      tenantId: 'tenant-connectshyft-alpha',
-      orgUnitId: 'org-connectshyft-alpha-east',
-      firstName: 'Second',
-      lastName: 'Match',
-      phones: [
-        {
-          label: 'mobile',
-          value: '+12605550303',
-          isShared: false,
-          verificationStatus: 'verified',
-        },
-      ],
-    });
-
-    if (!first.ok || !second.ok) {
-      throw new Error('Expected duplicate contact neighbors to be created for ambiguity test');
-    }
-
-    const evaluated = service.evaluateIdentityMatch({
+    const evaluated = ambiguousService.evaluateIdentityMatch({
       actorRoles: ['ORGUNIT_MEMBER'],
       tenantId: 'tenant-connectshyft-alpha',
       contactPoint: {
@@ -1223,6 +1630,70 @@ describe('connectshyft async neighbor service', () => {
     expect(identityMatch).toMatchObject({
       ok: false,
       code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+    });
+  });
+
+  it('maps DB unique-index races to duplicate-phone refusals for create and update', async () => {
+    const duplicateError = new Error('duplicate key value violates unique constraint') as Error & {
+      code: string;
+      constraint: string;
+    };
+    duplicateError.code = '23505';
+    duplicateError.constraint = 'connectshyft_cs_neighbor_phones_current_unique_e164_uq';
+
+    const duplicateStore = {
+      findCurrentPhoneConflicts: jest.fn(async () => []),
+      createNeighbor: jest.fn(async () => {
+        throw duplicateError;
+      }),
+      updateNeighbor: jest.fn(async () => {
+        throw duplicateError;
+      }),
+    };
+
+    const service = new AsyncConnectShyftNeighborService(duplicateStore as any);
+
+    const created = await service.createNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      orgUnitId: 'org-connectshyft-alpha-east',
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550199',
+        },
+      ],
+    });
+    expect(created).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+      data: {
+        reason: 'duplicate_phone',
+      },
+    });
+
+    const updated = await service.updateNeighbor({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-alpha',
+      neighborId: 'neighbor-race-duplicate',
+      relationshipValidated: true,
+      firstName: 'Mina',
+      lastName: 'Lopez',
+      phones: [
+        {
+          label: 'mobile',
+          value: '+12605550199',
+        },
+      ],
+    });
+    expect(updated).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+      data: {
+        reason: 'duplicate_phone',
+      },
     });
   });
 });

--- a/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts
@@ -674,7 +674,7 @@ const mergePhoneRows = (
       return;
     }
 
-    const dedupeKey = `${label.toLowerCase()}::${value}`;
+    const dedupeKey = value;
     if (seen.has(dedupeKey)) {
       return;
     }
@@ -1964,6 +1964,15 @@ export class KnexConnectShyftNeighborStore {
         })
         .delete();
 
+      await trx
+        .withSchema('connectshyft')
+        .table('cs_neighbor_phones')
+        .where({
+          tenant_id: input.tenantId,
+          neighbor_id: input.sourceNeighborId,
+        })
+        .delete();
+
       const insertedPhones = mergedPhones.length > 0
         ? await trx
           .withSchema('connectshyft')
@@ -1995,15 +2004,6 @@ export class KnexConnectShyftNeighborStore {
           )
           .returning<DbNeighborPhoneRow[]>(this.neighborPhoneColumns())
         : [];
-
-      await trx
-        .withSchema('connectshyft')
-        .table('cs_neighbor_phones')
-        .where({
-          tenant_id: input.tenantId,
-          neighbor_id: input.sourceNeighborId,
-        })
-        .delete();
 
       await trx
         .withSchema('connectshyft')

--- a/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts
@@ -24,7 +24,9 @@ import { appendConnectShyftCommunicationAuditEntry } from './communicationAuditL
 type QueryBuilderLike = {
   withSchema(schema: string): QueryBuilderLike;
   table(tableName: string): QueryBuilderLike;
+  join(tableName: string, leftColumn: string, operator: string, rightColumn: string): QueryBuilderLike;
   where(condition: Record<string, unknown>): QueryBuilderLike;
+  whereNot(column: string, value: unknown): QueryBuilderLike;
   whereIn(column: string, values: string[]): QueryBuilderLike;
   orderBy(column: string, direction: 'asc' | 'desc'): QueryBuilderLike;
   insert(value: Record<string, unknown> | Array<Record<string, unknown>>): QueryBuilderLike;
@@ -50,6 +52,8 @@ type KnexLike = QueryBuilderLike & {
 
 export const CONNECTSHYFT_NEIGHBOR_MERGE_CONFIRMATION_PHRASE = 'IRREVERSIBLE MERGE';
 const CONNECTSHYFT_INBOUND_NEIGHBOR_AUDIT_OPERATION_NAME = 'connectshyft.inbound.neighbor_created';
+const CONNECTSHYFT_PHONE_DUPLICATE_INDEX = 'connectshyft_cs_neighbor_phones_current_unique_e164_uq';
+const CONNECTSHYFT_PHONE_DUPLICATE_MESSAGE = 'That phone number is already assigned to another current neighbor.';
 
 export type ConnectShyftNeighborPhoneInput = {
   label: string;
@@ -185,11 +189,12 @@ export type {
 
 type NeighborFieldError = {
   field: 'phones';
-  reason: 'REQUIRED' | 'INVALID_FORMAT';
+  reason: 'REQUIRED' | 'INVALID_FORMAT' | 'duplicate_phone';
   message: string;
 };
 
 type NeighborRefusalData = {
+  reason?: 'duplicate_phone';
   fieldErrors?: NeighborFieldError[];
   identityMatch?: ConnectShyftIdentityMatchDecision;
   manualResolution?: ConnectShyftIdentityManualResolutionContext;
@@ -203,7 +208,7 @@ type NeighborPersistenceResult =
   }
   | {
     ok: false;
-    reason: 'NEIGHBOR_ID_CONFLICT' | 'NEIGHBOR_NOT_FOUND';
+    reason: 'DUPLICATE_PHONE' | 'NEIGHBOR_ID_CONFLICT' | 'NEIGHBOR_NOT_FOUND';
   };
 
 type NeighborMergePersistenceResult =
@@ -230,6 +235,7 @@ type NeighborRefusalResult = {
     | 'CONNECTSHYFT_NEIGHBOR_EDIT_RELATIONSHIP_REQUIRED'
     | 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED'
     | 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT'
+    | 'CONNECTSHYFT_PHONE_DUPLICATE'
     | 'CONNECTSHYFT_NEIGHBOR_CREATE_CONFLICT'
     | 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND'
     | 'CONNECTSHYFT_NEIGHBOR_MERGE_FORBIDDEN'
@@ -366,6 +372,22 @@ const buildPhoneInvalidFormatRefusal = (): NeighborRefusalResult => ({
   },
 });
 
+const buildDuplicatePhoneRefusal = (): NeighborRefusalResult => ({
+  ok: false,
+  code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+  message: CONNECTSHYFT_PHONE_DUPLICATE_MESSAGE,
+  data: {
+    reason: 'duplicate_phone',
+    fieldErrors: [
+      {
+        field: 'phones',
+        reason: 'duplicate_phone',
+        message: CONNECTSHYFT_PHONE_DUPLICATE_MESSAGE,
+      },
+    ],
+  },
+});
+
 const buildCreateCapabilityRefusal = (): NeighborRefusalResult => ({
   ok: false,
   code: 'CONNECTSHYFT_NEIGHBOR_CREATE_FORBIDDEN',
@@ -480,6 +502,37 @@ const normalizePhones = (
   };
 };
 
+const listDistinctCandidateNormalizedPhones = (
+  phones: NormalizedConnectShyftNeighborPhoneInput[],
+): string[] => Array.from(new Set(phones.map((phone) => phone.normalizedE164)));
+
+const hasDuplicateCandidateNormalizedPhones = (
+  phones: NormalizedConnectShyftNeighborPhoneInput[],
+): boolean => listDistinctCandidateNormalizedPhones(phones).length !== phones.length;
+
+type NeighborPhoneConflictLookupInput = {
+  tenantId: string;
+  normalizedE164Values: string[];
+  excludeNeighborId?: string | null;
+};
+
+type NeighborPhoneConflict = {
+  normalizedE164: string;
+  neighborIds: string[];
+};
+
+const hasPhoneConflicts = (conflicts: NeighborPhoneConflict[]): boolean =>
+  conflicts.some((conflict) => conflict.neighborIds.length > 0);
+
+const isDuplicatePhoneConstraintViolation = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const candidate = error as { code?: string; constraint?: string };
+  return candidate.code === '23505' && candidate.constraint === CONNECTSHYFT_PHONE_DUPLICATE_INDEX;
+};
+
 const hasNeighborManageCapability = (actorRoles: Array<string | null | undefined>): boolean => {
   return hasCapability(actorRoles, CAPABILITIES.ORG_UNIT_NEIGHBOR_EDIT_RELATED)
     || hasCapability(actorRoles, CAPABILITIES.NEIGHBOR_EDIT_ALL)
@@ -542,6 +595,7 @@ type DbNeighborPhoneRow = {
   is_shared?: boolean | null;
   verification_status?: string | null;
   is_active?: boolean | null;
+  uniqueness_enforcement_state?: string | null;
   created_at_utc: string | Date;
   updated_at_utc: string | Date;
 };
@@ -767,6 +821,33 @@ export class InMemoryConnectShyftNeighborStore {
   private neighborIdsByScope = new Map<string, Set<string>>();
 
   private neighborIdsByTenant = new Map<string, Set<string>>();
+
+  private deletedNeighborIdsByTenant = new Map<string, Set<string>>();
+
+  private isNeighborDeleted(tenantId: string, neighborId: string): boolean {
+    return this.deletedNeighborIdsByTenant.get(tenantId)?.has(neighborId) === true;
+  }
+
+  setNeighborDeletedStateForTests(input: {
+    tenantId: string;
+    neighborId: string;
+    isDeleted: boolean;
+  }): void {
+    const deletedNeighborIds = this.deletedNeighborIdsByTenant.get(input.tenantId) || new Set<string>();
+    if (input.isDeleted) {
+      deletedNeighborIds.add(input.neighborId);
+      this.deletedNeighborIdsByTenant.set(input.tenantId, deletedNeighborIds);
+      return;
+    }
+
+    deletedNeighborIds.delete(input.neighborId);
+    if (deletedNeighborIds.size === 0) {
+      this.deletedNeighborIdsByTenant.delete(input.tenantId);
+      return;
+    }
+
+    this.deletedNeighborIdsByTenant.set(input.tenantId, deletedNeighborIds);
+  }
 
   createNeighbor(input: NeighborStoreCreateInput): NeighborPersistenceResult {
     const neighborId = input.neighborId || randomUUID();
@@ -1003,7 +1084,54 @@ export class InMemoryConnectShyftNeighborStore {
   }
 
   resolveActiveNeighborById(tenantId: string, neighborId: string): ConnectShyftNeighbor | null {
+    if (this.isNeighborDeleted(tenantId, neighborId)) {
+      return null;
+    }
+
     return this.resolveNeighborById(tenantId, neighborId);
+  }
+
+  findCurrentPhoneConflicts(
+    input: NeighborPhoneConflictLookupInput,
+  ): NeighborPhoneConflict[] {
+    if (input.normalizedE164Values.length === 0) {
+      return [];
+    }
+
+    const candidateValues = new Set(input.normalizedE164Values);
+    const conflictsByPhone = new Map<string, Set<string>>();
+    const tenantIds = this.neighborIdsByTenant.get(input.tenantId);
+    if (!tenantIds || tenantIds.size === 0) {
+      return [];
+    }
+
+    tenantIds.forEach((neighborId) => {
+      if (input.excludeNeighborId && neighborId === input.excludeNeighborId) {
+        return;
+      }
+
+      const neighbor = this.neighborsById.get(neighborId);
+      if (!neighbor || neighbor.tenantId !== input.tenantId || this.isNeighborDeleted(input.tenantId, neighborId)) {
+        return;
+      }
+
+      neighbor.phones.forEach((phone) => {
+        if (phone.isActive === false || !candidateValues.has(phone.value)) {
+          return;
+        }
+
+        const current = conflictsByPhone.get(phone.value) || new Set<string>();
+        current.add(neighborId);
+        conflictsByPhone.set(phone.value, current);
+      });
+    });
+
+    return Array.from(conflictsByPhone.entries())
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([normalizedE164, neighborIds]) => ({
+        normalizedE164,
+        neighborIds: Array.from(neighborIds).sort(),
+      }));
   }
 
   listByTenant(tenantId: string): ConnectShyftNeighbor[] {
@@ -1031,7 +1159,7 @@ export class InMemoryConnectShyftNeighborStore {
     const boundaryNeighbors: ConnectShyftIdentityBoundaryNeighbor[] = [];
     tenantIds.forEach((neighborId) => {
       const neighbor = this.neighborsById.get(neighborId);
-      if (!neighbor || neighbor.tenantId !== tenantId) {
+      if (!neighbor || neighbor.tenantId !== tenantId || this.isNeighborDeleted(tenantId, neighborId)) {
         return;
       }
 
@@ -1069,7 +1197,7 @@ export class InMemoryConnectShyftNeighborStore {
     const boundaryNeighbors: ConnectShyftIdentityBoundaryNeighbor[] = [];
     tenantIds.forEach((neighborId) => {
       const neighbor = this.neighborsById.get(neighborId);
-      if (!neighbor || neighbor.tenantId !== tenantId) {
+      if (!neighbor || neighbor.tenantId !== tenantId || this.isNeighborDeleted(tenantId, neighborId)) {
         return;
       }
 
@@ -1107,7 +1235,7 @@ export class InMemoryConnectShyftNeighborStore {
     const boundaryNeighbors: ConnectShyftIdentityBoundaryNeighbor[] = [];
     tenantIds.forEach((neighborId) => {
       const neighbor = this.neighborsById.get(neighborId);
-      if (!neighbor || neighbor.tenantId !== tenantId) {
+      if (!neighbor || neighbor.tenantId !== tenantId || this.isNeighborDeleted(tenantId, neighborId)) {
         return;
       }
 
@@ -1226,9 +1354,52 @@ export class KnexConnectShyftNeighborStore {
       'is_shared',
       'verification_status',
       'is_active',
+      'uniqueness_enforcement_state',
       'created_at_utc',
       'updated_at_utc',
     ];
+  }
+
+  async findCurrentPhoneConflicts(
+    input: NeighborPhoneConflictLookupInput,
+  ): Promise<NeighborPhoneConflict[]> {
+    if (input.normalizedE164Values.length === 0) {
+      return [];
+    }
+
+    const rows = await this.knexClient
+      .withSchema('connectshyft')
+      .table('cs_neighbor_phones')
+      .join('cs_neighbors', 'cs_neighbors.id', '=', 'cs_neighbor_phones.neighbor_id')
+      .where({
+        'cs_neighbor_phones.tenant_id': input.tenantId,
+        'cs_neighbors.tenant_id': input.tenantId,
+        'cs_neighbor_phones.is_active': true,
+        'cs_neighbors.is_deleted': false,
+      })
+      .whereIn('cs_neighbor_phones.normalized_e164', input.normalizedE164Values)
+      .orderBy('cs_neighbor_phones.normalized_e164', 'asc')
+      .orderBy('cs_neighbor_phones.neighbor_id', 'asc')
+      .select<Array<{ normalized_e164: string; neighbor_id: string }>>([
+        'cs_neighbor_phones.normalized_e164',
+        'cs_neighbor_phones.neighbor_id',
+      ]);
+
+    const conflictsByPhone = new Map<string, Set<string>>();
+    rows.forEach((row) => {
+      if (input.excludeNeighborId && row.neighbor_id === input.excludeNeighborId) {
+        return;
+      }
+
+      const current = conflictsByPhone.get(row.normalized_e164) || new Set<string>();
+      current.add(row.neighbor_id);
+      conflictsByPhone.set(row.normalized_e164, current);
+    });
+
+    return Array.from(conflictsByPhone.entries()).map(([normalizedE164, neighborIds]) => ({
+      normalizedE164,
+      neighborIds: Array.from(neighborIds).sort(),
+    }));
   }
 
   async createNeighbor(input: NeighborStoreCreateInput): Promise<NeighborPersistenceResult> {
@@ -1278,6 +1449,7 @@ export class KnexConnectShyftNeighborStore {
           is_shared: phone.isShared,
           verification_status: phone.verificationStatus,
           is_active: phone.isActive,
+          uniqueness_enforcement_state: 'ENFORCED',
           created_at_utc: trx.fn.now(),
           updated_at_utc: trx.fn.now(),
         }));
@@ -1294,6 +1466,13 @@ export class KnexConnectShyftNeighborStore {
         } as NeighborPersistenceResult;
       });
     } catch (error) {
+      if (isDuplicatePhoneConstraintViolation(error)) {
+        return {
+          ok: false,
+          reason: 'DUPLICATE_PHONE',
+        };
+      }
+
       if (error && typeof error === 'object') {
         const pg = error as { code?: string };
         if (pg.code === '23505') {
@@ -1686,6 +1865,7 @@ export class KnexConnectShyftNeighborStore {
           is_shared: phone.isShared,
           verification_status: phone.verificationStatus,
           is_active: phone.isActive,
+          uniqueness_enforcement_state: 'ENFORCED',
           created_at_utc: trx.fn.now(),
           updated_at_utc: trx.fn.now(),
         }));
@@ -1702,6 +1882,13 @@ export class KnexConnectShyftNeighborStore {
         } as NeighborPersistenceResult;
       });
     } catch (error) {
+      if (isDuplicatePhoneConstraintViolation(error)) {
+        return {
+          ok: false,
+          reason: 'DUPLICATE_PHONE',
+        };
+      }
+
       throw error;
     }
   }
@@ -1874,10 +2061,10 @@ export class ConnectShyftNeighborService {
     private readonly store: InMemoryConnectShyftNeighborStore = defaultNeighborStore,
     identityBoundary?: ConnectShyftIdentityBoundaryAdapter,
   ) {
-    const activeStore = this.store as InMemoryConnectShyftNeighborStore & {
-      listActiveIdentityBoundaryNeighborsByTenant?: (
-        tenantId: string,
-      ) => ConnectShyftIdentityBoundaryNeighbor[];
+      const activeStore = this.store as InMemoryConnectShyftNeighborStore & {
+        listActiveIdentityBoundaryNeighborsByTenant?: (
+          tenantId: string,
+        ) => ConnectShyftIdentityBoundaryNeighbor[];
       listActiveIdentityBoundaryNeighborsByPhoneValue?: (
         tenantId: string,
         normalizedContactPointValue: string,
@@ -1911,6 +2098,24 @@ export class ConnectShyftNeighborService {
       );
   }
 
+  private validateDuplicatePhones(
+    tenantId: string,
+    phones: NormalizedConnectShyftNeighborPhoneInput[],
+    excludeNeighborId?: string,
+  ): NeighborRefusalResult | null {
+    if (hasDuplicateCandidateNormalizedPhones(phones)) {
+      return buildDuplicatePhoneRefusal();
+    }
+
+    const conflicts = this.store.findCurrentPhoneConflicts({
+      tenantId,
+      normalizedE164Values: listDistinctCandidateNormalizedPhones(phones),
+      excludeNeighborId,
+    });
+
+    return hasPhoneConflicts(conflicts) ? buildDuplicatePhoneRefusal() : null;
+  }
+
   createNeighbor(input: ConnectShyftCreateNeighborCommand): ConnectShyftCreateNeighborResult {
     if (!hasNeighborManageCapability(input.actorRoles)) {
       return buildCreateCapabilityRefusal();
@@ -1919,6 +2124,11 @@ export class ConnectShyftNeighborService {
     const normalizedPhones = normalizePhones(input.phones);
     if (!normalizedPhones.ok) {
       return normalizedPhones;
+    }
+
+    const duplicateRefusal = this.validateDuplicatePhones(input.tenantId, normalizedPhones.phones);
+    if (duplicateRefusal) {
+      return duplicateRefusal;
     }
 
     const persisted = this.store.createNeighbor({
@@ -1932,6 +2142,10 @@ export class ConnectShyftNeighborService {
     });
 
     if (!persisted.ok) {
+      if (persisted.reason === 'DUPLICATE_PHONE') {
+        return buildDuplicatePhoneRefusal();
+      }
+
       return buildNeighborIdConflictRefusal();
     }
 
@@ -1985,6 +2199,11 @@ export class ConnectShyftNeighborService {
       return normalizedPhones;
     }
 
+    const duplicateRefusal = this.validateDuplicatePhones(input.tenantId, normalizedPhones.phones);
+    if (duplicateRefusal) {
+      return duplicateRefusal;
+    }
+
     const persisted = this.store.createNeighbor({
       tenantId: input.tenantId,
       orgUnitId: input.orgUnitId,
@@ -1995,6 +2214,10 @@ export class ConnectShyftNeighborService {
     });
 
     if (!persisted.ok) {
+      if (persisted.reason === 'DUPLICATE_PHONE') {
+        return buildDuplicatePhoneRefusal();
+      }
+
       return buildNeighborIdConflictRefusal();
     }
 
@@ -2055,6 +2278,15 @@ export class ConnectShyftNeighborService {
       return normalizedPhones;
     }
 
+    const duplicateRefusal = this.validateDuplicatePhones(
+      input.tenantId,
+      normalizedPhones.phones,
+      input.neighborId,
+    );
+    if (duplicateRefusal) {
+      return duplicateRefusal;
+    }
+
     const updated = this.store.updateNeighbor({
       tenantId: input.tenantId,
       neighborId: input.neighborId,
@@ -2065,6 +2297,10 @@ export class ConnectShyftNeighborService {
     });
 
     if (!updated.ok) {
+      if (updated.reason === 'DUPLICATE_PHONE') {
+        return buildDuplicatePhoneRefusal();
+      }
+
       return buildNeighborNotFoundRefusal();
     }
 
@@ -2176,6 +2412,34 @@ export class AsyncConnectShyftNeighborService {
       );
   }
 
+  private async validateDuplicatePhones(
+    tenantId: string,
+    phones: NormalizedConnectShyftNeighborPhoneInput[],
+    excludeNeighborId?: string,
+  ): Promise<NeighborRefusalResult | null> {
+    if (hasDuplicateCandidateNormalizedPhones(phones)) {
+      return buildDuplicatePhoneRefusal();
+    }
+
+    const duplicateLookupStore = this.store as KnexConnectShyftNeighborStore & {
+      findCurrentPhoneConflicts?: (
+        input: NeighborPhoneConflictLookupInput,
+      ) => Promise<NeighborPhoneConflict[]>;
+    };
+
+    if (!duplicateLookupStore.findCurrentPhoneConflicts) {
+      return null;
+    }
+
+    const conflicts = await duplicateLookupStore.findCurrentPhoneConflicts({
+      tenantId,
+      normalizedE164Values: listDistinctCandidateNormalizedPhones(phones),
+      excludeNeighborId,
+    });
+
+    return hasPhoneConflicts(conflicts) ? buildDuplicatePhoneRefusal() : null;
+  }
+
   async createNeighbor(input: ConnectShyftCreateNeighborCommand): Promise<ConnectShyftCreateNeighborResult> {
     if (!hasNeighborManageCapability(input.actorRoles)) {
       return buildCreateCapabilityRefusal();
@@ -2184,6 +2448,11 @@ export class AsyncConnectShyftNeighborService {
     const normalizedPhones = normalizePhones(input.phones);
     if (!normalizedPhones.ok) {
       return normalizedPhones;
+    }
+
+    const duplicateRefusal = await this.validateDuplicatePhones(input.tenantId, normalizedPhones.phones);
+    if (duplicateRefusal) {
+      return duplicateRefusal;
     }
 
     try {
@@ -2198,6 +2467,10 @@ export class AsyncConnectShyftNeighborService {
       });
 
       if (!persisted.ok) {
+        if (persisted.reason === 'DUPLICATE_PHONE') {
+          return buildDuplicatePhoneRefusal();
+        }
+
         return buildNeighborIdConflictRefusal();
       }
 
@@ -2210,6 +2483,10 @@ export class AsyncConnectShyftNeighborService {
         },
       };
     } catch (error) {
+      if (isDuplicatePhoneConstraintViolation(error)) {
+        return buildDuplicatePhoneRefusal();
+      }
+
       if (!isMissingPersistenceError(error)) {
         throw error;
       }
@@ -2238,6 +2515,10 @@ export class AsyncConnectShyftNeighborService {
         },
       };
     } catch (error) {
+      if (isDuplicatePhoneConstraintViolation(error)) {
+        return buildDuplicatePhoneRefusal();
+      }
+
       if (!isMissingPersistenceError(error)) {
         throw error;
       }
@@ -2266,6 +2547,11 @@ export class AsyncConnectShyftNeighborService {
       return normalizedPhones;
     }
 
+    const duplicateRefusal = await this.validateDuplicatePhones(input.tenantId, normalizedPhones.phones);
+    if (duplicateRefusal) {
+      return duplicateRefusal;
+    }
+
     try {
       const persisted = await this.store.createNeighbor({
         tenantId: input.tenantId,
@@ -2277,6 +2563,10 @@ export class AsyncConnectShyftNeighborService {
       });
 
       if (!persisted.ok) {
+        if (persisted.reason === 'DUPLICATE_PHONE') {
+          return buildDuplicatePhoneRefusal();
+        }
+
         return buildNeighborIdConflictRefusal();
       }
 
@@ -2289,6 +2579,10 @@ export class AsyncConnectShyftNeighborService {
         },
       };
     } catch (error) {
+      if (isDuplicatePhoneConstraintViolation(error)) {
+        return buildDuplicatePhoneRefusal();
+      }
+
       if (!isMissingPersistenceError(error)) {
         throw error;
       }
@@ -2316,6 +2610,10 @@ export class AsyncConnectShyftNeighborService {
         neighbor: promoted.neighbor,
       };
     } catch (error) {
+      if (isDuplicatePhoneConstraintViolation(error)) {
+        return buildDuplicatePhoneRefusal();
+      }
+
       if (!isMissingPersistenceError(error)) {
         throw error;
       }
@@ -2340,6 +2638,10 @@ export class AsyncConnectShyftNeighborService {
         },
       };
     } catch (error) {
+      if (isDuplicatePhoneConstraintViolation(error)) {
+        return buildDuplicatePhoneRefusal();
+      }
+
       if (!isMissingPersistenceError(error)) {
         throw error;
       }
@@ -2361,6 +2663,15 @@ export class AsyncConnectShyftNeighborService {
       return normalizedPhones;
     }
 
+    const duplicateRefusal = await this.validateDuplicatePhones(
+      input.tenantId,
+      normalizedPhones.phones,
+      input.neighborId,
+    );
+    if (duplicateRefusal) {
+      return duplicateRefusal;
+    }
+
     try {
       const updated = await this.store.updateNeighbor({
         tenantId: input.tenantId,
@@ -2372,6 +2683,10 @@ export class AsyncConnectShyftNeighborService {
       });
 
       if (!updated.ok) {
+        if (updated.reason === 'DUPLICATE_PHONE') {
+          return buildDuplicatePhoneRefusal();
+        }
+
         return buildNeighborNotFoundRefusal();
       }
 
@@ -2384,6 +2699,10 @@ export class AsyncConnectShyftNeighborService {
         },
       };
     } catch (error) {
+      if (isDuplicatePhoneConstraintViolation(error)) {
+        return buildDuplicatePhoneRefusal();
+      }
+
       if (!isMissingPersistenceError(error)) {
         throw error;
       }

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
@@ -200,6 +200,89 @@ describe('connectshyft identity-match route', () => {
     });
   });
 
+  it('returns ambiguity without selecting a winner when multiple current neighbors share the phone', async () => {
+    jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      message: 'Identity match is ambiguous and requires manual resolution.',
+      data: {
+        identityMatch: {
+          decision: 'AMBIGUOUS',
+          reason: 'MULTIPLE_EXACT_CONTACT_POINT_MATCHES',
+          autoMergeAllowed: false,
+          contactPoint: {
+            value: '+12605550998',
+            isShared: false,
+            verificationStatus: 'verified',
+          },
+          matchedNeighborId: null,
+          candidateCount: 2,
+          candidateNeighborIds: ['neighbor-a', 'neighbor-b'],
+          exactMatches: [
+            {
+              neighborId: 'neighbor-a',
+              phoneId: 'phone-a',
+              isShared: false,
+              verificationStatus: 'verified',
+            },
+            {
+              neighborId: 'neighbor-b',
+              phoneId: 'phone-b',
+              isShared: false,
+              verificationStatus: 'verified',
+            },
+          ],
+        },
+        manualResolution: {
+          required: true,
+          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+          nextAction: 'manual-merge',
+          mergeEndpoint: '/api/v1/connectshyft/neighbors/merge',
+          candidateNeighborIds: ['neighbor-a', 'neighbor-b'],
+          guidance: 'Multiple identities share this contact point. Resolve manually before any merge.',
+        },
+        idempotency: {
+          key: 'identity-replay-key-ambiguous-no-winner',
+          semantics: 'REPLAY_SAFE',
+        },
+      },
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/neighbors/identity-match')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: TEST_ORG_UNIT_ID,
+        contactPoint: {
+          label: 'mobile',
+          value: '(260) 555-0998',
+          isShared: false,
+          verificationStatus: 'verified',
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      data: {
+        identityMatch: {
+          matchedNeighborId: null,
+          candidateCount: 2,
+          candidateNeighborIds: ['neighbor-a', 'neighbor-b'],
+          contactPoint: {
+            value: '+12605550998',
+          },
+        },
+        manualResolution: {
+          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+          candidateNeighborIds: ['neighbor-a', 'neighbor-b'],
+        },
+      },
+    });
+  });
+
   it('records identity-match audit hash as keyed hmac output', async () => {
     jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
       ok: true,

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts
@@ -1,0 +1,303 @@
+// @ts-nocheck
+import express from 'express';
+import request from 'supertest';
+import * as TenantModuleEntitlements from '../../../../platform/tenantModuleEntitlements';
+import { connectShyftNeighborServiceAsync } from '../../../../modules/connectshyft/neighbors';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import connectShyftRouter from '../connectshyft';
+
+const TEST_TENANT_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_ORG_UNIT_ID = '22222222-2222-4222-8222-222222222222';
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(responseEnvelope);
+
+  app.use((req, _res, next) => {
+    const tenantId = req.header('x-test-connectshyft-tenant-id') || TEST_TENANT_ID;
+    const orgUnitId = req.header('x-test-connectshyft-orgunit-id') || TEST_ORG_UNIT_ID;
+    const role = req.header('x-test-connectshyft-role') || 'ORGUNIT_MEMBER';
+    const userId = req.header('x-test-connectshyft-user-id') || 'user-connectshyft-neighbors';
+
+    req.user = {
+      userId,
+      email: `${userId}@connectshyft.test`,
+      householdId: tenantId,
+      activeTenantId: tenantId,
+      activeOrgUnitId: orgUnitId,
+      role,
+    };
+    req.tenantId = tenantId;
+    req.orgUnitId = orgUnitId;
+    req.tenantContext = {
+      tenantId,
+      orgUnitId,
+      scopeMode: 'ORG_UNIT',
+      source: 'auth',
+    };
+
+    next();
+  });
+
+  app.use('/api/v1/connectshyft', connectShyftRouter);
+  return app;
+};
+
+const buildHeaders = (overrides: Record<string, string> = {}): Record<string, string> => ({
+  'x-correlation-id': 'corr-connectshyft-neighbors',
+  'x-test-connectshyft-flags': JSON.stringify({
+    connectshyft_enabled: true,
+    connectshyft_inbox_enabled: true,
+    connectshyft_escalation_enabled: true,
+    connectshyft_webhooks_enabled: true,
+  }),
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-neighbors',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  ...overrides,
+});
+
+describe('connectshyft neighbors routes', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+  let entitlementSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+    process.env.CONNECTSHYFT_ENABLED = 'true';
+    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+    entitlementSpy = jest.spyOn(TenantModuleEntitlements, 'evaluateActorTenantModuleEntitlement').mockResolvedValue({
+      tenantId: TEST_TENANT_ID,
+      moduleKey: 'connectshyft',
+      enabled: true,
+      reason: 'enabled',
+      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+      message: 'ConnectShyft entitlement enabled for tests.',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    entitlementSpy = jest.spyOn(TenantModuleEntitlements, 'evaluateActorTenantModuleEntitlement').mockResolvedValue({
+      tenantId: TEST_TENANT_ID,
+      moduleKey: 'connectshyft',
+      enabled: true,
+      reason: 'enabled',
+      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+      message: 'ConnectShyft entitlement enabled for tests.',
+    });
+  });
+
+  afterAll(() => {
+    entitlementSpy.mockRestore();
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+  });
+
+  it('returns standardized duplicate-phone refusal data for neighbor create', async () => {
+    jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor').mockResolvedValue({
+      ok: false,
+      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+      message: 'That phone number is already assigned to another current neighbor.',
+      data: {
+        reason: 'duplicate_phone',
+        fieldErrors: [
+          {
+            field: 'phones',
+            reason: 'duplicate_phone',
+            message: 'That phone number is already assigned to another current neighbor.',
+          },
+        ],
+      },
+    } as any);
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/neighbors')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: TEST_ORG_UNIT_ID,
+        firstName: 'Mina',
+        lastName: 'Lopez',
+        prefersTexting: 'YES',
+        phones: [
+          {
+            label: 'mobile',
+            value: '+1 (260) 555-0199',
+            verificationStatus: 'verified',
+          },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+      refusalType: 'business',
+      data: {
+        reason: 'duplicate_phone',
+        fieldErrors: [
+          {
+            field: 'phones',
+            reason: 'duplicate_phone',
+          },
+        ],
+        scope: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+        },
+      },
+    });
+  });
+
+  it('returns standardized duplicate-phone refusal data for neighbor update', async () => {
+    jest.spyOn(connectShyftNeighborServiceAsync, 'updateNeighbor').mockResolvedValue({
+      ok: false,
+      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+      message: 'That phone number is already assigned to another current neighbor.',
+      data: {
+        reason: 'duplicate_phone',
+        fieldErrors: [
+          {
+            field: 'phones',
+            reason: 'duplicate_phone',
+            message: 'That phone number is already assigned to another current neighbor.',
+          },
+        ],
+      },
+    } as any);
+
+    const app = buildApp();
+    const response = await request(app)
+      .put('/api/v1/connectshyft/neighbors/neighbor-duplicate-update')
+      .set(buildHeaders({
+        'x-test-connectshyft-role': 'TENANT_ADMIN',
+      }))
+      .send({
+        orgUnitId: TEST_ORG_UNIT_ID,
+        firstName: 'Mina',
+        lastName: 'Lopez',
+        prefersTexting: 'YES',
+        phones: [
+          {
+            label: 'mobile',
+            value: '+1 (260) 555-0199',
+            verificationStatus: 'verified',
+          },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+      refusalType: 'business',
+      data: {
+        reason: 'duplicate_phone',
+        fieldErrors: [
+          {
+            field: 'phones',
+            reason: 'duplicate_phone',
+          },
+        ],
+        scope: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+        },
+      },
+    });
+  });
+
+  it('returns neighbor-create success when reusing a phone held only by a soft-deleted neighbor', async () => {
+    jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor').mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+      httpStatus: 201,
+      data: {
+        neighbor: {
+          neighborId: 'neighbor-soft-delete-reuse',
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          firstName: 'Reused',
+          lastName: 'Number',
+          prefersTexting: 'YES',
+          phones: [
+            {
+              phoneId: 'phone-soft-delete-reuse',
+              label: 'mobile',
+              value: '+12605550198',
+              displayNational: '(260) 555-0198',
+              countryCode: '1',
+              nationalNumber: '2605550198',
+              extension: null,
+              validationStatus: 'valid',
+              usageType: 'personal',
+              source: 'user_entered',
+              sortOrder: 0,
+              isPrimary: true,
+              isShared: false,
+              verificationStatus: 'verified',
+              isActive: true,
+              createdAtUtc: '2026-03-18T12:00:00.000Z',
+              updatedAtUtc: '2026-03-18T12:00:00.000Z',
+            },
+          ],
+          createdAtUtc: '2026-03-18T12:00:00.000Z',
+          updatedAtUtc: '2026-03-18T12:00:00.000Z',
+        },
+      },
+    } as any);
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/neighbors')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: TEST_ORG_UNIT_ID,
+        firstName: 'Reused',
+        lastName: 'Number',
+        prefersTexting: 'YES',
+        phones: [
+          {
+            label: 'mobile',
+            value: '(260) 555-0198',
+            verificationStatus: 'verified',
+          },
+        ],
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+      data: {
+        neighborId: 'neighbor-soft-delete-reuse',
+        neighbor: {
+          phones: [
+            expect.objectContaining({
+              value: '+12605550198',
+            }),
+          ],
+        },
+        scope: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+        },
+      },
+    });
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts
@@ -262,6 +262,7 @@ describe('connectshyft provider adapter registry route integration - guardrails'
 
   it('refuses inbound SMS when multiple active neighbors share the same sender phone', async () => {
     const app = buildApp();
+    const createInboundSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound');
     const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
       .mockResolvedValue(null);
     const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
@@ -293,7 +294,9 @@ describe('connectshyft provider adapter registry route integration - guardrails'
           candidateNeighborIds: ['neighbor-a-2003', 'neighbor-b-2003'],
         },
       });
+      expect(createInboundSpy).not.toHaveBeenCalled();
     } finally {
+      createInboundSpy.mockRestore();
       resolveSubjectSpy.mockRestore();
       resolveActiveSpy.mockRestore();
     }

--- a/shared/database/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts
+++ b/shared/database/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts
@@ -1,0 +1,104 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const NEIGHBOR_PHONES_TABLE = 'cs_neighbor_phones';
+const NEIGHBORS_TABLE = 'cs_neighbors';
+const UNIQUENESS_STATE_COLUMN = 'uniqueness_enforcement_state';
+const UNIQUENESS_STATE_CHECK = 'cs_neighbor_phones_uniqueness_enforcement_state_ck';
+const CURRENT_UNIQUE_E164_INDEX = 'connectshyft_cs_neighbor_phones_current_unique_e164_uq';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      ADD COLUMN IF NOT EXISTS ${UNIQUENESS_STATE_COLUMN} TEXT NOT NULL DEFAULT 'ENFORCED'
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${UNIQUENESS_STATE_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+          ADD CONSTRAINT ${UNIQUENESS_STATE_CHECK}
+          CHECK (${UNIQUENESS_STATE_COLUMN} IN ('ENFORCED', 'LEGACY_EXEMPT'));
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+    SET ${UNIQUENESS_STATE_COLUMN} = 'LEGACY_EXEMPT'
+    WHERE phones.is_active = FALSE
+       OR EXISTS (
+         SELECT 1
+         FROM ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+         WHERE neighbors.tenant_id = phones.tenant_id
+           AND neighbors.id = phones.neighbor_id
+           AND neighbors.is_deleted = TRUE
+       )
+  `);
+
+  await knex.raw(`
+    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+    SET ${UNIQUENESS_STATE_COLUMN} = 'LEGACY_EXEMPT'
+    FROM (
+      SELECT
+        phones.tenant_id,
+        phones.normalized_e164
+      FROM ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+      JOIN ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+        ON neighbors.tenant_id = phones.tenant_id
+       AND neighbors.id = phones.neighbor_id
+      WHERE phones.is_active = TRUE
+        AND neighbors.is_deleted = FALSE
+        AND phones.normalized_e164 IS NOT NULL
+      GROUP BY phones.tenant_id, phones.normalized_e164
+      HAVING COUNT(DISTINCT phones.neighbor_id) > 1
+    ) AS duplicate_current_claims
+    JOIN ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+      ON neighbors.tenant_id = phones.tenant_id
+     AND neighbors.id = phones.neighbor_id
+    WHERE phones.tenant_id = duplicate_current_claims.tenant_id
+      AND phones.normalized_e164 = duplicate_current_claims.normalized_e164
+      AND phones.is_active = TRUE
+      AND neighbors.is_deleted = FALSE
+  `);
+
+  await knex.raw(`
+    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+    SET ${UNIQUENESS_STATE_COLUMN} = 'ENFORCED'
+    FROM ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+    WHERE neighbors.tenant_id = phones.tenant_id
+      AND neighbors.id = phones.neighbor_id
+      AND phones.is_active = TRUE
+      AND neighbors.is_deleted = FALSE
+      AND phones.normalized_e164 IS NOT NULL
+      AND phones.${UNIQUENESS_STATE_COLUMN} <> 'LEGACY_EXEMPT'
+  `);
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS ${CURRENT_UNIQUE_E164_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} (tenant_id, normalized_e164)
+    WHERE is_active = TRUE AND ${UNIQUENESS_STATE_COLUMN} = 'ENFORCED' AND normalized_e164 IS NOT NULL
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${CURRENT_UNIQUE_E164_INDEX}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP CONSTRAINT IF EXISTS ${UNIQUENESS_STATE_CHECK}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+      DROP COLUMN IF EXISTS ${UNIQUENESS_STATE_COLUMN}
+  `);
+}

--- a/shared/database/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts
+++ b/shared/database/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts
@@ -59,11 +59,11 @@ export async function up(knex: Knex): Promise<void> {
       GROUP BY phones.tenant_id, phones.normalized_e164
       HAVING COUNT(DISTINCT phones.neighbor_id) > 1
     ) AS duplicate_current_claims
-    JOIN ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
-      ON neighbors.tenant_id = phones.tenant_id
-     AND neighbors.id = phones.neighbor_id
+    , ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
     WHERE phones.tenant_id = duplicate_current_claims.tenant_id
       AND phones.normalized_e164 = duplicate_current_claims.normalized_e164
+      AND neighbors.tenant_id = phones.tenant_id
+      AND neighbors.id = phones.neighbor_id
       AND phones.is_active = TRUE
       AND neighbors.is_deleted = FALSE
   `);

--- a/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/checklists/requirements.md
+++ b/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: ConnectShyft Duplicate Phone Handling
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-03-18  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation iteration 1 added an explicit `Dependencies` section and clarified that ambiguity must return a structured refusal outcome.
+- No open clarification markers remain.
+- Spec is ready for `/speckit.plan`.

--- a/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/contracts/duplicate-phone-enforcement.md
+++ b/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/contracts/duplicate-phone-enforcement.md
@@ -1,0 +1,100 @@
+# Contract: ConnectShyft Duplicate Phone Enforcement
+
+## Objective
+
+Prevent new duplicate canonical phone assignments across current ConnectShyft neighbors while preserving deterministic ambiguity behavior for legacy duplicates that already exist.
+
+## Allowed runtime surface
+
+- `shared/database/migrations/*_connectshyft_neighbor_phone_uniqueness*.ts`
+  - canonical schema authority for the forward uniqueness safety net
+- `apps/connectshyft-api/src/migrations/*_connectshyft_neighbor_phone_uniqueness*.ts`
+  - lane-local mirror for local tooling compatibility
+- `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+  - duplicate-owner lookup
+  - create and update refusal shaping
+  - inbound-create safety check
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+  - unchanged subject-resolution result contract
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+  - neighbor create and update route refusal passthrough
+- Existing related tests only:
+  - `apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts`
+  - `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`
+  - `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts`
+  - `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+  - `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts`
+  - migration SQL-shape tests under `apps/connectshyft-api/src/migrations/__tests__/`
+
+## Neighbor write contract
+
+### Route surface
+
+- `POST /api/v1/connectshyft/neighbors` remains the create endpoint.
+- `PUT /api/v1/connectshyft/neighbors/:neighborId` remains the full update and phone replacement endpoint.
+- Business refusals for these endpoints remain HTTP `200` with `refusalType: 'business'`, consistent with current ConnectShyft route conventions.
+
+### Internal write surface
+
+- `createNeighbor(...)`
+- `updateNeighbor(...)`
+- `createNeighborFromInbound(...)`
+
+These write paths must all consult the same duplicate-owner rule before mutating storage.
+
+## Duplicate comparison rules
+
+1. Compare only canonical normalized E.164 values.
+2. A conflicting owner is another row in the same tenant where:
+   - `cs_neighbor_phones.is_active = true`
+   - the parent neighbor has `is_deleted = false`
+   - the conflicting `neighborId` is not the same neighbor currently being updated
+3. Soft-deleted neighbors do not count toward uniqueness and do not block reuse.
+4. Legacy duplicate current rows still block new writes to the same canonical phone until cleanup removes the duplicate condition.
+5. No caller may bypass duplicate checks with raw string formatting variants.
+
+## Duplicate refusal contract
+
+When a write attempts to assign a canonical phone already owned by another current non-deleted neighbor, the system must return a business refusal with:
+
+- `code: CONNECTSHYFT_PHONE_DUPLICATE`
+- `data.reason: duplicate_phone`
+- `data.fieldErrors[]` containing a `phones` field error with reason `duplicate_phone`
+
+The refusal must also guarantee:
+
+- no phone ownership transfer
+- no overwrite of the existing owner
+- no merge or reactivation side effects
+- no partial write of the attempted mutation
+
+## DB safety-net contract
+
+- The schema adds a narrow phone-row grandfathering marker so the DB safety net can distinguish forward-enforced rows from legacy duplicate rows that must remain stored.
+- A partial unique index protects enforced current phone rows by canonical value within tenant scope.
+- Any unique-constraint violation from that partial unique index must map back to the same `CONNECTSHYFT_PHONE_DUPLICATE` refusal returned by service preflight validation.
+- The DB safety net must not silently hide legacy duplicates from identity-resolution reads.
+
+## Identity resolution contract
+
+### `resolveSubjectByContactPoint(input)`
+
+**Output**
+
+- `single_match`
+- `no_match`
+- `multiple_matches`
+
+### Rules
+
+1. More than one current non-deleted owner for the same canonical phone must return `multiple_matches`.
+2. `multiple_matches` is a hard refusal outcome. No silent fallback or arbitrary selection is allowed.
+3. Deleted-only matches must return `no_match`.
+4. A mix of one current owner plus deleted owners must return `single_match` for the current owner.
+
+## Must hold constant
+
+- `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain `admin-api` owned.
+- Shared host Nginx, localhost-only API binding, and shared Postgres topology remain unchanged.
+- `shared/database/migrations` remains the only canonical production schema authority.
+- No merge tooling, cleanup tooling, heuristic winner selection, or PeopleCore integration is added by this feature.

--- a/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/data-model.md
+++ b/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/data-model.md
@@ -1,0 +1,190 @@
+# Data Model: ConnectShyft Duplicate Phone Uniqueness Enforcement
+
+## Overview
+
+This feature closes the write-time corruption gap for ConnectShyft neighbor phones by enforcing canonical duplicate checks on current non-deleted neighbors while still tolerating legacy duplicate data that already exists. The design adds a narrow grandfathering state for the DB safety net, but identity resolution continues to see legacy duplicates and must keep refusing them as ambiguous.
+
+## Entity: Neighbor Record
+
+**Purpose**
+
+Represents the ConnectShyft person identity that owns one or more phone assignments and can be current or soft-deleted.
+
+**Fields**
+
+- `neighborId`: unique neighbor identity
+- `tenantId`: tenant scope
+- `orgUnitId`: org-unit scope
+- `firstName`: profile value
+- `lastName`: profile value
+- `prefersTexting`: `UNKNOWN`, `YES`, or `NO`
+- `isDeleted`: current lifecycle flag
+- `deletedAtUtc`: optional deletion timestamp
+- `phones`: associated phone assignments
+
+**Validation rules**
+
+- Duplicate-prevention checks include the neighbor only when `isDeleted = false`.
+- Soft-deleted neighbors never qualify as reusable owners for uniqueness or identity resolution.
+- The feature must not resurrect a deleted neighbor to solve a duplicate collision.
+
+**Relationships**
+
+- Owns one or more `Neighbor Phone Assignment` records.
+- Participates in `Legacy Duplicate Set` membership when more than one current neighbor shares a canonical phone.
+
+## Entity: Neighbor Phone Assignment
+
+**Purpose**
+
+Represents one persisted canonical phone value attached to a neighbor and evaluated for current ownership, duplicate prevention, and identity lookup.
+
+**Fields**
+
+- `phoneId`: unique phone assignment identity
+- `tenantId`: tenant scope
+- `neighborId`: owning neighbor
+- `normalizedE164`: canonical comparison value
+- `rawInput`: user-entered source value
+- `displayNational`: formatted display value
+- `isActive`: current assignment flag
+- `isPrimary`: primary-phone flag
+- `isShared`: shared-phone indicator
+- `verificationStatus`: `verified` or `unverified`
+- `uniquenessEnforcementState`: `ENFORCED` or `LEGACY_EXEMPT`
+
+**Validation rules**
+
+- `normalizedE164` is the only value allowed for duplicate comparison and identity lookup.
+- A phone assignment participates in current-owner checks only when `isActive = true` and the parent neighbor is not deleted.
+- `ENFORCED` current phone assignments must be unique per tenant and canonical phone value.
+- `LEGACY_EXEMPT` exists only to grandfather already-stored duplicate rows until cleanup; it must not be used to create new duplicate ownership.
+
+**Relationships**
+
+- Belongs to one `Neighbor Record`.
+- May belong to one `Legacy Duplicate Set` when its canonical phone is already shared across current neighbors.
+- Feeds both `Duplicate Phone Check` and `Identity Resolution Outcome`.
+
+## Entity: Legacy Duplicate Set
+
+**Purpose**
+
+Represents an already-stored canonical phone value shared by multiple current non-deleted neighbors that must remain unresolved until cleanup.
+
+**Fields**
+
+- `tenantId`: tenant scope
+- `normalizedE164`: duplicated canonical phone
+- `currentNeighborIds`: current non-deleted neighbors sharing the phone
+- `currentPhoneIds`: current phone assignments sharing the phone
+- `deletedNeighborIds`: deleted neighbors sharing the phone but excluded from current ambiguity
+- `containsGrandfatheredRows`: whether one or more rows are marked `LEGACY_EXEMPT`
+
+**Validation rules**
+
+- The feature must not merge, delete, or silently reassign rows in the duplicate set.
+- New writes attempting to use `normalizedE164` must be refused while any current non-deleted owner remains in the set.
+- Identity resolution against a duplicate set with more than one current non-deleted owner must return ambiguity.
+
+**Relationships**
+
+- Aggregates multiple `Neighbor Phone Assignment` rows.
+- Produces an `Identity Resolution Outcome` of `multiple_matches` when more than one current owner remains.
+
+## Entity: Duplicate Phone Check
+
+**Purpose**
+
+Represents the business-rule evaluation run before a phone write is allowed to persist.
+
+**Fields**
+
+- `operation`: `create`, `update`, or `inbound_create`
+- `tenantId`: tenant scope
+- `excludeNeighborId`: optional current neighbor excluded during self-retaining update
+- `candidateNormalizedPhones`: canonical phones proposed by the write
+- `conflictingNeighborIds`: current owners that block the write
+- `outcome`: `allow` or `duplicate_refusal`
+
+**Validation rules**
+
+- The check must run after phone normalization and before persistence mutates rows.
+- `excludeNeighborId` allows the same neighbor to retain the same canonical phone without triggering a duplicate refusal.
+- Any conflict with another current non-deleted owner forces `duplicate_refusal`.
+
+**Relationships**
+
+- Reads from `Neighbor Phone Assignment` and `Neighbor Record`.
+- Produces `Duplicate Phone Refusal` on failure.
+
+## Entity: Duplicate Phone Refusal
+
+**Purpose**
+
+Represents the deterministic refusal returned when a write attempts to claim another neighbor's current phone.
+
+**Fields**
+
+- `code`: `CONNECTSHYFT_PHONE_DUPLICATE`
+- `reason`: `duplicate_phone`
+- `fieldErrors`: refusal details attached to the `phones` field
+- `normalizedPhones`: canonical phones that triggered the refusal
+- `operation`: originating write operation
+
+**Validation rules**
+
+- The refusal must be returned identically for preflight duplicate detection and DB race-condition enforcement.
+- The refusal must not commit any ownership change, merge, or overwrite behavior.
+- Caller-visible refusal data must remain business-safe and deterministic.
+
+**Relationships**
+
+- Produced by `Duplicate Phone Check`.
+- Returned by neighbor create, update, or replacement flows.
+
+## Entity: Identity Resolution Outcome
+
+**Purpose**
+
+Represents the deterministic phone-lookup result consumed by ConnectShyft identity-driven workflows.
+
+**Fields**
+
+- `outcome`: `single_match`, `no_match`, or `multiple_matches`
+- `normalizedContactPoint`: canonical lookup value
+- `neighborId`: single owner when `single_match`
+- `candidateNeighborIds`: current owners when `multiple_matches`
+- `deletedOwnersExcluded`: whether deleted-neighbor filtering removed non-current rows from consideration
+
+**Validation rules**
+
+- `single_match` requires exactly one current non-deleted owner.
+- `multiple_matches` requires more than one current non-deleted owner and must remain a hard refusal.
+- `no_match` applies when no current non-deleted owners remain after deleted neighbors are excluded.
+
+**Relationships**
+
+- Consumes `Neighbor Phone Assignment` and `Neighbor Record`.
+- Reflects `Legacy Duplicate Set` membership when ambiguity exists.
+
+## State Transitions
+
+### Phone Uniqueness Enforcement
+
+- `new clean current assignment -> ENFORCED`
+- `existing duplicate current assignment -> LEGACY_EXEMPT`
+- `LEGACY_EXEMPT -> ENFORCED` only when later cleanup or a phone rewrite removes the duplicate condition
+- `current assignment -> excluded from current-owner checks` when the phone becomes inactive or the parent neighbor becomes deleted
+
+### Duplicate Write Outcome
+
+- `candidate phones -> allow` when no other current non-deleted owner exists
+- `candidate phones -> duplicate_refusal` when another current non-deleted owner exists
+- `candidate phones -> duplicate_refusal` even when the conflicting owner is a grandfathered legacy duplicate
+
+### Identity Resolution
+
+- `canonical phone -> single_match` when exactly one current non-deleted owner exists
+- `canonical phone -> multiple_matches` when multiple current non-deleted owners exist
+- `canonical phone -> no_match` when only deleted or inactive rows remain

--- a/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/plan.md
+++ b/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/plan.md
@@ -1,0 +1,263 @@
+# Implementation Plan: ConnectShyft Duplicate Phone Uniqueness Enforcement
+
+**Branch**: `023-duplicate-handling-and-phone-uniqueness-enforcement` | **Date**: 2026-03-18 | **Spec**: [/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/spec.md](/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/spec.md)
+**Input**: Feature specification from `/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/spec.md`
+
+## Summary
+
+Implement feature `023` by blocking duplicate current phone assignments before ConnectShyft neighbor writes commit, preserving the existing `multiple_matches` ambiguity result when legacy duplicate data already exists, and adding a migration-backed uniqueness safety net that does not auto-resolve or silently rewrite those legacy duplicates. The current `neighbors.ts` create and update flows normalize phones but never check cross-neighbor ownership, the canonical `normalized_e164` lookup index is non-unique, and `identityResolver.ts` already surfaces ambiguity for active duplicate matches. This plan closes the write-time corruption gap with canonical duplicate-owner checks, a standardized duplicate refusal, and a forward-enforced partial unique index strategy that coexists with tolerated legacy duplicate records.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022) on Node.js >=20  
+**Primary Dependencies**: Express, Knex, `pg`, Jest/ts-jest, shared `domains/communication` phone normalization, ConnectShyft neighbor service/store modules, existing `identityBoundary.ts` and `identityResolver.ts`  
+**Storage**: Shared PostgreSQL `connectshyft` schema with canonical phone columns in `cs_neighbor_phones`, canonical production migration authority under `shared/database/migrations`, and lane-local migration mirrors for local build/test compatibility  
+**Testing**: `npm run build` in `apps/connectshyft-api`, targeted Jest suites for neighbor service/store, identity resolver, route refusal behavior, and migration SQL shape  
+**Target Platform**: ConnectShyft API lane behind host-managed Nginx, Dockerized Node runtime, and shared host-managed PostgreSQL  
+**Project Type**: Monorepo backend lane feature with shared schema authority, route/domain modules, and Jest-based regression coverage  
+**Performance Goals**: Keep duplicate refusal within the same request that performs the write, preserve indexed canonical phone lookups, add no network calls, and keep identity resolution deterministic in one lookup pass  
+**Constraints**: Compare only canonical normalized E.164 values; no raw string comparison; no silent override, merge, or heuristic winner selection; legacy duplicates remain stored and readable; soft-deleted neighbors do not count toward uniqueness; no background cleanup; `admin-api` remains the sole authorized production migration runner  
+**Scale/Scope**: One shared migration plus mirror and tests, one current-owner query helper in the neighbor store, one standardized duplicate refusal across create and update flows, one identity-resolution regression pass, and focused route contract verification for neighbor refusal semantics
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Platform shell authority**: Pass. No changes affect `admin-web`, `admin-api`, shared auth ownership, or shell routing.
+- **Lane isolation preserved**: Pass. Runtime changes stay within ConnectShyft neighbor persistence, ConnectShyft route refusal shaping, and shared migration authority only.
+- **Routing delegation preserved**: Pass. `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain `admin-api` owned; ConnectShyft neighbor routes remain lane-owned.
+- **Deployment topology preserved**: Pass. No Nginx, port, Docker binding, or static frontend changes are introduced.
+- **Database ownership preserved**: Pass. Shared Postgres remains the storage model, and the schema change is routed through `shared/database/migrations` while `admin-api` remains the authorized production executor.
+- **Security boundaries preserved**: Pass. No public API surface, session behavior, or cross-lane ingress behavior changes.
+- **Workflow compliance**: Pass. The plan is derived directly from the approved `023` spec and stays within duplicate prevention plus deterministic ambiguity handling.
+- **Acceptance criteria present**: Pass. The plan includes schema, service, route, and identity-resolution validation plus unchanged platform-contract verification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-duplicate-handling-and-phone-uniqueness-enforcement/
+├── 01-specify.md
+├── 02-plan.md
+├── 03-tasks.md
+├── 04-implement.md
+├── 05-testing.md
+├── 06-pr-template.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   └── duplicate-phone-enforcement.md
+├── data-model.md
+├── plan.md
+├── quickstart.md
+├── research.md
+└── spec.md
+```
+
+### Source Code (repository root)
+
+```text
+shared/database/migrations/
+└── *_connectshyft_neighbor_phone_uniqueness*.ts
+
+apps/connectshyft-api/
+├── src/
+│   ├── config/
+│   │   └── knex.ts
+│   ├── migrations/
+│   │   ├── *_connectshyft_neighbor_phone_uniqueness*.ts
+│   │   └── __tests__/
+│   │       ├── connectShyftNeighborCanonicalPhoneLookupMigration.test.ts
+│   │       ├── connectShyftNeighborPhoneUniquenessMigration.test.ts
+│   │       └── connectShyftNeighborsMigration.test.ts
+│   ├── modules/connectshyft/
+│   │   ├── __tests__/
+│   │   │   ├── identityResolver.test.ts
+│   │   │   └── neighbors.test.ts
+│   │   ├── identityResolver.ts
+│   │   └── neighbors.ts
+│   └── routes/api/v1/
+│       ├── __tests__/
+│       │   ├── connectshyft.identity-match.test.ts
+│       │   ├── connectshyft.neighbors.test.ts
+│       │   └── connectshyft.provider-registry.guardrails.test.ts
+│       └── connectshyft.ts
+├── knexfile.js
+└── Dockerfile.production
+
+apps/admin-api/
+└── knexfile.js
+
+nginx/nginx.conf
+docker-compose.example.yml
+docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+```
+
+**Structure Decision**: This is a backend-only ConnectShyft lane feature. Runtime behavior stays inside `apps/connectshyft-api/src/modules/connectshyft` and the existing ConnectShyft route surface, while the schema change lands through canonical shared migration authority and is mirrored into the lane-local migration tree for local development and test compatibility. The identity resolver remains the existing replaceable boundary; the primary new behavior is write-time duplicate prevention plus refusal shaping, not a new identity engine.
+
+## Complexity Tracking
+
+No constitution exceptions are required for this feature.
+
+## Current Context Holders
+
+- `shared/database/migrations/20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.ts` creates the current non-unique `(tenant_id, normalized_e164, neighbor_id, sort_order, id)` lookup index, so canonical lookup exists today but write-time uniqueness does not.
+- `shared/database/migrations/20260318130000_add_connectshyft_neighbor_lifecycle_state.ts` already provides `cs_neighbors.is_deleted`, so deleted-neighbor exclusion can rely on existing lifecycle state rather than inventing a new delete model.
+- `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts` normalizes phones and persists them through `createNeighbor`, `createNeighborFromInbound`, and `updateNeighbor`, but it never checks whether another current non-deleted neighbor already owns the same normalized phone.
+- `KnexConnectShyftNeighborStore.updateNeighbor(...)` deletes and reinserts the entire phone set, so duplicate-prevention must run before destructive replacement or else re-map any DB safety-net violation back to the same business refusal.
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` already returns business refusals for neighbor create and update flows through `buildNeighborRefusalData(...)`, and `updateNeighborWithSideEffects(...)` must propagate any new duplicate refusal without turning it into a side-effect failure.
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts` already converts ambiguous phone matches into `multiple_matches`; this feature must preserve that outcome and only harden regression coverage around it.
+- `InMemoryConnectShyftNeighborStore` currently has no deleted-neighbor state or duplicate-owner lookup helper, so unit-test support needs either a narrow internal test seam or explicit mocked-store coverage for deleted and grandfathered duplicate cases.
+
+## Planned Contract Deltas
+
+- Add a standardized duplicate refusal with code `CONNECTSHYFT_PHONE_DUPLICATE` and refusal reason `duplicate_phone` for any create, update, or replacement write that attempts to assign a canonical phone already owned by another current non-deleted neighbor.
+- Extend neighbor refusal data so duplicate refusals carry `data.reason = 'duplicate_phone'` plus a `phones` field error, while keeping existing business-refusal HTTP semantics unchanged.
+- Add a reusable current-owner lookup helper in the neighbor store that:
+  - filters `cs_neighbor_phones.is_active = true`
+  - filters parent `cs_neighbors.is_deleted = false`
+  - scopes by `tenant_id`
+  - ignores the current `neighborId` during self-retaining updates
+- Add a narrow phone-row uniqueness eligibility marker and a partial unique index over enforced current canonical phone claims so new clean writes gain a DB safety net without auto-resolving legacy duplicate rows that must remain ambiguous until cleanup.
+- Map unique-constraint races from that partial unique index back to the same `CONNECTSHYFT_PHONE_DUPLICATE` refusal so service-layer preflight and DB safety net stay behaviorally identical.
+- Preserve `resolveSubjectByContactPoint(...)` and `IDENTITY_MATCH_AMBIGUOUS` semantics: multiple current eligible matches remain a hard refusal, deleted-only matches remain excluded, and no silent fallback path is introduced.
+- Terminology note: the spec's user-facing term is `ambiguity refusal`. Existing internals may continue to use `multiple_matches` as the resolver outcome and `IDENTITY_MATCH_AMBIGUOUS` as the established refusal semantic, but all three refer to the same deterministic no-selection outcome.
+
+## Phase 0 Research Output
+
+- Research findings are captured in [/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/research.md](/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/research.md).
+- No unresolved `NEEDS CLARIFICATION` items remain.
+
+## Phase 1 Design Output
+
+- Data model is captured in [/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/data-model.md](/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/data-model.md).
+- Boundary and refusal contract is captured in [/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/contracts/duplicate-phone-enforcement.md](/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/contracts/duplicate-phone-enforcement.md).
+- Execution and verification flow is captured in [/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/quickstart.md](/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/quickstart.md).
+
+## Post-Design Constitution Check
+
+- **Platform shell authority**: Pass. Design leaves shell, auth authority, and shared-domain ingress behavior untouched.
+- **Lane isolation preserved**: Pass. Design stays inside the ConnectShyft backend lane and canonical shared migration authority only.
+- **Routing delegation preserved**: Pass. No auth or platform-admin route behavior changes are introduced.
+- **Deployment topology preserved**: Pass. Design changes schema, service logic, and tests only.
+- **Database ownership preserved**: Pass. Shared Postgres compatibility remains intact and the migration path stays under `shared/database/migrations` with `admin-api` still the only production executor.
+- **Security boundaries preserved**: Pass. Duplicate refusal logic and identity ambiguity checks do not expose new ingress or public port behavior.
+- **Workflow compliance**: Pass. The design slices map directly to the approved `023` spec.
+- **Acceptance criteria present**: Pass. The design includes schema validation, deterministic write refusal validation, ambiguity regression validation, and unchanged platform-contract verification.
+
+## Implementation Slices
+
+### Slice 1 - Shared Migration and Forward Uniqueness Safety Net
+
+**Primary goal**: add the narrow schema support needed for a DB safety net without auto-resolving or silently hiding legacy duplicate phone assignments.
+
+**Exact file targets**
+
+- `shared/database/migrations/*_connectshyft_neighbor_phone_uniqueness*.ts`
+- `apps/connectshyft-api/src/migrations/*_connectshyft_neighbor_phone_uniqueness*.ts`
+- `apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts`
+- `apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts`
+- `apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborsMigration.test.ts`
+
+**Required changes**
+
+- Add a shared migration that introduces a narrow phone-row uniqueness eligibility marker for canonical phone assignments and a partial unique index over enforced current rows.
+- Backfill current phone rows so legacy duplicate sets remain stored but are explicitly grandfathered rather than auto-merged, auto-deleted, or re-assigned.
+- Ensure deleted and inactive phone rows are excluded from the uniqueness safety net without removing them from normal historical storage.
+- Mirror the shared migration into the ConnectShyft lane-local migration tree for local tooling compatibility and add SQL-shape regression tests.
+
+**Must hold constant**
+
+- `normalized_e164` remains the canonical comparison value.
+- Shared migration authority remains canonical; no lane-local-only production schema path is introduced.
+- The migration must not choose a canonical survivor or merge duplicate neighbor records.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts src/migrations/__tests__/connectShyftNeighborsMigration.test.ts`
+
+**Commit checkpoint**
+
+- Safe to commit once the shared migration, mirror, and migration tests agree on the new grandfathering marker and partial unique index shape.
+
+### Slice 2 - Store and Service Duplicate Refusal Enforcement
+
+**Primary goal**: make every relevant neighbor write refuse duplicate current phone ownership deterministically before mutating rows, while mapping DB races back to the same refusal.
+
+**Exact file targets**
+
+- `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+
+**Required changes**
+
+- Add a reusable duplicate-owner lookup helper for both in-memory and Knex-backed stores.
+- Run duplicate-owner checks after normalization and before `createNeighbor`, `createNeighborFromInbound`, `updateNeighbor`, and any dedicated phone add or replace persistence path commits.
+- Allow self-retaining updates by excluding the current `neighborId` from duplicate detection.
+- Standardize a new refusal with:
+  - code `CONNECTSHYFT_PHONE_DUPLICATE`
+  - reason `duplicate_phone`
+  - `phones` field-error data for caller surfaces
+- Map DB unique-index violations for the new partial unique index back to the same refusal so concurrent writes behave the same as preflight checks.
+- Ensure `updateNeighborWithSideEffects(...)` propagates duplicate refusal unchanged instead of masking it as a side-effect outage.
+
+**Must hold constant**
+
+- Existing phone normalization rules and phone-required validation.
+- Existing business-refusal HTTP shape for ConnectShyft neighbor endpoints.
+- Existing generic neighbor ID conflict and persistence-unavailable behavior outside duplicate-phone scenarios.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/modules/connectshyft/__tests__/neighbors.test.ts src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+
+**Commit checkpoint**
+
+- Safe to commit once create, update, and inbound-create paths all return the same duplicate refusal and self-retaining updates still succeed.
+
+### Slice 3 - Identity Ambiguity Preservation and Final Verification
+
+**Primary goal**: keep identity resolution deterministic when legacy duplicates remain and verify that deleted-neighbor reuse plus duplicate refusal do not reintroduce silent fallback behavior.
+
+**Exact file targets**
+
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts`
+- verification-only platform contract files:
+  - `nginx/nginx.conf`
+  - `docker-compose.example.yml`
+  - `apps/connectshyft-api/Dockerfile.production`
+  - `apps/admin-api/knexfile.js`
+  - `docs/PRODUCTION_DEPLOYMENT_GUIDE.md`
+
+**Required changes**
+
+- Preserve `resolveSubjectByContactPoint(...)` return semantics: `single_match`, `no_match`, and `multiple_matches`.
+- Add regression coverage proving:
+  - multiple current duplicate owners still return ambiguity
+  - deleted-only matches return `no_match`
+  - a mix of deleted and one current owner resolves to the current owner
+  - no write path or identity path silently falls back after ambiguity
+- Reconfirm that the duplicate-prevention feature does not alter route ownership, Nginx delegation, Docker binding, or production migration authority contracts.
+
+**Must hold constant**
+
+- Existing `IDENTITY_MATCH_AMBIGUOUS` business meaning.
+- Existing inbound/provider guardrail refusal behavior outside duplicate-owner hardening.
+- No merge tooling, cleanup tooling, or PeopleCore integration.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/modules/connectshyft/__tests__/neighbors.test.ts src/modules/connectshyft/__tests__/identityResolver.test.ts src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts`
+
+**Commit checkpoint**
+
+- Safe to commit once duplicate writes fail deterministically, legacy duplicates still surface ambiguity, deleted-neighbor reuse works, and platform-contract verification shows no routing or migration-authority drift.

--- a/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/quickstart.md
+++ b/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/quickstart.md
@@ -1,0 +1,134 @@
+# Quickstart: ConnectShyft Duplicate Phone Uniqueness Enforcement
+
+## Goal
+
+Implement deterministic duplicate-phone refusal for ConnectShyft neighbor writes, keep legacy duplicates ambiguous during identity resolution, and add a forward DB safety net without auto-resolving existing duplicate records.
+
+## Slice Order
+
+1. Shared migration and forward uniqueness safety net
+2. Neighbor store and service duplicate-preflight enforcement
+3. Identity ambiguity regression and route contract verification
+
+## Slice 1: Shared Migration and Forward Uniqueness Safety Net
+
+**Legacy duplicate inventory query**
+
+```sql
+SELECT
+  phones.tenant_id,
+  phones.normalized_e164,
+  COUNT(DISTINCT phones.neighbor_id) AS current_owner_count,
+  ARRAY_AGG(DISTINCT phones.neighbor_id ORDER BY phones.neighbor_id) AS current_neighbor_ids
+FROM connectshyft.cs_neighbor_phones AS phones
+JOIN connectshyft.cs_neighbors AS neighbors
+  ON neighbors.tenant_id = phones.tenant_id
+ AND neighbors.id = phones.neighbor_id
+WHERE phones.is_active = TRUE
+  AND neighbors.is_deleted = FALSE
+GROUP BY phones.tenant_id, phones.normalized_e164
+HAVING COUNT(DISTINCT phones.neighbor_id) > 1
+ORDER BY phones.tenant_id, phones.normalized_e164;
+```
+
+**Grandfathering expectation**
+
+- Current duplicate sets returned by the inventory query remain stored and readable.
+- Duplicate current rows are backfilled to `LEGACY_EXEMPT` so the DB safety net does not choose a winner or block rollout.
+- Clean current rows remain or become `ENFORCED`, which is the only state protected by the forward partial unique index.
+
+**Rollback notes**
+
+- Drop the partial unique index and the `uniqueness_enforcement_state` column by rolling back the shared migration and its lane-local mirror.
+- Revert or disable the service/store duplicate preflight only if the refusal behavior itself must be withdrawn after the schema rollback.
+- Do not mutate legacy duplicate ownership during rollback; rollback is limited to the migration/index seam and the write-validation seam.
+
+**Source targets**
+
+- `shared/database/migrations/*_connectshyft_neighbor_phone_uniqueness*.ts`
+- `apps/connectshyft-api/src/migrations/*_connectshyft_neighbor_phone_uniqueness*.ts`
+- `apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts`
+- `apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts`
+- `apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborsMigration.test.ts`
+
+**Work**
+
+1. Add the shared migration plus lane-local mirror.
+2. Introduce the narrow grandfathering marker for legacy duplicate rows.
+3. Add the partial unique index for forward-enforced current phone rows.
+4. Prove the SQL is idempotent and reversible without choosing merge winners.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts src/migrations/__tests__/connectShyftNeighborsMigration.test.ts`
+
+**Commit checkpoint**
+
+- Safe to commit once the shared migration, mirror, and migration tests agree on the grandfathering marker and partial unique index behavior.
+
+## Slice 2: Neighbor Store and Service Duplicate-Preflight Enforcement
+
+**Source targets**
+
+- `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+
+**Work**
+
+1. Add a reusable current-owner lookup helper for in-memory and Knex-backed stores.
+2. Run duplicate checks after normalization and before create, update, and inbound-create persistence.
+3. Allow self-retaining updates by excluding the current neighbor from duplicate detection.
+4. Return one standardized refusal:
+   - `code: CONNECTSHYFT_PHONE_DUPLICATE`
+   - `reason: duplicate_phone`
+5. Map DB unique-index races back to the same refusal.
+6. Keep update side-effect wrappers transparent to duplicate refusals.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/modules/connectshyft/__tests__/neighbors.test.ts src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+
+**Commit checkpoint**
+
+- Safe to commit once create, update, and inbound-create all refuse duplicate current ownership consistently and same-neighbor saves still pass.
+
+## Slice 3: Identity Ambiguity Regression and Route Contract Verification
+
+**Source targets**
+
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts`
+- any Slice 1 or Slice 2 files that need final regression tightening
+
+**Work**
+
+1. Keep `single_match`, `no_match`, and `multiple_matches` unchanged at the resolver boundary.
+2. Prove multiple current owners still yield ambiguity.
+3. Prove deleted-only owners yield `no_match`.
+4. Prove one current owner plus deleted owners still yields `single_match`.
+5. Verify duplicate-prevention changes did not introduce silent fallback or route-ownership drift.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/modules/connectshyft/__tests__/neighbors.test.ts src/modules/connectshyft/__tests__/identityResolver.test.ts src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts`
+
+**Final acceptance**
+
+- Duplicate current phone assignments are refused deterministically before write completion.
+- The same canonical phone in different raw formats is treated as one identity.
+- Legacy duplicate data still produces ambiguity rather than silent selection.
+- Soft-deleted neighbors do not block reuse and do not re-enter identity resolution as current owners.
+- Shared routing, Nginx delegation, Docker binding, and migration-authority contracts remain unchanged.
+
+## Rollback Levers
+
+1. Revert the shared migration and partial unique index if the DB safety net causes rollout issues.
+2. Revert or disable the service/store duplicate-preflight helper and unique-violation mapping if write-time validation needs to be removed.
+3. Revert the route refusal passthrough changes if caller surfaces need temporary rollback while preserving current lookup semantics.

--- a/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/research.md
+++ b/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/research.md
@@ -1,0 +1,59 @@
+# Research: ConnectShyft Duplicate Phone Uniqueness Enforcement
+
+No open clarification markers remained after loading the `023` spec, reviewing the current ConnectShyft neighbor store and resolver code, and tracing the repository's shared migration authority rules. The decisions below resolve the planning inputs needed for implementation.
+
+## Decision 1: Route schema changes through shared migration authority and mirror them into the lane-local migration tree
+
+- **Decision**: Create the schema change in `shared/database/migrations` and mirror it in `apps/connectshyft-api/src/migrations` through the existing re-export pattern used by recent ConnectShyft schema work.
+- **Rationale**: The constitution and the repository's migration-authority convergence work already make `shared/database/migrations` the canonical production source while preserving lane-local mirrors for app-local tooling. Feature `023` changes storage rules, so it must follow that canonical path.
+- **Alternatives considered**:
+  - Add a lane-local-only migration under `apps/connectshyft-api/src/migrations`: rejected because production schema authority is already shared and lane-local-only schema work is out of policy.
+  - Avoid schema work entirely: rejected because the user explicitly asked for a DB safety net in addition to service validation.
+
+## Decision 2: A direct unique partial index on current phone rows is not sufficient while legacy duplicates remain, so the safety net needs a narrow grandfathering marker
+
+- **Decision**: Add a narrow phone-row uniqueness eligibility marker and build the partial unique index only over enforced current rows, while grandfathering existing legacy duplicate rows so they remain stored and readable.
+- **Rationale**: The feature must simultaneously block new duplicates and tolerate old duplicates until cleanup. A direct unique partial index over all current phone rows would fail as soon as legacy duplicates exist, and the uniqueness predicate cannot rely on a cross-table deleted-neighbor filter alone. A narrow grandfathering marker preserves the legacy data without choosing a merge winner and still allows a DB safety net for forward-enforced rows.
+- **Alternatives considered**:
+  - Create a direct unique partial index on `normalized_e164` for all active rows immediately: rejected because it conflicts with the requirement to tolerate existing duplicate rows.
+  - Rely only on a non-unique lookup index: rejected because the user explicitly requested a DB safety net and the feature would remain vulnerable to concurrent writes if service validation regressed.
+
+## Decision 3: Service-level duplicate preflight remains the authoritative write gate
+
+- **Decision**: Keep a canonical duplicate-owner preflight check in the neighbor service/store and use the DB constraint only as a race-condition safety net.
+- **Rationale**: The service can evaluate the full business rule in one place: canonical E.164 only, same-tenant scope, phone row active, neighbor not deleted, and self-retaining updates excluded. The grandfathered-index strategy deliberately leaves legacy duplicate rows outside the unique index, so service validation must remain the authoritative blocker for clean UX and complete rule coverage.
+- **Alternatives considered**:
+  - Depend on the DB safety net alone: rejected because it cannot produce the desired refusal shape early and cannot fully cover grandfathered legacy duplicates.
+  - Put duplicate detection in the route only: rejected because write-time duplicate prevention belongs with neighbor persistence rules and must also protect non-route callers such as inbound-created neighbors.
+
+## Decision 4: Standardize one duplicate refusal across create, update, and replacement writes
+
+- **Decision**: Introduce a single business refusal with code `CONNECTSHYFT_PHONE_DUPLICATE` and refusal reason `duplicate_phone`, and use it across create, update, and any phone replacement path that would assign another neighbor's current phone.
+- **Rationale**: The feature requires deterministic failure and a structured refusal. A single refusal code keeps create, update, and DB-race mapping aligned and allows route responses, tests, and future caller surfaces to handle one stable contract.
+- **Alternatives considered**:
+  - Reuse `CONNECTSHYFT_NEIGHBOR_CREATE_CONFLICT`: rejected because it is currently tied to generic create conflict semantics and does not distinguish duplicate phone ownership from ID conflicts.
+  - Return different duplicate codes for create and update: rejected because the business rule is the same and split codes would add avoidable drift.
+
+## Decision 5: Preserve the existing subject resolver contract and hard-fail ambiguity semantics
+
+- **Decision**: Keep `resolveSubjectByContactPoint(...)` returning `single_match`, `no_match`, and `multiple_matches`, and preserve the current ambiguity behavior instead of introducing any fallback or winner-selection logic.
+- **Rationale**: The resolver already provides the deterministic identity contract required by the feature. The gap is write-time prevention, not resolver taxonomy. Feature `023` must ensure that legacy duplicates continue to surface ambiguity explicitly.
+- **Alternatives considered**:
+  - Add fallback selection logic after `multiple_matches`: rejected because the spec explicitly forbids arbitrary selection and silent fallback.
+  - Replace the resolver with a new duplicate-specific adapter: rejected because the current boundary already matches the approved deterministic outcomes.
+
+## Decision 6: Exclude soft-deleted neighbors through existing lifecycle state, not through heuristic phone filtering
+
+- **Decision**: Duplicate detection and identity resolution will continue to exclude soft-deleted neighbors by consulting `cs_neighbors.is_deleted` together with current phone rows.
+- **Rationale**: The repository already has lifecycle state for neighbors, and the business rule is explicitly about active non-deleted neighbors. Filtering only on phone-row activity would be insufficient because deleted and inactive are different concepts.
+- **Alternatives considered**:
+  - Treat inactive phone rows as equivalent to deleted neighbors: rejected because it would mix lifecycle meaning and could hide valid current ownership state.
+  - Ignore deleted-neighbor exclusion in write-time checks: rejected because the spec explicitly allows reuse for soft-deleted neighbors.
+
+## Decision 7: Keep rollback isolated to the migration/index seam and the validation seam
+
+- **Decision**: Preserve two primary rollback levers: revert the shared migration and partial unique index, and revert or disable the service/store duplicate preflight plus unique-violation mapping.
+- **Rationale**: Those are the two runtime seams that actually change behavior. Keeping them isolated allows incident response without reopening unrelated identity-resolution or routing work.
+- **Alternatives considered**:
+  - Add a permanent runtime feature flag for duplicate prevention: rejected because the approved spec does not authorize a new long-lived toggle surface.
+  - Treat resolver ambiguity as a rollback seam: rejected because ambiguity behavior already exists and should remain stable.

--- a/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/spec.md
+++ b/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/spec.md
@@ -1,0 +1,144 @@
+# Feature Specification: ConnectShyft Duplicate Phone Handling
+
+**Feature Branch**: `023-duplicate-handling-and-phone-uniqueness-enforcement`  
+**Created**: 2026-03-18  
+**Status**: Ready for Planning  
+**Input**: User description: "Stop creation of duplicate phone assignments across neighbors and enforce deterministic identity behavior when duplicates exist. This PR prevents further data corruption while tolerating existing legacy duplicates until cleanup."
+
+## Scope
+
+- Stop new duplicate normalized phone assignments from being created for current neighbors within the existing ConnectShyft identity boundary.
+- Apply the same duplicate-prevention rule to neighbor creation, neighbor updates, and phone add or replace actions.
+- Preserve existing legacy duplicate records without automatically merging, deleting, or rewriting them.
+- Make phone-based identity resolution fail closed when legacy duplicate records make the result ambiguous.
+- Allow phone numbers held only by soft-deleted neighbors to be reused safely.
+
+## Non-Goals
+
+- Background deduplication or automated cleanup of existing duplicate records.
+- Identity merging workflows or silent reassignment of phone ownership.
+- Household or shared-phone modeling changes beyond the existing current-neighbor rules.
+- PeopleCore integration or new cross-system identity orchestration.
+- Cleanup tooling, operator merge tools, or other follow-up remediation work planned for PR 024.
+
+## Operational Boundaries
+
+- This feature changes existing ConnectShyft neighbor-management and phone-based identity behaviors only.
+- No Admin or MoneyShyft ownership boundaries change.
+- No new background jobs, manual cleanup workflows, or operator decision trees are introduced.
+
+## Routing Ownership & Shared-Database Compatibility
+
+- `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain owned by `admin-api`.
+- ConnectShyft neighbor-management and phone-identity routes remain owned by the ConnectShyft API lane.
+- Shared PostgreSQL remains the only production data store for this feature, and production schema changes continue to run through canonical shared migration authority rather than a lane-owned production migration path.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reject Duplicate Assignment Attempts (Priority: P1)
+
+As a ConnectShyft operator, I need phone assignment to stop when a number is already attached to another current neighbor, so I do not create additional identity corruption while editing neighbor records.
+
+**Why this priority**: Preventing new duplicate assignments is the core safety outcome. If this fails, legacy ambiguity keeps growing and downstream identity behavior becomes harder to trust.
+
+**Independent Test**: This can be tested by creating neighbors, updating neighbors, and adding or replacing phones with both unique and already-used phone inputs, then confirming only unique current assignments are accepted and duplicate attempts fail without changing prior ownership.
+
+**Acceptance Scenarios**:
+
+1. **Given** no other current non-deleted neighbor already owns a phone's canonical normalized value, **When** an operator creates a neighbor with that phone, **Then** the create succeeds and the phone remains assigned to the new neighbor.
+2. **Given** another current non-deleted neighbor already owns a phone's canonical normalized value in any formatting variant, **When** an operator creates a new neighbor with that phone, **Then** the system refuses the write with a structured duplicate-phone refusal and leaves the existing assignment unchanged.
+3. **Given** another current non-deleted neighbor already owns a phone's canonical normalized value, **When** an operator updates a neighbor or adds or replaces a phone with that value, **Then** the system refuses the write with the same duplicate-phone refusal and does not move or merge the phone assignment.
+4. **Given** a neighbor already owns a phone's canonical normalized value, **When** the operator saves that same phone for the same neighbor during an edit, **Then** the system treats the phone as unchanged rather than as a duplicate collision.
+
+---
+
+### User Story 2 - Refuse Ambiguous Phone Identity Resolution (Priority: P2)
+
+As a ConnectShyft operator, I need phone lookup to fail clearly when legacy duplicates already exist, so messages and other identity-driven actions never attach to the wrong neighbor.
+
+**Why this priority**: Existing duplicate data cannot be trusted to produce a single owner. The feature must fail deterministically instead of guessing and causing silent misrouting.
+
+**Independent Test**: This can be tested by running phone-based lookup flows with one current match, no current match, and multiple current matches and confirming the result is always a single deterministic outcome with no arbitrary selection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a phone lookup finds exactly one current eligible neighbor for a canonical normalized phone value, **When** identity resolution runs, **Then** the system returns that neighbor as the single match.
+2. **Given** a phone lookup finds multiple current eligible neighbors for the same canonical normalized phone value, **When** identity resolution runs, **Then** the system hard fails with an explicit ambiguity refusal and does not select any neighbor.
+3. **Given** an upstream workflow depends on phone-based identity resolution and the lookup is ambiguous, **When** the workflow completes, **Then** it returns the ambiguity refusal without creating a new identity, merging records, or attaching the action to any neighbor.
+
+---
+
+### User Story 3 - Reuse Numbers Released by Soft Deletion (Priority: P3)
+
+As a ConnectShyft operator, I need phone numbers from soft-deleted neighbors to be available for reuse, so deleted history does not block valid current neighbor records.
+
+**Why this priority**: Operators still need to recover from ordinary lifecycle changes while the system tightens identity safety. Deleted records should not permanently reserve a phone number.
+
+**Independent Test**: This can be tested by soft-deleting a neighbor that owns a phone, reusing that phone on a different current neighbor, and running phone lookup flows that include deleted-only matches.
+
+**Acceptance Scenarios**:
+
+1. **Given** a phone number is owned only by soft-deleted neighbors, **When** an operator assigns that phone to a current neighbor, **Then** the assignment succeeds and the deleted neighbors remain deleted.
+2. **Given** phone lookup finds one current eligible neighbor and one or more soft-deleted neighbors with the same canonical normalized phone value, **When** identity resolution runs, **Then** the deleted neighbors are ignored and the current eligible neighbor is returned as the single match.
+3. **Given** phone lookup finds only soft-deleted neighbors for a canonical normalized phone value, **When** identity resolution runs, **Then** the system returns no current match rather than an ambiguity refusal or a resurrected deleted neighbor.
+
+### Edge Cases
+
+- The same phone is entered in different raw formats; all duplicate checks and lookups must still resolve from the same canonical normalized E.164 value.
+- A current neighbor edit keeps the same canonical phone value already owned by that same neighbor; the save must not fail as a self-duplicate.
+- A legacy duplicate set contains both current and soft-deleted neighbors; ambiguity still applies whenever more than one current eligible neighbor remains after deleted neighbors are excluded.
+- A phone number owned by a soft-deleted neighbor is also still owned by a different current neighbor; reuse must still be refused because a current eligible owner exists.
+- Legacy duplicate records remain in place during this feature; unrelated reads and writes must not auto-merge, auto-delete, or silently rewrite those records.
+
+### Platform Compatibility Scenarios
+
+1. **Given** the platform routing delegation contract is already in place, **When** this feature is exercised through ConnectShyft neighbor and identity routes, **Then** `/api/v1/auth/*` and `/api/v1/platform/admin/*` continue delegating to `admin-api` and only ConnectShyft-owned routes change behavior.
+2. **Given** production uses shared PostgreSQL with canonical migration authority, **When** this feature is rolled out, **Then** the schema change remains compatible with shared Postgres and does not require a ConnectShyft-owned production migration path.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST evaluate phone uniqueness and phone-based identity resolution using canonical normalized E.164 values only.
+- **FR-002**: Within the existing tenant-scoped ConnectShyft identity boundary, the system MUST allow at most one current active phone assignment for a canonical normalized E.164 value across non-deleted neighbors.
+- **FR-003**: The system MUST enforce the uniqueness rule during neighbor creation.
+- **FR-004**: The system MUST enforce the uniqueness rule during neighbor updates and during phone add or replace actions.
+- **FR-005**: The system MUST exclude soft-deleted neighbors from duplicate-assignment enforcement so their phone numbers can be reused.
+- **FR-006**: If a write operation attempts to assign a canonical normalized phone value that is already owned by another current non-deleted neighbor, the system MUST fail deterministically and return a structured refusal that identifies the outcome as a duplicate-phone refusal.
+- **FR-007**: A duplicate-phone refusal MUST leave all existing phone ownership unchanged and MUST NOT silently override, merge, transfer, or reactivate any neighbor identity.
+- **FR-008**: Existing duplicate phone assignments already present in stored data MUST be tolerated temporarily and MUST NOT be auto-resolved by this feature.
+- **FR-009**: Phone-based identity resolution MUST return one and only one of these deterministic outcomes for a canonical normalized phone value: single current match, no current match, or structured ambiguity refusal.
+- **FR-010**: If phone-based identity resolution finds multiple current eligible neighbors for the same canonical normalized phone value, the system MUST hard fail with a structured ambiguity refusal and MUST NOT select a neighbor arbitrarily.
+- **FR-011**: Workflows that depend on phone-based identity resolution MUST propagate ambiguity refusal as a refusal outcome and MUST NOT convert it into a successful association, a new identity, or a silent fallback.
+- **FR-012**: If a phone number is held only by soft-deleted neighbors, the system MUST allow the number to be assigned to a current neighbor and MUST continue to treat deleted neighbors as unavailable for identity reuse.
+- **FR-013**: If a phone value already belongs to the same current neighbor after canonical normalization, the system MUST treat the write as retaining the same ownership rather than as a duplicate conflict.
+- **FR-014**: This feature MUST remain limited to duplicate-prevention and deterministic ambiguity behavior and MUST NOT introduce background deduplication, merge tooling, heuristic resolution, household or shared-phone modeling changes, PeopleCore integration, or cleanup tooling.
+
+### Key Entities *(include if feature involves data)*
+
+- **Neighbor Record**: A ConnectShyft person record that can be current or soft-deleted and can hold one or more phone assignments.
+- **Current Phone Assignment**: A phone value that is still active for a non-deleted neighbor and therefore participates in uniqueness checks and identity resolution.
+- **Duplicate-Phone Refusal**: The deterministic structured refusal returned when a write attempts to assign a phone already owned by another current non-deleted neighbor.
+- **Identity Resolution Outcome**: The phone-lookup result for a canonical normalized phone value, limited to a single current match, no current match, or ambiguity refusal.
+
+## Dependencies
+
+- Existing canonical phone normalization remains the source of truth for comparing differently formatted phone inputs.
+- Existing ConnectShyft workflows that resolve neighbor identity by phone continue to consume a single-match, no-match, or ambiguity outcome without inventing extra fallback paths.
+
+## Assumptions
+
+- Phone uniqueness and phone-based identity resolution remain tenant-scoped, consistent with the current ConnectShyft identity boundary.
+- Only current active phone assignments on non-deleted neighbors participate in uniqueness enforcement and lookup ambiguity; inactive phone history does not block reuse unless it becomes current again.
+- Structured refusals provide a stable outcome category that calling surfaces can handle consistently, while exact presentation wording may vary by surface.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In regression validation, 100% of create, update, and phone add or replace attempts using a unique canonical normalized phone value succeed without changing any other neighbor's phone ownership.
+- **SC-002**: In regression validation, 100% of duplicate assignment attempts against a phone already owned by another current non-deleted neighbor return a duplicate-phone refusal on the first attempt and make zero ownership changes.
+- **SC-003**: In regression validation, 100% of formatting variants for the same phone value are treated as the same canonical identity for both duplicate enforcement and lookup behavior.
+- **SC-004**: In regression validation, 100% of phone-based identity lookups with exactly one current eligible match return that match, and 100% of lookups with multiple current eligible matches return ambiguity refusal with zero arbitrary selections.
+- **SC-005**: In regression validation, 100% of assignment attempts involving phone numbers owned only by soft-deleted neighbors succeed without reviving deleted records, and 100% of deleted-only phone lookups return no current match.
+- **SC-006**: During rollout validation, 0 legacy duplicate phone assignments are auto-merged, auto-deleted, or silently rewritten by this feature.

--- a/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/tasks.md
+++ b/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/tasks.md
@@ -1,0 +1,205 @@
+# Tasks: ConnectShyft Duplicate Phone Uniqueness Enforcement
+
+**Input**: Design documents from `/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/`  
+**Prerequisites**: `/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/plan.md`, `/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/spec.md`, `/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/research.md`, `/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/data-model.md`, `/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/contracts/duplicate-phone-enforcement.md`, `/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/quickstart.md`
+
+**Tests**: Included because the spec and user input explicitly require duplicate create and update refusals, migration safety validation, soft-deleted reuse coverage, and ambiguity regression coverage.
+
+**Organization**: Tasks are grouped into setup, foundational prerequisites, then one phase per user story in spec priority order so each story remains independently implementable and testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other tasks in the same phase
+- **[Story]**: Maps to the feature spec user stories where applicable
+- **All task descriptions include exact file paths**
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the missing regression surfaces needed by later phases.
+
+- [X] T001 [P] Create neighbor duplicate-refusal route regressions in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+- [X] T002 [P] Create phone-uniqueness migration regressions in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core migration and rollout prerequisites that MUST be complete before ANY user story work can be considered done.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Identify existing duplicate current phone assignments and record the inventory query, grandfathering expectation, and rollback notes in `/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/quickstart.md`
+- [X] T004 Create the shared migration and lane-local mirror for phone uniqueness enforcement in `/Users/jeremiahotis/projects/connectshyft/shared/database/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts`
+- [X] T005 [P] Validate grandfathering, partial unique index creation, and down-migration rollback in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts`
+- [X] T006 [P] Tighten migration safety coverage for canonical phone lookup and lifecycle coexistence in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborsMigration.test.ts`
+
+**Checkpoint**: Shared migration authority, safety-net shape, and rollout validation are in place.
+
+---
+
+## Phase 3: User Story 1 - Reject Duplicate Assignment Attempts (Priority: P1) 🎯 MVP
+
+**Goal**: Refuse duplicate current phone assignments during create, update, and phone replacement flows without changing existing ownership.
+
+**Independent Test**: Create a neighbor with a unique phone, then attempt duplicate create, duplicate update, and same-neighbor save flows; only the unique create and self-retaining update should succeed, and all conflicting writes should return the standardized duplicate refusal without changing ownership.
+
+### Tests for User Story 1
+
+- [X] T007 [P] [US1] Add duplicate create, duplicate update, duplicate phone add or replace, self-retaining update, and formatting-variant coverage in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts`
+- [X] T008 [P] [US1] Add business-refusal route coverage for duplicate create and duplicate update in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T009 [US1] Define `CONNECTSHYFT_PHONE_DUPLICATE`, `duplicate_phone`, and `phones` field-error refusal builders in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T010 [US1] Add current-owner lookup helpers for canonical active phones in the in-memory and Knex stores inside `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T011 [US1] Enforce duplicate preflight in `createNeighbor(...)`, `createNeighborFromInbound(...)`, `updateNeighbor(...)`, and any dedicated phone add or replace entrypoint with same-neighbor exclusion in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T012 [US1] Propagate duplicate refusal data through neighbor create and update route responses in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T013 [US1] Map partial-unique-index race failures back to `CONNECTSHYFT_PHONE_DUPLICATE` in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T014 [US1] Run focused US1 verification from `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/package.json` against `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+
+**Checkpoint**: User Story 1 should now block duplicate current ownership deterministically for create, update, and replacement writes.
+
+---
+
+## Phase 4: User Story 2 - Refuse Ambiguous Phone Identity Resolution (Priority: P2)
+
+**Goal**: Preserve explicit ambiguity when legacy duplicate current owners exist and ensure no caller silently falls back after an ambiguity outcome.
+
+**Independent Test**: Resolve phone-based identity for one current owner, no current owner, and multiple current owners; confirm the resolver and its callers return `single_match`, `no_match`, or ambiguity only, with no arbitrary winner selection or hidden fallback path.
+
+### Tests for User Story 2
+
+- [X] T015 [P] [US2] Add resolver coverage for canonical formatting variants, multiple current matches, deleted-only no-match, and mixed current plus deleted outcomes in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`
+- [X] T016 [P] [US2] Add route and guardrail ambiguity coverage with no fallback selection in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T017 [US2] Preserve the ambiguity outcome for legacy duplicate current owners in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`, keeping internal resolver naming aligned with the spec contract
+- [X] T018 [US2] Audit and tighten ambiguity propagation so no caller falls back after `multiple_matches` in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T019 [US2] Run focused US2 verification from `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/package.json` against `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts`, and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts`
+
+**Checkpoint**: User Story 2 should now keep legacy duplicate sets ambiguous everywhere the phone identity result is consumed.
+
+---
+
+## Phase 5: User Story 3 - Reuse Numbers Released by Soft Deletion (Priority: P3)
+
+**Goal**: Exclude soft-deleted neighbors from uniqueness enforcement and identity reuse so deleted numbers can be reassigned safely while current owners still block duplicates.
+
+**Independent Test**: Reassign a phone owned only by soft-deleted neighbors, then test deleted-only, deleted-plus-current, and current-owner-conflict scenarios; deleted-only cases should allow reuse or resolve to `no_match`, while any remaining current owner still blocks reuse or produces the expected match outcome.
+
+### Tests for User Story 3
+
+- [X] T020 [P] [US3] Add soft-deleted reuse and mixed-owner coverage in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts`
+- [X] T021 [P] [US3] Add route coverage for soft-deleted phone reuse and unchanged refusal semantics in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`
+
+### Implementation for User Story 3
+
+- [X] T022 [US3] Extend duplicate-owner lookup and in-memory deleted-neighbor test support to exclude soft-deleted neighbors in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- [X] T023 [US3] Preserve deleted-neighbor exclusion in canonical phone identity resolution queries and outcomes in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+- [X] T024 [US3] Run focused US3 verification from `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/package.json` against `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`, and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`
+
+**Checkpoint**: User Story 3 should now allow deleted-only phone reuse while preserving duplicate blocking for any remaining current owner.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification across migration, runtime, and platform-contract surfaces.
+
+- [X] T025 [P] Verify ConnectShyft route ownership and Nginx delegation remain unchanged using `/Users/jeremiahotis/projects/connectshyft/nginx/nginx.conf` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T026 [P] Verify Docker binding, shared Postgres connectivity, production migration authority, and reproducible deployment runbook steps remain unchanged using `/Users/jeremiahotis/projects/connectshyft/docker-compose.example.yml`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/Dockerfile.production`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/config/knex.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/admin-api/knexfile.js`, and `/Users/jeremiahotis/projects/connectshyft/docs/PRODUCTION_DEPLOYMENT_GUIDE.md`
+- [X] T027 Run final build and regression verification from `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/package.json` against `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborPhoneUniquenessMigration.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborCanonicalPhoneLookupMigration.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/migrations/__tests__/connectShyftNeighborsMigration.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts`, and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Starts immediately.
+- **Foundational (Phase 2)**: Depends on Phase 1 and blocks all user stories.
+- **User Story 1 (Phase 3)**: Depends on Phase 2 and delivers the first usable increment.
+- **User Story 2 (Phase 4)**: Depends on Phase 2 and should land after US1 so duplicate-write behavior is fixed before ambiguity regression hardening.
+- **User Story 3 (Phase 5)**: Depends on Phase 2 and on the duplicate-owner lookup introduced in US1.
+- **Polish (Phase 6)**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other stories after foundation; this is the recommended MVP.
+- **US2 (P2)**: Depends on the write- and lookup-shaping work from US1 only where shared duplicate-owner helpers are reused.
+- **US3 (P3)**: Depends on the duplicate-owner lookup from US1 and shares resolver verification with US2, but remains independently testable once those prerequisites exist.
+
+### Within Each User Story
+
+- Tests must be written and fail before implementation tasks are considered complete.
+- Refusal builders and lookup helpers precede write-path wiring.
+- Store and resolver behavior precede route-level propagation checks.
+- Focused story verification precedes final cross-story regression runs.
+
+## Parallel Opportunities
+
+- **Setup**: T001 and T002 can run in parallel because they create different test files.
+- **Foundational**: T005 and T006 can run in parallel after T004 because they tighten different migration test files.
+- **US1**: T007 and T008 can run in parallel because they touch different test surfaces.
+- **US2**: T015 and T016 can run in parallel because they touch different test surfaces.
+- **US3**: T020 and T021 can run in parallel because they touch different test surfaces.
+- **Polish**: T025 and T026 can run in parallel because route delegation verification is independent of deployment and DB contract verification.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "T007 Add duplicate create, duplicate update, and self-retaining update coverage in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts"
+Task: "T008 Add business-refusal route coverage for duplicate create and duplicate update in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts"
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "T015 Add resolver coverage for multiple current matches, deleted-only no-match, and mixed current plus deleted outcomes in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts"
+Task: "T016 Add route and guardrail ambiguity coverage with no fallback selection in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts and /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts"
+```
+
+---
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "T020 Add soft-deleted reuse and mixed-owner coverage in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts"
+Task: "T021 Add route coverage for soft-deleted phone reuse and unchanged refusal semantics in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational migration and rollout prerequisites.
+3. Complete Phase 3: User Story 1.
+4. **STOP and VALIDATE**: Run the US1 independent tests before taking on ambiguity or deleted-neighbor behavior.
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational to lock the shared migration and regression surfaces.
+2. Deliver User Story 1 and validate duplicate-write refusals as the first product increment.
+3. Deliver User Story 2 and validate that legacy duplicates still hard-fail as ambiguous.
+4. Deliver User Story 3 and validate deleted-only reuse without breaking current-owner blocking.
+5. Finish with Phase 6 full verification and platform-contract review.
+
+### Suggested MVP Scope
+
+- **Recommended MVP**: Phase 1 + Phase 2 + Phase 3.
+- **Second increment**: Phase 4 to harden deterministic ambiguity behavior once duplicate writes are blocked.
+- **Third increment**: Phase 5 to finish soft-deleted reuse semantics.
+
+### Notes
+
+- Keep tests failing first before implementation in each story phase.
+- Do not add raw-string phone comparisons anywhere in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts` or `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`.
+- Keep rollback isolated to the shared migration safety net and the duplicate-preflight validation seam described in `/Users/jeremiahotis/projects/connectshyft/specs/023-duplicate-handling-and-phone-uniqueness-enforcement/research.md`.

--- a/tests/api/platform/b-2-shared-tenant-identity-and-shared-phone-indicators.api.spec.ts
+++ b/tests/api/platform/b-2-shared-tenant-identity-and-shared-phone-indicators.api.spec.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from '../../support/helpers/apiClient';
+import { createUniqueConnectShyftTestPhone } from '../../support/factories/connectShyftTestPhoneFactory';
 import { test, expect } from '../../support/fixtures/connectShyftStoryB2.fixture';
 
 const REQUIRED_ENVELOPE_KEYS = ['ok', 'code', 'message', 'correlationId', 'tenantId'];
@@ -28,6 +29,9 @@ const seedNeighbor = async (
   },
   headers: Record<string, string>,
 ): Promise<SeedNeighborResult> => {
+  const sharedPhone = createUniqueConnectShyftTestPhone('7');
+  const nonSharedPhone = createUniqueConnectShyftTestPhone('8');
+
   const createResponse = await apiRequest(request, {
     method: 'POST',
     path: context.paths.neighborsCollection,
@@ -39,13 +43,13 @@ const seedNeighbor = async (
       phones: [
         {
           label: 'mobile',
-          value: context.sharedPhoneRaw,
+          value: sharedPhone.raw,
           isShared: true,
           verificationStatus: 'verified',
         },
         {
           label: 'home',
-          value: context.nonSharedPhoneRaw,
+          value: nonSharedPhone.raw,
           isShared: false,
           verificationStatus: 'unverified',
         },

--- a/tests/api/platform/b-3-relationship-gated-neighbor-edits-with-provenance-audit.api.spec.ts
+++ b/tests/api/platform/b-3-relationship-gated-neighbor-edits-with-provenance-audit.api.spec.ts
@@ -3,6 +3,7 @@ import {
   createStoryB3Headers,
   type StoryB3Context,
 } from '../../support/factories/connectShyftStoryB3Factory';
+import { createUniqueConnectShyftTestPhone } from '../../support/factories/connectShyftTestPhoneFactory';
 import { test, expect } from '../../support/fixtures/connectShyftStoryB3.fixture';
 
 const REQUIRED_ENVELOPE_KEYS = ['ok', 'code', 'message', 'correlationId', 'tenantId'];
@@ -15,6 +16,9 @@ const seedNeighbor = async (
   request: Parameters<typeof apiRequest>[0],
   context: StoryB3Context,
 ): Promise<SeedNeighborResult> => {
+  const sharedPhone = createUniqueConnectShyftTestPhone('4');
+  const nonSharedPhone = createUniqueConnectShyftTestPhone('5');
+
   const createHeaders = createStoryB3Headers(context, {
     role: 'ORGUNIT_MEMBER',
     userId: `user-connectshyft-b3-seed-${Date.now()}`,
@@ -33,13 +37,13 @@ const seedNeighbor = async (
       phones: [
         {
           label: 'mobile',
-          value: context.sharedPhoneRaw,
+          value: sharedPhone.raw,
           isShared: true,
           verificationStatus: 'verified',
         },
         {
           label: 'home',
-          value: context.nonSharedPhoneRaw,
+          value: nonSharedPhone.raw,
           isShared: false,
           verificationStatus: 'unverified',
         },

--- a/tests/api/platform/b-4-role-restricted-neighbor-merge-with-irreversible-confirmation.automate.api.spec.ts
+++ b/tests/api/platform/b-4-role-restricted-neighbor-merge-with-irreversible-confirmation.automate.api.spec.ts
@@ -1,5 +1,6 @@
 import { apiRequest } from '../../support/helpers/apiClient';
 import { createStoryB4Headers } from '../../support/factories/connectShyftStoryB4Factory';
+import { createUniqueConnectShyftTestPhone } from '../../support/factories/connectShyftTestPhoneFactory';
 import { ensureConnectShyftDbHousehold } from '../../support/helpers/connectShyftDbActor';
 import { test, expect } from '../../support/fixtures/connectShyftStoryB4.fixture';
 
@@ -22,6 +23,8 @@ const seedNeighbor = async (
   firstName: string,
   lastName: string,
 ): Promise<string> => {
+  const phone = createUniqueConnectShyftTestPhone('9');
+
   const response = await apiRequest(request, {
     method: 'POST',
     path,
@@ -32,7 +35,7 @@ const seedNeighbor = async (
       phones: [
         {
           label: 'mobile',
-          value: '+12605550199',
+          value: phone.raw,
           isShared: true,
           verificationStatus: 'verified',
         },

--- a/tests/e2e/platform/b-1-tenant-scoped-neighbor-creation-with-required-phone.atdd.spec.ts
+++ b/tests/e2e/platform/b-1-tenant-scoped-neighbor-creation-with-required-phone.atdd.spec.ts
@@ -9,6 +9,7 @@ test.describe(
     test(
       '[P0] operator can submit neighbor create form with one valid phone and see normalized result state @P0',
       async ({ page }) => {
+        const context = createStoryB1Context();
         await login(page);
         await page.goto(
           '/app/connectshyft/neighbors/new?flags=module:on,inbox:on,escalation:on,webhooks:on&tenantId=tenant-connectshyft-alpha&orgUnitId=org-connectshyft-alpha-east&tenantRole=ORGUNIT_MEMBER&orgUnitMemberships=org-connectshyft-alpha-east',
@@ -18,7 +19,7 @@ test.describe(
 
         await page.getByTestId('connectshyft-neighbor-first-name-input').fill('Mina');
         await page.getByTestId('connectshyft-neighbor-last-name-input').fill('Lopez');
-        await page.getByTestId('connectshyft-neighbor-phone-input').fill('+1 (260) 555-0199');
+        await page.getByTestId('connectshyft-neighbor-phone-input').fill(context.validPhoneRaw);
         await page.getByTestId('connectshyft-neighbor-phone-label-select').selectOption('mobile');
 
         const createResponse = page.waitForResponse(
@@ -34,7 +35,7 @@ test.describe(
           'Neighbor created',
         );
         await expect(page.getByTestId('connectshyft-neighbor-phone-value')).toContainText(
-          '+12605550199',
+          context.validPhoneNormalized,
         );
       },
     );

--- a/tests/e2e/platform/b-1-tenant-scoped-neighbor-creation-with-required-phone.spec.ts
+++ b/tests/e2e/platform/b-1-tenant-scoped-neighbor-creation-with-required-phone.spec.ts
@@ -14,6 +14,7 @@ test.describe(
     test(
       '[P0] operator submits valid neighbor create form and sees normalized phone result state @P0',
       async ({ page }) => {
+        const context = createStoryB1Context();
         await login(page);
         await page.goto(
           buildNeighborCreateUrl(
@@ -25,7 +26,7 @@ test.describe(
 
         await page.getByTestId('connectshyft-neighbor-first-name-input').fill('Mina');
         await page.getByTestId('connectshyft-neighbor-last-name-input').fill('Lopez');
-        await page.getByTestId('connectshyft-neighbor-phone-input').fill('+1 (260) 555-0199');
+        await page.getByTestId('connectshyft-neighbor-phone-input').fill(context.validPhoneRaw);
         await page.getByTestId('connectshyft-neighbor-phone-label-select').selectOption('mobile');
 
         const createResponse = page.waitForResponse(
@@ -41,7 +42,7 @@ test.describe(
           'Neighbor created',
         );
         await expect(page.getByTestId('connectshyft-neighbor-phone-value')).toContainText(
-          '+12605550199',
+          context.validPhoneNormalized,
         );
       },
     );
@@ -70,6 +71,7 @@ test.describe(
     test(
       '[P1] tenant-viewer role is blocked with deterministic refusal messaging and no success state @P1',
       async ({ page }) => {
+        const context = createStoryB1Context();
         await login(page);
         await page.goto(
           buildNeighborCreateUrl(
@@ -79,7 +81,7 @@ test.describe(
 
         await page.getByTestId('connectshyft-neighbor-first-name-input').fill('Ari');
         await page.getByTestId('connectshyft-neighbor-last-name-input').fill('Quinn');
-        await page.getByTestId('connectshyft-neighbor-phone-input').fill('+1 (260) 555-0199');
+        await page.getByTestId('connectshyft-neighbor-phone-input').fill(context.validPhoneRaw);
         await page.getByTestId('connectshyft-neighbor-phone-label-select').selectOption('mobile');
 
         const refusalResponse = page.waitForResponse(

--- a/tests/e2e/platform/b-2-shared-tenant-identity-and-shared-phone-indicators.spec.ts
+++ b/tests/e2e/platform/b-2-shared-tenant-identity-and-shared-phone-indicators.spec.ts
@@ -6,6 +6,7 @@ import {
   createStoryB2Headers,
   type StoryB2Context,
 } from '../../support/factories/connectShyftStoryB2Factory';
+import { createUniqueConnectShyftTestPhone } from '../../support/factories/connectShyftTestPhoneFactory';
 
 const buildNeighborProfileUrl = (
   context: StoryB2Context,
@@ -57,6 +58,8 @@ const seedNeighbor = async (
     lastName?: string;
   } = {},
 ): Promise<{ neighborId: string }> => {
+  const sharedPhone = createUniqueConnectShyftTestPhone('7');
+  const nonSharedPhone = createUniqueConnectShyftTestPhone('8');
   const headers = createStoryB2Headers(context, {
     role: 'ORGUNIT_MEMBER',
     orgUnitId: context.primaryOrgUnitId,
@@ -74,13 +77,13 @@ const seedNeighbor = async (
       phones: [
         {
           label: 'mobile',
-          value: context.sharedPhoneRaw,
+          value: sharedPhone.raw,
           isShared: true,
           verificationStatus: 'verified',
         },
         {
           label: 'home',
-          value: context.nonSharedPhoneRaw,
+          value: nonSharedPhone.raw,
           isShared: false,
           verificationStatus: 'unverified',
         },

--- a/tests/e2e/platform/b-3-relationship-gated-neighbor-edits-with-provenance-audit.spec.ts
+++ b/tests/e2e/platform/b-3-relationship-gated-neighbor-edits-with-provenance-audit.spec.ts
@@ -6,6 +6,7 @@ import {
   createStoryB3Headers,
   type StoryB3Context,
 } from '../../support/factories/connectShyftStoryB3Factory';
+import { createUniqueConnectShyftTestPhone } from '../../support/factories/connectShyftTestPhoneFactory';
 
 const buildNeighborProfileUrl = (
   context: StoryB3Context,
@@ -36,6 +37,8 @@ const seedNeighbor = async (
   request: APIRequestContext,
   context: StoryB3Context,
 ): Promise<{ neighborId: string }> => {
+  const sharedPhone = createUniqueConnectShyftTestPhone('4');
+  const nonSharedPhone = createUniqueConnectShyftTestPhone('5');
   const seedHeaders = createStoryB3Headers(context, {
     role: 'ORGUNIT_MEMBER',
     userId: `user-connectshyft-b3-seed-ui-${Date.now()}`,
@@ -57,13 +60,13 @@ const seedNeighbor = async (
           phones: [
             {
               label: 'mobile',
-              value: context.sharedPhoneRaw,
+              value: sharedPhone.raw,
               isShared: true,
               verificationStatus: 'verified',
             },
             {
               label: 'home',
-              value: context.nonSharedPhoneRaw,
+              value: nonSharedPhone.raw,
               isShared: false,
               verificationStatus: 'unverified',
             },

--- a/tests/e2e/platform/b-4-role-restricted-neighbor-merge-with-irreversible-confirmation.automate.spec.ts
+++ b/tests/e2e/platform/b-4-role-restricted-neighbor-merge-with-irreversible-confirmation.automate.spec.ts
@@ -7,6 +7,7 @@ import {
   createStoryB4Headers,
   type StoryB4Context,
 } from '../../support/factories/connectShyftStoryB4Factory';
+import { createUniqueConnectShyftTestPhone } from '../../support/factories/connectShyftTestPhoneFactory';
 
 const DB_CONNECTION_RETRY_LIMIT = 8;
 
@@ -67,6 +68,7 @@ const seedNeighbor = async (
   firstName: string,
   lastName: string,
 ): Promise<string> => {
+  const phone = createUniqueConnectShyftTestPhone('9');
   const response = await apiRequest(request, {
     method: 'POST',
     path,
@@ -77,7 +79,7 @@ const seedNeighbor = async (
       phones: [
         {
           label: 'mobile',
-          value: '+12605550199',
+          value: phone.raw,
           isShared: true,
           verificationStatus: 'verified',
         },

--- a/tests/support/factories/connectShyftStoryB1Factory.ts
+++ b/tests/support/factories/connectShyftStoryB1Factory.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { connectShyftContextEnforcementData } from '../../fixtures/test-data';
+import { createUniqueConnectShyftTestPhone } from './connectShyftTestPhoneFactory';
 import { createTenantScopeHeaders } from './tenantRepositoryFactory';
 
 export type ConnectShyftFlags = {
@@ -63,6 +64,8 @@ export type StoryB1Context = {
 export function createStoryB1Context(
   overrides: StoryB1ContextOverrides = {},
 ): StoryB1Context {
+  const validPhone = createUniqueConnectShyftTestPhone('6');
+
   return {
     storyId: 'b-1',
     tenantId: overrides.tenantId ?? connectShyftContextEnforcementData.tenantAlphaId,
@@ -80,8 +83,8 @@ export function createStoryB1Context(
       ?? `csrf-story-b1-${randomUUID().slice(0, 8)}`,
     crossTenantOrgUnitId: connectShyftContextEnforcementData.orgUnitBravoNorthId,
     flags: { ...connectShyftContextEnforcementData.flagsAllEnabled },
-    validPhoneRaw: '+1 (260) 555-0199',
-    validPhoneNormalized: '+12605550199',
+    validPhoneRaw: validPhone.raw,
+    validPhoneNormalized: validPhone.normalized,
     invalidPhoneRaw: '260-ABC-0199',
     paths: {
       neighborsCollection: '/api/v1/connectshyft/neighbors',
@@ -116,4 +119,3 @@ export function createStoryB1Headers(
 
   return resolvedHeaders;
 }
-

--- a/tests/support/factories/connectShyftStoryB2Factory.ts
+++ b/tests/support/factories/connectShyftStoryB2Factory.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { connectShyftContextEnforcementData } from '../../fixtures/test-data';
+import { createUniqueConnectShyftTestPhone } from './connectShyftTestPhoneFactory';
 import { createTenantScopeHeaders } from './tenantRepositoryFactory';
 
 export type ConnectShyftFlags = {
@@ -76,6 +77,8 @@ export function createStoryB2Context(
   overrides: StoryB2ContextOverrides = {},
 ): StoryB2Context {
   const neighborId = overrides.neighborId ?? `neighbor-b2-${randomUUID().slice(0, 8)}`;
+  const sharedPhone = createUniqueConnectShyftTestPhone('7');
+  const nonSharedPhone = createUniqueConnectShyftTestPhone('8');
 
   return {
     storyId: 'b-2',
@@ -101,10 +104,10 @@ export function createStoryB2Context(
     baseLastName: 'Lopez',
     updatedFirstName: 'Mina Shared',
     updatedLastName: 'Lopez Shared',
-    sharedPhoneRaw: '+1 (260) 555-0231',
-    sharedPhoneNormalized: '+12605550231',
-    nonSharedPhoneRaw: '+1 (260) 555-0232',
-    nonSharedPhoneNormalized: '+12605550232',
+    sharedPhoneRaw: sharedPhone.raw,
+    sharedPhoneNormalized: sharedPhone.normalized,
+    nonSharedPhoneRaw: nonSharedPhone.raw,
+    nonSharedPhoneNormalized: nonSharedPhone.normalized,
     flags: { ...connectShyftContextEnforcementData.flagsAllEnabled },
     paths: {
       neighborsCollection: '/api/v1/connectshyft/neighbors',

--- a/tests/support/factories/connectShyftStoryB3Factory.ts
+++ b/tests/support/factories/connectShyftStoryB3Factory.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { connectShyftContextEnforcementData } from '../../fixtures/test-data';
+import { createUniqueConnectShyftTestPhone } from './connectShyftTestPhoneFactory';
 import { createTenantScopeHeaders } from './tenantRepositoryFactory';
 
 export type ConnectShyftFlags = {
@@ -89,6 +90,8 @@ export function createStoryB3Context(
   const relatedActorUserId = `user-connectshyft-b3-related-${randomUUID().slice(0, 8)}`;
   const unrelatedActorUserId = `user-connectshyft-b3-unrelated-${randomUUID().slice(0, 8)}`;
   const tenantPrivilegedUserId = `user-connectshyft-b3-tenant-staff-${randomUUID().slice(0, 8)}`;
+  const sharedPhone = createUniqueConnectShyftTestPhone('4');
+  const nonSharedPhone = createUniqueConnectShyftTestPhone('5');
 
   return {
     storyId: 'b-3',
@@ -120,10 +123,10 @@ export function createStoryB3Context(
     relatedUpdateLastName: 'Lopez Governed',
     tenantPrivilegedUpdateFirstName: 'Mina Privileged',
     tenantPrivilegedUpdateLastName: 'Lopez Privileged',
-    sharedPhoneRaw: '+1 (260) 555-0311',
-    sharedPhoneNormalized: '+12605550311',
-    nonSharedPhoneRaw: '+1 (260) 555-0312',
-    nonSharedPhoneNormalized: '+12605550312',
+    sharedPhoneRaw: sharedPhone.raw,
+    sharedPhoneNormalized: sharedPhone.normalized,
+    nonSharedPhoneRaw: nonSharedPhone.raw,
+    nonSharedPhoneNormalized: nonSharedPhone.normalized,
     refusalCodes: {
       relationshipRequired: 'CONNECTSHYFT_NEIGHBOR_EDIT_RELATIONSHIP_REQUIRED',
     },

--- a/tests/support/factories/connectShyftTestPhoneFactory.ts
+++ b/tests/support/factories/connectShyftTestPhoneFactory.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from 'node:crypto';
+
+let connectShyftTestPhoneCounter = 0;
+
+const normalizeSeriesDigit = (seriesDigit: string): string =>
+  /^[2-9]$/.test(seriesDigit) ? seriesDigit : '9';
+
+const nextPhoneSeed = (): string => {
+  connectShyftTestPhoneCounter += 1;
+  const uuidDigits = randomUUID().replace(/\D/g, '');
+  return `${process.pid}${Date.now()}${connectShyftTestPhoneCounter}${uuidDigits}`
+    .slice(-6)
+    .padStart(6, '0');
+};
+
+export const createUniqueConnectShyftTestPhone = (
+  seriesDigit: string,
+): {
+  raw: string;
+  normalized: string;
+} => {
+  const seed = nextPhoneSeed();
+  const exchange = `${normalizeSeriesDigit(seriesDigit)}${seed.slice(0, 2)}`;
+  const line = seed.slice(2, 6);
+
+  return {
+    raw: `+1 (260) ${exchange}-${line}`,
+    normalized: `+1260${exchange}${line}`,
+  };
+};


### PR DESCRIPTION
# PR 023 — Duplicate Handling + Phone Uniqueness Enforcement

## Summary

Prevents duplicate phone assignments and enforces deterministic identity behavior.

---

## Changes

- Added a grandfathered DB-level uniqueness safety net via shared and lane-local migrations
- Added service-layer duplicate validation for create, inbound-create, and update flows
- Standardized duplicate refusal handling as `CONNECTSHYFT_PHONE_DUPLICATE` with `duplicate_phone`
- Reinforced ambiguity behavior and soft-delete exclusion in identity resolution

---

## Why

Duplicate phone records create ambiguous identity resolution and break inbound SMS handling.

---

## Testing

- Verified duplicate rejection on create, inbound-create, update, replacement, and DB-race fallback paths
- Verified soft-delete reuse and deleted-only no-match behavior
- Verified ambiguity handling with no fallback winner selection
- `npm run policy:check`
- `bash scripts/verify-connectshyft-route-ownership.sh`
- `bash scripts/lint-or-discovery.sh`
- `bash scripts/ci-run-playwright-stack.sh bash scripts/backend-jest-ci.sh`
- `bash scripts/ci-run-playwright-stack.sh bash scripts/test-changed.sh origin/codex/dev` (reported no changed spec files and skipped)
- `bash scripts/ci-run-playwright-stack.sh bash scripts/burn-in.sh 3 origin/codex/dev` (3 iterations; each skipped for the same reason)
- `bash scripts/quality-gates.sh`
- `npm run build` in `apps/connectshyft-api`

---

## Risks

- migration conflicts with existing duplicates if the grandfathering query is changed incorrectly
- incorrect normalization edge cases could still surface if a new phone write path bypasses canonical normalization

---

## Rollback

- drop the uniqueness index and grandfathering column through the paired migration down path
- remove duplicate preflight validation and duplicate-race mapping from neighbor write flows

---

## Checklist

- [x] Migration tested on production-like data
- [x] No duplicate creation paths remain
- [x] Identity resolution unchanged except for enforced ambiguity
