### PR TITLE
Feat: add ConnectShyft message timeline projection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,8 @@ Docker:
 - Shared PostgreSQL `connectshyft` schema with canonical phone columns in `cs_neighbor_phones`, canonical production migration authority under `shared/database/migrations`, and lane-local migration mirrors for local build/test compatibility (023-duplicate-handling-and-phone-uniqueness-enforcement)
 - TypeScript (ES2022) on Node.js >=20 + Express, Knex, `pg`, Jest/ts-jest, shared `libs/platform` RBAC and mutation helpers, existing ConnectShyft neighbor/read-contract modules, shared `domains/communication` phone normalization (024-neighbor-soft-delete-admin-controls)
 - Shared PostgreSQL `connectshyft` schema with existing neighbor lifecycle columns on `cs_neighbors`, canonical production migration authority under `shared/database/migrations`, and lane-local mirrors for local build/test compatibility (024-neighbor-soft-delete-admin-controls)
+- TypeScript (ES2022) on Node.js >=20 + Express, Knex, `pg`, Jest/ts-jest, existing ConnectShyft `canonicalEvents`, `readContracts`, `threads`, and provider-dispatch modules, shared `libs/platform` mutation helpers, shared telephony contracts under `domains/communication` (025-message-timeline-persistence-and-projection)
+- Shared PostgreSQL using `platform.events` for canonical event persistence plus existing `connectshyft` thread and neighbor read tables; no dedicated timeline table or timeline write model (025-message-timeline-persistence-and-projection)
 
 ## Recent Changes
 - 001-tighten-deployment-contracts: Added TypeScript (Node.js APIs), Vue 3 TypeScript frontends + Express APIs, host Nginx reverse proxy, Docker Compose

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts
@@ -40,6 +40,36 @@ describe('connectshyft canonical event store', () => {
     });
   });
 
+  it('preserves projection-ready outbound sms artifact fields while stripping provider-specific keys', () => {
+    const payload = sanitizeConnectShyftCanonicalPayload({
+      direction: 'outbound',
+      channel: 'sms',
+      actor: 'user',
+      eventName: 'connectshyft.outbound.sms_appended',
+      outboundMessageArtifact: {
+        body: 'Projection-ready outbound message',
+        from: '+13175550101',
+        to: '+13175550102',
+        providerMessageId: 'provider-message-hidden',
+      },
+      providerMetadata: {
+        providerEventId: 'provider-event-hidden',
+      },
+    });
+
+    expect(payload).toEqual({
+      direction: 'outbound',
+      channel: 'sms',
+      actor: 'user',
+      eventName: 'connectshyft.outbound.sms_appended',
+      outboundMessageArtifact: {
+        body: 'Projection-ready outbound message',
+        from: '+13175550101',
+        to: '+13175550102',
+      },
+    });
+  });
+
   it('records and lists canonical events with deterministic ordering and filtering', async () => {
     await recordConnectShyftCanonicalEvent({
       tenantId: 'tenant-connectshyft-f2',
@@ -91,6 +121,51 @@ describe('connectshyft canonical event store', () => {
 
     expect(filtered).toHaveLength(1);
     expect(filtered[0].eventType).toBe('CallConnected');
+  });
+
+  it('returns the most recent canonical event window while preserving ascending order', async () => {
+    await recordConnectShyftCanonicalEvent({
+      tenantId: 'tenant-connectshyft-f2',
+      orgUnitId: 'org-connectshyft-f2-east',
+      aggregateId: 'thread-f2-window-1001',
+      aggregateType: 'Thread',
+      eventType: 'MessageQueued',
+      payload: { sequence: 1 },
+      occurredAtUtc: '2026-02-28T09:00:01.000Z',
+    });
+    await recordConnectShyftCanonicalEvent({
+      tenantId: 'tenant-connectshyft-f2',
+      orgUnitId: 'org-connectshyft-f2-east',
+      aggregateId: 'thread-f2-window-1001',
+      aggregateType: 'Thread',
+      eventType: 'MessageQueued',
+      payload: { sequence: 2 },
+      occurredAtUtc: '2026-02-28T09:00:02.000Z',
+    });
+    await recordConnectShyftCanonicalEvent({
+      tenantId: 'tenant-connectshyft-f2',
+      orgUnitId: 'org-connectshyft-f2-east',
+      aggregateId: 'thread-f2-window-1001',
+      aggregateType: 'Thread',
+      eventType: 'MessageQueued',
+      payload: { sequence: 3 },
+      occurredAtUtc: '2026-02-28T09:00:03.000Z',
+    });
+
+    const mostRecent = await listConnectShyftCanonicalEvents({
+      tenantId: 'tenant-connectshyft-f2',
+      orgUnitId: 'org-connectshyft-f2-east',
+      aggregateId: 'thread-f2-window-1001',
+      aggregateType: 'Thread',
+      limit: 2,
+      window: 'most_recent',
+    });
+
+    expect(mostRecent).toHaveLength(2);
+    expect(mostRecent.map((event) => event.payload)).toEqual([
+      { sequence: 2 },
+      { sequence: 3 },
+    ]);
   });
 
   it('does not swallow canonical DB persistence failures', async () => {

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts
@@ -26,6 +26,7 @@ describe('connectshyft inbound sms domain mapping', () => {
       routingDecision: 'accepted',
       deterministicOrdering: true,
       canonicalEventType: 'MessageDelivered',
+      actor: 'neighbor',
       inboundMessageArtifact: {
         channel: 'sms',
         direction: 'inbound',
@@ -78,6 +79,7 @@ describe('connectshyft inbound sms domain mapping', () => {
       channel: 'sms',
       eventType: 'MessageDelivered',
       eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+      actor: 'neighbor',
       routingDecision: 'accepted',
       deterministicOrdering: true,
       threadState: 'UNCLAIMED',

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts
@@ -5,6 +5,7 @@ import {
   resolveConnectShyftPriorityRank,
   resolveConnectShyftThreadDetailContract,
   resolveConnectShyftThreadDetailContractAsync,
+  resolveConnectShyftThreadTimelineMetadata,
   resolveConnectShyftUrgencyLabel,
 } from '../readContracts';
 
@@ -214,6 +215,58 @@ describe('connectshyft read contracts', () => {
     expect(unclaimed?.actions).toEqual(['Call', 'Text', 'Claim']);
     expect(claimed?.actions).toEqual(['Call', 'Text', 'Close']);
     expect(closed?.actions).toEqual(['Call', 'Send Message']);
+  });
+
+  it('exposes deleted-neighbor metadata for timeline reads and hides deleted threads by default', async () => {
+    const db = buildReadContractsDbMock({
+      threadRows: [
+        {
+          thread_id: 'thread-soft-delete-timeline-1001',
+          neighbor_id: 'neighbor-soft-delete-timeline-1001',
+          tenant_id: 'tenant-connectshyft-soft-delete',
+          org_unit_id: 'org-connectshyft-soft-delete-east',
+          state: 'CLAIMED',
+          claimed_by_user_id: 'user-connectshyft-soft-delete',
+          escalation_stage: 1,
+          is_new_unread: false,
+          last_activity_at_utc: '2026-03-18T12:12:00.000Z',
+          last_inbound_cs_number_id: 'cs-number-1005',
+          preferred_outbound_cs_number_id: 'cs-number-2005',
+          preferred_outbound_label: 'Deleted Neighbor Queue',
+          summary: 'Deleted neighbor thread detail',
+        },
+      ],
+      neighborRows: [
+        {
+          id: 'neighbor-soft-delete-timeline-1001',
+          tenant_id: 'tenant-connectshyft-soft-delete',
+          is_deleted: true,
+          deleted_at_utc: '2026-03-18T12:10:00.000Z',
+        },
+      ],
+    });
+
+    const hidden = await resolveConnectShyftThreadDetailContractAsync({
+      tenantId: 'tenant-connectshyft-soft-delete',
+      orgUnitId: 'org-connectshyft-soft-delete-east',
+      threadId: 'thread-soft-delete-timeline-1001',
+      includeDeleted: false,
+      db,
+    });
+    const visible = await resolveConnectShyftThreadDetailContractAsync({
+      tenantId: 'tenant-connectshyft-soft-delete',
+      orgUnitId: 'org-connectshyft-soft-delete-east',
+      threadId: 'thread-soft-delete-timeline-1001',
+      includeDeleted: true,
+      db,
+    });
+
+    expect(hidden).toBeNull();
+    expect(resolveConnectShyftThreadTimelineMetadata(visible!)).toEqual({
+      threadId: 'thread-soft-delete-timeline-1001',
+      neighborDeleted: true,
+      neighborDeletedAtUtc: '2026-03-18T12:10:00.000Z',
+    });
   });
 
   it('resolves d-4 seeded thread-detail action matrix without hidden fallback actions', () => {

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts
@@ -1,0 +1,333 @@
+import * as canonicalEventsModule from '../canonicalEvents';
+import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../inboundSms';
+import {
+  CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+} from '../inboundVoice';
+import {
+  CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+  CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES,
+  getThreadTimeline,
+  mapConnectShyftCanonicalEventToTimelineItem,
+  sortConnectShyftThreadTimelineItems,
+} from '../threadTimeline';
+
+describe('connectshyft thread timeline projection', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('maps canonical inbound sms events into first-class inbound timeline items', () => {
+    const item = mapConnectShyftCanonicalEventToTimelineItem({
+      eventId: 'event-inbound-001',
+      aggregateId: 'thread-timeline-1001',
+      aggregateType: 'Thread',
+      eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+      occurredAtUtc: '2026-03-19T10:00:00.000Z',
+      payload: {
+        direction: 'inbound',
+        channel: 'sms',
+        actor: 'neighbor',
+        eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+        inboundMessageArtifact: {
+          body: 'Need help with delivery window',
+          from: '+13175550100',
+          to: '+13175550101',
+        },
+      },
+    });
+
+    expect(item).toEqual({
+      id: 'event-inbound-001',
+      threadId: 'thread-timeline-1001',
+      type: 'message',
+      direction: 'inbound',
+      channel: 'sms',
+      body: 'Need help with delivery window',
+      occurredAtUtc: '2026-03-19T10:00:00.000Z',
+      actor: 'neighbor',
+      providerMetadata: null,
+      deliveryStatus: null,
+    });
+  });
+
+  it('maps canonical outbound sms events into first-class outbound timeline items', () => {
+    const item = mapConnectShyftCanonicalEventToTimelineItem({
+      eventId: 'event-outbound-001',
+      aggregateId: 'thread-timeline-1001',
+      aggregateType: 'Thread',
+      eventType: 'MessageQueued',
+      occurredAtUtc: '2026-03-19T10:05:00.000Z',
+      payload: {
+        direction: 'outbound',
+        channel: 'sms',
+        actor: 'user',
+        eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+        outboundMessageArtifact: {
+          body: 'On my way now',
+          from: '+13175550101',
+          to: '+13175550100',
+        },
+      },
+    });
+
+    expect(item).toEqual({
+      id: 'event-outbound-001',
+      threadId: 'thread-timeline-1001',
+      type: 'message',
+      direction: 'outbound',
+      channel: 'sms',
+      body: 'On my way now',
+      occurredAtUtc: '2026-03-19T10:05:00.000Z',
+      actor: 'user',
+      providerMetadata: null,
+      deliveryStatus: null,
+    });
+  });
+
+  it('sorts projected timeline items by occurredAtUtc then canonical event id', () => {
+    const sorted = sortConnectShyftThreadTimelineItems([
+      {
+        id: 'event-b',
+        threadId: 'thread-timeline-1001',
+        type: 'message',
+        direction: 'outbound',
+        channel: 'sms',
+        body: 'second',
+        occurredAtUtc: '2026-03-19T10:00:00.000Z',
+        actor: 'user',
+        providerMetadata: null,
+        deliveryStatus: null,
+      },
+      {
+        id: 'event-a',
+        threadId: 'thread-timeline-1001',
+        type: 'message',
+        direction: 'inbound',
+        channel: 'sms',
+        body: 'first',
+        occurredAtUtc: '2026-03-19T10:00:00.000Z',
+        actor: 'neighbor',
+        providerMetadata: null,
+        deliveryStatus: null,
+      },
+      {
+        id: 'event-c',
+        threadId: 'thread-timeline-1001',
+        type: 'message',
+        direction: 'outbound',
+        channel: 'sms',
+        body: 'third',
+        occurredAtUtc: '2026-03-19T10:01:00.000Z',
+        actor: 'user',
+        providerMetadata: null,
+        deliveryStatus: null,
+      },
+    ]);
+
+    expect(sorted.map((item) => item.id)).toEqual([
+      'event-a',
+      'event-b',
+      'event-c',
+    ]);
+  });
+
+  it('returns the most recent bounded timeline window and an empty timeline when no events are eligible', async () => {
+    const listSpy = jest.spyOn(canonicalEventsModule, 'listConnectShyftCanonicalEvents')
+      .mockResolvedValueOnce([
+        {
+          eventId: 'event-001',
+          aggregateId: 'thread-timeline-1001',
+          aggregateType: 'Thread',
+          eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+          occurredAtUtc: '2026-03-19T10:00:00.000Z',
+          payload: {
+            direction: 'inbound',
+            channel: 'sms',
+            actor: 'neighbor',
+            eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+            inboundMessageArtifact: {
+              body: 'oldest',
+            },
+          },
+        },
+        {
+          eventId: 'event-002',
+          aggregateId: 'thread-timeline-1001',
+          aggregateType: 'Thread',
+          eventType: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+          occurredAtUtc: '2026-03-19T10:01:00.000Z',
+          payload: {
+            direction: 'outbound',
+            channel: 'sms',
+            actor: 'user',
+            eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+            outboundMessageArtifact: {
+              body: 'middle',
+            },
+          },
+        },
+        {
+          eventId: 'event-003',
+          aggregateId: 'thread-timeline-1001',
+          aggregateType: 'Thread',
+          eventType: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+          occurredAtUtc: '2026-03-19T10:02:00.000Z',
+          payload: {
+            direction: 'outbound',
+            channel: 'sms',
+            actor: 'user',
+            eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+            outboundMessageArtifact: {
+              body: 'newest',
+            },
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          eventId: 'event-ignored-001',
+          aggregateId: 'thread-empty-1001',
+          aggregateType: 'Thread',
+          eventType: 'connectshyft.thread.claimed',
+          occurredAtUtc: '2026-03-19T11:00:00.000Z',
+          payload: {
+            direction: 'outbound',
+            channel: 'sms',
+            eventName: 'connectshyft.thread.claimed',
+          },
+        },
+      ]);
+
+    const limited = await getThreadTimeline({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-timeline-1001',
+      limit: 2,
+    });
+    const empty = await getThreadTimeline({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-empty-1001',
+    });
+
+    expect(listSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      aggregateId: 'thread-timeline-1001',
+      aggregateType: 'Thread',
+      limit: 200,
+      window: 'most_recent',
+    }));
+    expect(limited.limitApplied).toBe(2);
+    expect(limited.items.map((item) => item.id)).toEqual([
+      'event-002',
+      'event-003',
+    ]);
+    expect(empty.items).toEqual([]);
+  });
+
+  it('maps explicit voice lifecycle and voicemail placeholder events without changing sms ordering semantics', async () => {
+    jest.spyOn(canonicalEventsModule, 'listConnectShyftCanonicalEvents').mockResolvedValue([
+      {
+        eventId: 'event-sms-001',
+        aggregateId: 'thread-timeline-voice-1001',
+        aggregateType: 'Thread',
+        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+        occurredAtUtc: '2026-03-19T10:00:00.000Z',
+        payload: {
+          direction: 'inbound',
+          channel: 'sms',
+          actor: 'neighbor',
+          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+          inboundMessageArtifact: {
+            body: 'sms first',
+          },
+        },
+      },
+      {
+        eventId: 'event-voice-001',
+        aggregateId: 'thread-timeline-voice-1001',
+        aggregateType: 'Thread',
+        eventType: CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started,
+        occurredAtUtc: '2026-03-19T10:01:00.000Z',
+        payload: {
+          direction: 'outbound',
+          channel: 'voice',
+          actor: 'user',
+          eventName: CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started,
+        },
+      },
+      {
+        eventId: 'event-voicemail-001',
+        aggregateId: 'thread-timeline-voice-1001',
+        aggregateType: 'Thread',
+        eventType: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+        occurredAtUtc: '2026-03-19T10:02:00.000Z',
+        payload: {
+          direction: 'inbound',
+          channel: 'voice',
+          eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+          voicemailArtifact: {
+            artifactId: 'vm-001',
+            recordingUrl: 'https://example.test/vm-001.mp3',
+            durationSeconds: 42,
+          },
+        },
+      },
+      {
+        eventId: 'event-voicemail-002',
+        aggregateId: 'thread-timeline-voice-1001',
+        aggregateType: 'Thread',
+        eventType: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+        occurredAtUtc: '2026-03-19T10:03:00.000Z',
+        payload: {
+          direction: 'inbound',
+          channel: 'voice',
+          eventName: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+          metadata: {
+            transcriptText: 'Leave package at the side door',
+          },
+          voicemailArtifact: {
+            artifactId: 'vm-001',
+            transcription: {
+              available: true,
+              text: 'Leave package at the side door',
+            },
+          },
+        },
+      },
+    ]);
+
+    const timeline = await getThreadTimeline({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-timeline-voice-1001',
+    });
+
+    expect(timeline.items.map((item) => item.type)).toEqual([
+      'message',
+      'voice_event',
+      'voicemail',
+      'voicemail',
+    ]);
+    expect(timeline.items[1]).toMatchObject({
+      id: 'event-voice-001',
+      channel: 'voice',
+      type: 'voice_event',
+    });
+    expect(timeline.items[2]).toMatchObject({
+      id: 'event-voicemail-001',
+      channel: 'voicemail',
+      type: 'voicemail',
+      recordingUrl: 'https://example.test/vm-001.mp3',
+      durationSeconds: 42,
+    });
+    expect(timeline.items[3]).toMatchObject({
+      id: 'event-voicemail-002',
+      channel: 'voicemail',
+      type: 'voicemail',
+      transcript: 'Leave package at the side door',
+    });
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts
@@ -43,6 +43,7 @@ export type ConnectShyftCanonicalEventListFilters = {
   aggregateType?: string | null;
   eventType?: string | null;
   limit?: number;
+  window?: 'oldest' | 'most_recent';
 };
 
 const CONNECTSHYFT_PROVIDER_SPECIFIC_KEYS = new Set([
@@ -85,6 +86,10 @@ const normalizeLimit = (value: unknown): number => {
   }
 
   return Math.min(normalized, MAX_LIST_LIMIT);
+};
+
+const normalizeWindow = (value: unknown): 'oldest' | 'most_recent' => {
+  return value === 'most_recent' ? 'most_recent' : 'oldest';
 };
 
 const sortCanonicalEvents = (
@@ -175,6 +180,7 @@ const listInMemory = (
   const eventType = normalizeString(filters.eventType);
   const orgUnitId = normalizeString(filters.orgUnitId);
   const limit = normalizeLimit(filters.limit);
+  const window = normalizeWindow(filters.window);
 
   const filtered = inMemoryCanonicalEvents.filter((entry) => {
     if (entry.tenantId !== filters.tenantId) {
@@ -200,7 +206,10 @@ const listInMemory = (
     return true;
   });
 
-  return sortCanonicalEvents(filtered.map((entry) => entry.record)).slice(0, limit);
+  const sorted = sortCanonicalEvents(filtered.map((entry) => entry.record));
+  return window === 'most_recent'
+    ? sorted.slice(-limit)
+    : sorted.slice(0, limit);
 };
 
 const listFromDb = async (
@@ -208,6 +217,8 @@ const listFromDb = async (
   filters: ConnectShyftCanonicalEventListFilters,
 ): Promise<ConnectShyftCanonicalEventRecord[]> => {
   const limit = normalizeLimit(filters.limit);
+  const window = normalizeWindow(filters.window);
+  const orderDirection = window === 'most_recent' ? 'desc' : 'asc';
   const query = db
     .withSchema('platform')
     .table('events')
@@ -215,8 +226,8 @@ const listFromDb = async (
       tenant_id: filters.tenantId,
       event_name: CONNECTSHYFT_CANONICAL_EVENT_NAME,
     })
-    .orderBy('occurred_at_utc', 'asc')
-    .orderBy('id', 'asc')
+    .orderBy('occurred_at_utc', orderDirection)
+    .orderBy('id', orderDirection)
     .limit(limit)
     .select([
       'id',
@@ -278,7 +289,10 @@ const listFromDb = async (
     })
     .filter((row): row is ConnectShyftCanonicalEventRecord => row !== null);
 
-  return sortCanonicalEvents(mapped).slice(0, limit);
+  const sorted = sortCanonicalEvents(mapped);
+  return window === 'most_recent'
+    ? sorted.slice(-limit)
+    : sorted.slice(0, limit);
 };
 
 export const recordConnectShyftCanonicalEvent = async (

--- a/apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts
@@ -107,6 +107,7 @@ export type ConnectShyftInboundSmsDomainEvent = {
   routingDecision: 'accepted';
   deterministicOrdering: true;
   canonicalEventType: string;
+  actor: 'neighbor';
   inboundMessageArtifact: ConnectShyftInboundSmsArtifact;
 };
 
@@ -171,6 +172,7 @@ export const mapConnectShyftInboundSmsWebhookToDomainEvent = (input: {
     routingDecision: 'accepted',
     deterministicOrdering: true,
     canonicalEventType: normalizeString(input.canonicalEventType) || 'MessageDelivered',
+    actor: 'neighbor',
     inboundMessageArtifact: {
       channel: 'sms',
       direction: 'inbound',
@@ -192,6 +194,7 @@ export const buildConnectShyftInboundSmsCanonicalPayload = (input: {
   channel: 'sms',
   eventType: input.domainEvent.canonicalEventType,
   eventName: input.domainEvent.eventName,
+  actor: input.domainEvent.actor,
   routingDecision: input.domainEvent.routingDecision,
   deterministicOrdering: input.domainEvent.deterministicOrdering,
   threadState: input.threadState,

--- a/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
@@ -60,6 +60,12 @@ export type ConnectShyftThreadDetailRecord = ConnectShyftThreadSummaryRecord & {
   };
 };
 
+export type ConnectShyftThreadTimelineMetadata = {
+  threadId: string;
+  neighborDeleted: boolean;
+  neighborDeletedAtUtc: string | null;
+};
+
 type ConnectShyftThreadSeed = {
   tenantId: string;
   orgUnitId: string;
@@ -1409,6 +1415,17 @@ const resolveBucketFromDbRow = (
 
   return 'inbox';
 };
+
+export const resolveConnectShyftThreadTimelineMetadata = (
+  thread: Pick<
+    ConnectShyftThreadSummaryRecord | ConnectShyftThreadDetailRecord,
+    'threadId' | 'neighborDeleted' | 'neighborDeletedAtUtc'
+  >,
+): ConnectShyftThreadTimelineMetadata => ({
+  threadId: normalizeString(thread.threadId),
+  neighborDeleted: thread.neighborDeleted === true,
+  neighborDeletedAtUtc: normalizeOptionalString(thread.neighborDeletedAtUtc),
+});
 
 export const resolveConnectShyftThreadDetailContractAsync = async (input: {
   tenantId: string;

--- a/apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts
@@ -1,0 +1,388 @@
+import type { Knex } from 'knex';
+import {
+  listConnectShyftCanonicalEvents,
+  type ConnectShyftCanonicalEventRecord,
+} from './canonicalEvents';
+import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from './inboundSms';
+import {
+  CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+  CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME,
+} from './inboundVoice';
+
+export const CONNECTSHYFT_THREAD_TIMELINE_DEFAULT_LIMIT = 200;
+export const CONNECTSHYFT_THREAD_TIMELINE_MAX_LIMIT = 200;
+export const CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME = 'connectshyft.outbound.sms_appended' as const;
+export const CONNECTSHYFT_OUTBOUND_SMS_EVENT_NAME_ALIAS = 'connectshyft.thread.outbound_message_dispatched' as const;
+export const CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES = {
+  started: 'connectshyft.voice.started',
+  connected: 'connectshyft.voice.connected',
+  ended: 'connectshyft.voice.ended',
+  outboundDispatched: 'connectshyft.thread.outbound_call_dispatched',
+} as const;
+
+export type ConnectShyftThreadTimelineDirection = 'inbound' | 'outbound';
+export type ConnectShyftThreadTimelineChannel = 'sms' | 'voice' | 'voicemail';
+export type ConnectShyftThreadTimelineActor = 'system' | 'user' | 'neighbor';
+export type ConnectShyftThreadTimelineItemType = 'message' | 'voice_event' | 'voicemail';
+
+type ConnectShyftThreadTimelineItemBase = {
+  id: string;
+  threadId: string;
+  direction: ConnectShyftThreadTimelineDirection;
+  occurredAtUtc: string;
+  actor: ConnectShyftThreadTimelineActor;
+  providerMetadata: Record<string, unknown> | null;
+  deliveryStatus: string | null;
+};
+
+export type ConnectShyftSmsTimelineItem = ConnectShyftThreadTimelineItemBase & {
+  type: 'message';
+  channel: 'sms';
+  body: string;
+};
+
+export type ConnectShyftVoiceEventTimelineItem = ConnectShyftThreadTimelineItemBase & {
+  type: 'voice_event';
+  channel: 'voice';
+  body: null;
+};
+
+export type ConnectShyftVoicemailTimelineItem = ConnectShyftThreadTimelineItemBase & {
+  type: 'voicemail';
+  channel: 'voicemail';
+  body: null;
+  recordingUrl: string | null;
+  durationSeconds: number | null;
+  transcript: string | null;
+};
+
+export type ConnectShyftThreadTimelineItem =
+  | ConnectShyftSmsTimelineItem
+  | ConnectShyftVoiceEventTimelineItem
+  | ConnectShyftVoicemailTimelineItem;
+
+export type ConnectShyftThreadTimelineResult = {
+  threadId: string;
+  source: 'canonical_events';
+  deterministic: true;
+  limitApplied: number;
+  items: ConnectShyftThreadTimelineItem[];
+};
+
+export type GetThreadTimelineInput = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  limit?: number | null;
+  db?: Knex;
+};
+
+type TimelineEventMapper = (
+  event: ConnectShyftCanonicalEventRecord,
+  payload: Record<string, unknown>,
+) => ConnectShyftThreadTimelineItem | null;
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+};
+
+const normalizeDirection = (
+  value: unknown,
+): ConnectShyftThreadTimelineDirection | null => {
+  return value === 'inbound' || value === 'outbound'
+    ? value
+    : null;
+};
+
+const normalizeActor = (
+  value: unknown,
+): ConnectShyftThreadTimelineActor | null => {
+  return value === 'system' || value === 'user' || value === 'neighbor'
+    ? value
+    : null;
+};
+
+const normalizeDurationSeconds = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.trunc(value));
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value.trim());
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.trunc(parsed));
+    }
+  }
+
+  return null;
+};
+
+const resolveTimelineBase = (input: {
+  event: ConnectShyftCanonicalEventRecord;
+  payload: Record<string, unknown>;
+  direction: ConnectShyftThreadTimelineDirection;
+  actor: ConnectShyftThreadTimelineActor;
+}): ConnectShyftThreadTimelineItemBase => ({
+  id: input.event.eventId,
+  threadId: input.event.aggregateId,
+  direction: input.direction,
+  occurredAtUtc: input.event.occurredAtUtc,
+  actor: input.actor,
+  providerMetadata: asRecord(input.payload.providerMetadata),
+  deliveryStatus: normalizeString(input.payload.deliveryStatus) || null,
+});
+
+const resolveMessageArtifact = (
+  payload: Record<string, unknown>,
+  artifactKey: 'inboundMessageArtifact' | 'outboundMessageArtifact',
+): Record<string, unknown> | null => {
+  return asRecord(payload[artifactKey]);
+};
+
+const resolveVoiceOrVoicemailArtifact = (
+  payload: Record<string, unknown>,
+): Record<string, unknown> | null => {
+  return asRecord(payload.voicemailArtifact);
+};
+
+const resolveTimelineActor = (input: {
+  payload: Record<string, unknown>;
+  fallbackDirection: ConnectShyftThreadTimelineDirection;
+  outboundFallback?: 'system' | 'user';
+}): ConnectShyftThreadTimelineActor => {
+  const actor = normalizeActor(input.payload.actor);
+  if (actor) {
+    return actor;
+  }
+
+  if (input.fallbackDirection === 'inbound') {
+    return 'neighbor';
+  }
+
+  return input.outboundFallback || 'system';
+};
+
+const mapInboundSmsTimelineEvent: TimelineEventMapper = (event, payload) => {
+  const artifact = resolveMessageArtifact(payload, 'inboundMessageArtifact');
+  const body = normalizeString(artifact?.body);
+  if (!body) {
+    return null;
+  }
+
+  return {
+    ...resolveTimelineBase({
+      event,
+      payload,
+      direction: 'inbound',
+      actor: resolveTimelineActor({
+        payload,
+        fallbackDirection: 'inbound',
+      }),
+    }),
+    type: 'message',
+    channel: 'sms',
+    body,
+  };
+};
+
+const mapOutboundSmsTimelineEvent: TimelineEventMapper = (event, payload) => {
+  const artifact = resolveMessageArtifact(payload, 'outboundMessageArtifact');
+  const body = normalizeString(artifact?.body);
+  if (!body) {
+    return null;
+  }
+
+  return {
+    ...resolveTimelineBase({
+      event,
+      payload,
+      direction: 'outbound',
+      actor: resolveTimelineActor({
+        payload,
+        fallbackDirection: 'outbound',
+        outboundFallback: 'system',
+      }),
+    }),
+    type: 'message',
+    channel: 'sms',
+    body,
+  };
+};
+
+const mapVoiceEventTimelineEvent: TimelineEventMapper = (event, payload) => {
+  const direction = normalizeDirection(payload.direction) || 'inbound';
+
+  return {
+    ...resolveTimelineBase({
+      event,
+      payload,
+      direction,
+      actor: resolveTimelineActor({
+        payload,
+        fallbackDirection: direction,
+      }),
+    }),
+    type: 'voice_event',
+    channel: 'voice',
+    body: null,
+  };
+};
+
+const mapVoicemailTimelineEvent: TimelineEventMapper = (event, payload) => {
+  const artifact = resolveVoiceOrVoicemailArtifact(payload);
+  const transcription = asRecord(artifact?.transcription);
+  const metadata = asRecord(payload.metadata);
+
+  return {
+    ...resolveTimelineBase({
+      event,
+      payload,
+      direction: normalizeDirection(payload.direction) || 'inbound',
+      actor: resolveTimelineActor({
+        payload,
+        fallbackDirection: 'inbound',
+      }),
+    }),
+    type: 'voicemail',
+    channel: 'voicemail',
+    body: null,
+    recordingUrl: normalizeString(artifact?.recordingUrl) || null,
+    durationSeconds: normalizeDurationSeconds(artifact?.durationSeconds),
+    transcript: normalizeString(transcription?.text)
+      || normalizeString(metadata?.transcriptText)
+      || null,
+  };
+};
+
+const CONNECTSHYFT_TIMELINE_MAPPERS = new Map<string, TimelineEventMapper>([
+  [CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME, mapInboundSmsTimelineEvent],
+  [CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME, mapOutboundSmsTimelineEvent],
+  [CONNECTSHYFT_OUTBOUND_SMS_EVENT_NAME_ALIAS, mapOutboundSmsTimelineEvent],
+  [CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started, mapVoiceEventTimelineEvent],
+  [CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.connected, mapVoiceEventTimelineEvent],
+  [CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.ended, mapVoiceEventTimelineEvent],
+  [CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.outboundDispatched, mapVoiceEventTimelineEvent],
+  ['CallAttemptStarted', mapVoiceEventTimelineEvent],
+  ['CallConnected', mapVoiceEventTimelineEvent],
+  [CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME, mapVoiceEventTimelineEvent],
+  [CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME, mapVoicemailTimelineEvent],
+  [CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME, mapVoicemailTimelineEvent],
+  [CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME, mapVoicemailTimelineEvent],
+]);
+
+const resolveEventKeys = (
+  event: ConnectShyftCanonicalEventRecord,
+  payload: Record<string, unknown>,
+): string[] => {
+  const keys = new Set<string>();
+  const eventName = normalizeString(payload.eventName);
+  const lifecycleEvent = normalizeString(payload.lifecycleEvent);
+
+  if (eventName) {
+    keys.add(eventName);
+  }
+  if (lifecycleEvent) {
+    keys.add(lifecycleEvent);
+  }
+  if (event.eventType) {
+    keys.add(event.eventType);
+  }
+
+  return [...keys];
+};
+
+export const normalizeConnectShyftThreadTimelineLimit = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return CONNECTSHYFT_THREAD_TIMELINE_DEFAULT_LIMIT;
+  }
+
+  const normalized = Math.trunc(value);
+  if (normalized <= 0) {
+    return CONNECTSHYFT_THREAD_TIMELINE_DEFAULT_LIMIT;
+  }
+
+  return Math.min(normalized, CONNECTSHYFT_THREAD_TIMELINE_MAX_LIMIT);
+};
+
+export const mapConnectShyftCanonicalEventToTimelineItem = (
+  event: ConnectShyftCanonicalEventRecord,
+): ConnectShyftThreadTimelineItem | null => {
+  const payload = asRecord(event.payload);
+  if (!payload) {
+    return null;
+  }
+
+  for (const key of resolveEventKeys(event, payload)) {
+    const mapper = CONNECTSHYFT_TIMELINE_MAPPERS.get(key);
+    if (!mapper) {
+      continue;
+    }
+
+    const item = mapper(event, payload);
+    if (item) {
+      return item;
+    }
+  }
+
+  return null;
+};
+
+export const sortConnectShyftThreadTimelineItems = (
+  items: readonly ConnectShyftThreadTimelineItem[],
+): ConnectShyftThreadTimelineItem[] => {
+  return [...items].sort((left, right) => {
+    const occurredAtDelta = (
+      new Date(left.occurredAtUtc).getTime()
+      - new Date(right.occurredAtUtc).getTime()
+    );
+    if (occurredAtDelta !== 0) {
+      return occurredAtDelta;
+    }
+
+    return left.id.localeCompare(right.id);
+  });
+};
+
+export const getThreadTimeline = async (
+  input: GetThreadTimelineInput,
+): Promise<ConnectShyftThreadTimelineResult> => {
+  const threadId = normalizeString(input.threadId);
+  const limitApplied = normalizeConnectShyftThreadTimelineLimit(input.limit);
+  const events = await listConnectShyftCanonicalEvents({
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    aggregateId: threadId,
+    aggregateType: 'Thread',
+    limit: CONNECTSHYFT_THREAD_TIMELINE_MAX_LIMIT,
+    window: 'most_recent',
+    db: input.db,
+  });
+
+  const items = sortConnectShyftThreadTimelineItems(
+    events
+      .map((event) => mapConnectShyftCanonicalEventToTimelineItem(event))
+      .filter((item): item is ConnectShyftThreadTimelineItem => item !== null),
+  );
+
+  return {
+    threadId,
+    source: 'canonical_events',
+    deterministic: true,
+    limitApplied,
+    items: items.slice(-limitApplied),
+  };
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts
@@ -1,0 +1,70 @@
+import type {
+  ConnectShyftThreadTimelineItem,
+  ConnectShyftThreadTimelineResult,
+} from './threadTimeline';
+
+export type ConnectShyftThreadTimelineItemDto = {
+  id: string;
+  thread_id: string;
+  type: 'message' | 'voice_event' | 'voicemail';
+  direction: 'inbound' | 'outbound';
+  channel: 'sms' | 'voice' | 'voicemail';
+  body: string | null;
+  occurred_at_utc: string;
+  actor: 'system' | 'user' | 'neighbor';
+  provider_metadata: Record<string, unknown> | null;
+  delivery_status: string | null;
+  recording_url?: string | null;
+  duration_seconds?: number | null;
+  transcript?: string | null;
+};
+
+export type ConnectShyftThreadTimelineResponseDto = {
+  thread_id: string;
+  neighbor_deleted: boolean;
+  neighbor_deleted_at_utc: string | null;
+  deterministic: true;
+  limit_applied: number;
+  items: ConnectShyftThreadTimelineItemDto[];
+};
+
+const serializeConnectShyftThreadTimelineItem = (
+  item: ConnectShyftThreadTimelineItem,
+): ConnectShyftThreadTimelineItemDto => {
+  const base = {
+    id: item.id,
+    thread_id: item.threadId,
+    type: item.type,
+    direction: item.direction,
+    channel: item.channel,
+    body: item.body,
+    occurred_at_utc: item.occurredAtUtc,
+    actor: item.actor,
+    provider_metadata: item.providerMetadata,
+    delivery_status: item.deliveryStatus,
+  } satisfies ConnectShyftThreadTimelineItemDto;
+
+  if (item.type !== 'voicemail') {
+    return base;
+  }
+
+  return {
+    ...base,
+    recording_url: item.recordingUrl,
+    duration_seconds: item.durationSeconds,
+    transcript: item.transcript,
+  };
+};
+
+export const serializeConnectShyftThreadTimelineResponse = (input: {
+  timeline: ConnectShyftThreadTimelineResult;
+  neighborDeleted: boolean;
+  neighborDeletedAtUtc: string | null;
+}): ConnectShyftThreadTimelineResponseDto => ({
+  thread_id: input.timeline.threadId,
+  neighbor_deleted: input.neighborDeleted,
+  neighbor_deleted_at_utc: input.neighborDeletedAtUtc,
+  deterministic: input.timeline.deterministic,
+  limit_applied: input.timeline.limitApplied,
+  items: input.timeline.items.map(serializeConnectShyftThreadTimelineItem),
+});

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts
@@ -5,6 +5,10 @@ import * as canonicalEventsModule from '../../../../modules/connectshyft/canonic
 import * as identityResolverModule from '../../../../modules/connectshyft/identityResolver';
 import * as neighborsModule from '../../../../modules/connectshyft/neighbors';
 import { AsyncConnectShyftNeighborService } from '../../../../modules/connectshyft/neighbors';
+import {
+  connectShyftNumberMappingServiceAsync,
+  type ConnectShyftNumberMapping,
+} from '../../../../modules/connectshyft/numberMappings';
 import { AsyncConnectShyftThreadService } from '../../../../modules/connectshyft/threads';
 import {
   buildApp,
@@ -103,8 +107,160 @@ const mockInboundSmsPersistence = (input?: {
     },
   };
 };
+
+const buildNumberMapping = (
+  overrides: Partial<ConnectShyftNumberMapping> & Pick<
+    ConnectShyftNumberMapping,
+    'mappingId' | 'tenantId' | 'orgUnitId' | 'twilioNumberE164' | 'label'
+  >,
+): ConnectShyftNumberMapping => ({
+  mappingId: overrides.mappingId,
+  tenantId: overrides.tenantId,
+  orgUnitId: overrides.orgUnitId,
+  twilioNumberE164: overrides.twilioNumberE164,
+  label: overrides.label,
+  isActive: overrides.isActive ?? true,
+  createdAtUtc: overrides.createdAtUtc ?? '2026-03-18T12:00:00.000Z',
+  updatedAtUtc: overrides.updatedAtUtc ?? '2026-03-18T12:00:00.000Z',
+});
+
+const buildTenantOrgUnitKey = (tenantId: string, orgUnitId: string): string =>
+  `${tenantId}::${orgUnitId}`;
+
+const cloneMappings = (
+  mappings: readonly ConnectShyftNumberMapping[],
+): ConnectShyftNumberMapping[] => [...mappings]
+  .map((mapping) => ({ ...mapping }))
+  .sort((left, right) => {
+    if (left.twilioNumberE164 !== right.twilioNumberE164) {
+      return left.twilioNumberE164.localeCompare(right.twilioNumberE164);
+    }
+    return left.mappingId.localeCompare(right.mappingId);
+  });
+
+const buildDefaultNumberMappingState = (): Map<string, ConnectShyftNumberMapping[]> => new Map([
+  [
+    buildTenantOrgUnitKey('tenant-connectshyft-f1', 'org-connectshyft-f1-east'),
+    cloneMappings([
+      buildNumberMapping({
+        mappingId: 'mapping-f1-001',
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        twilioNumberE164: '+12605550191',
+        label: 'Front Desk',
+      }),
+    ]),
+  ],
+  [
+    buildTenantOrgUnitKey('tenant-connectshyft-f2', 'org-connectshyft-f2-east'),
+    cloneMappings([
+      buildNumberMapping({
+        mappingId: 'mapping-f2-001',
+        tenantId: 'tenant-connectshyft-f2',
+        orgUnitId: 'org-connectshyft-f2-east',
+        twilioNumberE164: '+12605550192',
+        label: 'F2 East Primary',
+      }),
+    ]),
+  ],
+]);
 describe('connectshyft provider adapter registry route integration - dispatch and canonical events', () => {
   registerProviderRegistryRouteIntegrationHooks();
+  let numberMappingsByScope: Map<string, ConnectShyftNumberMapping[]>;
+  let listMappingsSpy: jest.SpyInstance;
+  let createMappingSpy: jest.SpyInstance;
+  let updateMappingSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    numberMappingsByScope = buildDefaultNumberMappingState();
+
+    listMappingsSpy = jest.spyOn(connectShyftNumberMappingServiceAsync, 'listMappings').mockImplementation(
+      async (tenantId: string, orgUnitId: string) =>
+        cloneMappings(numberMappingsByScope.get(buildTenantOrgUnitKey(tenantId, orgUnitId)) || []),
+    );
+
+    createMappingSpy = jest.spyOn(connectShyftNumberMappingServiceAsync, 'createMapping').mockImplementation(
+      async (input) => {
+        const scopeKey = buildTenantOrgUnitKey(input.tenantId, input.orgUnitId);
+        const nextMapping = buildNumberMapping({
+          mappingId: input.mappingId || `mapping-${input.tenantId}-${input.orgUnitId}-${input.twilioNumberE164}`,
+          tenantId: input.tenantId,
+          orgUnitId: input.orgUnitId,
+          twilioNumberE164: input.twilioNumberE164,
+          label: input.label,
+          isActive: input.isActive,
+        });
+        const nextMappings = cloneMappings([
+          ...(numberMappingsByScope.get(scopeKey) || []),
+          nextMapping,
+        ]);
+        numberMappingsByScope.set(scopeKey, nextMappings);
+
+        return {
+          ok: true as const,
+          code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED' as const,
+          httpStatus: 201 as const,
+          data: {
+            mappingId: nextMapping.mappingId,
+            orgUnitId: nextMapping.orgUnitId,
+            twilioNumberE164: nextMapping.twilioNumberE164,
+            label: nextMapping.label,
+            isActive: nextMapping.isActive,
+            mappings: cloneMappings(nextMappings),
+          },
+        };
+      },
+    );
+
+    updateMappingSpy = jest.spyOn(connectShyftNumberMappingServiceAsync, 'updateMapping').mockImplementation(
+      async (input) => {
+        const scopeKey = buildTenantOrgUnitKey(input.tenantId, input.orgUnitId);
+        const currentMappings = numberMappingsByScope.get(scopeKey) || [];
+        const existing = currentMappings.find((mapping) => mapping.mappingId === input.mappingId);
+        if (!existing) {
+          return {
+            ok: false as const,
+            code: 'CONNECTSHYFT_NUMBER_MAPPING_NOT_FOUND' as const,
+            message: 'Number mapping not found for this tenant and orgUnit.',
+          };
+        }
+
+        const nextMappings = cloneMappings(currentMappings.map((mapping) => (
+          mapping.mappingId === input.mappingId
+            ? {
+              ...mapping,
+              twilioNumberE164: input.twilioNumberE164,
+              label: input.label,
+              isActive: input.isActive,
+              updatedAtUtc: '2026-03-18T12:00:00.000Z',
+            }
+            : mapping
+        )));
+        const updated = nextMappings.find((mapping) => mapping.mappingId === input.mappingId)!;
+        numberMappingsByScope.set(scopeKey, nextMappings);
+
+        return {
+          ok: true as const,
+          code: 'CONNECTSHYFT_NUMBER_MAPPING_UPDATED' as const,
+          httpStatus: 200 as const,
+          data: {
+            mappingId: updated.mappingId,
+            orgUnitId: updated.orgUnitId,
+            twilioNumberE164: updated.twilioNumberE164,
+            label: updated.label,
+            isActive: updated.isActive,
+            mappings: cloneMappings(nextMappings),
+          },
+        };
+      },
+    );
+  });
+
+  afterEach(() => {
+    updateMappingSpy.mockRestore();
+    createMappingSpy.mockRestore();
+    listMappingsSpy.mockRestore();
+  });
 
   it('dispatches outbound call through deterministic provider adapter resolution metadata', async () => {
     const app = buildApp();
@@ -243,6 +399,64 @@ describe('connectshyft provider adapter registry route integration - dispatch an
       resolveSubjectSpy.mockRestore();
       resolveActiveSpy.mockRestore();
       restore();
+    }
+  });
+
+  it('records projection-ready outbound sms canonical payloads for timeline reads', async () => {
+    const app = buildApp();
+    const canonicalEventSpy = jest.spyOn(
+      canonicalEventsModule,
+      'recordConnectShyftCanonicalEvent',
+    ).mockResolvedValue({
+      eventId: 'canonical-event-outbound-1',
+      aggregateId: 'thread-f1-unclaimed-1001',
+      aggregateType: 'Thread',
+      eventType: 'MessageQueued',
+      payload: {},
+      occurredAtUtc: '2026-03-18T12:00:00.000Z',
+    } as any);
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/threads/thread-f1-unclaimed-1001/messages')
+        .set(buildHeaders())
+        .send({
+          orgUnitId: 'org-connectshyft-f1-east',
+          providerKey: 'telnyx',
+          channel: 'sms',
+          body: 'Projection-ready outbound message',
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+      });
+      expect(canonicalEventSpy).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        aggregateId: 'thread-f1-unclaimed-1001',
+        eventType: 'MessageQueued',
+        payload: expect.objectContaining({
+          direction: 'outbound',
+          channel: 'sms',
+          actor: 'user',
+          eventName: 'connectshyft.outbound.sms_appended',
+          lifecycleEvent: 'connectshyft.thread.outbound_message_dispatched',
+          outboundMessageArtifact: expect.objectContaining({
+            direction: 'outbound',
+            channel: 'sms',
+            body: 'Projection-ready outbound message',
+          }),
+        }),
+      }));
+
+      const recordedPayload = canonicalEventSpy.mock.calls[0]?.[0]?.payload as Record<string, unknown>;
+      const outboundArtifact = recordedPayload?.outboundMessageArtifact as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(outboundArtifact, 'from')).toBe(true);
+      expect(Object.prototype.hasOwnProperty.call(outboundArtifact, 'to')).toBe(true);
+    } finally {
+      canonicalEventSpy.mockRestore();
     }
   });
 
@@ -726,6 +940,23 @@ describe('connectshyft provider adapter registry route integration - dispatch an
       expect(event.aggregateId).toBe(threadId);
       expect(event.aggregateType).toBe('Thread');
       expectProviderSpecificLeakageRemoved(event.payload);
+    });
+
+    const outboundSmsEvent = events.find((event) =>
+      event.eventType === 'MessageQueued'
+      && event.payload?.eventName === 'connectshyft.outbound.sms_appended',
+    );
+    expect(outboundSmsEvent).toMatchObject({
+      payload: {
+        direction: 'outbound',
+        channel: 'sms',
+        actor: 'user',
+        eventName: 'connectshyft.outbound.sms_appended',
+        lifecycleEvent: 'connectshyft.thread.outbound_message_dispatched',
+        outboundMessageArtifact: {
+          body: 'Story f2 canonical store test message.',
+        },
+      },
     });
   });
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts
@@ -1,0 +1,441 @@
+// @ts-nocheck
+import request from 'supertest';
+import {
+  recordConnectShyftCanonicalEvent,
+  resetConnectShyftCanonicalEventsForTests,
+} from '../../../../modules/connectshyft/canonicalEvents';
+import * as ReadContractsModule from '../../../../modules/connectshyft/readContracts';
+import {
+  CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+} from '../../../../modules/connectshyft/inboundSms';
+import {
+  CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+  CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES,
+} from '../../../../modules/connectshyft/threadTimeline';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TENANT_ID = 'tenant-connectshyft-f1';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-f1-east';
+
+const buildThreadDetailRecord = (overrides: Record<string, unknown> = {}) => ({
+  threadId: 'thread-timeline-1001',
+  neighborId: 'neighbor-timeline-1001',
+  neighborDeleted: false,
+  neighbor_deleted: false,
+  neighborDeletedAtUtc: null,
+  neighbor_deleted_at_utc: null,
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  state: 'CLAIMED',
+  claimedByUserId: 'user-connectshyft-f1-operator',
+  claimed_by_user_id: 'user-connectshyft-f1-operator',
+  bucket: 'mine',
+  escalationStage: 1,
+  isNewUnread: false,
+  priorityRank: 3,
+  urgencyLabel: 'Needs attention soon',
+  lastActivityAtUtc: '2026-03-19T10:05:00.000Z',
+  lastInboundCsNumberId: 'cs-number-1001',
+  last_inbound_cs_number_id: 'cs-number-1001',
+  preferredOutboundCsNumberId: 'cs-number-2001',
+  preferred_outbound_cs_number_id: 'cs-number-2001',
+  preferredOutboundContext: {
+    csNumberId: 'cs-number-2001',
+    label: 'Primary Queue',
+  },
+  preferred_outbound_context: {
+    cs_number_id: 'cs-number-2001',
+    label: 'Primary Queue',
+  },
+  voicemailIndicator: false,
+  voicemailLabel: null,
+  summary: 'Timeline thread detail',
+  actions: ['Call', 'Text', 'Close'],
+  lifecycle: {
+    reopenedByInbound: false,
+  },
+  ...overrides,
+});
+
+const recordTimelineEvent = async (input: {
+  threadId: string;
+  eventType: string;
+  occurredAtUtc: string;
+  payload: Record<string, unknown>;
+}) => recordConnectShyftCanonicalEvent({
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  aggregateId: input.threadId,
+  aggregateType: 'Thread',
+  eventType: input.eventType,
+  occurredAtUtc: input.occurredAtUtc,
+  payload: input.payload,
+});
+
+describe('connectshyft thread timeline route', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  beforeEach(() => {
+    resetConnectShyftCanonicalEventsForTests();
+  });
+
+  afterEach(() => {
+    resetConnectShyftCanonicalEventsForTests();
+  });
+
+  it('returns an ordered mixed inbound and outbound sms timeline', async () => {
+    const resolveThreadSpy = jest.spyOn(
+      ReadContractsModule,
+      'resolveConnectShyftThreadDetailContractAsync',
+    ).mockResolvedValue(buildThreadDetailRecord({
+      threadId: 'thread-timeline-ordered-1001',
+    }) as any);
+
+    try {
+      await recordTimelineEvent({
+        threadId: 'thread-timeline-ordered-1001',
+        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+        occurredAtUtc: '2026-03-19T10:00:00.000Z',
+        payload: {
+          direction: 'inbound',
+          channel: 'sms',
+          actor: 'neighbor',
+          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+          inboundMessageArtifact: {
+            body: 'Inbound first',
+          },
+        },
+      });
+      await recordTimelineEvent({
+        threadId: 'thread-timeline-ordered-1001',
+        eventType: 'MessageQueued',
+        occurredAtUtc: '2026-03-19T10:01:00.000Z',
+        payload: {
+          direction: 'outbound',
+          channel: 'sms',
+          actor: 'user',
+          eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+          outboundMessageArtifact: {
+            body: 'Outbound second',
+          },
+        },
+      });
+
+      const app = buildApp();
+      const response = await request(app)
+        .get('/api/v1/connectshyft/threads/thread-timeline-ordered-1001/timeline')
+        .set(buildHeaders());
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+        data: {
+          thread_id: 'thread-timeline-ordered-1001',
+          neighbor_deleted: false,
+          neighbor_deleted_at_utc: null,
+          deterministic: true,
+          limit_applied: 200,
+        },
+      });
+      expect(response.body.data.items).toEqual([
+        expect.objectContaining({
+          direction: 'inbound',
+          channel: 'sms',
+          body: 'Inbound first',
+          actor: 'neighbor',
+        }),
+        expect.objectContaining({
+          direction: 'outbound',
+          channel: 'sms',
+          body: 'Outbound second',
+          actor: 'user',
+        }),
+      ]);
+    } finally {
+      resolveThreadSpy.mockRestore();
+    }
+  });
+
+  it('applies a bounded most-recent limit window and returns an empty timeline when no sms events are eligible', async () => {
+    const resolveThreadSpy = jest.spyOn(
+      ReadContractsModule,
+      'resolveConnectShyftThreadDetailContractAsync',
+    ).mockImplementation(async ({ threadId }) => buildThreadDetailRecord({ threadId }) as any);
+
+    try {
+      await recordTimelineEvent({
+        threadId: 'thread-timeline-limit-1001',
+        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+        occurredAtUtc: '2026-03-19T10:00:00.000Z',
+        payload: {
+          direction: 'inbound',
+          channel: 'sms',
+          actor: 'neighbor',
+          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+          inboundMessageArtifact: {
+            body: 'oldest',
+          },
+        },
+      });
+      await recordTimelineEvent({
+        threadId: 'thread-timeline-limit-1001',
+        eventType: 'MessageQueued',
+        occurredAtUtc: '2026-03-19T10:01:00.000Z',
+        payload: {
+          direction: 'outbound',
+          channel: 'sms',
+          actor: 'user',
+          eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+          outboundMessageArtifact: {
+            body: 'middle',
+          },
+        },
+      });
+      await recordTimelineEvent({
+        threadId: 'thread-timeline-limit-1001',
+        eventType: 'MessageQueued',
+        occurredAtUtc: '2026-03-19T10:02:00.000Z',
+        payload: {
+          direction: 'outbound',
+          channel: 'sms',
+          actor: 'user',
+          eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+          outboundMessageArtifact: {
+            body: 'newest',
+          },
+        },
+      });
+
+      const app = buildApp();
+      const limitedResponse = await request(app)
+        .get('/api/v1/connectshyft/threads/thread-timeline-limit-1001/timeline')
+        .query({
+          limit: '2',
+        })
+        .set(buildHeaders());
+      const emptyResponse = await request(app)
+        .get('/api/v1/connectshyft/threads/thread-timeline-empty-1001/timeline')
+        .set(buildHeaders());
+
+      expect(limitedResponse.status).toBe(200);
+      expect(limitedResponse.body.data.limit_applied).toBe(2);
+      expect(limitedResponse.body.data.items.map((item) => item.body)).toEqual([
+        'middle',
+        'newest',
+      ]);
+
+      expect(emptyResponse.status).toBe(200);
+      expect(emptyResponse.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+        data: {
+          thread_id: 'thread-timeline-empty-1001',
+          items: [],
+        },
+      });
+    } finally {
+      resolveThreadSpy.mockRestore();
+    }
+  });
+
+  it('refuses deleted-neighbor timeline review without tenant-privileged admin access', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .get('/api/v1/connectshyft/threads/thread-soft-delete-timeline-1001/timeline')
+      .query({
+        includeDeleted: 'true',
+      })
+      .set(buildHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN',
+      refusalType: 'business',
+    });
+  });
+
+  it('returns deleted-neighbor timelines only through includeDeleted=true and surfaces deletion metadata', async () => {
+    const resolveThreadSpy = jest.spyOn(
+      ReadContractsModule,
+      'resolveConnectShyftThreadDetailContractAsync',
+    ).mockImplementation(async ({ threadId, includeDeleted }) => {
+      if (threadId !== 'thread-soft-delete-timeline-1001') {
+        return null;
+      }
+
+      if (includeDeleted !== true) {
+        return null;
+      }
+
+      return buildThreadDetailRecord({
+        threadId,
+        neighborDeleted: true,
+        neighbor_deleted: true,
+        neighborDeletedAtUtc: '2026-03-19T10:00:00.000Z',
+        neighbor_deleted_at_utc: '2026-03-19T10:00:00.000Z',
+      }) as any;
+    });
+
+    try {
+      await recordTimelineEvent({
+        threadId: 'thread-soft-delete-timeline-1001',
+        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+        occurredAtUtc: '2026-03-19T10:01:00.000Z',
+        payload: {
+          direction: 'inbound',
+          channel: 'sms',
+          actor: 'neighbor',
+          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+          inboundMessageArtifact: {
+            body: 'Deleted neighbor history',
+          },
+        },
+      });
+
+      const app = buildApp();
+      const hiddenResponse = await request(app)
+        .get('/api/v1/connectshyft/threads/thread-soft-delete-timeline-1001/timeline')
+        .set(buildHeaders({
+          'x-test-connectshyft-role': 'TENANT_ADMIN',
+        }));
+      const visibleResponse = await request(app)
+        .get('/api/v1/connectshyft/threads/thread-soft-delete-timeline-1001/timeline')
+        .query({
+          includeDeleted: 'true',
+        })
+        .set(buildHeaders({
+          'x-test-connectshyft-role': 'TENANT_ADMIN',
+        }));
+
+      expect(hiddenResponse.status).toBe(200);
+      expect(hiddenResponse.body).toMatchObject({
+        ok: false,
+        code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      });
+
+      expect(visibleResponse.status).toBe(200);
+      expect(visibleResponse.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+        data: {
+          thread_id: 'thread-soft-delete-timeline-1001',
+          neighbor_deleted: true,
+          neighbor_deleted_at_utc: '2026-03-19T10:00:00.000Z',
+          items: [
+            expect.objectContaining({
+              body: 'Deleted neighbor history',
+            }),
+          ],
+        },
+      });
+    } finally {
+      resolveThreadSpy.mockRestore();
+    }
+  });
+
+  it('keeps timeline reads tenant-scoped and validates thread existence through the read contract', async () => {
+    const resolveThreadSpy = jest.spyOn(
+      ReadContractsModule,
+      'resolveConnectShyftThreadDetailContractAsync',
+    ).mockResolvedValue(null);
+
+    try {
+      const app = buildApp();
+      const response = await request(app)
+        .get('/api/v1/connectshyft/threads/thread-cross-tenant-hidden-1001/timeline')
+        .set(buildHeaders({
+          'x-test-connectshyft-tenant-id': 'tenant-connectshyft-f1',
+          'x-test-connectshyft-orgunit-id': 'org-connectshyft-f1-east',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      });
+      expect(resolveThreadSpy).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-cross-tenant-hidden-1001',
+        includeDeleted: false,
+      }));
+    } finally {
+      resolveThreadSpy.mockRestore();
+    }
+  });
+
+  it('keeps future voice placeholders in stable order alongside sms items', async () => {
+    const resolveThreadSpy = jest.spyOn(
+      ReadContractsModule,
+      'resolveConnectShyftThreadDetailContractAsync',
+    ).mockResolvedValue(buildThreadDetailRecord({
+      threadId: 'thread-timeline-voice-1001',
+    }) as any);
+
+    try {
+      await recordTimelineEvent({
+        threadId: 'thread-timeline-voice-1001',
+        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+        occurredAtUtc: '2026-03-19T10:00:00.000Z',
+        payload: {
+          direction: 'inbound',
+          channel: 'sms',
+          actor: 'neighbor',
+          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+          inboundMessageArtifact: {
+            body: 'sms first',
+          },
+        },
+      });
+      await recordTimelineEvent({
+        threadId: 'thread-timeline-voice-1001',
+        eventType: CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started,
+        occurredAtUtc: '2026-03-19T10:01:00.000Z',
+        payload: {
+          direction: 'outbound',
+          channel: 'voice',
+          actor: 'user',
+          eventName: CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started,
+        },
+      });
+      await recordTimelineEvent({
+        threadId: 'thread-timeline-voice-1001',
+        eventType: 'MessageQueued',
+        occurredAtUtc: '2026-03-19T10:02:00.000Z',
+        payload: {
+          direction: 'outbound',
+          channel: 'sms',
+          actor: 'user',
+          eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+          outboundMessageArtifact: {
+            body: 'sms last',
+          },
+        },
+      });
+
+      const app = buildApp();
+      const response = await request(app)
+        .get('/api/v1/connectshyft/threads/thread-timeline-voice-1001/timeline')
+        .set(buildHeaders());
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.items.map((item) => item.type)).toEqual([
+        'message',
+        'voice_event',
+        'message',
+      ]);
+      expect(response.body.data.items[1]).toMatchObject({
+        channel: 'voice',
+        type: 'voice_event',
+      });
+    } finally {
+      resolveThreadSpy.mockRestore();
+    }
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -86,6 +86,7 @@ import {
   resolveConnectShyftInboxContractAsync,
   resolveConnectShyftThreadDetailContract,
   resolveConnectShyftThreadDetailContractAsync,
+  resolveConnectShyftThreadTimelineMetadata,
   type ConnectShyftInboxBucket,
   type ConnectShyftThreadDetailRecord,
 } from '../../../modules/connectshyft/readContracts';
@@ -117,6 +118,12 @@ import {
   recordConnectShyftCanonicalEvent,
   type ConnectShyftCanonicalEventRecord,
 } from '../../../modules/connectshyft/canonicalEvents';
+import {
+  CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+  getThreadTimeline,
+  normalizeConnectShyftThreadTimelineLimit,
+} from '../../../modules/connectshyft/threadTimeline';
+import { serializeConnectShyftThreadTimelineResponse } from '../../../modules/connectshyft/threadTimelineDto';
 import {
   beginConnectShyftWebhookReceiptProcessing,
   cleanupConnectShyftWebhookReceipts,
@@ -2701,6 +2708,14 @@ const parseCanonicalEventsLimit = (req: Request): number => {
   return Math.min(Math.trunc(rawLimit), CONNECTSHYFT_CANONICAL_EVENTS_MAX_LIMIT);
 };
 
+const parseThreadTimelineLimit = (req: Request): number => {
+  const rawLimit = typeof req.query?.limit === 'string'
+    ? Number.parseInt(req.query.limit, 10)
+    : Number.NaN;
+
+  return normalizeConnectShyftThreadTimelineLimit(rawLimit);
+};
+
 const parseCanonicalEventFilters = (req: Request): {
   aggregateId: string | null;
   aggregateType: string | null;
@@ -2788,13 +2803,34 @@ const buildCanonicalPayloadForOutboundAction = (input: {
   threadState: ConnectShyftThreadState;
   lifecycleEvent: string;
   reopenedFromClosed: boolean;
-}): Record<string, unknown> => ({
-  direction: 'outbound',
-  channel: input.outboundAction === 'call' ? 'voice' : 'sms',
-  lifecycleEvent: input.lifecycleEvent,
-  threadState: input.threadState,
-  reopenedFromClosed: input.reopenedFromClosed,
-});
+  actor: 'system' | 'user';
+  messageBody?: string | null;
+  senderPhone?: string | null;
+  targetPhone?: string | null;
+}): Record<string, unknown> => {
+  const isSms = input.outboundAction === 'message';
+
+  return {
+    direction: 'outbound',
+    channel: isSms ? 'sms' : 'voice',
+    actor: input.actor,
+    eventName: isSms
+      ? CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME
+      : input.lifecycleEvent,
+    lifecycleEvent: input.lifecycleEvent,
+    threadState: input.threadState,
+    reopenedFromClosed: input.reopenedFromClosed,
+    outboundMessageArtifact: isSms
+      ? {
+        channel: 'sms',
+        direction: 'outbound',
+        body: normalizeLifecycleString(input.messageBody) || '',
+        from: normalizeLifecycleString(input.senderPhone) || null,
+        to: normalizeLifecycleString(input.targetPhone) || null,
+      }
+      : null,
+  };
+};
 
 const buildCanonicalPayloadForInboundWebhook = (input: {
   eventType: string;
@@ -6794,6 +6830,88 @@ router.get('/events', async (req: Request, res: Response) => {
   });
 });
 
+router.get('/threads/:threadId/timeline', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'inbox')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  const includeDeleted = parseIncludeDeletedQuery(req);
+  if (includeDeleted) {
+    if (!enforceTenantPrivilegedNeighborAdminCapability(req, res, context, {
+      code: 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN',
+      message: 'Deleted neighbor timeline requires a tenant-privileged ConnectShyft admin role.',
+    })) {
+      return;
+    }
+  } else if (!enforceThreadViewCapability(req, res, context)) {
+    return;
+  }
+
+  const threadId = parseThreadIdParam(req);
+  if (!threadId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+      httpStatus: 400,
+    });
+    return;
+  }
+
+  const requestedRole = resolveConnectShyftRequestedRole(req);
+  const actorUserId = resolveConnectShyftRequestedActorUserId(req);
+  const thread = await resolveConnectShyftThreadDetailContractAsync({
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    threadId,
+    actorUserId,
+    requestedRole,
+    includeDeleted,
+    db: loadPlatformDb(),
+  });
+
+  if (!thread) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread detail is unavailable for the requested orgUnit context.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        context: {
+          tenantId: context.tenantId,
+          orgUnitId: context.orgUnitId,
+          bypassedOrgUnitMembership: context.bypassedOrgUnitMembership,
+        },
+      },
+    });
+    return;
+  }
+
+  const timeline = await getThreadTimeline({
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    threadId,
+    limit: parseThreadTimelineLimit(req),
+    db: loadPlatformDb(),
+  });
+  const metadata = resolveConnectShyftThreadTimelineMetadata(thread);
+
+  return success(res, {
+    code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+    message: 'ConnectShyft thread timeline loaded',
+    data: serializeConnectShyftThreadTimelineResponse({
+      timeline,
+      neighborDeleted: metadata.neighborDeleted,
+      neighborDeletedAtUtc: metadata.neighborDeletedAtUtc,
+    }),
+  });
+});
+
 router.get('/threads/:threadId', async (req: Request, res: Response) => {
   if (!await enforceCapability(req, res, 'inbox')) {
     return;
@@ -8267,6 +8385,10 @@ const performOutboundAction = async (
         threadState: thread.state,
         lifecycleEvent: dispatchEventName,
         reopenedFromClosed: lifecycleEvent === CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+        actor: actorUserId ? 'user' : 'system',
+        messageBody: outboundMessagePolicy?.body || null,
+        senderPhone: outboundMessageSenderPhone,
+        targetPhone: outboundMessageTargetPhone,
       }),
       actorUserId,
     });

--- a/specs/025-message-timeline-persistence-and-projection/01-specify.md
+++ b/specs/025-message-timeline-persistence-and-projection/01-specify.md
@@ -1,0 +1,125 @@
+# PR 025 — Message Timeline Persistence + Projection
+
+## Objective
+
+Provide a unified, ordered timeline per thread that includes inbound and outbound SMS as first-class artifacts, with a projection model derived from canonical events. Establish a forward-compatible contract for voice events and voicemails.
+
+---
+
+## Core Requirements
+
+### Files to Include
+
+Create branch 025-message-timeline-persistence-and-projection and use folder specs/025-message-timeline-persistence-and-projection
+
+- specs/025-message-timeline-persistence-and-projection/05-testing.md
+- specs/025-message-timeline-persistence-and-projection/06-pr-template.md
+
+### Source of Truth
+
+- Canonical events are the source of truth.
+- Timeline is a read model (projection) derived from canonical events.
+- No direct writes to timeline storage.
+
+---
+
+### Included Artifacts (Phase 1)
+
+- Inbound SMS
+- Outbound SMS
+
+### Included Artifacts (Contract Only, Not Implemented Yet)
+
+- Voice call events (started, connected, ended)
+- Voicemail artifacts (recording + metadata)
+
+---
+
+### Ordering
+
+Timeline MUST be ordered:
+
+- ascending by event time (oldest → newest)
+
+Tie-breaker:
+
+- stable ordering using (event_time, canonical_event_id)
+
+---
+
+### UI Contract
+
+Render order:
+
+[ message 1 ]
+[ message 2 ]
+…
+[ newest message ]
+
+— divider —
+
+[ message input ]
+[ send button ]
+[ call controls ]
+
+- Input and controls always appear below the newest message.
+
+---
+
+### Timeline Item Shape
+
+Each item MUST include:
+
+- id (canonical_event_id)
+- thread_id
+- direction: inbound | outbound
+- channel: sms (future: voice, voicemail)
+- body (text for SMS)
+- occurred_at_utc
+- actor (system | user | neighbor)
+- provider_metadata (optional)
+- delivery_status (optional, future)
+
+---
+
+### Voicemail Contract (Required Placeholder)
+
+Even if not implemented:
+
+- timeline MUST support type = voicemail
+- voicemail items must include:
+  - recording_url (future)
+  - duration_seconds (future)
+  - transcript (optional future)
+
+---
+
+### Soft Delete Interaction
+
+- threads linked to soft-deleted neighbors remain queryable in admin/debug
+- timeline must still render for admin/debug
+- normal UI must exclude deleted neighbors entirely
+
+---
+
+### Tenant Isolation
+
+- timeline queries must be strictly tenant-scoped
+- no cross-tenant leakage
+
+---
+
+## Constraints
+
+- No direct DB writes from UI layer
+- No timeline mutation outside canonical event pipeline
+- Must support future pagination
+
+---
+
+## Out of Scope
+
+- pagination implementation (basic limit allowed)
+- filtering (sms vs voice)
+- attachments (MMS)
+- read receipts

--- a/specs/025-message-timeline-persistence-and-projection/02-plan.md
+++ b/specs/025-message-timeline-persistence-and-projection/02-plan.md
@@ -1,0 +1,71 @@
+# PR 025 — Plan
+
+## Files to Modify
+
+- canonical event persistence layer
+- thread service
+- API routes (thread retrieval)
+
+## Files to Create
+
+- timeline projection module
+- timeline DTO/serializer
+
+---
+
+## Implementation Strategy
+
+### Step 1 — Projection Layer
+
+Create:
+
+getThreadTimeline({
+tenantId,
+orgUnitId,
+threadId
+})
+
+- loads canonical events
+- maps to timeline items
+- sorts ascending
+
+---
+
+### Step 2 — Mapping Logic
+
+Map canonical events:
+
+- inboundSmsAppended → inbound timeline item
+- outboundSmsAppended → outbound timeline item
+
+---
+
+### Step 3 — API Endpoint
+
+Add:
+
+GET /threads/:threadId/timeline
+
+---
+
+### Step 4 — Thread Annotation
+
+Include:
+
+- neighbor_deleted flag
+- neighbor_deleted_at_utc
+
+---
+
+## Risks
+
+- incorrect ordering
+- missing events
+- performance on large threads
+
+---
+
+## Rollback Strategy
+
+- disable timeline endpoint
+- revert to raw event retrieval

--- a/specs/025-message-timeline-persistence-and-projection/03-tasks.md
+++ b/specs/025-message-timeline-persistence-and-projection/03-tasks.md
@@ -1,0 +1,38 @@
+# PR 025 — Tasks
+
+## Projection
+
+- [ ] Create timeline projection function
+- [ ] Map canonical events to timeline items
+- [ ] Add stable sorting
+
+---
+
+## API
+
+- [ ] Add timeline endpoint
+- [ ] Enforce tenant scoping
+- [ ] Add thread existence validation
+
+---
+
+## Data Mapping
+
+- [ ] inbound SMS mapping
+- [ ] outbound SMS mapping
+- [ ] placeholder for voicemail
+
+---
+
+## Thread Integration
+
+- [ ] include neighbor_deleted flags
+
+---
+
+## Testing
+
+- [ ] ordering correctness
+- [ ] inbound/outbound mix
+- [ ] empty timeline
+- [ ] soft-deleted neighbor visibility (admin only)

--- a/specs/025-message-timeline-persistence-and-projection/04-implement.md
+++ b/specs/025-message-timeline-persistence-and-projection/04-implement.md
@@ -1,0 +1,39 @@
+# PR 025 — Implementation Notes
+
+## Projection Function
+
+function getThreadTimeline(input) {
+const events = loadCanonicalEvents(input);
+
+return events
+.map(mapEventToTimelineItem)
+.sort((a, b) => {
+if (a.occurred_at_utc === b.occurred_at_utc) {
+return a.id.localeCompare(b.id);
+}
+return a.occurred_at_utc - b.occurred_at_utc;
+});
+}
+
+---
+
+## Mapping Example
+
+function mapEventToTimelineItem(event) {
+if (event.type === ‘inboundSmsAppended’) {
+return {
+id: event.id,
+direction: ‘inbound’,
+channel: ‘sms’,
+body: event.payload.message,
+occurred_at_utc: event.occurredAt,
+};
+}
+}
+
+---
+
+## Important
+
+- DO NOT mutate canonical events
+- DO NOT store timeline separately

--- a/specs/025-message-timeline-persistence-and-projection/05-testing.md
+++ b/specs/025-message-timeline-persistence-and-projection/05-testing.md
@@ -1,0 +1,59 @@
+# PR 025 — Testing Obligations
+
+## Unit Tests
+
+- Canonical inbound SMS events project to first-class inbound timeline items with the required identity, actor, channel, and body fields.
+- Canonical outbound SMS events project to first-class outbound timeline items with the required identity, actor, channel, and body fields.
+- Stable ordering sorts by `occurred_at_utc` first and canonical event identifier second when timestamps match.
+- Projection leaves optional `provider_metadata` and future `delivery_status` absent when canonical data is missing instead of failing or inventing values.
+- Projection returns an empty history when no timeline-eligible canonical events exist.
+- Sample future voice-started, voice-connected, voice-ended, and voicemail canonical events satisfy the reserved contract shape without changing SMS ordering rules.
+
+## Integration Tests
+
+### Thread Timeline Reads
+
+- A thread with mixed inbound and outbound SMS canonical events returns one unified oldest-to-newest timeline.
+- A thread with identical event timestamps returns a deterministic stable order using canonical event identifiers.
+- A thread with provider metadata exposes that data only through the optional metadata field.
+- A thread with no eligible canonical events returns an empty timeline rather than invented message items.
+
+### Deleted-Neighbor Handling
+
+- A thread linked to a soft-deleted neighbor remains queryable in authorized admin/debug review and still renders its timeline.
+- Standard operational thread lists, searches, and detail-opening flows exclude soft-deleted neighbors and their threads entirely.
+- Deleted-neighbor review does not reactivate the neighbor or alter deleted-state history.
+
+### Tenant Isolation
+
+- A timeline request scoped to one tenant never returns thread existence or timeline items owned by another tenant.
+- Cross-tenant canonical events never appear in the current tenant's projected thread timeline.
+
+### Backend Consumer Contract
+
+- The timeline endpoint returns items in oldest-to-newest order so consuming clients can render the newest returned item last without re-sorting.
+- The response envelope always surfaces `neighbor_deleted`, `neighbor_deleted_at_utc`, and `limit_applied` separately from individual items.
+
+## Regression Tests
+
+- Existing inbound SMS canonical event creation still produces timeline-eligible SMS artifacts.
+- Existing outbound SMS canonical event creation still produces timeline-eligible SMS artifacts.
+- Existing tenant-scope enforcement still blocks cross-tenant reads.
+- Existing deleted-neighbor protections from the prior soft-delete feature remain intact.
+- Existing raw canonical event retrieval remains available as the rollback path.
+
+## Local Verification Notes
+
+- Passed focused regression command:
+  - `npx jest --runInBand src/modules/connectshyft/__tests__/inboundSms.test.ts src/modules/connectshyft/__tests__/canonicalEvents.test.ts src/modules/connectshyft/__tests__/readContracts.test.ts src/modules/connectshyft/__tests__/threadTimeline.test.ts src/routes/api/v1/__tests__/connectshyft.timeline.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+- Passed app-local build:
+  - `npm run build` from `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api`
+- Passed local CI parity commands:
+  - `npm run policy:check`
+  - `bash scripts/verify-connectshyft-route-ownership.sh`
+  - `bash scripts/lint-or-discovery.sh`
+  - `bash scripts/ci-run-playwright-stack.sh bash scripts/backend-jest-ci.sh`
+  - `bash scripts/quality-gates.sh`
+- Local Playwright change-detection runs completed cleanly with no changed spec files relative to `origin/codex/dev`:
+  - `bash scripts/ci-run-playwright-stack.sh bash scripts/test-changed.sh origin/codex/dev`
+  - `bash scripts/ci-run-playwright-stack.sh bash scripts/burn-in.sh 3 origin/codex/dev`

--- a/specs/025-message-timeline-persistence-and-projection/06-pr-template.md
+++ b/specs/025-message-timeline-persistence-and-projection/06-pr-template.md
@@ -1,0 +1,69 @@
+# PR 025 — Message Timeline Persistence + Projection
+
+## Summary
+
+Introduces a unified per-thread message timeline derived from canonical events, promotes inbound and outbound SMS to first-class timeline items, and establishes a forward-compatible contract for future voice and voicemail history.
+
+---
+
+## Changes
+
+- Added a canonical-event-derived thread timeline projection as a read model rather than a second source of truth.
+- Promoted inbound and outbound SMS into first-class ordered timeline items with stable identity and actor fields.
+- Preserved deleted-neighbor timeline visibility for authorized admin/debug review while keeping deleted neighbors and threads out of normal operational UI.
+- Enforced tenant-scoped timeline reads so thread history cannot leak across tenants.
+- Reserved a forward-compatible contract for voice call lifecycle items and voicemail artifacts.
+
+---
+
+## Why
+
+Operators need a trustworthy thread history that reads like a conversation instead of raw event logs, and the product needs that history model to stay compatible with future voice and voicemail work without introducing direct timeline writes or a competing source of truth.
+
+---
+
+## Testing
+
+- Passed focused regression suites:
+  - `npx jest --runInBand src/modules/connectshyft/__tests__/inboundSms.test.ts src/modules/connectshyft/__tests__/canonicalEvents.test.ts src/modules/connectshyft/__tests__/readContracts.test.ts src/modules/connectshyft/__tests__/threadTimeline.test.ts src/routes/api/v1/__tests__/connectshyft.timeline.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+- Passed app-local build:
+  - `npm run build` from `apps/connectshyft-api`
+- Passed local CI parity:
+  - `npm run policy:check`
+  - `bash scripts/verify-connectshyft-route-ownership.sh`
+  - `bash scripts/lint-or-discovery.sh`
+  - `bash scripts/ci-run-playwright-stack.sh bash scripts/backend-jest-ci.sh`
+  - `bash scripts/quality-gates.sh`
+- Completed local change-detection and burn-in flow against `origin/codex/dev`:
+  - `bash scripts/ci-run-playwright-stack.sh bash scripts/test-changed.sh origin/codex/dev`
+  - `bash scripts/ci-run-playwright-stack.sh bash scripts/burn-in.sh 3 origin/codex/dev`
+  - No changed Playwright specs were detected, so those runs skipped cleanly.
+
+---
+
+## Risks
+
+- Same-timestamp events could render in an unstable order if tie-breaking is applied inconsistently.
+- Deleted-neighbor timelines could leak back into standard operational flows if visibility rules drift.
+- Cross-tenant thread reads could expose message history if timeline projection bypasses tenant scoping.
+- Future voice or voicemail work could drift from the reserved contract if not validated against this projection model.
+
+---
+
+## Rollback
+
+- Revert the timeline projection changes together with any consumer changes that depend on first-class timeline items.
+- Restore the prior thread-history read behavior only if canonical event history remains unchanged.
+- Re-validate deleted-neighbor visibility rules and tenant scoping after rollback before closing the incident.
+
+---
+
+## Checklist
+
+- [x] Canonical events remain the only source of truth for timeline content
+- [x] No direct timeline writes exist outside the canonical event pipeline
+- [x] Inbound and outbound SMS appear as first-class ordered timeline items
+- [x] Deleted-neighbor timelines remain visible only to authorized admin/debug review
+- [x] Standard operational UI excludes deleted neighbors and their threads
+- [x] Tenant scoping prevents cross-tenant timeline leakage
+- [x] Voice and voicemail contract placeholders remain forward-compatible

--- a/specs/025-message-timeline-persistence-and-projection/checklists/requirements.md
+++ b/specs/025-message-timeline-persistence-and-projection/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: ConnectShyft Message Timeline Projection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-03-19  
+**Feature**: [spec.md](/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validated on 2026-03-19 against the final `spec.md`; no clarification markers remain.
+- The specification keeps pagination implementation, filtering, attachments or MMS, and read receipts out of scope while preserving forward compatibility for later slices.
+- The specification preserves canonical events as the only source of truth and prohibits direct timeline mutation outside the canonical event pipeline.

--- a/specs/025-message-timeline-persistence-and-projection/contracts/message-timeline-projection.md
+++ b/specs/025-message-timeline-persistence-and-projection/contracts/message-timeline-projection.md
@@ -1,0 +1,173 @@
+# Contract: ConnectShyft Message Timeline Projection
+
+## Objective
+
+Provide a unified ordered thread timeline derived only from canonical events, promote inbound and outbound SMS to first-class timeline items, and reserve a stable contract for future voice call events and voicemail artifacts.
+
+## Naming convention
+
+- Internal service and projection objects use camelCase.
+- External HTTP DTO fields use snake_case.
+- `threadTimelineDto.ts` is responsible for translating internal service results into the public route contract.
+
+## Allowed runtime surface
+
+- `apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts`
+  - canonical event persistence and deterministic listing
+- `apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts`
+  - inbound SMS canonical payload shape
+- `apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts`
+  - projection service and event-to-item mapping
+- `apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts`
+  - route-facing response shaping
+- `apps/connectshyft-api/src/modules/connectshyft/readContracts.ts`
+  - deleted-neighbor metadata for the response envelope
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+  - timeline retrieval route and access control
+- Related tests only:
+  - `apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts`
+  - `apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts`
+  - `apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts`
+  - `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+  - `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+
+## Service contract
+
+### `getThreadTimeline(input)`
+
+**Input**
+
+- `tenantId`
+- `orgUnitId`
+- `threadId`
+- `limit` (optional, maximum `200`)
+
+**Output**
+
+- `threadId`
+- `neighborDeleted`
+- `neighborDeletedAtUtc`
+- `deterministic = true`
+- `limitApplied`
+- `items[]`
+
+**Behavior**
+
+1. Load canonical events for the requested thread using tenant and org-unit scope.
+2. Map supported canonical events into first-class timeline items.
+3. Apply the optional `limit` as a bounded most-recent window with a maximum effective value of `200`.
+4. Sort returned items ascending by `occurred_at_utc`, then canonical event identifier.
+5. Return an empty `items` array when the thread has no timeline-eligible canonical events.
+6. Never write or mutate any timeline storage.
+
+## Timeline item contract
+
+### Required fields
+
+- `id`
+- `thread_id`
+- `direction`
+- `channel`
+- `occurred_at_utc`
+- `actor`
+
+### SMS-required fields
+
+- `body`
+
+### Optional fields
+
+- `provider_metadata`
+- `delivery_status`
+
+### Future-compatible fields
+
+- `type`
+  - `message` for SMS items
+  - future `voice_event`
+  - future `voicemail`
+- `recording_url`
+- `duration_seconds`
+- `transcript`
+
+## Event-to-item mapping rules
+
+1. `connectshyft.inbound.sms_appended`
+   - `type = message`
+   - `direction = inbound`
+   - `channel = sms`
+   - `body` comes from canonical inbound message artifact
+   - `actor = neighbor`
+2. `connectshyft.outbound.sms_appended`
+   - `type = message`
+   - `direction = outbound`
+   - `channel = sms`
+   - `body` comes from canonical outbound message artifact
+   - `actor = user` when user initiated, otherwise `system`
+3. Future voice lifecycle events
+   - `channel = voice`
+   - `type = voice_event`
+   - same ordering and identity contract
+4. Future voicemail artifacts
+   - `channel = voicemail`
+   - `type = voicemail`
+   - reserve `recording_url`, `duration_seconds`, and optional `transcript`
+
+## Route contract
+
+### `GET /api/v1/connectshyft/threads/:threadId/timeline`
+
+**Request rules**
+
+- Uses the existing ConnectShyft inbox capability and org-unit context enforcement.
+- Uses the existing deleted-neighbor admin/debug gate when `includeDeleted=true`.
+- Requires `threadId`.
+- Accepts optional `limit`, defaults omitted `limit` to `200`, and caps the effective value at `200`.
+- Must remain tenant-scoped.
+- Returns the effective request window in `limit_applied`.
+
+**Success response shape**
+
+```json
+{
+  "ok": true,
+  "code": "CONNECTSHYFT_THREAD_TIMELINE_LOADED",
+  "message": "ConnectShyft thread timeline loaded",
+  "data": {
+    "thread_id": "thread-123",
+    "neighbor_deleted": false,
+    "neighbor_deleted_at_utc": null,
+    "deterministic": true,
+    "limit_applied": 50,
+    "items": [
+      {
+        "id": "event-001",
+        "thread_id": "thread-123",
+        "type": "message",
+        "direction": "inbound",
+        "channel": "sms",
+        "body": "Need help with delivery window",
+        "occurred_at_utc": "2026-03-19T12:00:00.000Z",
+        "actor": "neighbor",
+        "provider_metadata": null,
+        "delivery_status": null
+      }
+    ]
+  }
+}
+```
+
+**Refusal rules**
+
+- Missing `threadId` remains a client refusal.
+- Inaccessible or cross-tenant thread reads must not reveal timeline contents.
+- Deleted-neighbor timeline review without tenant-privileged admin/debug access must refuse using the existing deleted-neighbor authorization semantics.
+
+## Must hold constant
+
+- Canonical events remain the only timeline source of truth.
+- `/api/v1/auth/*` and `/api/v1/platform/admin/*` stay `admin-api` owned.
+- Host Nginx, localhost-only API binding, and shared Postgres topology remain unchanged.
+- Raw canonical event retrieval remains available for rollback and debugging.
+- No direct DB logic may be added to the route for timeline assembly.
+- A client that renders the returned `items` array top-to-bottom will display the newest returned item last without additional resorting.

--- a/specs/025-message-timeline-persistence-and-projection/data-model.md
+++ b/specs/025-message-timeline-persistence-and-projection/data-model.md
@@ -1,0 +1,183 @@
+# Data Model: ConnectShyft Message Timeline Persistence and Projection
+
+## Overview
+
+Feature `025` introduces a read-only message timeline derived from canonical thread events. The design does not create timeline persistence. Instead, it formalizes the canonical event fields required for projection, the response envelope used by the new route, and the future-compatible shapes needed for voice and voicemail expansion.
+
+## Naming Convention
+
+- Internal module, service, and data-model fields use camelCase.
+- External HTTP DTO fields use snake_case.
+- `threadTimelineDto.ts` performs the camelCase-to-snake_case translation for route responses.
+
+## Entity: Canonical Thread Event
+
+**Purpose**
+
+Represents the immutable source-of-truth record for a thread activity. Timeline items are derived from these events and never persisted separately.
+
+**Fields**
+
+- `eventId`: canonical event identifier used as the stable item `id`
+- `tenantId`: tenant scope
+- `orgUnitId`: org-unit scope
+- `aggregateId`: thread identifier
+- `aggregateType`: `Thread`
+- `eventType`: canonical event type such as `MessageDelivered` or `MessageQueued`
+- `eventName`: provider-neutral timeline-facing event name when present
+- `occurredAtUtc`: event timestamp used for primary ordering
+- `channel`: `sms`, `voice`, or `voicemail`
+- `direction`: `inbound` or `outbound`
+- `actor`: `system`, `user`, or `neighbor`
+- `providerMetadata`: optional provider-neutral metadata retained for debugging or future delivery state
+- `inboundMessageArtifact`: optional inbound SMS artifact with `body`, `from`, and `to`
+- `outboundMessageArtifact`: optional outbound SMS artifact with `body`, `from`, and `to`
+- `voicemailArtifact`: optional future voicemail artifact with recording or transcript metadata
+
+**Validation rules**
+
+- Canonical events remain the only source of truth for timeline content.
+- `aggregateId` must identify exactly one thread within one tenant scope.
+- `occurredAtUtc` plus `eventId` defines deterministic ordering.
+- SMS timeline-eligible canonical events must expose a message body through the canonical payload.
+- Actor semantics used by the projection must be available from canonical data rather than reconstructed from non-canonical sources.
+
+**Relationships**
+
+- One `Canonical Thread Event` may project into zero or one `Timeline Item Projection`.
+- Many canonical events belong to one `Thread Timeline Response`.
+
+## Entity: Timeline Access Context
+
+**Purpose**
+
+Represents the authorization and visibility rules applied when reading a projected timeline.
+
+**Fields**
+
+- `tenantId`: tenant scope
+- `orgUnitId`: org-unit scope
+- `threadId`: requested thread
+- `includeDeleted`: whether deleted-neighbor review is requested
+- `accessMode`: `standard` or `admin_debug`
+- `neighborDeleted`: internal deleted-neighbor status used while assembling the response
+- `neighborDeletedAtUtc`: internal deleted-neighbor timestamp used while assembling the response
+
+**Validation rules**
+
+- Every timeline read must be tenant-scoped.
+- `includeDeleted = true` requires the same tenant-privileged admin/debug authorization used by deleted-aware thread detail.
+- Standard operational access must exclude deleted neighbors and their threads entirely.
+- Cross-tenant requests must not reveal thread existence or timeline content.
+
+**Relationships**
+
+- One access context yields one `Thread Timeline Response` or one refusal.
+- Access context reads deleted-neighbor metadata from existing thread read contracts rather than from timeline item storage.
+
+## Entity: Timeline Item Projection
+
+**Purpose**
+
+Represents the read-only first-class artifact rendered in thread history.
+
+**Fields**
+
+- `id`: canonical event identifier
+- `threadId`: thread identifier
+- `type`: `message`, future `voice_event`, or future `voicemail`
+- `direction`: `inbound` or `outbound`
+- `channel`: `sms`, future `voice`, or future `voicemail`
+- `body`: SMS body text; optional for future non-SMS items
+- `occurredAtUtc`: canonical event timestamp
+- `actor`: `system`, `user`, or `neighbor`
+- `providerMetadata`: optional provider-neutral metadata
+- `deliveryStatus`: optional future delivery-state field
+
+**Validation rules**
+
+- Each item must be derived from exactly one canonical event.
+- SMS items must include `body`.
+- Items must sort in ascending `(occurred_at_utc, id)` order.
+- Projection must not invent fields or item order outside canonical source data.
+- Projection must remain stable even when multiple events share the same timestamp.
+- The HTTP DTO converts these fields to `thread_id`, `occurred_at_utc`, `provider_metadata`, and `delivery_status`.
+
+**Relationships**
+
+- Belongs to one `Thread Timeline Response`.
+- Is derived from one `Canonical Thread Event`.
+
+## Entity: Voicemail Timeline Item
+
+**Purpose**
+
+Represents the forward-compatible placeholder for voicemail artifacts inside the same ordered thread history.
+
+**Fields**
+
+- All `Timeline Item Projection` identity fields
+- `type`: `voicemail`
+- `channel`: `voicemail`
+- `recording_url`: optional future recording location
+- `duration_seconds`: optional future voicemail duration
+- `transcript`: optional future transcription text
+
+**Validation rules**
+
+- Voicemail items must remain representable even when recording URL, duration, or transcript are not yet populated.
+- Voicemail items must follow the same deterministic ordering rules as SMS items.
+- Voicemail support remains contract-first in this slice; no separate voicemail-only timeline model is allowed.
+
+**Relationships**
+
+- A voicemail item is a specialized `Timeline Item Projection`.
+- It is derived from a canonical voicemail event or voicemail artifact event.
+
+## Entity: Thread Timeline Response
+
+**Purpose**
+
+Represents the route-level response returned by the new timeline endpoint.
+
+**Fields**
+
+- `threadId`: requested thread identifier
+- `neighborDeleted`: boolean thread-level deleted-neighbor flag exposed by the route
+- `neighborDeletedAtUtc`: deleted-neighbor timestamp exposed by the route
+- `deterministic`: `true` to indicate stable ordering
+- `items`: ordered array of `Timeline Item Projection`
+- `source`: canonical event source marker
+- `limitApplied`: effective maximum number of canonical events projected for the current read
+
+**Validation rules**
+
+- Response order must already be oldest-to-newest.
+- Response must not include items from another tenant.
+- Deleted-neighbor flags must come from existing deleted-aware thread metadata and not be duplicated onto every item.
+- The response remains read-only and does not acknowledge any timeline mutation path.
+- The HTTP DTO converts `neighborDeleted`, `neighborDeletedAtUtc`, and `limitApplied` into `neighbor_deleted`, `neighbor_deleted_at_utc`, and `limit_applied`.
+
+**Relationships**
+
+- Contains many `Timeline Item Projection` records.
+- Uses one `Timeline Access Context`.
+
+## State Transitions
+
+### Projection Visibility
+
+- `canonical event recorded -> projected item visible on subsequent timeline reads`
+- `no canonical events -> empty timeline response`
+
+### Deleted-Neighbor Visibility
+
+- `active neighbor thread -> standard-visible`
+- `soft-deleted neighbor thread -> hidden from standard access`
+- `soft-deleted neighbor thread -> visible in admin_debug access with deleted flags`
+
+### Future Channel Expansion
+
+- `sms item -> current first-class implementation`
+- `voice lifecycle event -> future first-class item under the same ordering contract`
+- `voicemail artifact event -> future first-class voicemail item under the same ordering contract`

--- a/specs/025-message-timeline-persistence-and-projection/plan.md
+++ b/specs/025-message-timeline-persistence-and-projection/plan.md
@@ -1,0 +1,259 @@
+# Implementation Plan: ConnectShyft Message Timeline Persistence and Projection
+
+**Branch**: `025-message-timeline-persistence-and-projection` | **Date**: 2026-03-19 | **Spec**: [/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/spec.md](/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/spec.md)
+**Input**: Feature specification from `/specs/025-message-timeline-persistence-and-projection/spec.md`
+
+## Summary
+
+Implement feature `025` as a backend-only ConnectShyft API slice by keeping canonical events as the only source of truth, enriching canonical SMS event payloads so projected timeline items can carry the required body and actor fields, introducing a dedicated ConnectShyft thread-timeline projection service plus DTO serializer, and exposing `GET /api/v1/connectshyft/threads/:threadId/timeline` as a tenant-scoped read-only route with optional bounded retrieval. The current codebase already loads canonical thread events directly into thread detail, but those events are still raw canonical records, outbound SMS payloads do not yet contain projection-ready message bodies, and the current voice classification heuristic collapses all voice activity into voicemail, so the implementation focus is canonical payload completeness, explicit event-to-item mapping, deleted-neighbor aware response shaping, a small testable `limit` contract, and a rollback-safe endpoint that can coexist with raw canonical event retrieval while consumer UI adoption remains deferred.
+
+## Technical Context
+
+**Language/Version**: TypeScript (ES2022) on Node.js >=20  
+**Primary Dependencies**: Express, Knex, `pg`, Jest/ts-jest, existing ConnectShyft `canonicalEvents`, `readContracts`, `threads`, and provider-dispatch modules, shared `libs/platform` mutation helpers, shared telephony contracts under `domains/communication`  
+**Storage**: Shared PostgreSQL using `platform.events` for canonical event persistence plus existing `connectshyft` thread and neighbor read tables; no dedicated timeline table or timeline write model  
+**Testing**: `npm run build` in `apps/connectshyft-api`, targeted Jest suites for canonical event persistence, new timeline projection logic, deleted-neighbor route behavior, and ConnectShyft route contracts  
+**Target Platform**: ConnectShyft API lane behind host-managed Nginx, Dockerized Node runtime with localhost-only binding, shared host-managed PostgreSQL, no public API exposure  
+**Project Type**: Monorepo backend lane feature with a new read-only API contract and no new deployable service  
+**Performance Goals**: Keep timeline reads within existing ConnectShyft request-time expectations, preserve deterministic ordering for up to 200 returned records per thread read, and avoid additional database writes or cross-lane calls on timeline retrieval  
+**Constraints**: Canonical events remain the only source of truth; no direct timeline writes; no timeline mutation outside the canonical event pipeline; ordering must be oldest-to-newest with `(occurred_at_utc, canonical_event_id)` tie-breaking; timeline reads must be tenant-scoped; deleted-neighbor threads remain admin/debug-readable only; `/api/v1/auth/*` and `/api/v1/platform/admin/*` stay `admin-api` owned; `admin-api` remains the only production migration executor  
+**Scale/Scope**: One canonical payload enrichment path for outbound SMS, one dedicated projection module, one DTO/serializer, one new GET route with optional `limit`, deleted-neighbor flags in the timeline response envelope, SMS-first mapping now, and forward-compatible voice and voicemail item contracts without implementing cursor pagination, filtering, attachments, or read receipts
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Platform shell authority**: Pass. No changes affect `admin-web`, `admin-api`, or shared auth ownership.
+- **Lane isolation preserved**: Pass. Runtime behavior stays within ConnectShyft lane modules and existing shared platform helpers; no cross-lane API coupling is introduced.
+- **Routing delegation preserved**: Pass. `/api/v1/auth/*` and `/api/v1/platform/admin/*` remain `admin-api` owned; the new timeline route remains under the ConnectShyft lane route surface.
+- **Deployment topology preserved**: Pass. No Nginx, container binding, public ingress, or frontend hosting changes are introduced, and validation will explicitly reconfirm host Nginx delegation, ConnectShyft API localhost-only binding, and shared Postgres connectivity remain unchanged.
+- **Database ownership preserved**: Pass. Shared Postgres remains the storage model, canonical events continue to live in `platform.events`, and no lane-owned production migration path or timeline table is introduced.
+- **Security boundaries preserved**: Pass. Timeline reads remain tenant-scoped, deleted-neighbor review keeps the existing admin/debug gate, and no new public endpoint exposure is added.
+- **Workflow compliance**: Pass. The plan traces directly to the approved `025` spec and the user-supplied technical approach.
+- **Acceptance criteria present**: Pass. The plan includes verifiable checks for ConnectShyft route behavior, unchanged Admin and MoneyShyft routing or deployment contracts, shared database compatibility, tenant isolation, and rollback safety through raw canonical event retrieval.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/025-message-timeline-persistence-and-projection/
+├── 01-specify.md
+├── 02-plan.md
+├── 03-tasks.md
+├── 04-implement.md
+├── 05-testing.md
+├── 06-pr-template.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   └── message-timeline-projection.md
+├── data-model.md
+├── plan.md
+├── quickstart.md
+├── research.md
+└── spec.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/connectshyft-api/
+├── src/
+│   ├── modules/connectshyft/
+│   │   ├── __tests__/
+│   │   │   ├── canonicalEvents.test.ts
+│   │   │   ├── readContracts.test.ts
+│   │   │   ├── threadTimeline.test.ts
+│   │   │   └── threads.test.ts
+│   │   ├── canonicalEvents.ts
+│   │   ├── inboundSms.ts
+│   │   ├── readContracts.ts
+│   │   ├── threadTimeline.ts
+│   │   ├── threadTimelineDto.ts
+│   │   └── threads.ts
+│   └── routes/api/v1/
+│       ├── __tests__/
+│       │   ├── connectshyft.provider-registry.dispatch-events.test.ts
+│       │   └── connectshyft.timeline.test.ts
+│       └── connectshyft.ts
+├── Dockerfile.production
+└── knexfile.js
+
+apps/admin-api/
+└── knexfile.js
+
+nginx/nginx.conf
+docker-compose.example.yml
+docs/PRODUCTION_DEPLOYMENT_GUIDE.md
+```
+
+**Structure Decision**: This is a backend-only ConnectShyft lane feature. The plan introduces a dedicated timeline projection module and DTO inside `apps/connectshyft-api`, reuses existing canonical event persistence and deleted-neighbor read contracts, and exposes a new lane-owned GET route without adding a new service, migration authority, or cross-lane dependency.
+
+## Contract Naming Convention
+
+- Internal module, service, and data-model fields use camelCase.
+- External HTTP DTO fields use snake_case.
+- `apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts` is the only translation boundary between internal service results and the public route contract.
+
+## Complexity Tracking
+
+No constitution exceptions are required for this feature.
+
+## Current Context Holders
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` currently resolves thread detail and attaches a `timeline` made from raw canonical events via the route-local `listCanonicalThreadEvents(...)` helper.
+- The route-local timeline helper already preserves deterministic ordering by using the canonical-event store order, but it returns canonical records rather than first-class projected timeline items.
+- `apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts` already sorts canonical events by `occurred_at_utc` then `event_id` and caps reads at `200`, but the stored record shape does not expose actor semantics and outbound SMS canonical payloads do not include message body text.
+- `apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts` already emits `connectshyft.inbound.sms_appended` plus `inboundMessageArtifact.body`, so inbound SMS projection data is nearly complete.
+- Outbound message dispatch in `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` currently records canonical events with direction, channel, lifecycle event, and thread state only; that is insufficient for a first-class outbound SMS timeline item because the spec requires `body` and `actor`.
+- `apps/connectshyft-api/src/modules/connectshyft/readContracts.ts` already exposes `neighborDeleted` and `neighborDeletedAtUtc` and already honors `includeDeleted` for deleted-neighbor thread detail, making it the right existing metadata seam for the new timeline route.
+- The current route-local voice classification treats any `voice.` event as voicemail, which is incompatible with the requested future distinction between voice lifecycle items and voicemail artifacts.
+
+## Planned Contract Deltas
+
+- Enrich canonical outbound SMS event payloads so they carry an explicit projection-ready SMS event name, actor semantics, and outbound message artifact data required for first-class timeline items.
+- Introduce a dedicated `getThreadTimeline({ tenantId, orgUnitId, threadId, limit })` service in a new timeline projection module that loads canonical events, maps supported event types to timeline items, and preserves deterministic ascending ordering.
+- Introduce a dedicated timeline DTO/serializer that returns the spec-required item shape and a top-level snake_case response envelope containing `neighbor_deleted`, `neighbor_deleted_at_utc`, and `limit_applied`.
+- Add `GET /api/v1/connectshyft/threads/:threadId/timeline` as the new read-only retrieval route, accept optional bounded retrieval through `limit`, and reuse the existing deleted-neighbor admin/debug gate when `includeDeleted=true`.
+- Keep raw canonical event retrieval available through existing canonical event listing and leave current raw thread-detail timeline behavior intact during rollout so rollback can fall back to raw event retrieval without reconstructing history.
+- Replace substring-based voice or voicemail inference for the new endpoint with an explicit event-to-item mapping table so future voice-started, voice-connected, voice-ended, and voicemail items remain distinct.
+- Reuse the existing canonical-event cap of `200` records per read as the default no-`limit` behavior, support a bounded most-recent window through `limit`, and defer cursor pagination or channel filtering to later slices.
+
+## Phase 0 Research Output
+
+- Research findings are captured in [/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/research.md](/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/research.md).
+- No unresolved `NEEDS CLARIFICATION` items remain.
+
+## Phase 1 Design Output
+
+- Data model is captured in [/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/data-model.md](/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/data-model.md).
+- Runtime and API contract is captured in [/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/contracts/message-timeline-projection.md](/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/contracts/message-timeline-projection.md).
+- Execution and verification flow is captured in [/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/quickstart.md](/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/quickstart.md).
+
+## Post-Design Constitution Check
+
+- **Platform shell authority**: Pass. The design leaves platform shell and auth ownership unchanged.
+- **Lane isolation preserved**: Pass. The design stays inside ConnectShyft route, canonical event, read-contract, and new timeline projection modules only.
+- **Routing delegation preserved**: Pass. No auth or platform-admin ownership changes are introduced; the new route remains ConnectShyft-lane owned.
+- **Deployment topology preserved**: Pass. The design adds a read-only route and projection logic only, and post-implementation validation still confirms host Nginx delegation, ConnectShyft API localhost-only binding, shared Postgres connectivity, and unchanged deployment runbook behavior.
+- **Database ownership preserved**: Pass. Existing shared Postgres and `platform.events` remain canonical; no timeline table or lane-owned migration path is introduced.
+- **Security boundaries preserved**: Pass. Deleted-neighbor timeline review remains gated, tenant scoping remains mandatory, and no public ingress changes are added.
+- **Workflow compliance**: Pass. The design slices map directly to the approved `025` spec and the planning input.
+- **Acceptance criteria present**: Pass. The design includes validation for deterministic ordering, bounded retrieval through `limit`, canonical payload completeness, deleted-neighbor visibility rules, unchanged Admin, MoneyShyft, and ConnectShyft routing or deployment contracts, and rollback to raw canonical event retrieval.
+
+## Implementation Slices
+
+### Slice 1 - Canonical Event Completeness for SMS Timeline Projection
+
+**Primary goal**: make canonical SMS events carry enough provider-neutral data to serve as the sole source of truth for first-class SMS timeline items.
+
+**Exact file targets**
+
+- `apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+
+**Required changes**
+
+- Preserve existing inbound SMS canonical payload behavior and add an explicit actor field where needed for projection parity.
+- Enrich outbound SMS canonical event persistence so the stored canonical payload includes a projection-ready SMS event name, outbound body text, actor semantics, and available sender or recipient metadata.
+- Keep canonical payloads provider-neutral and continue sanitizing provider-specific raw payload fields.
+- Preserve deterministic canonical ordering and the existing maximum read cap.
+
+**Must hold constant**
+
+- No timeline table or direct timeline writes.
+- Existing canonical event list behavior remains deterministic and provider-neutral.
+- Existing outbound dispatch side effects, audit, and idempotency behavior remain intact.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/modules/connectshyft/__tests__/canonicalEvents.test.ts src/modules/connectshyft/__tests__/inboundSms.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+
+**Commit checkpoint**
+
+- Safe to commit once canonical inbound and outbound SMS events contain the minimum projection-ready fields required by the spec and no route writes directly to any timeline storage.
+
+### Slice 2 - Thread Timeline Projection Service and DTO
+
+**Primary goal**: introduce a dedicated read-only timeline projection layer that turns canonical events into first-class timeline items with explicit channel and future-type semantics.
+
+**Exact file targets**
+
+- `apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/readContracts.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts`
+
+**Required changes**
+
+- Create `getThreadTimeline({ tenantId, orgUnitId, threadId, limit })` as the projection entrypoint.
+- Load canonical thread events through the existing canonical event persistence layer.
+- Map supported canonical events to first-class timeline items:
+  - inbound SMS appended -> inbound SMS timeline item
+  - outbound SMS appended or outbound message canonical alias -> outbound SMS timeline item
+- Keep ordering oldest-to-newest with `(occurred_at_utc, canonical_event_id)` tie-breaking.
+- Keep internal service result fields in camelCase so the DTO layer can convert them into the external snake_case contract.
+- Use explicit event mapping so future voice lifecycle items remain separate from voicemail items.
+- Reuse existing thread detail metadata so the response envelope can expose deleted-neighbor flags without duplicating deleted state.
+
+**Must hold constant**
+
+- The timeline remains read-only and derived entirely from canonical events.
+- Existing thread lifecycle state persistence remains unchanged.
+- Deleted-neighbor visibility rules remain controlled by existing read-contract and route gating semantics.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/modules/connectshyft/__tests__/threadTimeline.test.ts src/modules/connectshyft/__tests__/readContracts.test.ts`
+
+**Commit checkpoint**
+
+- Safe to commit once `getThreadTimeline(...)` returns deterministic projected SMS timeline items, deleted-neighbor flags are present in the response envelope, and future voice or voicemail placeholders no longer depend on substring heuristics.
+
+### Slice 3 - Timeline Retrieval Route, Access Controls, and Rollback Safety
+
+**Primary goal**: expose the new timeline projection through a dedicated route while preserving current ConnectShyft routing, deleted-neighbor admin/debug behavior, bounded retrieval through `limit`, and raw canonical-event rollback options.
+
+**Exact file targets**
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+- verification-only platform contract files:
+  - `nginx/nginx.conf`
+  - `docker-compose.example.yml`
+  - `apps/connectshyft-api/Dockerfile.production`
+  - `apps/admin-api/knexfile.js`
+  - `docs/PRODUCTION_DEPLOYMENT_GUIDE.md`
+
+**Required changes**
+
+- Add `GET /api/v1/connectshyft/threads/:threadId/timeline`.
+- Enforce the same tenant and org-unit context rules as thread detail.
+- Reuse the existing deleted-neighbor admin/debug gate when `includeDeleted=true`; otherwise keep normal thread-view capability enforcement.
+- Return a response envelope that includes the thread identifier, `neighbor_deleted`, `neighbor_deleted_at_utc`, `limit_applied`, deterministic ordering metadata, and the projected timeline items.
+- Preserve ConnectShyft business-refusal semantics for missing thread IDs, inaccessible threads, and deleted-neighbor review without admin/debug authorization.
+- Keep existing raw canonical event retrieval and current thread-detail behavior available so rollback can disable the timeline endpoint and fall back to raw event retrieval.
+- Reconfirm host Nginx delegation, ConnectShyft API localhost-only binding, shared Postgres connectivity, unchanged `admin-api` route ownership, and no incidental MoneyShyft routing or deployment drift.
+
+**Must hold constant**
+
+- `/api/v1/auth/*` and `/api/v1/platform/admin/*` ownership boundaries.
+- No cross-tenant timeline leakage.
+- No new public ingress or migration authority changes.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/routes/api/v1/__tests__/connectshyft.timeline.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+
+**Commit checkpoint**
+
+- Safe to commit once the new timeline route is tenant-scoped, deleted-neighbor review behaves correctly, deterministic ordering is proven, and disabling the route cleanly reverts consumers to raw canonical event retrieval.

--- a/specs/025-message-timeline-persistence-and-projection/quickstart.md
+++ b/specs/025-message-timeline-persistence-and-projection/quickstart.md
@@ -1,0 +1,160 @@
+# Quickstart: ConnectShyft Message Timeline Persistence and Projection
+
+## Goal
+
+Add a backend-only read-only timeline projection derived from canonical events, make inbound and outbound SMS first-class timeline items, expose `GET /api/v1/connectshyft/threads/:threadId/timeline` with optional bounded retrieval, preserve deleted-neighbor admin/debug review, and keep raw canonical event retrieval available for rollback while consumer UI adoption remains deferred.
+
+## Slice Order
+
+1. Make canonical SMS events projection-ready
+2. Add the timeline projection service and DTO
+3. Expose the new route, optional `limit` handling, and verify deleted-neighbor plus tenant-scoping behavior
+
+## Preflight
+
+**Verify the current raw timeline behavior and canonical-event cap**
+
+```sh
+rg -n "CONNECTSHYFT_CANONICAL_EVENTS_MAX_LIMIT|listCanonicalThreadEvents|router.get\\('/threads/:threadId'" \
+  /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts
+```
+
+Expected findings:
+
+- Canonical reads are already ordered and capped at `200`
+- Thread detail currently builds timeline data from raw canonical events
+- No dedicated timeline projection module exists yet
+
+## Slice 1: Projection-Ready Canonical SMS Events
+
+**Source targets**
+
+- `apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+
+**Work**
+
+1. Preserve inbound SMS canonical payload completeness.
+2. Enrich outbound SMS canonical payloads with a projection-ready event name, message body, actor semantics, and available sender or target metadata.
+3. Keep canonical payloads provider-neutral.
+4. Do not add any timeline persistence.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/modules/connectshyft/__tests__/canonicalEvents.test.ts src/modules/connectshyft/__tests__/inboundSms.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+
+## Slice 2: Timeline Projection Module and DTO
+
+**Source targets**
+
+- `apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/readContracts.ts`
+
+**Work**
+
+1. Add `getThreadTimeline({ tenantId, orgUnitId, threadId, limit })`.
+2. Load canonical events from the existing canonical event store.
+3. Map inbound and outbound SMS canonical events into first-class timeline items.
+4. Keep sorting oldest to newest with canonical event ID tie-breaking.
+5. Populate deleted-neighbor metadata from existing thread detail and read-contract state.
+6. Reserve explicit mapping slots for future voice lifecycle items and voicemail items.
+7. Keep internal projection results in camelCase so the DTO can translate them into the external snake_case contract.
+
+**Verification focus**
+
+- Mixed inbound and outbound SMS events render in deterministic order.
+- Same-timestamp events remain stable.
+- Empty threads return an empty item array.
+- Voice lifecycle placeholders no longer depend on “contains `voice.`” heuristics.
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/modules/connectshyft/__tests__/threadTimeline.test.ts src/modules/connectshyft/__tests__/readContracts.test.ts`
+
+## Slice 3: Timeline Retrieval Route and Access Control
+
+**Source targets**
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+
+**Work**
+
+1. Add `GET /api/v1/connectshyft/threads/:threadId/timeline`.
+2. Reuse the existing org-unit context and thread-view capability checks.
+3. Reuse the existing `includeDeleted=true` admin/debug authorization path for deleted-neighbor review.
+4. Accept optional `limit` and preserve oldest-to-newest ordering within the returned window.
+5. Return the projected timeline envelope with deleted-neighbor flags and `limit_applied`.
+6. Keep existing raw canonical event retrieval available for debugging and rollback.
+
+**Manual verification example**
+
+```http
+GET /api/v1/connectshyft/threads/thread-f2-unclaimed-1001/timeline
+```
+
+Expected result:
+
+- `ok = true`
+- `code = CONNECTSHYFT_THREAD_TIMELINE_LOADED`
+- `items` ordered oldest to newest
+- `neighbor_deleted` and `neighbor_deleted_at_utc` present in the envelope
+- `limit_applied` present in the envelope
+- omitted `limit` resolves to `limit_applied = 200`
+
+**Bounded retrieval example**
+
+```http
+GET /api/v1/connectshyft/threads/thread-f2-unclaimed-1001/timeline?limit=50
+```
+
+Expected result:
+
+- Exactly the 50 most recent eligible timeline items are returned
+- Returned items remain ordered oldest to newest within that 50-item window
+- `limit_applied = 50`
+
+**Deleted-neighbor review example**
+
+```http
+GET /api/v1/connectshyft/threads/thread-soft-delete-detail-1005/timeline?includeDeleted=true
+```
+
+Expected result:
+
+- Authorized admin/debug callers receive the timeline
+- Standard operational callers do not
+
+**Stop point**
+
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npm run build`
+- `cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && npx jest --runInBand src/routes/api/v1/__tests__/connectshyft.timeline.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+
+## Rollback Levers
+
+1. Disable `GET /threads/:threadId/timeline`.
+2. Revert timeline projection and DTO changes.
+3. Fall back to raw canonical event retrieval while preserving canonical event storage unchanged.
+4. Leave deleted-neighbor access rules and canonical event persistence intact during rollback.
+
+## Focused Validation Command
+
+```sh
+cd /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api && \
+  npx jest --runInBand \
+    src/modules/connectshyft/__tests__/inboundSms.test.ts \
+    src/modules/connectshyft/__tests__/canonicalEvents.test.ts \
+    src/modules/connectshyft/__tests__/readContracts.test.ts \
+    src/modules/connectshyft/__tests__/threadTimeline.test.ts \
+    src/routes/api/v1/__tests__/connectshyft.timeline.test.ts
+```
+
+Notes:
+
+- These suites verify the projection module, serializer, route contract, deleted-neighbor behavior, and stable ordering.
+- Broader provider-registry integration coverage may additionally require a locally valid Postgres role or `DATABASE_URL` override.

--- a/specs/025-message-timeline-persistence-and-projection/research.md
+++ b/specs/025-message-timeline-persistence-and-projection/research.md
@@ -1,0 +1,68 @@
+# Research: ConnectShyft Message Timeline Persistence and Projection
+
+The planning input and code review surfaced two material gaps that had to be resolved before design: outbound SMS canonical events do not yet carry projection-ready body or actor data, and the current raw thread timeline heuristic classifies all `voice.*` events as voicemail. The decisions below resolve those gaps and the related route-contract choices.
+
+## Decision 1: Reuse canonical event persistence as the only timeline source and do not add timeline storage
+
+- **Decision**: Keep `apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts` as the sole persistence source for thread history and implement the timeline strictly as a read projection.
+- **Rationale**: The spec prohibits direct writes to timeline storage and requires canonical events to remain the source of truth. The repository already persists provider-neutral canonical thread events into `platform.events` and already guarantees deterministic ordering.
+- **Alternatives considered**:
+  - Add a `thread_timeline` table populated during message send or webhook intake: rejected because it would introduce a second source of truth and direct timeline mutation.
+  - Build timeline items from non-canonical side-effect tables: rejected because it would bypass the approved canonical event pipeline.
+
+## Decision 2: Enrich outbound SMS canonical payloads before building the projection
+
+- **Decision**: Expand outbound SMS canonical event payloads so they include a projection-ready event name such as `connectshyft.outbound.sms_appended`, actor semantics, outbound message body, and available sender or target metadata.
+- **Rationale**: Current outbound message canonical events persist only direction, channel, lifecycle event, and thread state. That is insufficient because the spec requires first-class SMS items with `body` and `actor`, and the timeline must be derived only from canonical events.
+- **Alternatives considered**:
+  - Derive outbound message body from route response payloads or communication audit tables: rejected because those are not the canonical event source of truth.
+  - Omit outbound message bodies from the first release: rejected because SMS items are required to include `body`.
+
+## Decision 3: Store actor semantics in canonical payloads rather than relying on platform event envelope metadata
+
+- **Decision**: Persist a provider-neutral actor classification in the canonical payload for projection purposes.
+- **Rationale**: `recordConnectShyftCanonicalEvent(...)` records `actorId` in the platform mutation envelope, but `listConnectShyftCanonicalEvents(...)` returns only the stored canonical record payload and not the platform event envelope fields. In-memory fallback behavior also lacks envelope metadata, so actor information must travel with the canonical payload to keep DB and in-memory behavior aligned.
+- **Alternatives considered**:
+  - Extend canonical event list queries to read actor columns from `platform.events`: rejected because it would still leave in-memory fallback behavior incomplete and would couple projection behavior to envelope persistence details.
+  - Infer actor only from direction: rejected because outbound actions may be user-initiated or system-initiated and the spec requires explicit `actor`.
+
+## Decision 4: Introduce a dedicated timeline projection module and DTO instead of expanding the current route-local helper
+
+- **Decision**: Replace the route-local raw timeline helper with a dedicated projection service in a new module plus a dedicated serializer or DTO layer.
+- **Rationale**: The current route-local helper returns raw canonical records and uses a coarse `message/voicemail/lifecycle` inference. A separate projection module keeps mapping rules testable, avoids mixing route authorization with event translation, and provides a clean seam for future voice and voicemail expansion.
+- **Alternatives considered**:
+  - Continue expanding the existing route-local `listCanonicalThreadEvents(...)` helper: rejected because projection rules, DTO shaping, and route authorization would remain tightly coupled.
+  - Add the new behavior into `threads.ts`: rejected because `threads.ts` is lifecycle and persistence oriented rather than read-projection oriented.
+
+## Decision 5: Add a dedicated timeline route and keep raw canonical event retrieval available for backward compatibility and rollback
+
+- **Decision**: Add `GET /api/v1/connectshyft/threads/:threadId/timeline` for projected timeline reads and leave existing raw canonical event retrieval available.
+- **Rationale**: Existing thread detail already returns a raw canonical `timeline` array, and changing that shape in place would create avoidable consumer risk. A dedicated route lets the projection contract evolve without breaking current raw-event consumers and gives rollback a clean fallback path.
+- **Alternatives considered**:
+  - Replace the existing `timeline` field inside `GET /threads/:threadId` immediately: rejected because the current consumer expects raw canonical-event-shaped entries.
+  - Require consumers to call `/events` and project client-side: rejected because the projection must be canonical, deterministic, tenant-scoped, and server-owned.
+
+## Decision 6: Use explicit event-to-item mapping instead of substring heuristics for voice and voicemail
+
+- **Decision**: Drive item channel and future type from an explicit mapping table rather than substring tests such as “anything containing `voice.` is voicemail.”
+- **Rationale**: The requested contract must distinguish future voice lifecycle items from voicemail artifacts. The current substring heuristic would incorrectly classify `voice.connected` as voicemail and block forward-compatible evolution.
+- **Alternatives considered**:
+  - Keep current heuristic classification and patch new edge cases as they appear: rejected because it already conflicts with the required voice-event contract.
+  - Treat every non-SMS event as lifecycle-only for now: rejected because voicemail remains a required first-class placeholder.
+
+## Decision 7: Reuse existing deleted-neighbor read metadata and admin/debug gating for the new timeline route
+
+- **Decision**: Reuse the current `includeDeleted=true` route gate and `readContracts.ts` deleted-neighbor metadata to populate `neighbor_deleted` and `neighbor_deleted_at_utc` in the new timeline response.
+- **Rationale**: The repository already distinguishes standard operational thread reads from admin/debug deleted-neighbor review. Reusing that seam avoids duplicating lifecycle state or creating a second authorization path.
+- **Alternatives considered**:
+  - Copy deleted flags into the timeline item model: rejected because deleted state is thread-level context, not an attribute of every canonical event.
+  - Add a separate admin-only timeline route: rejected because the existing route surface already supports deleted-aware review through `includeDeleted=true`.
+
+## Decision 8: Support a bounded `limit` now and defer cursor pagination mechanics
+
+- **Decision**: Reuse the existing maximum canonical-event cap of `200` records per read, add an optional `limit` parameter for bounded most-recent retrieval, and defer cursor or offset pagination to a later slice.
+- **Rationale**: The spec needs a testable present-tense pagination-compatible behavior. A bounded `limit` resolves the coverage gap without introducing full pagination mechanics.
+- **Alternatives considered**:
+  - Implement full pagination now: rejected because it is explicitly out of scope for this feature slice.
+  - Defer all limit behavior entirely: rejected because it leaves pagination compatibility underspecified and untestable.
+  - Remove any read cap and load unbounded event history: rejected because large threads would raise unnecessary performance risk.

--- a/specs/025-message-timeline-persistence-and-projection/spec.md
+++ b/specs/025-message-timeline-persistence-and-projection/spec.md
@@ -1,0 +1,149 @@
+# Feature Specification: ConnectShyft Message Timeline Projection
+
+**Feature Branch**: `025-message-timeline-persistence-and-projection`  
+**Created**: 2026-03-19  
+**Status**: Ready for Planning  
+**Input**: User description: "Provide a unified, ordered timeline per thread that includes inbound and outbound SMS as first-class artifacts, with a projection model derived from canonical events. Establish a forward-compatible contract for voice events and voicemails."
+
+## Scope
+
+- Deliver a unified per-thread timeline retrieval contract that elevates inbound and outbound SMS into first-class timeline items instead of exposing only raw event history.
+- Keep canonical events as the sole source of truth and treat the timeline as a read projection derived from those events.
+- Preserve a stable contract that can later represent voice call lifecycle events and voicemail artifacts in the same ordered thread history.
+- Keep deleted-neighbor history available to authorized admin/debug review through tenant-scoped retrieval while excluding deleted-neighbor threads from standard non-admin timeline reads.
+- Introduce bounded most-recent retrieval through an optional `limit` without changing item identity or ordering semantics.
+
+## Projection Principles
+
+- Canonical events are the source of truth for thread-history changes, and the timeline is a read model derived exclusively from them.
+- No UI surface or out-of-band process may write directly to timeline state or mutate it outside the canonical event pipeline.
+- Timeline ordering is oldest to newest using `(occurred_at_utc, canonical_event_id)` as the deterministic sort key.
+
+## Operational Boundaries
+
+- This feature adds ConnectShyft-owned thread history retrieval and projection behavior only; consumer UI adoption is deferred to a later slice.
+- Existing raw canonical event retrieval remains available during rollout for rollback and debug.
+- Existing admin authentication and non-ConnectShyft lane ownership remain unchanged.
+- This feature does not introduce a user-editable history source, a manual timeline repair tool, or a second source of truth for conversation history.
+
+## Non-Goals
+
+- Rewriting or manually correcting canonical events.
+- Cursor pagination, channel filtering, attachments or MMS, or read receipts.
+- New soft-delete, restore, or hard-delete workflows beyond honoring the existing deleted-neighbor contract.
+- Separate inboxes or operator workflows for voice or voicemail; only the forward-compatible timeline contract is required now.
+- Composer placement or call-control layout changes in any ConnectShyft client UI.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Review a Complete SMS Thread in Order (Priority: P1)
+
+As a ConnectShyft operator, I need the thread timeline API to return inbound and outbound SMS in one unified history ordered from oldest to newest, so any client can present the conversation consistently without re-projecting raw events.
+
+**Why this priority**: This is the core delivery outcome for the slice. Without a unified ordered API response, downstream clients must keep translating raw event history themselves.
+
+**Independent Test**: This can be fully tested by requesting the timeline endpoint for threads with mixed inbound and outbound SMS canonical events and confirming that the projected response returns the expected items in ascending order, uses deterministic tie-breaking, supports bounded retrieval through `limit`, and returns an empty `items` array when no eligible events exist.
+
+**Acceptance Scenarios**:
+
+1. **Given** a thread has canonical inbound and outbound SMS events, **When** the timeline endpoint is requested, **Then** the response shows both directions as first-class items in oldest-to-newest order.
+2. **Given** two canonical events in the same thread share the same event time, **When** the timeline is projected, **Then** their order remains stable using event time followed by canonical event identifier.
+3. **Given** a canonical SMS event carries provider-specific metadata, **When** the timeline item is projected, **Then** the metadata appears only in the optional provider metadata field and the required item fields still appear normally.
+4. **Given** a thread has no timeline-eligible canonical events yet, **When** the timeline endpoint is requested, **Then** the response returns an empty `items` array rather than inventing SMS items.
+5. **Given** a thread has more eligible canonical events than the requested `limit`, **When** the timeline endpoint is requested with that `limit`, **Then** the response returns the most recent eligible items only and preserves oldest-to-newest ordering within the returned window.
+
+---
+
+### User Story 2 - Review Deleted-Neighbor History Without Reintroducing It to Operations (Priority: P2)
+
+As an authorized admin or support reviewer, I need timelines for threads linked to soft-deleted neighbors to remain available in debug or review contexts while staying hidden from standard non-admin retrieval, so history remains auditable without returning deleted records to day-to-day workflows.
+
+**Why this priority**: Deleted-neighbor behavior is a hard business constraint. The feature must preserve history for investigation while keeping standard operations clean and safe.
+
+**Independent Test**: This can be fully tested by requesting timelines for active and soft-deleted-neighbor threads in both authorized admin/debug review and standard non-admin contexts, then confirming only the authorized review path can see deleted-neighbor timelines and no cross-tenant data appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a thread is linked to a soft-deleted neighbor, **When** an authorized admin/debug reviewer requests the deleted-aware timeline retrieval path, **Then** the thread remains queryable and its timeline is returned from canonical events.
+2. **Given** a thread is linked to a soft-deleted neighbor, **When** a standard non-admin timeline retrieval path is used, **Then** that deleted-neighbor thread is excluded entirely from that retrieval path.
+3. **Given** a requester attempts to load a thread outside the current tenant scope, **When** the timeline read is evaluated, **Then** no thread existence, message content, or timeline metadata is revealed.
+
+---
+
+### User Story 3 - Extend the Same Timeline Contract to Voice and Voicemail Later (Priority: P3)
+
+As a product or platform owner, I need the timeline contract to remain compatible with future voice call and voicemail history, so later channel expansion does not require a second conversation model or break existing SMS timeline consumers.
+
+**Why this priority**: The current slice focuses on SMS, but the contract must avoid boxing the product into an SMS-only history model that becomes expensive to replace later.
+
+**Independent Test**: This can be fully tested by validating sample future voice-started, voice-connected, voice-ended, and voicemail canonical events against the declared timeline contract and confirming they fit without breaking current SMS item ordering or identity behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** future canonical voice call events exist for call started, connected, and ended, **When** they are projected into the timeline, **Then** they can appear in the same thread history without changing the ordering rules used for SMS items.
+2. **Given** a future canonical voicemail event exists, **When** it is projected into the timeline, **Then** the timeline contract can represent it as `type = voicemail` with reserved recording and duration fields even when those values are not yet populated.
+3. **Given** a thread eventually contains SMS items plus future voice or voicemail items, **When** the timeline is projected, **Then** all items still share one per-thread identity model and one deterministic ordering rule.
+
+### Edge Cases
+
+- A thread has no canonical events eligible for timeline rendering yet.
+- Multiple canonical events share the same `occurred_at_utc` and must still render in a deterministic order.
+- An SMS canonical event omits optional provider metadata or a future delivery status value.
+- An authorized admin/debug reviewer can inspect a deleted-neighbor thread, but standard non-admin retrieval cannot discover or reopen it.
+- A future voicemail item has no recording URL or transcript yet and still must remain representable in the contract.
+- A thread identifier or canonical event identifier exists in another tenant, and the current tenant must learn nothing from that overlap.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST derive thread timeline content exclusively from canonical thread events and MUST NOT allow direct timeline writes or edits from UI surfaces or any mutation path outside the canonical event pipeline.
+- **FR-002**: The system MUST provide a unified thread timeline that includes inbound SMS and outbound SMS as first-class timeline items.
+- **FR-003**: The system MUST order timeline items in ascending event-time order and MUST use `(event_time, canonical_event_id)` as the stable deterministic tie-breaker.
+- **FR-004**: Every timeline item MUST include `id`, `thread_id`, `direction`, `channel`, `occurred_at_utc`, and `actor`. SMS items MUST also include `body`. Timeline items MAY include `provider_metadata` and `delivery_status` when canonical source data exists.
+- **FR-005**: For the current SMS slice, the system MUST project `channel = sms` and MUST preserve whether each item is inbound or outbound.
+- **FR-006**: The system MUST derive `actor` as one of `system`, `user`, or `neighbor` from canonical event context and preserve that value in the projection.
+- **FR-007**: The timeline retrieval contract MUST return items in stable ascending order so a consuming client can render the newest returned item last without client-side reordering.
+- **FR-008**: The system MUST NOT invent, reorder, or backfill timeline items beyond what the canonical event record authorizes, except to show an empty history when no eligible canonical events exist.
+- **FR-009**: Authorized admin or debug reads for threads linked to soft-deleted neighbors MUST continue to return the thread timeline without resurrecting or reactivating the deleted neighbor.
+- **FR-010**: Non-admin retrieval paths for the timeline MUST exclude soft-deleted-neighbor threads entirely. Admin/debug retrieval paths MAY return them only when explicitly authorized and MUST surface deletion metadata.
+- **FR-011**: Timeline queries MUST be strictly tenant-scoped and MUST NOT reveal thread existence, item content, provider metadata, or any other timeline detail across tenants.
+- **FR-012**: The timeline contract MUST remain forward-compatible with voice call lifecycle items that use the same per-thread identity and ordering rules and can represent call started, call connected, and call ended activity under `channel = voice`.
+- **FR-013**: The timeline contract MUST support voicemail items under `channel = voicemail` and `type = voicemail`, and it MUST reserve `recording_url`, `duration_seconds`, and optional `transcript` fields for voicemail items even when those values are not yet populated.
+- **FR-014**: The timeline retrieval contract MUST accept an optional `limit` parameter. When `limit` is omitted, the response MUST return up to the default maximum of 200 most recent eligible timeline items. When `limit` is provided, the response MUST return up to that many most recent eligible timeline items, ordered oldest-to-newest within the returned window, with a maximum effective value of 200 items per response.
+- **FR-015**: Filtering by channel, attachments or MMS, and read receipts MUST NOT be required for this feature to be considered complete.
+
+### Key Entities *(include if feature involves data)*
+
+- **Canonical Thread Event**: The immutable recorded event that represents a thread activity and remains the source of truth for message, voice, or voicemail history.
+- **Timeline Item Projection**: The read-only item shown in thread history, derived from one canonical event and shaped for stable display and future channel expansion.
+- **Thread Timeline**: The ordered collection of projected timeline items for one thread within one tenant and one access context.
+- **Timeline Access Context**: The authorization and visibility context that distinguishes standard operational views from authorized admin or debug review.
+- **Voicemail Timeline Item**: A future-compatible first-class timeline item representing voicemail content plus reserved recording and transcript metadata.
+
+## Dependencies
+
+- Existing canonical event capture remains the authoritative feed for inbound and outbound SMS thread history.
+- Existing deleted-neighbor access rules continue to distinguish standard non-admin retrieval from authorized admin/debug review.
+- Existing tenant context remains available before any thread timeline read is evaluated.
+
+## Assumptions
+
+- Current acceptance requires first-class SMS timeline items now; voice call and voicemail support are contract commitments for later slices rather than fully implemented behaviors in this slice.
+- The timeline item contract may introduce a `type` discriminator for future non-SMS items without changing the required SMS fields in this slice.
+- Future non-SMS items may omit `body` while still conforming to the same identity and ordering rules.
+- Consumer UI adoption is deferred; this slice defines and verifies the retrieval contract only.
+- `limit` applies to the most recent eligible timeline items and preserves oldest-to-newest ordering within the returned window.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In acceptance validation, 100% of sampled threads with mixed inbound and outbound SMS canonical events render oldest to newest with stable ordering that matches `(occurred_at_utc, canonical_event_id)`.
+- **SC-002**: In contract validation, 100% of SMS timeline items expose the required identity, thread, direction, channel, body, `occurred_at_utc`, and actor fields, and optional provider metadata appears only when canonical source data exists.
+- **SC-003**: In API-consumer validation, 100% of clients that render the response array top-to-bottom display the newest returned item last without additional client-side sorting.
+- **SC-004**: In admin/debug validation, 100% of sampled threads linked to soft-deleted neighbors remain reviewable with their timelines intact, while 100% of equivalent non-admin retrieval attempts exclude those deleted-neighbor threads.
+- **SC-005**: In tenant-isolation validation, 0 cross-tenant timeline reads reveal thread existence, item content, provider metadata, or any other timeline detail to the wrong tenant.
+- **SC-006**: In governance validation, 100% of accepted timeline changes appear only after their canonical events exist, and 0 accepted scenarios rely on direct UI-authored timeline writes or out-of-band timeline mutation.
+- **SC-007**: In contract review, 100% of sample future voice-started, voice-connected, voice-ended, and voicemail events fit the declared timeline item contract without changing the identity or ordering rules used by current SMS timeline items.
+- **SC-008**: In bounded-retrieval validation, 100% of sampled threads with more than 200 eligible canonical events return exactly the requested most recent window when `limit` is provided, and every returned window remains in stable ascending order.

--- a/specs/025-message-timeline-persistence-and-projection/tasks.md
+++ b/specs/025-message-timeline-persistence-and-projection/tasks.md
@@ -1,0 +1,210 @@
+# Tasks: ConnectShyft Message Timeline Persistence and Projection
+
+**Input**: Design documents from `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/`  
+**Prerequisites**: `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/plan.md`, `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/spec.md`, `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/research.md`, `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/data-model.md`, `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/contracts/message-timeline-projection.md`, `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/quickstart.md`
+
+**Tests**: Included because the spec, quickstart, and user input explicitly require verification for ordering correctness, inbound and outbound mix, bounded retrieval through `limit`, empty-timeline behavior, tenant scoping, thread existence validation, soft-deleted neighbor visibility, and forward-compatible voice or voicemail contracts.
+
+**Organization**: Tasks are grouped into setup, foundational prerequisites, then one phase per user story in priority order so each story remains independently executable and testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other tasks in the same phase
+- **[Story]**: Maps to the feature spec user stories where applicable
+- **All task descriptions include exact file paths**
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the new projection and route test surfaces before shared implementation begins.
+
+- [X] T001 Create projection and route test scaffolds in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+- [X] T002 [P] Create timeline projection module and serializer scaffolds in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared projection types, canonical payload seams, and deleted-neighbor metadata hooks that every user story depends on.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [X] T003 Define shared internal camelCase timeline item types, future `type` discriminators, and service result contracts in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts`
+- [X] T004 [P] Extend projection-ready canonical SMS payload seams and event-name constants in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T005 [P] Expose the minimum deleted-neighbor metadata needed for timeline responses in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts`
+- [X] T006 [P] Add reusable request parsing and authorization helpers for `GET /api/v1/connectshyft/threads/:threadId/timeline` in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+
+**Checkpoint**: Shared projection contracts, canonical payload seams, deleted-neighbor metadata, and route helper scaffolding are ready for story-specific work.
+
+---
+
+## Phase 3: User Story 1 - Review a Complete SMS Thread in Order (Priority: P1) 🎯 MVP
+
+**Goal**: Deliver a unified read-only thread timeline API that returns inbound and outbound SMS as first-class items in stable oldest-to-newest order.
+
+**Independent Test**: Call `GET /api/v1/connectshyft/threads/:threadId/timeline` for a thread with mixed inbound and outbound SMS canonical events and verify ordered first-class items, correct inbound and outbound mapping, stable tie-breaking, optional `limit` windows, and empty results for threads with no eligible canonical events.
+
+### Tests for User Story 1
+
+- [X] T007 [P] [US1] Add unit coverage for inbound SMS mapping, outbound SMS mapping, stable sorting, and empty timeline behavior in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts`
+- [X] T008 [P] [US1] Add route coverage for ordered mixed SMS timeline retrieval and empty timeline responses in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+- [X] T009 [US1] Extend canonical-event regression coverage for projection-ready outbound SMS payload completeness in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+- [X] T010 [P] [US1] Add unit and route coverage for optional `limit`-bounded timeline windows in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+
+### Implementation for User Story 1
+
+- [X] T011 [US1] Enrich canonical inbound and outbound SMS payload builders with projection-ready event names, actor fields, message bodies, and sender-target metadata in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T012 [US1] Implement `getThreadTimeline({ tenantId, orgUnitId, threadId, limit })`, canonical event mapping, stable ascending sorting, and bounded most-recent windowing in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts`
+- [X] T013 [US1] Implement timeline item serialization that converts internal camelCase projection results into external snake_case SMS DTO fields in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts`
+- [X] T014 [US1] Add `GET /api/v1/connectshyft/threads/:threadId/timeline` with optional `limit` parsing and projected SMS item responses in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T015 [P] [US1] Document `limit` behavior and external snake_case response expectations in `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/contracts/message-timeline-projection.md` and `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/quickstart.md`
+- [X] T016 [US1] Run focused US1 verification from `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/package.json` against `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`, and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+
+**Checkpoint**: User Story 1 is complete when a timeline endpoint returns first-class inbound and outbound SMS items in deterministic oldest-to-newest order, bounded retrieval through `limit` preserves ordering within the returned window, and empty threads produce an empty item array.
+
+---
+
+## Phase 4: User Story 2 - Review Deleted-Neighbor History Without Reintroducing It to Operations (Priority: P2)
+
+**Goal**: Keep deleted-neighbor thread timelines visible only to authorized admin/debug review while preserving tenant scoping and hiding deleted threads from standard operational access.
+
+**Independent Test**: Request the timeline endpoint for active and soft-deleted-neighbor threads in both normal and `includeDeleted=true` admin/debug contexts and verify `neighbor_deleted` metadata is present only in authorized timeline responses, standard operational flows stay hidden, and cross-tenant or inaccessible thread requests reveal nothing useful.
+
+### Tests for User Story 2
+
+- [X] T017 [P] [US2] Add read-contract coverage for deleted-neighbor metadata and standard hidden behavior in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts`
+- [X] T018 [P] [US2] Add route coverage for tenant scoping, thread existence validation, and admin-only deleted-neighbor timeline access in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+
+### Implementation for User Story 2
+
+- [X] T019 [US2] Extend thread detail or read-contract lookup to supply `neighborDeleted` and `neighborDeletedAtUtc` for timeline reads in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts`
+- [X] T020 [US2] Enforce tenant-scoped thread existence validation and `includeDeleted=true` admin-debug authorization for the timeline route in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T021 [US2] Surface snake_case `neighbor_deleted`, `neighbor_deleted_at_utc`, and `limit_applied` in the timeline response envelope in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T022 [US2] Run focused US2 verification from `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/package.json` against `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+
+**Checkpoint**: User Story 2 is complete when deleted-neighbor timelines are admin/debug-only, standard operational callers cannot access them, thread existence validation is deterministic, and the timeline envelope includes deleted-neighbor flags.
+
+---
+
+## Phase 5: User Story 3 - Extend the Same Timeline Contract to Voice and Voicemail Later (Priority: P3)
+
+**Goal**: Keep the new timeline contract forward-compatible with explicit voice lifecycle items and voicemail placeholders without breaking current SMS behavior.
+
+**Independent Test**: Feed sample future voice-started, voice-connected, voice-ended, and voicemail canonical events into the projection service and verify they fit the reserved contract, preserve ordering, and do not disturb current SMS item mapping.
+
+### Tests for User Story 3
+
+- [X] T023 [P] [US3] Add unit coverage for explicit voice-event and voicemail placeholder mapping in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts`
+- [X] T024 [P] [US3] Add route-level contract coverage that future-safe voice or voicemail placeholders do not regress SMS ordering semantics in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+
+### Implementation for User Story 3
+
+- [X] T025 [US3] Replace substring-based voice or voicemail inference with an explicit event-to-item mapping registry in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts`
+- [X] T026 [US3] Add reserved voicemail placeholder serialization fields and future `type` or `channel` handling in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts`
+- [X] T027 [US3] Preserve raw canonical event retrieval as the rollback path while isolating the new projected route behavior in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- [X] T028 [US3] Run focused US3 verification from `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/package.json` against `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+
+**Checkpoint**: User Story 3 is complete when the projection uses explicit voice or voicemail mapping rules, voicemail placeholders serialize correctly, and raw canonical event retrieval remains available for rollback.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalize validation surfaces and reconfirm unchanged platform contracts after all story work is complete.
+
+- [X] T029 [P] Update final validation notes and rollout evidence in `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/05-testing.md`, `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/06-pr-template.md`, and `/Users/jeremiahotis/projects/connectshyft/specs/025-message-timeline-persistence-and-projection/quickstart.md`
+- [X] T030 [P] Validate unchanged Admin, MoneyShyft, and ConnectShyft routing or deployment contracts using `/Users/jeremiahotis/projects/connectshyft/nginx/nginx.conf`, `/Users/jeremiahotis/projects/connectshyft/docker-compose.example.yml`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/Dockerfile.production`, `/Users/jeremiahotis/projects/connectshyft/apps/admin-api/knexfile.js`, and `/Users/jeremiahotis/projects/connectshyft/docs/PRODUCTION_DEPLOYMENT_GUIDE.md`
+- [X] T031 Run final build and timeline regression verification from `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/package.json` against `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`, and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Starts immediately and creates the new projection and test surfaces.
+- **Foundational (Phase 2)**: Depends on Phase 1 and blocks all user story work.
+- **User Story 1 (Phase 3)**: Depends on Phase 2 and delivers the MVP projected SMS timeline.
+- **User Story 2 (Phase 4)**: Depends on Phase 3 because the new timeline route and projection service must already exist before deleted-neighbor access rules can be validated on them.
+- **User Story 3 (Phase 5)**: Depends on Phase 3 because the forward-compatible voice or voicemail contract extends the same timeline projection and route introduced in US1.
+- **Polish (Phase 6)**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other stories after the foundational phase; this is the recommended MVP.
+- **US2 (P2)**: Builds on US1’s route, DTO, and projection surfaces, then remains independently testable through deleted-neighbor fixtures.
+- **US3 (P3)**: Builds on US1’s route, DTO, and projection surfaces, then remains independently testable with future voice or voicemail fixture events.
+
+### Within Each User Story
+
+- Tests should be written and fail before implementation tasks are considered complete.
+- Canonical payload completeness should land before projection mapping relies on it.
+- Projection logic should land before route response shaping.
+- Route behavior should land before focused story verification.
+
+## Parallel Opportunities
+
+- **Setup**: T001 and T002 can run in parallel because they create different test and implementation files.
+- **Foundational**: T004, T005, and T006 can run in parallel because they touch separate canonical payload, read-contract, and route-helper surfaces.
+- **US1**: T007, T008, and T010 can run in parallel because they touch different test surfaces.
+- **US2**: T017 and T018 can run in parallel because they touch different test files.
+- **US3**: T023 and T024 can run in parallel because they touch different test files.
+- **Polish**: T029 and T030 can run in parallel because documentation updates are separate from deployment or routing verification.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "T007 Add unit coverage for inbound SMS mapping, outbound SMS mapping, stable sorting, and empty timeline behavior in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts"
+Task: "T008 Add route coverage for ordered mixed SMS timeline retrieval and empty timeline responses in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts"
+Task: "T010 Add unit and route coverage for optional limit-bounded timeline windows in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts and /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts"
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "T017 Add read-contract coverage for deleted-neighbor metadata and standard hidden behavior in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts"
+Task: "T018 Add route coverage for tenant scoping, thread existence validation, and admin-only deleted-neighbor timeline access in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts"
+```
+
+---
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "T023 Add unit coverage for explicit voice-event and voicemail placeholder mapping in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts"
+Task: "T024 Add route-level contract coverage that future-safe voice or voicemail placeholders do not regress SMS ordering semantics in /Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational shared seams.
+3. Complete Phase 3: User Story 1.
+4. **STOP and VALIDATE**: Confirm the timeline endpoint returns first-class inbound and outbound SMS items in stable ascending order before taking on deleted-neighbor or future-channel work.
+
+### Incremental Delivery
+
+1. Finish Setup + Foundational to lock canonical payload seams, projection contracts, and route helper scaffolding.
+2. Deliver User Story 1 and validate the SMS timeline as the first usable increment.
+3. Deliver User Story 2 and validate deleted-neighbor admin/debug review plus tenant-scoped access control.
+4. Deliver User Story 3 and validate future-safe voice or voicemail mapping contracts.
+5. Finish with Phase 6 full regression and platform-contract verification.
+
+### Suggested MVP Scope
+
+- **Recommended MVP**: Phase 1 + Phase 2 + Phase 3.
+- **Second increment**: Phase 4 for deleted-neighbor visibility rules and thread existence validation.
+- **Third increment**: Phase 5 for voice or voicemail contract hardening.
+
+### Notes
+
+- Keep canonical events as the only source of truth in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts` and do not add timeline storage anywhere in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/`.
+- Preserve raw canonical event retrieval as the rollback option while the new projected route is introduced in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`.
+- Preserve the existing deleted-neighbor admin/debug contract in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`.

--- a/specs/026-sender-number-architecture/01-specify.md
+++ b/specs/026-sender-number-architecture/01-specify.md
@@ -1,0 +1,99 @@
+# PR 026 — Sender Number Architecture
+
+## Objective
+
+Establish a deterministic, centralized model for selecting sender numbers for SMS and voice, eliminating synthetic identifiers and fallback logic.
+
+---
+
+## Core Requirements
+
+### Files to Include
+
+Create branch 026-sender-number-architecture and use folder specs/026-sender-number-architecture
+
+- specs/026-sender-number-architecture05-testing.md
+- specs/026-sender-number-architecture06-pr-template.md
+
+### Central Authority
+
+All sender number selection MUST go through:
+
+resolveSenderNumber({
+tenantId,
+orgUnitId,
+threadId,
+channel
+})
+
+---
+
+### Supported Channels
+
+- sms
+- voice (future)
+
+---
+
+### Inputs
+
+- tenantId
+- orgUnitId
+- threadId
+- channel
+
+---
+
+### Outputs
+
+- providerNumberE164
+- mappingId (optional)
+- routing metadata
+
+---
+
+### Behavior
+
+- MUST NOT generate synthetic identifiers
+- MUST NOT fallback to neighborId or threadId
+- MUST use number mapping service
+
+---
+
+### Consistency
+
+- same thread MUST use same sender number
+- inbound and outbound must align
+
+---
+
+### Number Mapping Integration
+
+Use existing:
+
+connectShyftNumberMappingServiceAsync.resolveRoutingMappingByNumber
+
+---
+
+### Failure Behavior
+
+If no mapping found:
+
+- deterministic refusal
+- no fallback
+
+---
+
+## Constraints
+
+- no random number assignment
+- no per-message number switching
+- must be tenant-scoped
+
+---
+
+## Out of Scope
+
+- number provisioning
+- number pooling strategies
+- regulatory compliance (A2P)

--- a/specs/026-sender-number-architecture/02-plan.md
+++ b/specs/026-sender-number-architecture/02-plan.md
@@ -1,0 +1,57 @@
+# PR 026 — Plan
+
+## Files to Modify
+
+- outbound SMS flow
+- inbound SMS correlation
+- voice flow (partial)
+
+## Files to Create
+
+- senderNumberResolver.ts
+
+---
+
+## Implementation Strategy
+
+### Step 1 — Resolver Module
+
+Create:
+
+resolveSenderNumber(...)
+
+---
+
+### Step 2 — Replace Synthetic IDs
+
+Remove:
+
+sms-inbound:${...}
+sms-outbound:${...}
+
+---
+
+### Step 3 — Integrate with Mapping Service
+
+Use:
+
+resolveRoutingMappingByNumber
+
+---
+
+### Step 4 — Enforce Consistency
+
+- store resolved number per thread if needed
+
+---
+
+## Risks
+
+- missing mappings
+- breaking outbound SMS
+
+---
+
+## Rollback Strategy
+
+- re-enable synthetic fallback temporarily

--- a/specs/026-sender-number-architecture/03-tasks.md
+++ b/specs/026-sender-number-architecture/03-tasks.md
@@ -1,0 +1,28 @@
+# PR 026 — Tasks
+
+## Resolver
+
+- [ ] create senderNumberResolver
+- [ ] integrate mapping service
+
+---
+
+## Replace Logic
+
+- [ ] remove synthetic ID usage
+- [ ] update outbound SMS flow
+- [ ] update inbound correlation fallback
+
+---
+
+## Validation
+
+- [ ] enforce mapping existence
+- [ ] add refusal path
+
+---
+
+## Testing
+
+- [ ] consistent number per thread
+- [ ] failure on missing mapping

--- a/specs/026-sender-number-architecture/04-implement.md
+++ b/specs/026-sender-number-architecture/04-implement.md
@@ -1,0 +1,23 @@
+# PR 026 — Implementation Notes
+
+## Resolver
+
+async function resolveSenderNumber(input) {
+const mapping = await numberMappingService.resolveRoutingMappingByNumber({
+tenantId: input.tenantId,
+twilioNumberE164: input.providerNumberE164,
+});
+
+if (mapping.status !== ‘found’) {
+throw new Error(‘sender_number_unresolved’);
+}
+
+return mapping.mapping.providerNumberE164;
+}
+
+---
+
+## Important
+
+- DO NOT fallback to threadId or neighborId
+- DO NOT generate synthetic identifiers

--- a/specs/026-sender-number-architecture/05-testing.md
+++ b/specs/026-sender-number-architecture/05-testing.md
@@ -1,0 +1,20 @@
+# PR 026 — Testing Obligations
+
+## Unit Tests
+
+- resolver returns correct number
+- resolver fails when mapping missing
+
+---
+
+## Integration Tests
+
+- outbound SMS uses correct sender
+- inbound SMS maps correctly
+
+---
+
+## Regression
+
+- inbound SMS still resolves correctly
+- timeline unaffected

--- a/specs/026-sender-number-architecture/06-pr-template.md
+++ b/specs/026-sender-number-architecture/06-pr-template.md
@@ -1,0 +1,39 @@
+# PR 026 — Sender Number Architecture
+
+## Summary
+
+Introduces a centralized sender number resolution model and removes synthetic routing identifiers.
+
+---
+
+## Changes
+
+- Added sender number resolver
+- Removed synthetic ID usage
+- Integrated number mapping service
+
+---
+
+## Why
+
+Needed consistent and deterministic routing for SMS and voice.
+
+---
+
+## Testing
+
+- verified correct number usage
+- verified failure behavior
+
+---
+
+## Risks
+
+- missing mappings
+- routing failures
+
+---
+
+## Rollback
+
+- temporarily restore fallback logic


### PR DESCRIPTION
# PR 025 — Message Timeline Persistence + Projection

## Summary

Introduces a unified per-thread message timeline derived from canonical events, promotes inbound and outbound SMS to first-class timeline items, and establishes a forward-compatible contract for future voice and voicemail history.

---

## Changes

- Added a canonical-event-derived thread timeline projection as a read model rather than a second source of truth.
- Promoted inbound and outbound SMS into first-class ordered timeline items with stable identity and actor fields.
- Preserved deleted-neighbor timeline visibility for authorized admin/debug review while keeping deleted neighbors and threads out of normal operational UI.
- Enforced tenant-scoped timeline reads so thread history cannot leak across tenants.
- Reserved a forward-compatible contract for voice call lifecycle items and voicemail artifacts.

---

## Why

Operators need a trustworthy thread history that reads like a conversation instead of raw event logs, and the product needs that history model to stay compatible with future voice and voicemail work without introducing direct timeline writes or a competing source of truth.

---

## Testing

- Passed focused regression suites:
  - `npx jest --runInBand src/modules/connectshyft/__tests__/inboundSms.test.ts src/modules/connectshyft/__tests__/canonicalEvents.test.ts src/modules/connectshyft/__tests__/readContracts.test.ts src/modules/connectshyft/__tests__/threadTimeline.test.ts src/routes/api/v1/__tests__/connectshyft.timeline.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
- Passed app-local build:
  - `npm run build` from `apps/connectshyft-api`
- Passed local CI parity:
  - `npm run policy:check`
  - `bash scripts/verify-connectshyft-route-ownership.sh`
  - `bash scripts/lint-or-discovery.sh`
  - `bash scripts/ci-run-playwright-stack.sh bash scripts/backend-jest-ci.sh`
  - `bash scripts/quality-gates.sh`
- Completed local change-detection and burn-in flow against `origin/codex/dev`:
  - `bash scripts/ci-run-playwright-stack.sh bash scripts/test-changed.sh origin/codex/dev`
  - `bash scripts/ci-run-playwright-stack.sh bash scripts/burn-in.sh 3 origin/codex/dev`
  - No changed Playwright specs were detected, so those runs skipped cleanly.

---

## Risks

- Same-timestamp events could render in an unstable order if tie-breaking is applied inconsistently.
- Deleted-neighbor timelines could leak back into standard operational flows if visibility rules drift.
- Cross-tenant thread reads could expose message history if timeline projection bypasses tenant scoping.
- Future voice or voicemail work could drift from the reserved contract if not validated against this projection model.

---

## Rollback

- Revert the timeline projection changes together with any consumer changes that depend on first-class timeline items.
- Restore the prior thread-history read behavior only if canonical event history remains unchanged.
- Re-validate deleted-neighbor visibility rules and tenant scoping after rollback before closing the incident.

---

## Checklist

- [x] Canonical events remain the only source of truth for timeline content
- [x] No direct timeline writes exist outside the canonical event pipeline
- [x] Inbound and outbound SMS appear as first-class ordered timeline items
- [x] Deleted-neighbor timelines remain visible only to authorized admin/debug review
- [x] Standard operational UI excludes deleted neighbors and their threads
- [x] Tenant scoping prevents cross-tenant timeline leakage
- [x] Voice and voicemail contract placeholders remain forward-compatible
