### PR TITLE
Slice 6: extract ConnectShyft lifecycle actions to thin-router handlers

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts
@@ -1,0 +1,280 @@
+import type { Request, Response } from 'express';
+import { CAPABILITIES } from '../../../platform/rbac/capabilities';
+import { resolveConnectShyftThreadLifecycleAccessContext } from '../http/threadLifecycleContext';
+import * as accessContextModule from '../http/accessContext';
+import * as readContractsModule from '../readContracts';
+import * as platformMutationsModule from '../../../platform/mutations/executePlatformMutation';
+
+type MockResponse = Response & {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+const createRequest = (overrides: Partial<Request> = {}): Request => {
+  const headers = Object.entries((overrides.headers || {}) as Record<string, string>).reduce<Record<string, string>>(
+    (acc, [key, value]) => {
+      acc[key.toLowerCase()] = value;
+      return acc;
+    },
+    {},
+  );
+
+  return {
+    params: {
+      threadId: 'thread-c5-unclaimed-1001',
+      ...(overrides.params || {}),
+    },
+    body: {
+      reason: 'Operator accepted ownership',
+      resolution: 'follow_up',
+      ...(overrides.body || {}),
+    },
+    query: {},
+    user: {
+      userId: 'user-thread-lifecycle-context-1001',
+      role: 'ORGUNIT_MEMBER',
+      activeTenantId: 'tenant-connectshyft-c5',
+      activeOrgUnitId: 'org-connectshyft-c5-east',
+      householdId: 'tenant-connectshyft-c5',
+      email: 'thread-lifecycle-context@test.local',
+      ...(overrides.user || {}),
+    },
+    header: (name: string) => headers[name.toLowerCase()] || undefined,
+    ...overrides,
+  } as unknown as Request;
+};
+
+const createMockResponse = (): MockResponse => {
+  const res = {
+    locals: {
+      responseEnvelope: {
+        correlationId: 'corr-thread-lifecycle-context',
+        tenantId: 'tenant-connectshyft-c5',
+      },
+    },
+    status: jest.fn(),
+    json: jest.fn(),
+  } as unknown as MockResponse;
+
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+
+  return res;
+};
+
+describe('connectshyft thread lifecycle helper boundary', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+  const resolvedContext = {
+    tenantId: 'tenant-connectshyft-c5',
+    orgUnitId: 'org-connectshyft-c5-east',
+    bypassedOrgUnitMembership: false,
+    effectiveRoles: ['ORGUNIT_MEMBER'],
+  } as const;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+  });
+
+  beforeEach(() => {
+    jest.spyOn(accessContextModule, 'enforceConnectShyftCapability').mockResolvedValue({
+      connectshyft_enabled: true,
+      connectshyft_inbox_enabled: true,
+      connectshyft_escalation_enabled: true,
+      connectshyft_webhooks_enabled: true,
+    } as any);
+    jest.spyOn(accessContextModule, 'resolveConnectShyftRouteContextDecision').mockResolvedValue({
+      ok: true,
+      context: resolvedContext,
+    } as any);
+    jest.spyOn(accessContextModule, 'requestHasAnyCapability').mockReturnValue(true);
+    jest.spyOn(accessContextModule, 'resolveConnectShyftRequestedActorUserId').mockReturnValue(
+      'user-thread-lifecycle-context-1001',
+    );
+    jest.spyOn(accessContextModule, 'resolveConnectShyftActorRoles').mockReturnValue([
+      'ORGUNIT_MEMBER',
+    ]);
+    jest.spyOn(accessContextModule, 'loadConnectShyftPlatformDb').mockReturnValue({ mocked: 'db' } as any);
+    jest.spyOn(accessContextModule, 'respondWithConnectShyftContextRefusal').mockImplementation((res) => res);
+    jest.spyOn(accessContextModule, 'sendConnectShyftRouteRefusal').mockImplementation((res) => res);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+  });
+
+  it('returns the scoped lifecycle prerequisites for a valid claim request', async () => {
+    const context = await resolveConnectShyftThreadLifecycleAccessContext(
+      createRequest(),
+      createMockResponse(),
+      'claim',
+    );
+
+    expect(context).toMatchObject({
+      action: 'claim',
+      context: resolvedContext,
+      threadId: 'thread-c5-unclaimed-1001',
+      actorUserId: 'user-thread-lifecycle-context-1001',
+      actorRoles: ['ORGUNIT_MEMBER'],
+      reason: 'Operator accepted ownership',
+      resolution: 'follow_up',
+      nextState: 'CLAIMED',
+      lifecycleContext: {
+        currentState: 'UNCLAIMED',
+        claimedByUserId: null,
+        syntheticThread: {
+          tenantId: 'tenant-connectshyft-c5',
+          orgUnitId: 'org-connectshyft-c5-east',
+          state: 'UNCLAIMED',
+        },
+      },
+    });
+    expect(Object.keys(context || {}).sort()).toEqual([
+      'action',
+      'actorRoles',
+      'actorUserId',
+      'context',
+      'lifecycleContext',
+      'nextState',
+      'reason',
+      'resolution',
+      'threadId',
+    ]);
+    expect(accessContextModule.requestHasAnyCapability).toHaveBeenCalledWith(
+      expect.anything(),
+      [
+        CAPABILITIES.ORG_UNIT_THREAD_CLAIM,
+        CAPABILITIES.THREAD_TAKEOVER_ALL,
+      ],
+      resolvedContext,
+    );
+  });
+
+  it('returns the current client refusal for a missing thread id', async () => {
+    const res = createMockResponse();
+
+    const context = await resolveConnectShyftThreadLifecycleAccessContext(
+      createRequest({
+        params: {
+          threadId: '   ',
+        } as any,
+      }),
+      res,
+      'claim',
+    );
+
+    expect(context).toBeNull();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+      correlationId: 'corr-thread-lifecycle-context',
+      tenantId: 'tenant-connectshyft-c5',
+    }));
+  });
+
+  it('maps unavailable lifecycle context to the current thread-not-found refusal', async () => {
+    const sendRefusalSpy = accessContextModule.sendConnectShyftRouteRefusal as jest.MockedFunction<
+      typeof accessContextModule.sendConnectShyftRouteRefusal
+    >;
+    const resolveContractSpy = jest.spyOn(
+      readContractsModule,
+      'resolveConnectShyftThreadDetailContractAsync',
+    ).mockResolvedValue(null);
+
+    const context = await resolveConnectShyftThreadLifecycleAccessContext(
+      createRequest({
+        params: {
+          threadId: '11111111-1111-4111-8111-111111111111',
+        } as any,
+      }),
+      createMockResponse(),
+      'claim',
+    );
+
+    expect(context).toBeNull();
+    expect(resolveContractSpy).toHaveBeenCalledWith({
+      tenantId: 'tenant-connectshyft-c5',
+      orgUnitId: 'org-connectshyft-c5-east',
+      threadId: '11111111-1111-4111-8111-111111111111',
+      actorUserId: 'user-thread-lifecycle-context-1001',
+      db: { mocked: 'db' },
+    });
+    expect(sendRefusalSpy).toHaveBeenCalledWith(expect.anything(), {
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread not found for this tenant/orgUnit context.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        context: resolvedContext,
+        threadId: '11111111-1111-4111-8111-111111111111',
+      },
+    });
+  });
+
+  it('maps missing actor attribution to the current lifecycle policy refusal', async () => {
+    const sendRefusalSpy = accessContextModule.sendConnectShyftRouteRefusal as jest.MockedFunction<
+      typeof accessContextModule.sendConnectShyftRouteRefusal
+    >;
+    jest.spyOn(accessContextModule, 'resolveConnectShyftRequestedActorUserId').mockReturnValue(null);
+
+    const context = await resolveConnectShyftThreadLifecycleAccessContext(
+      createRequest(),
+      createMockResponse(),
+      'claim',
+    );
+
+    expect(context).toBeNull();
+    expect(sendRefusalSpy).toHaveBeenCalledWith(expect.anything(), {
+      code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+      message: 'Lifecycle actions require actor attribution.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        context: resolvedContext,
+        threadId: 'thread-c5-unclaimed-1001',
+        priorState: 'UNCLAIMED',
+      },
+    });
+  });
+
+  it('stays limited to lifecycle prerequisites and does not perform transition side effects', async () => {
+    const executeMutationSpy = jest.spyOn(
+      platformMutationsModule,
+      'executePlatformMutation',
+    ).mockImplementation(async () => {
+      throw new Error('executePlatformMutation should not run during access-context resolution');
+    });
+    const res = createMockResponse();
+
+    const context = await resolveConnectShyftThreadLifecycleAccessContext(
+      createRequest({
+        body: {
+          reason: 'Need ownership',
+          resolution: 'call_back',
+        },
+      }),
+      res,
+      'claim',
+    );
+
+    expect(context).toMatchObject({
+      action: 'claim',
+      threadId: 'thread-c5-unclaimed-1001',
+      reason: 'Need ownership',
+      resolution: 'call_back',
+      nextState: 'CLAIMED',
+    });
+    expect(executeMutationSpy).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md
@@ -1,0 +1,77 @@
+# ConnectShyft Thread Lifecycle Notes
+
+## Current ownership
+
+The ConnectShyft lifecycle action surface is currently split across these files:
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+  - owns only route registration for:
+    - `POST /threads/:threadId/claim`
+    - `POST /threads/:threadId/takeover`
+    - `POST /threads/:threadId/close`
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClaim.ts`
+  - owns request handoff for claim and delegates lifecycle execution through the shared helper boundary
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadTakeover.ts`
+  - owns request handoff for takeover and delegates lifecycle execution through the shared helper boundary
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClose.ts`
+  - owns request handoff for close and delegates lifecycle execution through the shared helper boundary
+- `apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts`
+  - owns lifecycle prerequisite resolution, capability and membership gating, `threadId` parsing, lifecycle-context loading, refusal mapping, side-effect orchestration, and preserved response assembly for claim/takeover/close
+
+## Response shape preservation rule
+
+Slice 6 intentionally preserves the exact current lifecycle response shapes.
+
+That means claim, takeover, and close still return the existing envelope structure, including:
+
+- `threadId`
+- `context`
+- `reason`
+- `resolution`
+- `thread`
+- `lifecycleEvent`
+- `sideEffectsPersisted`
+- `escalation`
+- `audit`
+- `outbox`
+
+This was deliberate. The goal of this slice was thin-router extraction and a cleaner lifecycle boundary, not payload redesign.
+
+## Claim visibility rule
+
+Claim semantics remain unchanged in this slice:
+
+- a claimed thread moves into My Conversations
+- the same thread may still appear in Inbox
+- the thread should remain visibly recognized as claimed wherever it is rendered
+
+This behavior is preserved by characterization coverage and should not be tightened casually in follow-up cleanup.
+
+## Deferred scope
+
+The following work remains deferred beyond the lifecycle family:
+
+- outbound call extraction
+- outbound message extraction
+- inbound SMS extraction
+- inbound voice extraction
+- webhook and provider-correlation extraction
+- PeopleCore neighbor or identity bridge convergence work
+- lifecycle semantic redesign or response reshaping
+
+## Guardrails for future work
+
+When editing lifecycle handlers in later slices:
+
+1. Keep route registration thin in `connectshyft.ts`.
+2. Keep shared lifecycle prerequisite and refusal behavior in `threadLifecycleContext.ts`.
+3. Preserve the current response shapes unless characterization coverage is intentionally updated.
+4. Do not fold outbound dispatch logic into the lifecycle handlers.
+5. Do not pull webhook or inbound orchestration into the lifecycle helper boundary.
+6. Treat claim visibility semantics as locked until a later slice explicitly changes them.
+
+## Explicit separation note
+
+Lifecycle extraction is now separate from outbound and webhook extraction.
+
+That separation should remain explicit. Follow-up cleanup should not use the lifecycle helper boundary as a place to absorb outbound reopen rules, provider dispatch concerns, inbound correlation work, or webhook processing. The next extraction target after Slice 6 is neighbors / identity bridge, while outbound and webhook surfaces remain intentionally deferred.

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts
@@ -4,3 +4,6 @@ export { getConnectInbox } from './getConnectInbox';
 export { getConnectSettingsNavigation } from './getConnectSettingsNavigation';
 export { getConnectThreadDetail } from './getConnectThreadDetail';
 export { getConnectThreadTimeline } from './getConnectThreadTimeline';
+export { postConnectThreadClaim } from './postConnectThreadClaim';
+export { postConnectThreadClose } from './postConnectThreadClose';
+export { postConnectThreadTakeover } from './postConnectThreadTakeover';

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClaim.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClaim.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+import { executeConnectShyftThreadLifecycleAction } from '../http/threadLifecycleContext';
+
+export const postConnectThreadClaim = async (req: Request, res: Response) =>
+  executeConnectShyftThreadLifecycleAction(req, res, 'claim');

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClose.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClose.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+import { executeConnectShyftThreadLifecycleAction } from '../http/threadLifecycleContext';
+
+export const postConnectThreadClose = async (req: Request, res: Response) =>
+  executeConnectShyftThreadLifecycleAction(req, res, 'close');

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadTakeover.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadTakeover.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+import { executeConnectShyftThreadLifecycleAction } from '../http/threadLifecycleContext';
+
+export const postConnectThreadTakeover = async (req: Request, res: Response) =>
+  executeConnectShyftThreadLifecycleAction(req, res, 'takeover');

--- a/apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts
@@ -1,0 +1,1109 @@
+import { Request, Response } from 'express';
+import type { Knex } from 'knex';
+import { refusal, success } from '../../../platform/envelopes/response';
+import { executePlatformMutation } from '../../../platform/mutations/executePlatformMutation';
+import { CAPABILITIES } from '../../../platform/rbac/capabilities';
+import type { ResolvedConnectShyftContext } from '../contextAccess';
+import { isConnectShyftTestOverrideEnabled } from '../featureFlags';
+import {
+  resolveConnectShyftThreadDetailContract,
+  resolveConnectShyftThreadDetailContractAsync,
+} from '../readContracts';
+import {
+  AsyncConnectShyftThreadService,
+  KnexConnectShyftThreadStore,
+  connectShyftThreadServiceAsync,
+  evaluateConnectShyftLifecyclePolicy,
+  type ConnectShyftLifecycleAction,
+  type ConnectShyftThread,
+  type ConnectShyftThreadState,
+} from '../threads';
+import {
+  enforceConnectShyftCapability,
+  loadConnectShyftPlatformDb,
+  requestHasAnyCapability,
+  resolveConnectShyftActorRoles,
+  resolveConnectShyftRequestedActorUserId,
+  resolveConnectShyftRouteContextDecision,
+  respondWithConnectShyftContextRefusal,
+  sendConnectShyftRouteRefusal,
+} from './accessContext';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CONNECTSHYFT_LIFECYCLE_EVENT_NAMES = {
+  claimed: 'connectshyft.thread.claimed',
+  takenOver: 'connectshyft.thread.taken_over',
+  closed: 'connectshyft.thread.closed',
+} as const;
+const CONNECTSHYFT_ESCALATION_NOTIFICATION_EVENT_PREFIXES = [
+  'connectshyft.thread.escalation.',
+  'connectshyft.escalation.',
+] as const;
+
+type ConnectShyftSyntheticThreadDescriptor = {
+  tenantId: string;
+  orgUnitId: string;
+  state: ConnectShyftThreadState;
+  claimedByUserId: string | null;
+  escalationStage: number;
+  nextEvaluationAtUtc: string | null;
+  neighborId: string;
+  lastInboundCsNumberId: string;
+  preferredOutboundCsNumberId: string;
+  summary: string;
+};
+
+const CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS: Record<string, ConnectShyftSyntheticThreadDescriptor> = {
+  '483a4c51-e677-422a-8bc6-faeea89c6dcf': {
+    tenantId: 'tenant-connectshyft-c4',
+    orgUnitId: 'org-connectshyft-c4-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 2,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-c4-1001',
+    lastInboundCsNumberId: '+12605550198',
+    preferredOutboundCsNumberId: '+12605550198',
+    summary: 'Unclaimed intake ready for assignment',
+  },
+  '6fb01cbc-069d-485a-86f7-ee72359543b9': {
+    tenantId: 'tenant-connectshyft-c4',
+    orgUnitId: 'org-connectshyft-c4-east',
+    state: 'CLAIMED',
+    claimedByUserId: 'user-connectshyft-c4-other-operator',
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-c4-1002',
+    lastInboundCsNumberId: '+12605550198',
+    preferredOutboundCsNumberId: '+12605550198',
+    summary: 'Claimed thread eligible for takeover/close',
+  },
+  '2f6bbd34-49c7-4400-8982-889c996ab87b': {
+    tenantId: 'tenant-connectshyft-c4',
+    orgUnitId: 'org-connectshyft-c4-east',
+    state: 'CLOSED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-c4-1003',
+    lastInboundCsNumberId: '+12605550198',
+    preferredOutboundCsNumberId: '+12605550198',
+    summary: 'Closed thread awaiting explicit outbound reopen',
+  },
+  '4332bb8e-940f-4927-8320-a8d3f3093d72': {
+    tenantId: 'tenant-connectshyft-d4',
+    orgUnitId: 'org-connectshyft-d4-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 2,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-d4-1001',
+    lastInboundCsNumberId: '+12605550192',
+    preferredOutboundCsNumberId: '+12605550192',
+    summary: 'Unclaimed intake ready for policy-safe outbound action',
+  },
+  '0b3060e8-d0e1-4366-8655-8c7ec44cf0ee': {
+    tenantId: 'tenant-connectshyft-d4',
+    orgUnitId: 'org-connectshyft-d4-east',
+    state: 'CLAIMED',
+    claimedByUserId: 'user-connectshyft-d4-other-operator',
+    escalationStage: 1,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-d4-1002',
+    lastInboundCsNumberId: '+12605550192',
+    preferredOutboundCsNumberId: '+12605550192',
+    summary: 'Claimed thread eligible for close action',
+  },
+  '20ab942f-27c6-4ae5-8af2-06b727c36b2a': {
+    tenantId: 'tenant-connectshyft-d4',
+    orgUnitId: 'org-connectshyft-d4-east',
+    state: 'CLOSED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-d4-1003',
+    lastInboundCsNumberId: '+12605550192',
+    preferredOutboundCsNumberId: '+12605550192',
+    summary: 'Closed thread awaiting explicit same-thread reopen',
+  },
+  '06a77807-6575-4c63-8824-38a89f9dae12': {
+    tenantId: 'tenant-connectshyft-d4',
+    orgUnitId: 'org-connectshyft-d4-east',
+    state: 'CLOSED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-d4-pref-no-1005',
+    lastInboundCsNumberId: '+12605550192',
+    preferredOutboundCsNumberId: '+12605550192',
+    summary: 'Closed thread with prefers_texting=NO policy.',
+  },
+  '59b44eb4-c8e7-4cd1-8a22-bbeceb871dd7': {
+    tenantId: 'tenant-connectshyft-d4',
+    orgUnitId: 'org-connectshyft-d4-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 1,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-d4-pref-no-1004',
+    lastInboundCsNumberId: '+12605550192',
+    preferredOutboundCsNumberId: '+12605550192',
+    summary: 'Unclaimed thread with prefers_texting=NO policy.',
+  },
+  '1641c3dd-4d4c-4997-8b72-ae4876649b37': {
+    tenantId: 'tenant-connectshyft-ux-r4',
+    orgUnitId: 'org-connectshyft-ux-r4-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 2,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-ux-r4-1001',
+    lastInboundCsNumberId: '+12605550196',
+    preferredOutboundCsNumberId: '+12605550196',
+    summary: 'Unclaimed thread with explicit outbound guardrail controls.',
+  },
+  '69c239d2-8f02-4202-8cec-a7f0de61cbf7': {
+    tenantId: 'tenant-connectshyft-ux-r4',
+    orgUnitId: 'org-connectshyft-ux-r4-east',
+    state: 'CLAIMED',
+    claimedByUserId: 'user-connectshyft-ux-r4-other-operator',
+    escalationStage: 1,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-ux-r4-1002',
+    lastInboundCsNumberId: '+12605550196',
+    preferredOutboundCsNumberId: '+12605550196',
+    summary: 'Claimed thread with deterministic policy-safe outbound controls.',
+  },
+  'aedcda71-42b7-4857-8a0a-70013e01d4cd': {
+    tenantId: 'tenant-connectshyft-ux-r4',
+    orgUnitId: 'org-connectshyft-ux-r4-east',
+    state: 'CLOSED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-ux-r4-1003',
+    lastInboundCsNumberId: '+12605550196',
+    preferredOutboundCsNumberId: '+12605550196',
+    summary: 'Closed thread requiring explicit same-thread reopen before outbound.',
+  },
+  '21f2866f-37ff-42da-80fc-0b5d2c3bc09d': {
+    tenantId: 'tenant-connectshyft-ux-r4',
+    orgUnitId: 'org-connectshyft-ux-r4-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 1,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-ux-r4-pref-no-1004',
+    lastInboundCsNumberId: '+12605550196',
+    preferredOutboundCsNumberId: '+12605550196',
+    summary: 'Unclaimed thread with prefers_texting=NO policy.',
+  },
+  'e37b00e0-228f-43c0-8c70-b3d0a5bfad40': {
+    tenantId: 'tenant-connectshyft-ux-r4',
+    orgUnitId: 'org-connectshyft-ux-r4-east',
+    state: 'CLOSED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-ux-r4-pref-no-1005',
+    lastInboundCsNumberId: '+12605550196',
+    preferredOutboundCsNumberId: '+12605550196',
+    summary: 'Closed thread with prefers_texting=NO policy.',
+  },
+  'thread-c5-unclaimed-1001': {
+    tenantId: 'tenant-connectshyft-c5',
+    orgUnitId: 'org-connectshyft-c5-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-c5-1001',
+    lastInboundCsNumberId: '+12605550179',
+    preferredOutboundCsNumberId: '+12605550179',
+    summary: 'Unclaimed thread pending deterministic escalation evaluation',
+  },
+  'cc9bb30e-4b36-4419-8563-819432f4ba14': {
+    tenantId: 'tenant-connectshyft-c4',
+    orgUnitId: 'org-connectshyft-c4-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 1,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-c4-pref-no-1004',
+    lastInboundCsNumberId: '+12605550198',
+    preferredOutboundCsNumberId: '+12605550198',
+    summary: 'Unclaimed thread with prefers_texting=NO policy.',
+  },
+  '935eed99-c710-49e8-838d-ab25d02ca821': {
+    tenantId: 'tenant-connectshyft-c4',
+    orgUnitId: 'org-connectshyft-c4-east',
+    state: 'CLOSED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-c4-pref-no-1005',
+    lastInboundCsNumberId: '+12605550198',
+    preferredOutboundCsNumberId: '+12605550198',
+    summary: 'Closed thread with prefers_texting=NO policy.',
+  },
+  'thread-f1-unclaimed-1001': {
+    tenantId: 'tenant-connectshyft-f1',
+    orgUnitId: 'org-connectshyft-f1-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-f1-1001',
+    lastInboundCsNumberId: '+12605550191',
+    preferredOutboundCsNumberId: '+12605550191',
+    summary: 'F1 unclaimed thread for provider adapter registry contracts.',
+  },
+  'thread-f1-claimed-1002': {
+    tenantId: 'tenant-connectshyft-f1',
+    orgUnitId: 'org-connectshyft-f1-east',
+    state: 'CLAIMED',
+    claimedByUserId: 'user-connectshyft-f1-other-operator',
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-f1-1002',
+    lastInboundCsNumberId: '+12605550191',
+    preferredOutboundCsNumberId: '+12605550191',
+    summary: 'F1 claimed thread for provider disabled refusal validation.',
+  },
+  'thread-f1-closed-1003': {
+    tenantId: 'tenant-connectshyft-f1',
+    orgUnitId: 'org-connectshyft-f1-east',
+    state: 'CLOSED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-f1-1003',
+    lastInboundCsNumberId: '+12605550191',
+    preferredOutboundCsNumberId: '+12605550191',
+    summary: 'F1 closed thread for same-thread reopen provider dispatch validation.',
+  },
+  'thread-f2-unclaimed-1001': {
+    tenantId: 'tenant-connectshyft-f2',
+    orgUnitId: 'org-connectshyft-f2-east',
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 1,
+    nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+    neighborId: 'neighbor-connectshyft-f2-1001',
+    lastInboundCsNumberId: '+12605550192',
+    preferredOutboundCsNumberId: '+12605550192',
+    summary: 'F2 unclaimed thread for canonical event model contracts.',
+  },
+  'thread-f2-claimed-1002': {
+    tenantId: 'tenant-connectshyft-f2',
+    orgUnitId: 'org-connectshyft-f2-east',
+    state: 'CLAIMED',
+    claimedByUserId: 'user-connectshyft-f2-other-operator',
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-f2-1002',
+    lastInboundCsNumberId: '+12605550192',
+    preferredOutboundCsNumberId: '+12605550192',
+    summary: 'F2 claimed thread for canonical timeline validation.',
+  },
+  'thread-f2-closed-1003': {
+    tenantId: 'tenant-connectshyft-f2',
+    orgUnitId: 'org-connectshyft-f2-east',
+    state: 'CLOSED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: null,
+    neighborId: 'neighbor-connectshyft-f2-1003',
+    lastInboundCsNumberId: '+12605550192',
+    preferredOutboundCsNumberId: '+12605550192',
+    summary: 'F2 closed thread for canonical timeline validation.',
+  },
+};
+
+const CONNECTSHYFT_DYNAMIC_C5_THREAD_PREFIX = 'thread-c5-unclaimed-';
+const CONNECTSHYFT_DYNAMIC_C5_THREAD_TEMPLATE_ID = 'thread-c5-unclaimed-1001';
+
+type ResolvedLifecycleContext = {
+  syntheticThread: ConnectShyftSyntheticThreadDescriptor | null;
+  currentState: ConnectShyftThreadState | null;
+  claimedByUserId: string | null;
+};
+
+type LifecycleTransitionSideEffects = {
+  eventName: string;
+  metadata: Record<string, unknown>;
+};
+
+type LifecycleTransitionSideEffectInput =
+  | LifecycleTransitionSideEffects
+  | LifecycleTransitionSideEffects[];
+
+type ConnectShyftThreadLifecycleAccessContext = {
+  action: ConnectShyftLifecycleAction;
+  context: ResolvedConnectShyftContext;
+  threadId: string;
+  actorUserId: string | null;
+  actorRoles: string[];
+  reason: string | null;
+  resolution: string | null;
+  lifecycleContext: ResolvedLifecycleContext;
+  nextState: ConnectShyftThreadState;
+};
+
+class LifecycleTransitionRefusalError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'LifecycleTransitionRefusalError';
+  }
+}
+
+const nowIsoUtc = (): string => new Date().toISOString();
+
+const normalizeLifecycleString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const parseThreadIdParam = (req: Request): string => {
+  if (typeof req.params.threadId !== 'string') {
+    return '';
+  }
+
+  return req.params.threadId.trim();
+};
+
+const parseLifecycleReason = (req: Request): string | null => {
+  const reason = normalizeLifecycleString(req.body?.reason);
+  return reason || null;
+};
+
+const parseLifecycleResolution = (req: Request): string | null => {
+  const resolution = normalizeLifecycleString(req.body?.resolution);
+  return resolution || null;
+};
+
+const resolveLifecycleEventName = (action: ConnectShyftLifecycleAction): string => {
+  if (action === 'claim') {
+    return CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.claimed;
+  }
+
+  if (action === 'takeover') {
+    return CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.takenOver;
+  }
+
+  return CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.closed;
+};
+
+const buildLifecycleMetadata = (input: {
+  tenantId: string;
+  orgUnitId: string;
+  actorUserId: string | null;
+  threadId: string;
+  priorState: ConnectShyftThreadState;
+  newState: ConnectShyftThreadState;
+  action: string;
+  reason?: string | null;
+  resolution?: string | null;
+  threadReopenedByUser?: string | null;
+  lifecycleLineage?: Record<string, unknown> | null;
+}): Record<string, unknown> => ({
+  tenant_id: input.tenantId,
+  org_unit_id: input.orgUnitId,
+  actor_user_id: normalizeLifecycleString(input.actorUserId) || 'unknown',
+  thread_id: input.threadId,
+  prior_state: input.priorState,
+  new_state: input.newState,
+  action: input.action,
+  reason: input.reason || null,
+  resolution: input.resolution || null,
+  thread_reopened_by_user: input.threadReopenedByUser || null,
+  lifecycle_lineage: input.lifecycleLineage || null,
+});
+
+const buildLifecycleSideEffects = (input: {
+  eventName: string;
+  metadata: Record<string, unknown>;
+}) => ({
+  audit: {
+    eventName: input.eventName,
+    metadata: input.metadata,
+  },
+  outbox: {
+    eventName: input.eventName,
+    metadata: input.metadata,
+  },
+});
+
+const buildLifecycleThreadResponse = (
+  thread: ConnectShyftThread,
+): ConnectShyftThread & { escalationStage: number; nextEvaluationAtUtc: string | null } => ({
+  ...thread,
+  escalationStage: thread.escalation.stage,
+  nextEvaluationAtUtc: thread.escalation.nextEvaluationAtUtc,
+});
+
+const resolveMutationActorUserId = (actorUserId: string | null): string | null => {
+  const normalized = normalizeLifecycleString(actorUserId);
+  if (!normalized) {
+    return null;
+  }
+
+  return UUID_PATTERN.test(normalized) ? normalized : null;
+};
+
+const resolveSyntheticLifecycleThread = (input: {
+  threadId: string;
+  tenantId: string;
+  orgUnitId: string;
+}): ConnectShyftSyntheticThreadDescriptor | null => {
+  const existing = CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[input.threadId];
+  if (existing) {
+    if (existing.tenantId !== input.tenantId || existing.orgUnitId !== input.orgUnitId) {
+      return null;
+    }
+
+    return existing;
+  }
+
+  if (!UUID_PATTERN.test(input.threadId)) {
+    const seededThreadDetail = resolveConnectShyftThreadDetailContract({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      threadId: input.threadId,
+    });
+
+    if (seededThreadDetail) {
+      const seededDescriptor: ConnectShyftSyntheticThreadDescriptor = {
+        tenantId: seededThreadDetail.tenantId,
+        orgUnitId: seededThreadDetail.orgUnitId,
+        state: seededThreadDetail.state,
+        claimedByUserId: seededThreadDetail.claimedByUserId,
+        escalationStage: seededThreadDetail.escalationStage,
+        nextEvaluationAtUtc: seededThreadDetail.state === 'UNCLAIMED'
+          ? seededThreadDetail.lastActivityAtUtc
+          : null,
+        neighborId: `neighbor-${seededThreadDetail.threadId}`,
+        lastInboundCsNumberId: seededThreadDetail.lastInboundCsNumberId,
+        preferredOutboundCsNumberId: seededThreadDetail.preferredOutboundCsNumberId,
+        summary: seededThreadDetail.summary,
+      };
+
+      CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[input.threadId] = seededDescriptor;
+      return seededDescriptor;
+    }
+  }
+
+  if (!input.threadId.startsWith(CONNECTSHYFT_DYNAMIC_C5_THREAD_PREFIX)) {
+    return null;
+  }
+
+  const template = CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[CONNECTSHYFT_DYNAMIC_C5_THREAD_TEMPLATE_ID];
+  if (!template) {
+    return null;
+  }
+
+  const dynamicDescriptor: ConnectShyftSyntheticThreadDescriptor = {
+    ...template,
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    state: 'UNCLAIMED',
+    claimedByUserId: null,
+    escalationStage: 0,
+    nextEvaluationAtUtc: template.nextEvaluationAtUtc,
+    neighborId: `neighbor-${input.threadId}`,
+  };
+
+  CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[input.threadId] = dynamicDescriptor;
+  return dynamicDescriptor;
+};
+
+const updateSyntheticLifecycleThread = (thread: ConnectShyftThread): void => {
+  if (isConnectShyftTestOverrideEnabled() && !thread.threadId.startsWith('thread-c5-')) {
+    return;
+  }
+
+  const descriptor = CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[thread.threadId];
+  if (!descriptor) {
+    return;
+  }
+
+  descriptor.state = thread.state;
+  descriptor.claimedByUserId = thread.claimedByUserId;
+  descriptor.escalationStage = thread.escalation.stage;
+  descriptor.nextEvaluationAtUtc = thread.escalation.nextEvaluationAtUtc;
+  descriptor.neighborId = thread.neighborId;
+  descriptor.lastInboundCsNumberId = thread.lastInboundCsNumberId;
+  descriptor.preferredOutboundCsNumberId = thread.preferredOutboundCsNumberId;
+};
+
+const buildSyntheticThread = (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  currentState: ConnectShyftThreadState;
+  nextState: ConnectShyftThreadState;
+  actorUserId: string | null;
+  fallbackNeighborId?: string;
+  fallbackLastInboundCsNumberId?: string;
+  fallbackPreferredOutboundCsNumberId?: string;
+  fallbackEscalationStage?: number;
+  fallbackNextEvaluationAtUtc?: string | null;
+}): ConnectShyftThread => {
+  const now = nowIsoUtc();
+  const actorUserId = normalizeLifecycleString(input.actorUserId) || null;
+  const fallbackEscalationStage = Number.isFinite(input.fallbackEscalationStage)
+    ? Math.max(0, Math.trunc(input.fallbackEscalationStage as number))
+    : 0;
+  const fallbackNextEvaluationAtUtc = normalizeLifecycleString(input.fallbackNextEvaluationAtUtc || null) || null;
+  const isReopened = input.currentState === 'CLOSED' && input.nextState === 'UNCLAIMED';
+  const isNoopState = input.currentState === input.nextState;
+  const escalationStage = isReopened
+    ? 0
+    : isNoopState
+      ? fallbackEscalationStage
+      : input.nextState === 'UNCLAIMED' || input.nextState === 'CLAIMED'
+        ? 0
+        : fallbackEscalationStage;
+  const nextEvaluationAtUtc = input.nextState === 'UNCLAIMED'
+    ? (isNoopState ? (fallbackNextEvaluationAtUtc || now) : now)
+    : null;
+
+  return {
+    threadId: input.threadId,
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    neighborId: input.fallbackNeighborId || `neighbor-${input.threadId}`,
+    source: 'VOICE',
+    state: input.nextState,
+    lastInboundCsNumberId: input.fallbackLastInboundCsNumberId || '',
+    preferredOutboundCsNumberId: input.fallbackPreferredOutboundCsNumberId || '',
+    claimedByUserId: input.nextState === 'CLAIMED' ? actorUserId : null,
+    claimedAtUtc: input.nextState === 'CLAIMED' ? now : null,
+    closedByUserId: input.nextState === 'CLOSED' ? actorUserId : null,
+    closedAtUtc: input.nextState === 'CLOSED' ? now : null,
+    createdAtUtc: now,
+    updatedAtUtc: now,
+    escalation: {
+      stage: escalationStage,
+      nextEvaluationAtUtc,
+    },
+  };
+};
+
+const canPersistLifecycleSideEffects = (input: {
+  tenantId: string;
+  threadId: string;
+  syntheticThread: ConnectShyftSyntheticThreadDescriptor | null;
+  sideEffects?: LifecycleTransitionSideEffectInput;
+}): boolean => {
+  if (!input.sideEffects) {
+    return false;
+  }
+
+  if (input.syntheticThread) {
+    return false;
+  }
+
+  return UUID_PATTERN.test(input.tenantId) && UUID_PATTERN.test(input.threadId);
+};
+
+const resolveLifecycleContext = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  actorUserId: string | null;
+}): Promise<ResolvedLifecycleContext> => {
+  const syntheticThread = resolveSyntheticLifecycleThread({
+    threadId: input.threadId,
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+  });
+  if (syntheticThread) {
+    return {
+      syntheticThread,
+      currentState: syntheticThread.state,
+      claimedByUserId: syntheticThread.claimedByUserId,
+    };
+  }
+
+  const detail = await resolveConnectShyftThreadDetailContractAsync({
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    threadId: input.threadId,
+    actorUserId: input.actorUserId,
+    db: loadConnectShyftPlatformDb(),
+  });
+
+  if (detail) {
+    return {
+      syntheticThread: null,
+      currentState: detail.state,
+      claimedByUserId: detail.claimedByUserId || null,
+    };
+  }
+
+  return {
+    syntheticThread: null,
+    currentState: null,
+    claimedByUserId: null,
+  };
+};
+
+const transitionThreadWithSideEffects = async (input: {
+  actorRoles: Array<string | null | undefined>;
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  actorUserId: string | null;
+  currentState: ConnectShyftThreadState;
+  nextState: ConnectShyftThreadState;
+  syntheticThread: ConnectShyftSyntheticThreadDescriptor | null;
+  sideEffects?: LifecycleTransitionSideEffectInput;
+}): Promise<
+  | { ok: true; thread: ConnectShyftThread; sideEffectsPersisted: boolean }
+  | { ok: false; code: string; message: string }
+> => {
+  if (canPersistLifecycleSideEffects({
+    tenantId: input.tenantId,
+    threadId: input.threadId,
+    syntheticThread: input.syntheticThread,
+    sideEffects: input.sideEffects,
+  })) {
+    try {
+      const lifecycleSideEffects = Array.isArray(input.sideEffects)
+        ? input.sideEffects
+        : [input.sideEffects!];
+      const thread = await executePlatformMutation({
+        mutation: async (trx) => {
+          const txThreadService = new AsyncConnectShyftThreadService(
+            new KnexConnectShyftThreadStore(trx as unknown as Knex),
+          );
+          const transitioned = await txThreadService.transitionThreadState({
+            actorRoles: input.actorRoles,
+            tenantId: input.tenantId,
+            threadId: input.threadId,
+            nextState: input.nextState,
+            actorUserId: input.actorUserId,
+          });
+          if (!transitioned.ok) {
+            throw new LifecycleTransitionRefusalError(transitioned.code, transitioned.message);
+          }
+
+          return transitioned.data.thread;
+        },
+        event: lifecycleSideEffects.map((sideEffect) => ({
+          tenantId: input.tenantId,
+          actorId: resolveMutationActorUserId(input.actorUserId),
+          eventName: sideEffect.eventName,
+          entityType: 'connectshyft.thread',
+          entityId: input.threadId,
+          payload: sideEffect.metadata,
+        })),
+      }, loadConnectShyftPlatformDb());
+
+      return {
+        ok: true,
+        thread,
+        sideEffectsPersisted: true,
+      };
+    } catch (error: unknown) {
+      if (error instanceof LifecycleTransitionRefusalError) {
+        return {
+          ok: false,
+          code: error.code,
+          message: error.message,
+        };
+      }
+
+      return {
+        ok: false,
+        code: 'CONNECTSHYFT_LIFECYCLE_SIDE_EFFECTS_UNAVAILABLE',
+        message: 'Lifecycle transition side effects are temporarily unavailable. Please retry.',
+      };
+    }
+  }
+
+  if (!UUID_PATTERN.test(input.threadId) && input.syntheticThread) {
+    const thread = buildSyntheticThread({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      threadId: input.threadId,
+      currentState: input.currentState,
+      nextState: input.nextState,
+      actorUserId: input.actorUserId,
+      fallbackNeighborId: input.syntheticThread.neighborId,
+      fallbackLastInboundCsNumberId: input.syntheticThread.lastInboundCsNumberId,
+      fallbackPreferredOutboundCsNumberId: input.syntheticThread.preferredOutboundCsNumberId,
+      fallbackEscalationStage: input.syntheticThread.escalationStage,
+      fallbackNextEvaluationAtUtc: input.syntheticThread.nextEvaluationAtUtc,
+    });
+    updateSyntheticLifecycleThread(thread);
+
+    return {
+      ok: true,
+      thread,
+      sideEffectsPersisted: false,
+    };
+  }
+
+  const transitioned = await connectShyftThreadServiceAsync.transitionThreadState({
+    actorRoles: input.actorRoles,
+    tenantId: input.tenantId,
+    threadId: input.threadId,
+    nextState: input.nextState,
+    actorUserId: input.actorUserId,
+  });
+
+  if (transitioned.ok) {
+    return {
+      ok: true,
+      thread: transitioned.data.thread,
+      sideEffectsPersisted: false,
+    };
+  }
+
+  if (transitioned.code !== 'CONNECTSHYFT_THREAD_NOT_FOUND' || !input.syntheticThread) {
+    return {
+      ok: false,
+      code: transitioned.code,
+      message: transitioned.message,
+    };
+  }
+
+  const thread = buildSyntheticThread({
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    threadId: input.threadId,
+    currentState: input.currentState,
+    nextState: input.nextState,
+    actorUserId: input.actorUserId,
+    fallbackNeighborId: input.syntheticThread.neighborId,
+    fallbackLastInboundCsNumberId: input.syntheticThread.lastInboundCsNumberId,
+    fallbackPreferredOutboundCsNumberId: input.syntheticThread.preferredOutboundCsNumberId,
+    fallbackEscalationStage: input.syntheticThread.escalationStage,
+    fallbackNextEvaluationAtUtc: input.syntheticThread.nextEvaluationAtUtc,
+  });
+  updateSyntheticLifecycleThread(thread);
+
+  return {
+    ok: true,
+    thread,
+    sideEffectsPersisted: false,
+  };
+};
+
+const cancelPendingEscalationNotifications = async (input: {
+  tenantId: string;
+  threadId: string;
+}): Promise<number> => {
+  if (!UUID_PATTERN.test(input.tenantId) || !UUID_PATTERN.test(input.threadId)) {
+    return 0;
+  }
+
+  try {
+    const platformDb = loadConnectShyftPlatformDb();
+    const canceled = await platformDb
+      .withSchema('platform')
+      .table('outbox_events')
+      .where({
+        tenant_id: input.tenantId,
+        entity_type: 'connectshyft.thread',
+        entity_id: input.threadId,
+        delivery_status: 'pending',
+      })
+      .andWhere((queryBuilder) => {
+        CONNECTSHYFT_ESCALATION_NOTIFICATION_EVENT_PREFIXES.forEach((prefix, index) => {
+          if (index === 0) {
+            queryBuilder.where('event_name', 'like', `${prefix}%`);
+            return;
+          }
+
+          queryBuilder.orWhere('event_name', 'like', `${prefix}%`);
+        });
+      })
+      .update({
+        delivery_status: 'failed',
+        last_delivery_error: 'Canceled after explicit claim transition.',
+        available_at_utc: platformDb.fn.now(),
+      });
+
+    if (typeof canceled !== 'number' || !Number.isFinite(canceled)) {
+      return 0;
+    }
+
+    return Math.max(0, Math.trunc(canceled));
+  } catch (_error) {
+    return 0;
+  }
+};
+
+const sendLifecycleCapabilityRefusal = (
+  res: Response,
+  action: ConnectShyftLifecycleAction,
+): void => {
+  if (action === 'claim') {
+    sendConnectShyftRouteRefusal(res, {
+      code: 'CONNECTSHYFT_THREAD_CLAIM_FORBIDDEN',
+      message: 'Thread claim requires an authorized orgUnit role.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  if (action === 'takeover') {
+    sendConnectShyftRouteRefusal(res, {
+      code: 'CONNECTSHYFT_THREAD_TAKEOVER_FORBIDDEN',
+      message: 'Thread takeover requires an authorized orgUnit role.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  sendConnectShyftRouteRefusal(res, {
+    code: 'CONNECTSHYFT_THREAD_CLOSE_FORBIDDEN',
+    message: 'Thread close requires an authorized orgUnit role.',
+    refusalType: 'business',
+    httpStatus: 200,
+  });
+};
+
+const requestHasLifecycleActionCapability = (
+  req: Request,
+  action: ConnectShyftLifecycleAction,
+  context: Pick<ResolvedConnectShyftContext, 'effectiveRoles'>,
+): boolean => {
+  if (action === 'claim') {
+    return requestHasAnyCapability(req, [
+      CAPABILITIES.ORG_UNIT_THREAD_CLAIM,
+      CAPABILITIES.THREAD_TAKEOVER_ALL,
+    ], context);
+  }
+
+  if (action === 'takeover') {
+    return requestHasAnyCapability(req, [
+      CAPABILITIES.ORG_UNIT_THREAD_TAKEOVER,
+      CAPABILITIES.THREAD_TAKEOVER_ALL,
+    ], context);
+  }
+
+  return requestHasAnyCapability(req, [
+    CAPABILITIES.ORG_UNIT_THREAD_CLOSE,
+    CAPABILITIES.THREAD_TAKEOVER_ALL,
+  ], context);
+};
+
+const resolveLifecycleSuccessResponse = (action: ConnectShyftLifecycleAction) => {
+  if (action === 'claim') {
+    return {
+      code: 'CONNECTSHYFT_THREAD_CLAIMED',
+      message: 'ConnectShyft claim action accepted',
+    };
+  }
+
+  if (action === 'takeover') {
+    return {
+      code: 'CONNECTSHYFT_THREAD_TAKEOVER_READY',
+      message: 'ConnectShyft takeover action accepted',
+    };
+  }
+
+  return {
+    code: 'CONNECTSHYFT_THREAD_CLOSED',
+    message: 'ConnectShyft thread closed',
+  };
+};
+
+export const resolveConnectShyftThreadLifecycleAccessContext = async (
+  req: Request,
+  res: Response,
+  action: ConnectShyftLifecycleAction,
+): Promise<ConnectShyftThreadLifecycleAccessContext | null> => {
+  if (!await enforceConnectShyftCapability(req, res, 'escalation')) {
+    return null;
+  }
+
+  const contextDecision = await resolveConnectShyftRouteContextDecision(req);
+  if (!contextDecision.ok) {
+    respondWithConnectShyftContextRefusal(res, contextDecision);
+    return null;
+  }
+
+  if (!requestHasLifecycleActionCapability(req, action, contextDecision.context)) {
+    sendLifecycleCapabilityRefusal(res, action);
+    return null;
+  }
+
+  if (
+    contextDecision.context.bypassedOrgUnitMembership
+    && !requestHasAnyCapability(req, [CAPABILITIES.THREAD_TAKEOVER_ALL], contextDecision.context)
+  ) {
+    sendConnectShyftRouteRefusal(res, {
+      code: 'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+      message: 'orgUnit membership is required for this ConnectShyft route',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return null;
+  }
+
+  const threadId = parseThreadIdParam(req);
+  if (!threadId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+      httpStatus: 400,
+    });
+    return null;
+  }
+
+  const actorRoles = resolveConnectShyftActorRoles(req, contextDecision.context);
+  const actorUserId = resolveConnectShyftRequestedActorUserId(req);
+  const lifecycleContext = await resolveLifecycleContext({
+    tenantId: contextDecision.context.tenantId,
+    orgUnitId: contextDecision.context.orgUnitId,
+    threadId,
+    actorUserId,
+  });
+
+  if (!lifecycleContext.currentState) {
+    sendConnectShyftRouteRefusal(res, {
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread not found for this tenant/orgUnit context.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        context: contextDecision.context,
+        threadId,
+      },
+    });
+    return null;
+  }
+
+  const policyDecision = evaluateConnectShyftLifecyclePolicy({
+    action,
+    currentState: lifecycleContext.currentState,
+    claimedByUserId: lifecycleContext.claimedByUserId,
+    actorUserId,
+    actorRoles,
+  });
+  if (!policyDecision.ok) {
+    sendConnectShyftRouteRefusal(res, {
+      code: policyDecision.code,
+      message: policyDecision.message,
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        context: contextDecision.context,
+        threadId,
+        priorState: lifecycleContext.currentState,
+      },
+    });
+    return null;
+  }
+
+  return {
+    action,
+    context: contextDecision.context,
+    threadId,
+    actorUserId,
+    actorRoles,
+    reason: parseLifecycleReason(req),
+    resolution: parseLifecycleResolution(req),
+    lifecycleContext,
+    nextState: policyDecision.nextState,
+  };
+};
+
+export const executeConnectShyftThreadLifecycleAction = async (
+  req: Request,
+  res: Response,
+  action: ConnectShyftLifecycleAction,
+): Promise<void> => {
+  const lifecycleRequest = await resolveConnectShyftThreadLifecycleAccessContext(req, res, action);
+  if (!lifecycleRequest || !lifecycleRequest.lifecycleContext.currentState) {
+    return;
+  }
+
+  const eventName = resolveLifecycleEventName(action);
+  const metadata = buildLifecycleMetadata({
+    tenantId: lifecycleRequest.context.tenantId,
+    orgUnitId: lifecycleRequest.context.orgUnitId,
+    actorUserId: lifecycleRequest.actorUserId,
+    threadId: lifecycleRequest.threadId,
+    priorState: lifecycleRequest.lifecycleContext.currentState,
+    newState: lifecycleRequest.nextState,
+    action,
+    reason: lifecycleRequest.reason,
+    resolution: lifecycleRequest.resolution,
+  });
+  const transitioned = await transitionThreadWithSideEffects({
+    actorRoles: lifecycleRequest.actorRoles,
+    tenantId: lifecycleRequest.context.tenantId,
+    orgUnitId: lifecycleRequest.context.orgUnitId,
+    threadId: lifecycleRequest.threadId,
+    actorUserId: lifecycleRequest.actorUserId,
+    currentState: lifecycleRequest.lifecycleContext.currentState,
+    nextState: lifecycleRequest.nextState,
+    syntheticThread: lifecycleRequest.lifecycleContext.syntheticThread,
+    sideEffects: {
+      eventName,
+      metadata,
+    },
+  });
+
+  if (!transitioned.ok) {
+    sendConnectShyftRouteRefusal(res, {
+      code: transitioned.code,
+      message: transitioned.message,
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        context: lifecycleRequest.context,
+        threadId: lifecycleRequest.threadId,
+      },
+    });
+    return;
+  }
+
+  const sideEffects = buildLifecycleSideEffects({
+    eventName,
+    metadata,
+  });
+  const notificationsCanceled = action === 'claim'
+    ? await cancelPendingEscalationNotifications({
+      tenantId: lifecycleRequest.context.tenantId,
+      threadId: lifecycleRequest.threadId,
+    })
+    : 0;
+  const responseContract = resolveLifecycleSuccessResponse(action);
+
+  success(res, {
+    code: responseContract.code,
+    message: responseContract.message,
+    data: {
+      threadId: lifecycleRequest.threadId,
+      context: lifecycleRequest.context,
+      reason: lifecycleRequest.reason,
+      resolution: lifecycleRequest.resolution,
+      thread: buildLifecycleThreadResponse(transitioned.thread),
+      lifecycleEvent: eventName,
+      sideEffectsPersisted: transitioned.sideEffectsPersisted,
+      escalation: action === 'claim'
+        ? {
+          resetReason: 'claimed' as const,
+          notificationsCanceled,
+        }
+        : null,
+      ...sideEffects,
+    },
+  });
+};

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts
@@ -1,0 +1,353 @@
+// @ts-nocheck
+import express from 'express';
+import request from 'supertest';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import connectShyftRouter from '../connectshyft';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TENANT_ID = 'tenant-connectshyft-c5';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-c5-east';
+const TEST_ACTOR_USER_ID = 'user-connectshyft-c5-operator';
+const CLAIM_SUCCESS_THREAD_ID = 'thread-c5-unclaimed-claim-characterization-success-1001';
+const CLAIM_INVALID_STATE_THREAD_ID = 'thread-c5-unclaimed-claim-characterization-invalid-state-1001';
+const NOT_FOUND_THREAD_ID = '11111111-1111-4111-8111-111111111111';
+
+const buildLifecycleHeaders = (
+  overrides: Record<string, string> = {},
+): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': TEST_ACTOR_USER_ID,
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  ...overrides,
+});
+
+const buildLifecycleApp = (options: {
+  defaultOrgUnitId?: string | null;
+  defaultRole?: string;
+  defaultUserId?: string;
+} = {}) => {
+  const {
+    defaultOrgUnitId = TEST_ORG_UNIT_ID,
+    defaultRole = 'ORGUNIT_MEMBER',
+    defaultUserId = TEST_ACTOR_USER_ID,
+  } = options;
+
+  const app = express();
+  app.use(express.json());
+  app.use(responseEnvelope);
+
+  app.use((req, _res, next) => {
+    req.user = {
+      userId: defaultUserId,
+      email: `${defaultUserId}@connectshyft.test`,
+      householdId: TEST_TENANT_ID,
+      activeTenantId: TEST_TENANT_ID,
+      activeOrgUnitId: defaultOrgUnitId ?? undefined,
+      role: defaultRole,
+    };
+    req.tenantId = TEST_TENANT_ID;
+    req.orgUnitId = defaultOrgUnitId ?? undefined;
+    req.tenantContext = {
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: defaultOrgUnitId ?? undefined,
+      scopeMode: defaultOrgUnitId ? 'ORG_UNIT' : 'TENANT',
+      source: 'auth',
+    };
+
+    next();
+  });
+
+  app.use('/api/v1/connectshyft', connectShyftRouter);
+  return app;
+};
+
+const postClaim = (
+  app: ReturnType<typeof buildApp>,
+  threadId: string,
+  headers: Record<string, string>,
+  body: Record<string, unknown> = {},
+) => request(app)
+  .post(`/api/v1/connectshyft/threads/${threadId}/claim`)
+  .set(headers)
+  .send(body);
+
+describe('connectshyft thread claim route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the current claim success envelope, lifecycle side-effects, and claimed thread shape', async () => {
+    const app = buildApp();
+    const response = await postClaim(
+      app,
+      CLAIM_SUCCESS_THREAD_ID,
+      buildLifecycleHeaders(),
+      {
+        reason: 'Operator accepted ownership',
+        resolution: 'needs_follow_up',
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_CLAIMED',
+      message: 'ConnectShyft claim action accepted',
+      data: {
+        threadId: CLAIM_SUCCESS_THREAD_ID,
+        reason: 'Operator accepted ownership',
+        resolution: 'needs_follow_up',
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+          effectiveRoles: ['ORGUNIT_MEMBER'],
+        },
+        thread: {
+          threadId: CLAIM_SUCCESS_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          neighborId: `neighbor-${CLAIM_SUCCESS_THREAD_ID}`,
+          source: 'VOICE',
+          state: 'CLAIMED',
+          lastInboundCsNumberId: '+12605550179',
+          preferredOutboundCsNumberId: '+12605550179',
+          claimedByUserId: TEST_ACTOR_USER_ID,
+          claimedAtUtc: expect.any(String),
+          closedByUserId: null,
+          closedAtUtc: null,
+          createdAtUtc: expect.any(String),
+          updatedAtUtc: expect.any(String),
+          escalation: {
+            stage: 0,
+            nextEvaluationAtUtc: null,
+          },
+          escalationStage: 0,
+          nextEvaluationAtUtc: null,
+        },
+        lifecycleEvent: 'connectshyft.thread.claimed',
+        sideEffectsPersisted: false,
+        escalation: {
+          resetReason: 'claimed',
+          notificationsCanceled: 0,
+        },
+        audit: {
+          eventName: 'connectshyft.thread.claimed',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: TEST_ACTOR_USER_ID,
+            thread_id: CLAIM_SUCCESS_THREAD_ID,
+            prior_state: 'UNCLAIMED',
+            new_state: 'CLAIMED',
+            action: 'claim',
+            reason: 'Operator accepted ownership',
+            resolution: 'needs_follow_up',
+            thread_reopened_by_user: null,
+            lifecycle_lineage: null,
+          },
+        },
+        outbox: {
+          eventName: 'connectshyft.thread.claimed',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: TEST_ACTOR_USER_ID,
+            thread_id: CLAIM_SUCCESS_THREAD_ID,
+            prior_state: 'UNCLAIMED',
+            new_state: 'CLAIMED',
+            action: 'claim',
+            reason: 'Operator accepted ownership',
+            resolution: 'needs_follow_up',
+            thread_reopened_by_user: null,
+            lifecycle_lineage: null,
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'audit',
+      'context',
+      'escalation',
+      'lifecycleEvent',
+      'outbox',
+      'reason',
+      'resolution',
+      'sideEffectsPersisted',
+      'thread',
+      'threadId',
+    ].sort());
+    expect(Object.keys(response.body.data.context).sort()).toEqual([
+      'bypassedOrgUnitMembership',
+      'effectiveRoles',
+      'orgUnitId',
+      'tenantId',
+    ].sort());
+    expect(Object.keys(response.body.data.thread).sort()).toEqual([
+      'claimedAtUtc',
+      'claimedByUserId',
+      'closedAtUtc',
+      'closedByUserId',
+      'createdAtUtc',
+      'escalation',
+      'escalationStage',
+      'lastInboundCsNumberId',
+      'neighborId',
+      'nextEvaluationAtUtc',
+      'orgUnitId',
+      'preferredOutboundCsNumberId',
+      'source',
+      'state',
+      'tenantId',
+      'threadId',
+      'updatedAtUtc',
+    ].sort());
+    expect(response.body.data.audit).toEqual(response.body.data.outbox);
+  });
+
+  it('returns the current invalid-state refusal when claim is retried on an already claimed thread', async () => {
+    const app = buildApp();
+
+    await postClaim(
+      app,
+      CLAIM_INVALID_STATE_THREAD_ID,
+      buildLifecycleHeaders(),
+      {
+        reason: 'Initial owner assignment',
+      },
+    );
+
+    const response = await postClaim(
+      app,
+      CLAIM_INVALID_STATE_THREAD_ID,
+      buildLifecycleHeaders(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+      message: 'Lifecycle action "claim" is invalid from state CLAIMED.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: CLAIM_INVALID_STATE_THREAD_ID,
+        priorState: 'CLAIMED',
+      },
+    });
+  });
+
+  it('returns the current thread-not-found refusal for a claim outside the current tenant and orgUnit scope', async () => {
+    const app = buildApp();
+    const response = await postClaim(
+      app,
+      NOT_FOUND_THREAD_ID,
+      buildLifecycleHeaders(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread not found for this tenant/orgUnit context.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: NOT_FOUND_THREAD_ID,
+      },
+    });
+  });
+
+  it('returns the current orgUnit-membership refusal before claim evaluation', async () => {
+    const app = buildApp();
+    const response = await postClaim(
+      app,
+      CLAIM_SUCCESS_THREAD_ID,
+      buildLifecycleHeaders({
+        'x-test-connectshyft-orgunit-memberships': JSON.stringify([]),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+      message: 'orgUnit membership is required for this ConnectShyft route',
+      refusalType: 'business',
+    });
+  });
+
+  it('returns the current claim capability refusal for roles without claim access', async () => {
+    const app = buildApp();
+    const response = await postClaim(
+      app,
+      CLAIM_SUCCESS_THREAD_ID,
+      buildLifecycleHeaders({
+        'x-test-connectshyft-role': 'ORGUNIT_IDENTITY_LEAD',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_CLAIM_FORBIDDEN',
+      message: 'Thread claim requires an authorized orgUnit role.',
+      refusalType: 'business',
+    });
+  });
+
+  it('returns the current missing-orgUnit refusal for claim requests without orgUnit context', async () => {
+    const app = buildLifecycleApp({
+      defaultOrgUnitId: null,
+    });
+    const headers = buildLifecycleHeaders();
+    delete headers['x-test-connectshyft-orgunit-id'];
+    delete headers['x-test-connectshyft-orgunit-memberships'];
+
+    const response = await postClaim(
+      app,
+      CLAIM_SUCCESS_THREAD_ID,
+      headers,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+      message: 'orgUnit context is required for ConnectShyft orgUnit-scoped routes',
+      refusalType: 'business',
+    });
+  });
+
+  it('returns the current client refusal when claim receives a blank threadId param', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/threads/%20/claim')
+      .set(buildLifecycleHeaders())
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+    });
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts
@@ -1,0 +1,320 @@
+// @ts-nocheck
+import express from 'express';
+import request from 'supertest';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import connectShyftRouter from '../connectshyft';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TENANT_ID = 'tenant-connectshyft-c5';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-c5-east';
+const INITIAL_ACTOR_USER_ID = 'user-connectshyft-c5-operator';
+const SECOND_ACTOR_USER_ID = 'user-connectshyft-c5-second-operator';
+const CLOSE_SUCCESS_THREAD_ID = 'thread-c5-unclaimed-close-characterization-success-1001';
+const CLOSE_OWNERSHIP_THREAD_ID = 'thread-c5-unclaimed-close-characterization-ownership-1001';
+const NOT_FOUND_THREAD_ID = '33333333-3333-4333-8333-333333333333';
+
+const buildLifecycleHeaders = (
+  overrides: Record<string, string> = {},
+): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': INITIAL_ACTOR_USER_ID,
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  ...overrides,
+});
+
+const buildLifecycleApp = (options: {
+  defaultOrgUnitId?: string | null;
+  defaultRole?: string;
+  defaultUserId?: string;
+} = {}) => {
+  const {
+    defaultOrgUnitId = TEST_ORG_UNIT_ID,
+    defaultRole = 'ORGUNIT_MEMBER',
+    defaultUserId = INITIAL_ACTOR_USER_ID,
+  } = options;
+
+  const app = express();
+  app.use(express.json());
+  app.use(responseEnvelope);
+
+  app.use((req, _res, next) => {
+    req.user = {
+      userId: defaultUserId,
+      email: `${defaultUserId}@connectshyft.test`,
+      householdId: TEST_TENANT_ID,
+      activeTenantId: TEST_TENANT_ID,
+      activeOrgUnitId: defaultOrgUnitId ?? undefined,
+      role: defaultRole,
+    };
+    req.tenantId = TEST_TENANT_ID;
+    req.orgUnitId = defaultOrgUnitId ?? undefined;
+    req.tenantContext = {
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: defaultOrgUnitId ?? undefined,
+      scopeMode: defaultOrgUnitId ? 'ORG_UNIT' : 'TENANT',
+      source: 'auth',
+    };
+
+    next();
+  });
+
+  app.use('/api/v1/connectshyft', connectShyftRouter);
+  return app;
+};
+
+const postClaim = (
+  app: ReturnType<typeof buildApp>,
+  threadId: string,
+  headers: Record<string, string>,
+) => request(app)
+  .post(`/api/v1/connectshyft/threads/${threadId}/claim`)
+  .set(headers)
+  .send({});
+
+const postClose = (
+  app: ReturnType<typeof buildApp>,
+  threadId: string,
+  headers: Record<string, string>,
+  body: Record<string, unknown> = {},
+) => request(app)
+  .post(`/api/v1/connectshyft/threads/${threadId}/close`)
+  .set(headers)
+  .send(body);
+
+describe('connectshyft thread close route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the current close success envelope and closed thread shape', async () => {
+    const app = buildApp();
+    await postClaim(
+      app,
+      CLOSE_SUCCESS_THREAD_ID,
+      buildLifecycleHeaders(),
+    );
+
+    const response = await postClose(
+      app,
+      CLOSE_SUCCESS_THREAD_ID,
+      buildLifecycleHeaders(),
+      {
+        reason: 'Resident issue resolved',
+        resolution: 'closed_after_follow_up',
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_CLOSED',
+      message: 'ConnectShyft thread closed',
+      data: {
+        threadId: CLOSE_SUCCESS_THREAD_ID,
+        reason: 'Resident issue resolved',
+        resolution: 'closed_after_follow_up',
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+          effectiveRoles: ['ORGUNIT_MEMBER'],
+        },
+        thread: {
+          threadId: CLOSE_SUCCESS_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          neighborId: `neighbor-${CLOSE_SUCCESS_THREAD_ID}`,
+          source: 'VOICE',
+          state: 'CLOSED',
+          lastInboundCsNumberId: '+12605550179',
+          preferredOutboundCsNumberId: '+12605550179',
+          claimedByUserId: null,
+          claimedAtUtc: null,
+          closedByUserId: INITIAL_ACTOR_USER_ID,
+          closedAtUtc: expect.any(String),
+          createdAtUtc: expect.any(String),
+          updatedAtUtc: expect.any(String),
+          escalation: {
+            stage: 0,
+            nextEvaluationAtUtc: null,
+          },
+          escalationStage: 0,
+          nextEvaluationAtUtc: null,
+        },
+        lifecycleEvent: 'connectshyft.thread.closed',
+        sideEffectsPersisted: false,
+        escalation: null,
+        audit: {
+          eventName: 'connectshyft.thread.closed',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: INITIAL_ACTOR_USER_ID,
+            thread_id: CLOSE_SUCCESS_THREAD_ID,
+            prior_state: 'CLAIMED',
+            new_state: 'CLOSED',
+            action: 'close',
+            reason: 'Resident issue resolved',
+            resolution: 'closed_after_follow_up',
+            thread_reopened_by_user: null,
+            lifecycle_lineage: null,
+          },
+        },
+        outbox: {
+          eventName: 'connectshyft.thread.closed',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: INITIAL_ACTOR_USER_ID,
+            thread_id: CLOSE_SUCCESS_THREAD_ID,
+            prior_state: 'CLAIMED',
+            new_state: 'CLOSED',
+            action: 'close',
+            reason: 'Resident issue resolved',
+            resolution: 'closed_after_follow_up',
+            thread_reopened_by_user: null,
+            lifecycle_lineage: null,
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'audit',
+      'context',
+      'escalation',
+      'lifecycleEvent',
+      'outbox',
+      'reason',
+      'resolution',
+      'sideEffectsPersisted',
+      'thread',
+      'threadId',
+    ].sort());
+    expect(Object.keys(response.body.data.thread).sort()).toEqual([
+      'claimedAtUtc',
+      'claimedByUserId',
+      'closedAtUtc',
+      'closedByUserId',
+      'createdAtUtc',
+      'escalation',
+      'escalationStage',
+      'lastInboundCsNumberId',
+      'neighborId',
+      'nextEvaluationAtUtc',
+      'orgUnitId',
+      'preferredOutboundCsNumberId',
+      'source',
+      'state',
+      'tenantId',
+      'threadId',
+      'updatedAtUtc',
+    ].sort());
+    expect(response.body.data.audit).toEqual(response.body.data.outbox);
+  });
+
+  it('returns the current ownership-policy refusal when a different non-takeover actor closes the claimed thread', async () => {
+    const app = buildApp();
+    await postClaim(
+      app,
+      CLOSE_OWNERSHIP_THREAD_ID,
+      buildLifecycleHeaders(),
+    );
+
+    const response = await postClose(
+      app,
+      CLOSE_OWNERSHIP_THREAD_ID,
+      buildLifecycleHeaders({
+        'x-test-connectshyft-user-id': SECOND_ACTOR_USER_ID,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_OWNERSHIP_REQUIRED',
+      message: 'Only the claimed owner or takeover-authorized role may close this thread.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: CLOSE_OWNERSHIP_THREAD_ID,
+        priorState: 'CLAIMED',
+      },
+    });
+  });
+
+  it('returns the current thread-not-found refusal for close requests outside the active scope', async () => {
+    const app = buildApp();
+    const response = await postClose(
+      app,
+      NOT_FOUND_THREAD_ID,
+      buildLifecycleHeaders(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread not found for this tenant/orgUnit context.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: NOT_FOUND_THREAD_ID,
+      },
+    });
+  });
+
+  it('returns the current missing-orgUnit refusal for close requests without orgUnit context', async () => {
+    const app = buildLifecycleApp({
+      defaultOrgUnitId: null,
+    });
+    const headers = buildLifecycleHeaders();
+    delete headers['x-test-connectshyft-orgunit-id'];
+    delete headers['x-test-connectshyft-orgunit-memberships'];
+
+    const response = await postClose(
+      app,
+      CLOSE_SUCCESS_THREAD_ID,
+      headers,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+      message: 'orgUnit context is required for ConnectShyft orgUnit-scoped routes',
+      refusalType: 'business',
+    });
+  });
+
+  it('returns the current client refusal when close receives a blank threadId param', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/threads/%20/close')
+      .set(buildLifecycleHeaders())
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+    });
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts
@@ -1,0 +1,329 @@
+// @ts-nocheck
+import express from 'express';
+import request from 'supertest';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import connectShyftRouter from '../connectshyft';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TENANT_ID = 'tenant-connectshyft-c5';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-c5-east';
+const INITIAL_ACTOR_USER_ID = 'user-connectshyft-c5-operator';
+const TAKEOVER_ACTOR_USER_ID = 'user-connectshyft-c5-admin';
+const TAKEOVER_SUCCESS_THREAD_ID = 'thread-c5-unclaimed-takeover-characterization-success-1001';
+const TAKEOVER_INVALID_STATE_THREAD_ID = 'thread-c5-unclaimed-takeover-characterization-invalid-state-1001';
+const NOT_FOUND_THREAD_ID = '22222222-2222-4222-8222-222222222222';
+
+const buildLifecycleHeaders = (
+  overrides: Record<string, string> = {},
+): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': INITIAL_ACTOR_USER_ID,
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  ...overrides,
+});
+
+const buildLifecycleApp = (options: {
+  defaultOrgUnitId?: string | null;
+  defaultRole?: string;
+  defaultUserId?: string;
+} = {}) => {
+  const {
+    defaultOrgUnitId = TEST_ORG_UNIT_ID,
+    defaultRole = 'ORGUNIT_MEMBER',
+    defaultUserId = INITIAL_ACTOR_USER_ID,
+  } = options;
+
+  const app = express();
+  app.use(express.json());
+  app.use(responseEnvelope);
+
+  app.use((req, _res, next) => {
+    req.user = {
+      userId: defaultUserId,
+      email: `${defaultUserId}@connectshyft.test`,
+      householdId: TEST_TENANT_ID,
+      activeTenantId: TEST_TENANT_ID,
+      activeOrgUnitId: defaultOrgUnitId ?? undefined,
+      role: defaultRole,
+    };
+    req.tenantId = TEST_TENANT_ID;
+    req.orgUnitId = defaultOrgUnitId ?? undefined;
+    req.tenantContext = {
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: defaultOrgUnitId ?? undefined,
+      scopeMode: defaultOrgUnitId ? 'ORG_UNIT' : 'TENANT',
+      source: 'auth',
+    };
+
+    next();
+  });
+
+  app.use('/api/v1/connectshyft', connectShyftRouter);
+  return app;
+};
+
+const postTakeover = (
+  app: ReturnType<typeof buildApp>,
+  threadId: string,
+  headers: Record<string, string>,
+  body: Record<string, unknown> = {},
+) => request(app)
+  .post(`/api/v1/connectshyft/threads/${threadId}/takeover`)
+  .set(headers)
+  .send(body);
+
+const postClaim = (
+  app: ReturnType<typeof buildApp>,
+  threadId: string,
+  headers: Record<string, string>,
+) => request(app)
+  .post(`/api/v1/connectshyft/threads/${threadId}/claim`)
+  .set(headers)
+  .send({});
+
+describe('connectshyft thread takeover route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the current takeover success envelope and preserves the claimed lifecycle surface', async () => {
+    const app = buildApp();
+    await postClaim(
+      app,
+      TAKEOVER_SUCCESS_THREAD_ID,
+      buildLifecycleHeaders(),
+    );
+
+    const response = await postTakeover(
+      app,
+      TAKEOVER_SUCCESS_THREAD_ID,
+      buildLifecycleHeaders({
+        'x-test-connectshyft-role': 'ORGUNIT_ADMIN',
+        'x-test-connectshyft-user-id': TAKEOVER_ACTOR_USER_ID,
+      }),
+      {
+        reason: 'Escalation handoff',
+        resolution: 'swap_owner',
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_TAKEOVER_READY',
+      message: 'ConnectShyft takeover action accepted',
+      data: {
+        threadId: TAKEOVER_SUCCESS_THREAD_ID,
+        reason: 'Escalation handoff',
+        resolution: 'swap_owner',
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+          effectiveRoles: ['ORGUNIT_ADMIN'],
+        },
+        thread: {
+          threadId: TAKEOVER_SUCCESS_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          neighborId: `neighbor-${TAKEOVER_SUCCESS_THREAD_ID}`,
+          source: 'VOICE',
+          state: 'CLAIMED',
+          lastInboundCsNumberId: '+12605550179',
+          preferredOutboundCsNumberId: '+12605550179',
+          claimedByUserId: TAKEOVER_ACTOR_USER_ID,
+          claimedAtUtc: expect.any(String),
+          closedByUserId: null,
+          closedAtUtc: null,
+          createdAtUtc: expect.any(String),
+          updatedAtUtc: expect.any(String),
+          escalation: {
+            stage: 0,
+            nextEvaluationAtUtc: null,
+          },
+          escalationStage: 0,
+          nextEvaluationAtUtc: null,
+        },
+        lifecycleEvent: 'connectshyft.thread.taken_over',
+        sideEffectsPersisted: false,
+        escalation: null,
+        audit: {
+          eventName: 'connectshyft.thread.taken_over',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: TAKEOVER_ACTOR_USER_ID,
+            thread_id: TAKEOVER_SUCCESS_THREAD_ID,
+            prior_state: 'CLAIMED',
+            new_state: 'CLAIMED',
+            action: 'takeover',
+            reason: 'Escalation handoff',
+            resolution: 'swap_owner',
+            thread_reopened_by_user: null,
+            lifecycle_lineage: null,
+          },
+        },
+        outbox: {
+          eventName: 'connectshyft.thread.taken_over',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: TAKEOVER_ACTOR_USER_ID,
+            thread_id: TAKEOVER_SUCCESS_THREAD_ID,
+            prior_state: 'CLAIMED',
+            new_state: 'CLAIMED',
+            action: 'takeover',
+            reason: 'Escalation handoff',
+            resolution: 'swap_owner',
+            thread_reopened_by_user: null,
+            lifecycle_lineage: null,
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'audit',
+      'context',
+      'escalation',
+      'lifecycleEvent',
+      'outbox',
+      'reason',
+      'resolution',
+      'sideEffectsPersisted',
+      'thread',
+      'threadId',
+    ].sort());
+    expect(Object.keys(response.body.data.thread).sort()).toEqual([
+      'claimedAtUtc',
+      'claimedByUserId',
+      'closedAtUtc',
+      'closedByUserId',
+      'createdAtUtc',
+      'escalation',
+      'escalationStage',
+      'lastInboundCsNumberId',
+      'neighborId',
+      'nextEvaluationAtUtc',
+      'orgUnitId',
+      'preferredOutboundCsNumberId',
+      'source',
+      'state',
+      'tenantId',
+      'threadId',
+      'updatedAtUtc',
+    ].sort());
+    expect(response.body.data.audit).toEqual(response.body.data.outbox);
+  });
+
+  it('returns the current policy refusal when takeover is attempted from an unclaimed state', async () => {
+    const app = buildApp();
+    const response = await postTakeover(
+      app,
+      TAKEOVER_INVALID_STATE_THREAD_ID,
+      buildLifecycleHeaders({
+        'x-test-connectshyft-role': 'ORGUNIT_ADMIN',
+        'x-test-connectshyft-user-id': TAKEOVER_ACTOR_USER_ID,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+      message: 'Lifecycle action "takeover" is invalid from state UNCLAIMED.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: TAKEOVER_INVALID_STATE_THREAD_ID,
+        priorState: 'UNCLAIMED',
+      },
+    });
+  });
+
+  it('returns the current thread-not-found refusal for takeover requests outside the active scope', async () => {
+    const app = buildApp();
+    const response = await postTakeover(
+      app,
+      NOT_FOUND_THREAD_ID,
+      buildLifecycleHeaders({
+        'x-test-connectshyft-role': 'ORGUNIT_ADMIN',
+        'x-test-connectshyft-user-id': TAKEOVER_ACTOR_USER_ID,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread not found for this tenant/orgUnit context.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: NOT_FOUND_THREAD_ID,
+      },
+    });
+  });
+
+  it('returns the current missing-orgUnit refusal for takeover requests without orgUnit context', async () => {
+    const app = buildLifecycleApp({
+      defaultOrgUnitId: null,
+      defaultRole: 'ORGUNIT_ADMIN',
+      defaultUserId: TAKEOVER_ACTOR_USER_ID,
+    });
+    const headers = buildLifecycleHeaders({
+      'x-test-connectshyft-role': 'ORGUNIT_ADMIN',
+      'x-test-connectshyft-user-id': TAKEOVER_ACTOR_USER_ID,
+    });
+    delete headers['x-test-connectshyft-orgunit-id'];
+    delete headers['x-test-connectshyft-orgunit-memberships'];
+
+    const response = await postTakeover(
+      app,
+      TAKEOVER_SUCCESS_THREAD_ID,
+      headers,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+      message: 'orgUnit context is required for ConnectShyft orgUnit-scoped routes',
+      refusalType: 'business',
+    });
+  });
+
+  it('returns the current client refusal when takeover receives a blank threadId param', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/threads/%20/takeover')
+      .set(buildLifecycleHeaders({
+        'x-test-connectshyft-role': 'ORGUNIT_ADMIN',
+        'x-test-connectshyft-user-id': TAKEOVER_ACTOR_USER_ID,
+      }))
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+    });
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -24,6 +24,9 @@ import {
   getConnectSettingsNavigation,
   getConnectThreadDetail,
   getConnectThreadTimeline,
+  postConnectThreadClaim,
+  postConnectThreadClose,
+  postConnectThreadTakeover,
 } from '../../../modules/connectshyft/handlers';
 import {
   resolveConnectShyftOrgUnitContext,
@@ -57,7 +60,6 @@ import {
   AsyncConnectShyftThreadService,
   KnexConnectShyftThreadStore,
   connectShyftThreadServiceAsync,
-  evaluateConnectShyftLifecyclePolicy,
   type ConnectShyftEscalationTransition,
   type ConnectShyftThread,
   type ConnectShyftLifecycleAction,
@@ -6738,176 +6740,6 @@ router.post('/threads', async (req: Request, res: Response) => {
   });
 });
 
-const performLifecycleTransition = async (
-  req: Request,
-  res: Response,
-  action: ConnectShyftLifecycleAction,
-): Promise<void> => {
-  if (!await enforceCapability(req, res, 'escalation')) {
-    return;
-  }
-
-  const context = await enforceOrgUnitContext(req, res);
-  if (!context) {
-    return;
-  }
-
-  if (action === 'claim' && !enforceThreadClaimCapability(req, res, context)) {
-    return;
-  }
-  if (action === 'takeover' && !enforceThreadTakeoverCapability(req, res, context)) {
-    return;
-  }
-  if (action === 'close' && !enforceThreadCloseCapability(req, res, context)) {
-    return;
-  }
-
-  if (!enforceEscalationActionMembership(req, res, context)) {
-    return;
-  }
-
-  const threadId = parseThreadIdParam(req);
-  if (!threadId) {
-    respondConnectShyftClientRefusal(res, {
-      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
-      message: 'threadId is required',
-    });
-    return;
-  }
-
-  const actorRoles = resolveConnectShyftActorRoles(req, context);
-  const actorUserId = resolveConnectShyftRequestedActorUserId(req);
-  const reason = parseLifecycleReason(req);
-  const resolution = parseLifecycleResolution(req);
-  const lifecycleContext = await resolveLifecycleContext({
-    tenantId: context.tenantId,
-    orgUnitId: context.orgUnitId,
-    threadId,
-    actorUserId,
-  });
-
-  if (!lifecycleContext.currentState) {
-    respondConnectShyftBusinessRefusal(res, {
-      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
-      message: 'Thread not found for this tenant/orgUnit context.',
-      data: {
-        context,
-        threadId,
-      },
-    });
-    return;
-  }
-
-  const policyDecision = evaluateConnectShyftLifecyclePolicy({
-    action,
-    currentState: lifecycleContext.currentState,
-    claimedByUserId: lifecycleContext.claimedByUserId,
-    actorUserId,
-    actorRoles,
-  });
-  if (!policyDecision.ok) {
-    respondConnectShyftBusinessRefusal(res, {
-      code: policyDecision.code,
-      message: policyDecision.message,
-      data: {
-        context,
-        threadId,
-        priorState: lifecycleContext.currentState,
-      },
-    });
-    return;
-  }
-
-  const nextState = policyDecision.nextState;
-  const eventName = resolveLifecycleEventName(action);
-  const metadata = buildLifecycleMetadata({
-    tenantId: context.tenantId,
-    orgUnitId: context.orgUnitId,
-    actorUserId,
-    threadId,
-    priorState: lifecycleContext.currentState,
-    newState: nextState,
-    action,
-    reason,
-    resolution,
-  });
-  const transitioned = await transitionThreadWithSideEffects({
-    actorRoles,
-    tenantId: context.tenantId,
-    orgUnitId: context.orgUnitId,
-    threadId,
-    actorUserId,
-    currentState: lifecycleContext.currentState,
-    nextState,
-    syntheticThread: lifecycleContext.syntheticThread,
-    detail: lifecycleContext.detail,
-    sideEffects: {
-      eventName,
-      metadata,
-    },
-  });
-
-  if (!transitioned.ok) {
-    respondConnectShyftBusinessRefusal(res, {
-      code: transitioned.code,
-      message: transitioned.message,
-      data: {
-        context,
-        threadId,
-      },
-    });
-    return;
-  }
-
-  const sideEffects = buildLifecycleSideEffects({
-    eventName,
-    metadata,
-  });
-
-  const notificationsCanceled = action === 'claim'
-    ? await cancelPendingEscalationNotifications({
-      tenantId: context.tenantId,
-      threadId,
-    })
-    : 0;
-
-  const claimEscalation = action === 'claim'
-    ? {
-      resetReason: 'claimed' as const,
-      notificationsCanceled,
-    }
-    : null;
-
-  const responseCode = action === 'claim'
-    ? 'CONNECTSHYFT_THREAD_CLAIMED'
-    : action === 'takeover'
-      ? 'CONNECTSHYFT_THREAD_TAKEOVER_READY'
-      : 'CONNECTSHYFT_THREAD_CLOSED';
-
-  const responseMessage = action === 'claim'
-    ? 'ConnectShyft claim action accepted'
-    : action === 'takeover'
-      ? 'ConnectShyft takeover action accepted'
-      : 'ConnectShyft thread closed';
-
-  success(res, {
-    code: responseCode,
-    message: responseMessage,
-    data: {
-      threadId,
-      context,
-      reason,
-      resolution,
-      thread: buildLifecycleThreadResponse(transitioned.thread),
-      lifecycleEvent: eventName,
-      sideEffectsPersisted: transitioned.sideEffectsPersisted,
-      escalation: claimEscalation,
-      ...sideEffects,
-    },
-  });
-  return;
-};
-
 const performOutboundAction = async (
   req: Request,
   res: Response,
@@ -10248,17 +10080,11 @@ const handleInboundWebhook = async (
   return;
 };
 
-router.post('/threads/:threadId/claim', async (req: Request, res: Response) => {
-  await performLifecycleTransition(req, res, 'claim');
-});
+router.post('/threads/:threadId/claim', postConnectThreadClaim);
 
-router.post('/threads/:threadId/takeover', async (req: Request, res: Response) => {
-  await performLifecycleTransition(req, res, 'takeover');
-});
+router.post('/threads/:threadId/takeover', postConnectThreadTakeover);
 
-router.post('/threads/:threadId/close', async (req: Request, res: Response) => {
-  await performLifecycleTransition(req, res, 'close');
-});
+router.post('/threads/:threadId/close', postConnectThreadClose);
 
 router.post('/threads/:threadId/call', async (req: Request, res: Response) => {
   await performOutboundAction(req, res, 'call');

--- a/docs/architecture/connectshyft-router-refactor-plan.md
+++ b/docs/architecture/connectshyft-router-refactor-plan.md
@@ -1,83 +1,61 @@
-# ConnectShyft Router Refactor Plan
-
-## Purpose
-
-This plan tracks the controlled reduction of `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` into a thin router with route-family handlers.
-
-The goal is not stylistic churn. The goal is to lower architectural risk while preserving current ConnectShyft behavior.
+# ConnectShyft Router Refactor Plan — Add-on Update for Slice 6
 
 ## Current status
 
 ### Completed
+- Slice 4 extracted the first low-risk route family:
+  - `/settings/navigation`
+  - `/availability`
+  - `/context`
+  - `/inbox`
 
-#### Slice 4 completed
-- `/settings/navigation`
-- `/availability`
-- `/context`
-- `/inbox`
+- Slice 5 extracted the thread read surface:
+  - `/threads/:threadId`
+  - `/threads/:threadId/timeline`
 
-Outcome:
-- the first low-risk route family moved behind handler boundaries
-- shared access and orgUnit context resolution now live behind the handler-facing HTTP helper boundary
-- characterization coverage pinned the extracted behavior before moving routes
+### Next extraction target
+- Slice 6 extracts lifecycle actions:
+  - `/threads/:threadId/claim`
+  - `/threads/:threadId/takeover`
+  - `/threads/:threadId/close`
 
-#### Slice 5 thread read surface extracted
-- `/threads/:threadId`
-- `/threads/:threadId/timeline`
+## Why lifecycle is next
 
-Outcome:
-- the thread read surface now delegates through thin-router handlers
-- thread read access and prerequisite loading are centralized behind the thread read helper boundary
-- current thread detail and timeline response shapes were preserved on purpose
-- characterization coverage pins the current read-surface behavior
+Lifecycle is the next correct cut because it is directly tied to:
+- Inbox behavior
+- My Conversations behavior
+- ownership transitions
+- operator workflow
+- thread state transitions
 
-## Why the current response shape was preserved
+It is a safer and more coherent next move than outbound or webhook extraction.
 
-Slice 5 deliberately preserves the current thread detail and timeline payloads even though they are not the long-term ideal.
+## Lifecycle preservation rules for Slice 6
 
-This slice is about:
-- thinner router ownership
-- explicit handler boundaries
-- safer regression detection
+Slice 6 preserves:
+- exact current lifecycle response shapes
+- current claim/takeover/close behavior
+- claim visibility semantics:
+  - moves into My Conversations
+  - may still appear in Inbox
+  - remains visibly recognized as claimed
 
-It is not about redesigning the thread DTOs yet.
-
-## Next extraction target
-
-The next planned extraction target is lifecycle actions:
-
-- claim
-- takeover
-- close
-
-Lifecycle actions are next because they stay close to inbox and thread read behavior while avoiding the higher orchestration complexity of outbound and webhook flows.
-
-## Intentionally deferred
-
-The following areas remain intentionally deferred after Slice 5:
-
-- outbound call and message actions
-- inbound SMS and inbound voice flows
-- webhook/provider-correlation handling
-- telephony and bridge orchestration refactors
-- broader payload redesign toward a single canonical thread detail contract
-
-Outbound and webhooks remain deferred on purpose. They should not be pulled ahead of lifecycle extraction.
+This is deliberate. The goal is route extraction and boundary cleanup, not behavior redesign.
 
 ## Updated extraction order
 
-1. Slice 4: settings, availability, context, inbox
-2. Slice 5: thread read surface
-3. Next: lifecycle actions
-4. After lifecycle: neighbors / identity bridge
-5. Later: outbound actions
-6. Last: inbound, webhooks, and telephony-heavy flows
+1. settings/context/inbox/availability
+2. thread read surface
+3. lifecycle actions
+4. neighbors / identity bridge
+5. outbound actions
+6. inbound/webhooks/telephony
 
-## Practical rule for future slices
+## Practical rule
 
-Every router extraction slice should answer:
+Every lifecycle extraction must answer:
 
-1. what route family moved
-2. what behavior was pinned before moving it
-3. what handler/helper boundary now owns it
+1. what success/refusal behavior is pinned by characterization tests
+2. what handler boundary is introduced
+3. what response shape is preserved exactly
 4. what remains explicitly deferred

--- a/docs/architecture/connectshyft-router-refactor-plan.md
+++ b/docs/architecture/connectshyft-router-refactor-plan.md
@@ -13,13 +13,19 @@
   - `/threads/:threadId`
   - `/threads/:threadId/timeline`
 
-### Next extraction target
-- Slice 6 extracts lifecycle actions:
+- Slice 6 extracted lifecycle actions:
   - `/threads/:threadId/claim`
   - `/threads/:threadId/takeover`
   - `/threads/:threadId/close`
 
-## Why lifecycle is next
+### Next extraction target
+- neighbors / identity bridge
+
+### Intentionally deferred after Slice 6
+- outbound actions remain deferred on purpose
+- inbound, webhooks, and telephony remain deferred on purpose
+
+## Why lifecycle was the right next cut
 
 Lifecycle is the next correct cut because it is directly tied to:
 - Inbox behavior
@@ -44,12 +50,12 @@ This is deliberate. The goal is route extraction and boundary cleanup, not behav
 
 ## Updated extraction order
 
-1. settings/context/inbox/availability
-2. thread read surface
-3. lifecycle actions
-4. neighbors / identity bridge
-5. outbound actions
-6. inbound/webhooks/telephony
+1. settings/context/inbox/availability (Slice 4 complete)
+2. thread read surface (Slice 5 complete)
+3. lifecycle actions (Slice 6 complete)
+4. neighbors / identity bridge (next)
+5. outbound actions (deferred)
+6. inbound/webhooks/telephony (deferred)
 
 ## Practical rule
 

--- a/specs/codex_implementation_brief_slice_6.md
+++ b/specs/codex_implementation_brief_slice_6.md
@@ -1,0 +1,443 @@
+# Codex Implementation Brief — Slice 6
+## ConnectShyft Lifecycle Action Extraction (Repo-Specific)
+
+## Read this first
+
+This brief is written to be pasted directly into Codex.
+
+It is intentionally explicit so Codex does not improvise architecture, file locations, or scope.
+
+### Slice 6 objective
+
+Extract the ConnectShyft lifecycle action surface into thin-router handlers while preserving exact current lifecycle response shapes and current behavior.
+
+This slice should cover only:
+
+- `POST /api/v1/connectshyft/threads/:threadId/claim`
+- `POST /api/v1/connectshyft/threads/:threadId/takeover`
+- `POST /api/v1/connectshyft/threads/:threadId/close`
+
+### Locked behavioral decisions
+
+- Preserve exact current lifecycle response shape.
+- Claim moves the thread into My Conversations and it may still appear in Inbox, visibly recognized as claimed.
+- Takeover and close should preserve existing behavior only in this slice.
+- Do not tighten semantics in this slice beyond what is already pinned by characterization tests.
+
+### Hard rules
+
+- Do not restructure the repo.
+- Do not broaden `connectshyft-api:test` to the full legacy surface.
+- Do not touch outbound actions in this slice.
+- Do not touch webhook/inbound/telephony extraction in this slice.
+- Do not redesign lifecycle responses.
+- Do not change route paths.
+- Do not refactor thread read routes again unless required for a direct lifecycle import boundary.
+- Keep current tests green.
+- Preserve current behavior unless a characterization test explicitly documents and approves the change.
+
+### Why this slice exists
+
+After Slice 4 and Slice 5, the next correct cut is the lifecycle mutation surface because it is directly tied to:
+
+- Inbox
+- My Conversations
+- claim semantics
+- operator ownership model
+- thread state transitions
+
+This slice should produce a thinner router and a cleaner lifecycle boundary before any outbound or PeopleCore bridge extraction is attempted.
+
+---
+
+## Checkpoint structure
+
+This work should be done in five checkpoints.
+
+After each checkpoint:
+1. run the required validation commands
+2. inspect results
+3. create a commit before moving to the next checkpoint
+
+---
+
+# Checkpoint 1 — Add lifecycle characterization tests
+
+## Goal
+
+Pin the current behavior of claim, takeover, and close before moving code.
+
+## Create these files
+
+```text
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts
+```
+
+## Scope
+
+Add route characterization coverage for:
+
+- `POST /api/v1/connectshyft/threads/:threadId/claim`
+- `POST /api/v1/connectshyft/threads/:threadId/takeover`
+- `POST /api/v1/connectshyft/threads/:threadId/close`
+
+## What to pin
+
+### Claim
+Pin:
+- success response envelope and current shape
+- thread state transition fields currently returned
+- current claim side-effect metadata if present
+- current escalation reset / notifications canceled behavior if represented
+- current context and threadId failure behavior
+- current capability/membership refusal behavior
+
+### Takeover
+Pin:
+- success response envelope and current shape
+- current takeover lifecycle behavior
+- current policy refusal behavior
+- current context/threadId failure behavior
+
+### Close
+Pin:
+- success response envelope and current shape
+- current close lifecycle behavior
+- current policy refusal behavior
+- current context/threadId failure behavior
+
+## Important rule
+
+Use the existing route harness patterns already present in the route test suite.
+
+Do not invent a new full-stack harness.
+
+## Validation after Checkpoint 1
+
+Run:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath   src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts   src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts   src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts
+```
+
+## Commit after Checkpoint 1
+
+Suggested commit message:
+
+```text
+test(slice-6): add connectshyft lifecycle characterization tests
+```
+
+---
+
+# Checkpoint 2 — Add lifecycle handlers and helper boundary
+
+## Goal
+
+Create the thin-router target structure for lifecycle actions without changing router usage yet.
+
+## Create these files
+
+```text
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClaim.ts
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadTakeover.ts
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClose.ts
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts
+```
+
+## Update file
+
+```text
+apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts
+```
+
+Export the new handlers.
+
+## File responsibilities
+
+### `http/threadLifecycleContext.ts`
+Create a small helper boundary for lifecycle routes only.
+
+It should centralize:
+- inbox capability enforcement for lifecycle entry
+- orgUnit context resolution
+- thread id parsing
+- lifecycle action membership checks
+- current thread-not-found mapping
+- lifecycle context loading using existing helpers
+- current policy evaluation prerequisites that are repeated across claim/takeover/close
+
+This helper may call existing route-local helper functions temporarily if necessary, but should reduce duplication and prepare for thin-router delegation.
+
+### `postConnectThreadClaim.ts`
+Own:
+- request handoff
+- lifecycle context resolution
+- invoking the existing transition logic
+- preserving the exact current response shape
+
+### `postConnectThreadTakeover.ts`
+Own:
+- request handoff
+- lifecycle context resolution
+- invoking the existing transition logic
+- preserving the exact current response shape
+
+### `postConnectThreadClose.ts`
+Own:
+- request handoff
+- lifecycle context resolution
+- invoking the existing transition logic
+- preserving the exact current response shape
+
+## Important constraints
+
+- Do not redesign response payloads.
+- Do not move outbound reopen logic into this slice.
+- Do not alter the semantics that allow claimed threads to remain visible in Inbox.
+- It is acceptable if all three handlers call a shared lifecycle execution helper to preserve current behavior.
+
+## Validation after Checkpoint 2
+
+Run:
+- the Checkpoint 1 characterization tests
+- `pnpm nx run connectshyft-api:test`
+
+## Commit after Checkpoint 2
+
+Suggested commit message:
+
+```text
+refactor(slice-6): add connectshyft lifecycle handlers and context scaffolding
+```
+
+---
+
+# Checkpoint 3 — Convert lifecycle routes to thin-router usage
+
+## Goal
+
+Make the router thinner for claim, takeover, and close only.
+
+## Update file
+
+```text
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+```
+
+## Convert only these routes
+
+- `POST /threads/:threadId/claim`
+- `POST /threads/:threadId/takeover`
+- `POST /threads/:threadId/close`
+
+Replace the inline route bodies with thin handler delegation.
+
+Example pattern:
+
+```ts
+router.post('/threads/:threadId/claim', postConnectThreadClaim);
+router.post('/threads/:threadId/takeover', postConnectThreadTakeover);
+router.post('/threads/:threadId/close', postConnectThreadClose);
+```
+
+Use the repo’s actual import style.
+
+## Rules
+
+- keep route paths exactly the same
+- keep route order stable unless required for correctness
+- keep exact response behavior stable
+- remove route-local logic for these three routes only if fully moved
+
+Do not touch:
+- thread read routes
+- outbound routes
+- neighbor routes
+- webhook routes
+
+## Validation after Checkpoint 3
+
+Run:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath   src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts   src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts   src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+## Commit after Checkpoint 3
+
+Suggested commit message:
+
+```text
+refactor(slice-6): convert connectshyft lifecycle routes to thin router
+```
+
+---
+
+# Checkpoint 4 — Add focused lifecycle helper tests and update canonical router plan
+
+## Goal
+
+Make the lifecycle boundary explicit and harder to regress.
+
+## Create this file
+
+```text
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts
+```
+
+## Update this file
+
+```text
+docs/architecture/connectshyft-router-refactor-plan.md
+```
+
+## `handlers.threadLifecycleContext.test.ts`
+Add focused tests for the lifecycle helper boundary.
+
+Test:
+- valid context + threadId resolution path
+- refusal mapping for missing threadId
+- refusal mapping for thread not found / unavailable lifecycle context
+- refusal mapping for missing actor context or membership gate if deterministic
+- guardrail that this helper stays limited to lifecycle prerequisites and does not absorb outbound logic
+
+## Doc update
+Update the canonical router refactor plan to reflect:
+- Slice 4 completed
+- Slice 5 thread read surface extracted
+- Slice 6 lifecycle actions extracted
+- next planned extraction target is neighbors / identity bridge
+- outbound and webhooks remain intentionally deferred
+
+## Validation after Checkpoint 4
+
+Run:
+- lifecycle characterization tests
+- new lifecycle helper tests
+- narrow integration suite
+
+## Commit after Checkpoint 4
+
+Suggested commit message:
+
+```text
+docs(slice-6): update connectshyft router refactor plan for lifecycle extraction
+```
+
+---
+
+# Checkpoint 5 — Add lifecycle handler guardrails and notes
+
+## Goal
+
+Leave behind clear guardrails for future neighbor/outbound extraction and document the preserved lifecycle semantics.
+
+## Create this file
+
+```text
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md
+```
+
+## `THREAD_LIFECYCLE_NOTES.md`
+Document:
+- current ownership of claim/takeover/close handlers
+- exact response-shape preservation rule
+- claim visibility rule:
+  - moves into My Conversations
+  - may still appear in Inbox
+  - should be visibly recognized as claimed
+- what remains deferred
+- explicit separation between lifecycle extraction and outbound/webhook extraction
+
+## Optional safe cleanup
+If clearly isolated and helpful, extract a tiny shared helper for lifecycle action parsing or response-code mapping used by the three handlers.
+
+Do not broaden beyond the lifecycle family.
+
+## Final validation after Checkpoint 5
+
+Run:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath   src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts   src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts   src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts   src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+## Commit after Checkpoint 5
+
+Suggested commit message:
+
+```text
+chore(slice-6): add connectshyft lifecycle handler guardrails
+```
+
+---
+
+# Definition of done
+
+Slice 6 is complete only when all of these are true:
+
+- claim behavior is characterized by tests
+- takeover behavior is characterized by tests
+- close behavior is characterized by tests
+- handler files exist for claim, takeover, and close
+- the three lifecycle routes delegate through thin-router handlers
+- exact current lifecycle response shapes are preserved
+- a lifecycle helper boundary exists
+- claim semantics remain:
+  - in My Conversations
+  - still potentially visible in Inbox
+  - visibly recognized as claimed
+- narrow integration tests remain green
+- contract tests remain green
+- canonical router refactor plan doc is updated
+- lifecycle handler notes exist
+
+---
+
+# Explicit non-goals for this slice
+
+Do not implement any of these here:
+
+- outbound call/message extraction
+- webhook/inbound extraction
+- PeopleCore neighbor convergence rewrite
+- lifecycle semantic tightening
+- response redesign
+- telephony architecture changes
+- UI redesign
+
+---
+
+# Future extraction order after Slice 6
+
+If Slice 6 lands cleanly, next should be:
+
+1. neighbors / identity bridge
+2. outbound actions
+3. inbound/webhooks/telephony
+
+Do not jump to webhooks before outbound, and do not jump to webhooks before the neighbor/identity bridge decision is addressed.
+
+---
+
+# If Codex gets stuck
+
+If any of the following are unclear, Codex should stop and report the minimum blocker instead of improvising:
+- how current lifecycle route tests construct valid actor/context-aware requests
+- whether a handler should call route-local lifecycle helpers temporarily vs extracted helpers
+- exact current success envelope fields for claim/takeover/close
+- whether the current lifecycle orchestration is too intertwined to split without first extracting a shared lifecycle execution helper
+
+Do not guess. Report the blocker and wait.
+
+---
+
+# One-line paste version
+
+Implement Slice 6 only: add characterization tests for `POST /api/v1/connectshyft/threads/:threadId/claim`, `POST /api/v1/connectshyft/threads/:threadId/takeover`, and `POST /api/v1/connectshyft/threads/:threadId/close`; add lifecycle handlers plus a small lifecycle helper boundary under `apps/connectshyft-api/src/modules/connectshyft`; convert only those three routes in `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` to thin-router delegation; preserve exact current lifecycle response shapes; keep claim semantics as My Conversations plus still visible in Inbox and visibly claimed; add focused tests for the lifecycle helper boundary; update `docs/architecture/connectshyft-router-refactor-plan.md`; add lifecycle handler notes; keep narrow integration and contract tests green; and do not touch outbound, webhook, or telephony extraction in this slice.


### PR DESCRIPTION
## Summary
- add characterization coverage for ConnectShyft claim, takeover, and close routes
- add lifecycle handler/context scaffolding and convert only the lifecycle routes to thin-router delegation
- add focused lifecycle helper tests, update the router refactor plan, and document lifecycle guardrails

## Validation
- pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts
- pnpm nx run connectshyft-api:test
- pnpm nx run contracts:test