### PR TITLE
chore: extract connectshyft outbound action handlers

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts
@@ -1,0 +1,325 @@
+import type { Request, Response } from 'express';
+import { CAPABILITIES } from '../../../platform/rbac/capabilities';
+import {
+  executeConnectShyftThreadOutboundAction,
+  registerConnectShyftThreadOutboundCoreExecutor,
+  resolveConnectShyftThreadOutboundAccessContext,
+} from '../http/threadOutboundContext';
+import * as accessContextModule from '../http/accessContext';
+import * as threadLifecycleContextModule from '../http/threadLifecycleContext';
+import * as providerRegistryModule from '../providerRegistry';
+import * as bridgeSessionsModule from '../bridgeSessions';
+
+type MockResponse = Response & {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+const createRequest = (overrides: Partial<Request> = {}): Request => {
+  const headers = Object.entries((overrides.headers || {}) as Record<string, string>).reduce<Record<string, string>>(
+    (acc, [key, value]) => {
+      acc[key.toLowerCase()] = value;
+      return acc;
+    },
+    {},
+  );
+
+  return {
+    params: {
+      threadId: 'thread-c8-outbound-1001',
+      ...(overrides.params || {}),
+    },
+    body: {
+      message: 'Checking in with a short update.',
+      ...(overrides.body || {}),
+    },
+    query: {},
+    user: {
+      userId: 'user-thread-outbound-context-1001',
+      role: 'ORGUNIT_MEMBER',
+      activeTenantId: 'tenant-connectshyft-c8',
+      activeOrgUnitId: 'org-connectshyft-c8-east',
+      householdId: 'tenant-connectshyft-c8',
+      email: 'thread-outbound-context@test.local',
+      ...(overrides.user || {}),
+    },
+    header: (name: string) => headers[name.toLowerCase()] || undefined,
+    ...overrides,
+  } as unknown as Request;
+};
+
+const createMockResponse = (): MockResponse => {
+  const res = {
+    locals: {
+      responseEnvelope: {
+        correlationId: 'corr-thread-outbound-context',
+        tenantId: 'tenant-connectshyft-c8',
+      },
+    },
+    status: jest.fn(),
+    json: jest.fn(),
+  } as unknown as MockResponse;
+
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+
+  return res;
+};
+
+describe('connectshyft thread outbound helper boundary', () => {
+  const resolvedContext = {
+    tenantId: 'tenant-connectshyft-c8',
+    orgUnitId: 'org-connectshyft-c8-east',
+    bypassedOrgUnitMembership: false,
+    effectiveRoles: ['ORGUNIT_MEMBER'],
+  } as const;
+  const resolvedLifecycleContext = {
+    detail: {
+      threadId: 'thread-c8-outbound-1001',
+      tenantId: 'tenant-connectshyft-c8',
+      orgUnitId: 'org-connectshyft-c8-east',
+    },
+    syntheticThread: {
+      tenantId: 'tenant-connectshyft-c8',
+      orgUnitId: 'org-connectshyft-c8-east',
+      state: 'UNCLAIMED',
+    },
+    currentState: 'UNCLAIMED',
+    claimedByUserId: null,
+  } as const;
+
+  beforeEach(() => {
+    registerConnectShyftThreadOutboundCoreExecutor(async () => undefined);
+    jest.spyOn(accessContextModule, 'enforceConnectShyftCapability').mockResolvedValue({
+      connectshyft_enabled: true,
+      connectshyft_inbox_enabled: true,
+      connectshyft_escalation_enabled: true,
+      connectshyft_webhooks_enabled: true,
+    } as any);
+    jest.spyOn(accessContextModule, 'resolveConnectShyftRouteContextDecision').mockResolvedValue({
+      ok: true,
+      context: resolvedContext,
+    } as any);
+    jest.spyOn(accessContextModule, 'requestHasAnyCapability').mockReturnValue(true);
+    jest.spyOn(accessContextModule, 'resolveConnectShyftRequestedActorUserId').mockReturnValue(
+      'user-thread-outbound-context-1001',
+    );
+    jest.spyOn(accessContextModule, 'resolveConnectShyftActorRoles').mockReturnValue([
+      'ORGUNIT_MEMBER',
+    ]);
+    jest.spyOn(accessContextModule, 'respondWithConnectShyftContextRefusal').mockImplementation((res) => res);
+    jest.spyOn(accessContextModule, 'sendConnectShyftRouteRefusal').mockImplementation((res) => res);
+    jest.spyOn(
+      threadLifecycleContextModule,
+      'resolveConnectShyftThreadLifecycleStateContext',
+    ).mockResolvedValue(resolvedLifecycleContext as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the scoped outbound prerequisites for a valid call request', async () => {
+    const context = await resolveConnectShyftThreadOutboundAccessContext(
+      createRequest(),
+      createMockResponse(),
+      'call',
+    );
+
+    expect(context).toMatchObject({
+      context: resolvedContext,
+      threadId: 'thread-c8-outbound-1001',
+      actorUserId: 'user-thread-outbound-context-1001',
+      actorRoles: ['ORGUNIT_MEMBER'],
+      lifecycleContext: {
+        currentState: 'UNCLAIMED',
+        claimedByUserId: null,
+        syntheticThread: {
+          tenantId: 'tenant-connectshyft-c8',
+          orgUnitId: 'org-connectshyft-c8-east',
+          state: 'UNCLAIMED',
+        },
+      },
+    });
+    expect(Object.keys(context || {}).sort()).toEqual([
+      'actorRoles',
+      'actorUserId',
+      'context',
+      'lifecycleContext',
+      'threadId',
+    ]);
+    expect(accessContextModule.requestHasAnyCapability).toHaveBeenCalledWith(
+      expect.anything(),
+      [
+        CAPABILITIES.ORG_UNIT_THREAD_VIEW,
+        CAPABILITIES.THREAD_VIEW_ALL,
+      ],
+      resolvedContext,
+    );
+    expect(accessContextModule.requestHasAnyCapability).toHaveBeenCalledWith(
+      expect.anything(),
+      [
+        CAPABILITIES.ORG_UNIT_CALL_INITIATE,
+        CAPABILITIES.THREAD_TAKEOVER_ALL,
+      ],
+      resolvedContext,
+    );
+    expect(
+      threadLifecycleContextModule.resolveConnectShyftThreadLifecycleStateContext,
+    ).toHaveBeenCalledWith({
+      tenantId: 'tenant-connectshyft-c8',
+      orgUnitId: 'org-connectshyft-c8-east',
+      threadId: 'thread-c8-outbound-1001',
+      actorUserId: 'user-thread-outbound-context-1001',
+    });
+  });
+
+  it('returns the current client refusal for a missing thread id', async () => {
+    const res = createMockResponse();
+
+    const context = await resolveConnectShyftThreadOutboundAccessContext(
+      createRequest({
+        params: {
+          threadId: '   ',
+        } as any,
+      }),
+      res,
+      'message',
+    );
+
+    expect(context).toBeNull();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+      correlationId: 'corr-thread-outbound-context',
+      tenantId: 'tenant-connectshyft-c8',
+    }));
+  });
+
+  it('maps route context refusals through the shared context responder', async () => {
+    const res = createMockResponse();
+    jest.spyOn(accessContextModule, 'resolveConnectShyftRouteContextDecision').mockResolvedValueOnce({
+      ok: false,
+      reason: 'context-missing',
+    } as any);
+
+    const context = await resolveConnectShyftThreadOutboundAccessContext(
+      createRequest(),
+      res,
+      'call',
+    );
+
+    expect(context).toBeNull();
+    expect(accessContextModule.respondWithConnectShyftContextRefusal).toHaveBeenCalledWith(
+      res,
+      expect.objectContaining({
+        ok: false,
+        reason: 'context-missing',
+      }),
+    );
+    expect(
+      threadLifecycleContextModule.resolveConnectShyftThreadLifecycleStateContext,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('maps missing lifecycle prerequisites to the current thread-not-found refusal', async () => {
+    const sendRefusalSpy = accessContextModule.sendConnectShyftRouteRefusal as jest.MockedFunction<
+      typeof accessContextModule.sendConnectShyftRouteRefusal
+    >;
+    jest.spyOn(
+      threadLifecycleContextModule,
+      'resolveConnectShyftThreadLifecycleStateContext',
+    ).mockResolvedValueOnce({
+      detail: null,
+      syntheticThread: null,
+      currentState: null,
+      claimedByUserId: null,
+    } as any);
+
+    const context = await resolveConnectShyftThreadOutboundAccessContext(
+      createRequest({
+        params: {
+          threadId: '11111111-1111-4111-8111-111111111111',
+        } as any,
+      }),
+      createMockResponse(),
+      'message',
+    );
+
+    expect(context).toBeNull();
+    expect(sendRefusalSpy).toHaveBeenCalledWith(expect.anything(), {
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread not found for this tenant/orgUnit context.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        context: resolvedContext,
+        threadId: '11111111-1111-4111-8111-111111111111',
+      },
+    });
+  });
+
+  it('stays limited to prerequisite resolution and execution delegation without provider or bridge side effects', async () => {
+    const providerAdapterSpy = jest.spyOn(
+      providerRegistryModule,
+      'resolveConnectShyftProviderAdapter',
+    );
+    const startBridgeSessionSpy = jest.spyOn(
+      bridgeSessionsModule,
+      'startConnectShyftBridgeSession',
+    );
+    const coreExecutor = jest.fn(async (_input: unknown) => undefined);
+    const req = createRequest({
+      params: {
+        threadId: 'thread-c8-outbound-message-1001',
+      } as any,
+    });
+    const res = createMockResponse();
+
+    registerConnectShyftThreadOutboundCoreExecutor(coreExecutor);
+
+    await executeConnectShyftThreadOutboundAction(req, res, 'message');
+
+    expect(accessContextModule.requestHasAnyCapability).toHaveBeenCalledWith(
+      expect.anything(),
+      [
+        CAPABILITIES.ORG_UNIT_SMS_SEND,
+        CAPABILITIES.THREAD_TAKEOVER_ALL,
+      ],
+      resolvedContext,
+    );
+    expect(coreExecutor).toHaveBeenCalledTimes(1);
+
+    const executionInput = coreExecutor.mock.calls[0]?.[0];
+    if (!executionInput) {
+      throw new Error('Expected outbound core executor to receive execution input.');
+    }
+    expect(executionInput).toMatchObject({
+      req,
+      res,
+      outboundAction: 'message',
+      context: resolvedContext,
+      threadId: 'thread-c8-outbound-message-1001',
+      actorUserId: 'user-thread-outbound-context-1001',
+      actorRoles: ['ORGUNIT_MEMBER'],
+      lifecycleContext: resolvedLifecycleContext,
+    });
+    expect(Object.keys(executionInput).sort()).toEqual([
+      'actorRoles',
+      'actorUserId',
+      'context',
+      'lifecycleContext',
+      'outboundAction',
+      'req',
+      'res',
+      'threadId',
+    ]);
+    expect(providerAdapterSpy).not.toHaveBeenCalled();
+    expect(startBridgeSessionSpy).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md
@@ -1,0 +1,90 @@
+# ConnectShyft Thread Outbound Notes
+
+## Current ownership
+
+The ConnectShyft outbound thread surface is currently split across these files:
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+  - owns only route registration for:
+    - `POST /threads/:threadId/call`
+    - `POST /threads/:threadId/messages`
+  - owns the currently registered outbound core execution path that preserves the existing call and message behavior
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadCall.ts`
+  - owns call-route request handoff and delegates outbound execution through the shared helper boundary
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadMessage.ts`
+  - owns message-route request handoff and delegates outbound execution through the shared helper boundary
+- `apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts`
+  - owns shared outbound route-family context enforcement, `threadId` parsing, shared lifecycle prerequisite loading, capability and orgUnit-membership gating, prerequisite refusal mapping, and the shared execution wrapper that hands the request to the existing outbound core
+
+## What remains outside the handler boundary
+
+Slice 8 intentionally did not move outbound business internals out of their existing homes.
+
+That means the following concerns remain outside the thin handlers and outside `threadOutboundContext.ts`:
+
+- provider selection and provider dispatch policy behavior
+  - still owned by the existing outbound core in `connectshyft.ts` and provider-facing modules such as `providerRegistry.ts`
+- bridge session startup and bridge-session state orchestration
+  - still owned by the existing outbound core in `connectshyft.ts` and `bridgeSessions.ts`
+- durable idempotency and replay handling
+  - still owned by the existing outbound core in `connectshyft.ts` and `communicationReliability.ts`
+- communication audit persistence
+  - still owned by the existing outbound core in `connectshyft.ts` and `communicationAuditLog.ts`
+- SMS preference override validation and persistence
+  - still owned by the existing outbound core in `connectshyft.ts` and `smsPreferenceOverrides.ts`
+
+Slice 8 was an extraction slice, not a provider, bridge, reliability, or audit redesign.
+
+## Response shape preservation rule
+
+Slice 8 intentionally preserves the exact current outbound response shapes for both routes.
+
+That means:
+
+- `POST /threads/:threadId/call` still returns the existing success and refusal envelopes
+- `POST /threads/:threadId/messages` still returns the existing success and refusal envelopes
+- existing nested provider, bridge-session, idempotency, audit, override, and side-effect payload structure remains unchanged
+
+This was deliberate. The goal of this slice was thin-router extraction and an explicit outbound helper boundary, not payload cleanup or response redesign.
+
+## Reopen behavior preservation rule
+
+Slice 8 also intentionally preserves the exact current reopen behavior for closed-thread outbound flows.
+
+That includes:
+
+- the current same-thread reopen behavior for outbound calls
+- the current same-thread reopen behavior for outbound messages
+- the current response assembly that reflects reopened-thread execution exactly as characterized
+
+Follow-up cleanup should treat reopen semantics as locked unless characterization coverage is intentionally updated in a later slice.
+
+## Deferred scope
+
+The following work remains deferred beyond the outbound thread family:
+
+- inbound SMS extraction
+- inbound voice extraction
+- voicemail handling extraction
+- transcription callback extraction
+- webhook entry extraction
+- webhook correlation and receipt orchestration extraction
+- provider or bridge architecture redesign
+- idempotency, audit, sender-resolution, or SMS-override redesign
+
+## Guardrails for future work
+
+When editing outbound handlers in later slices:
+
+1. Keep route registration thin in `connectshyft.ts`.
+2. Keep shared outbound prerequisites and refusal mapping in `threadOutboundContext.ts`.
+3. Preserve the current response shapes unless characterization coverage is intentionally updated.
+4. Preserve the current reopen behavior unless a later slice explicitly changes and re-characterizes it.
+5. Do not fold provider, bridge, reliability, audit, or SMS-override internals into the thin handlers or helper boundary.
+6. Do not pull inbound, webhook, or telephony callback orchestration into the outbound handler family.
+
+## Explicit separation note
+
+Outbound extraction is now separate from inbound, webhook, and telephony extraction.
+
+That separation should stay explicit. Follow-up cleanup should not use the outbound handlers or `threadOutboundContext.ts` as a place to absorb inbound message intake, webhook correlation, provider signature handling, bridge webhook progression, voicemail processing, or transcription callbacks. Those surfaces remain intentionally deferred to the next slice after Slice 8.

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts
@@ -11,6 +11,8 @@ export { postConnectNeighborCreate } from './postConnectNeighborCreate';
 export { postConnectNeighborIdentityMatch } from './postConnectNeighborIdentityMatch';
 export { postConnectNeighborMerge } from './postConnectNeighborMerge';
 export { postConnectThreadClaim } from './postConnectThreadClaim';
+export { postConnectThreadCall } from './postConnectThreadCall';
 export { postConnectThreadClose } from './postConnectThreadClose';
+export { postConnectThreadMessage } from './postConnectThreadMessage';
 export { postConnectThreadTakeover } from './postConnectThreadTakeover';
 export { putConnectNeighbor } from './putConnectNeighbor';

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadCall.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadCall.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+import { executeConnectShyftThreadOutboundAction } from '../http/threadOutboundContext';
+
+export const postConnectThreadCall = async (req: Request, res: Response) =>
+  executeConnectShyftThreadOutboundAction(req, res, 'call');

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadMessage.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadMessage.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+import { executeConnectShyftThreadOutboundAction } from '../http/threadOutboundContext';
+
+export const postConnectThreadMessage = async (req: Request, res: Response) =>
+  executeConnectShyftThreadOutboundAction(req, res, 'message');

--- a/apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts
@@ -8,6 +8,7 @@ import { isConnectShyftTestOverrideEnabled } from '../featureFlags';
 import {
   resolveConnectShyftThreadDetailContract,
   resolveConnectShyftThreadDetailContractAsync,
+  type ConnectShyftThreadDetailRecord,
 } from '../readContracts';
 import {
   AsyncConnectShyftThreadService,
@@ -324,10 +325,13 @@ const CONNECTSHYFT_DYNAMIC_C5_THREAD_PREFIX = 'thread-c5-unclaimed-';
 const CONNECTSHYFT_DYNAMIC_C5_THREAD_TEMPLATE_ID = 'thread-c5-unclaimed-1001';
 
 type ResolvedLifecycleContext = {
+  detail: ConnectShyftThreadDetailRecord | null;
   syntheticThread: ConnectShyftSyntheticThreadDescriptor | null;
   currentState: ConnectShyftThreadState | null;
   claimedByUserId: string | null;
 };
+
+export type ConnectShyftResolvedThreadLifecycleContext = ResolvedLifecycleContext;
 
 type LifecycleTransitionSideEffects = {
   eventName: string;
@@ -626,6 +630,7 @@ const resolveLifecycleContext = async (input: {
   });
   if (syntheticThread) {
     return {
+      detail: null,
       syntheticThread,
       currentState: syntheticThread.state,
       claimedByUserId: syntheticThread.claimedByUserId,
@@ -642,6 +647,7 @@ const resolveLifecycleContext = async (input: {
 
   if (detail) {
     return {
+      detail,
       syntheticThread: null,
       currentState: detail.state,
       claimedByUserId: detail.claimedByUserId || null,
@@ -649,11 +655,19 @@ const resolveLifecycleContext = async (input: {
   }
 
   return {
+    detail: null,
     syntheticThread: null,
     currentState: null,
     claimedByUserId: null,
   };
 };
+
+export const resolveConnectShyftThreadLifecycleStateContext = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  actorUserId: string | null;
+}): Promise<ConnectShyftResolvedThreadLifecycleContext> => resolveLifecycleContext(input);
 
 const transitionThreadWithSideEffects = async (input: {
   actorRoles: Array<string | null | undefined>;

--- a/apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts
@@ -1,0 +1,201 @@
+import { Request, Response } from 'express';
+import { refusal } from '../../../platform/envelopes/response';
+import { CAPABILITIES } from '../../../platform/rbac/capabilities';
+import type { ResolvedConnectShyftContext } from '../contextAccess';
+import {
+  resolveConnectShyftThreadLifecycleStateContext,
+  type ConnectShyftResolvedThreadLifecycleContext,
+} from './threadLifecycleContext';
+import {
+  enforceConnectShyftCapability,
+  requestHasAnyCapability,
+  resolveConnectShyftActorRoles,
+  resolveConnectShyftRequestedActorUserId,
+  resolveConnectShyftRouteContextDecision,
+  respondWithConnectShyftContextRefusal,
+  sendConnectShyftRouteRefusal,
+} from './accessContext';
+
+export type ConnectShyftThreadOutboundAction = 'call' | 'message';
+
+export type ConnectShyftThreadOutboundAccessContext = {
+  context: ResolvedConnectShyftContext;
+  threadId: string;
+  actorUserId: string | null;
+  actorRoles: string[];
+  lifecycleContext: ConnectShyftResolvedThreadLifecycleContext;
+};
+
+export type ConnectShyftThreadOutboundCoreExecutionInput =
+  ConnectShyftThreadOutboundAccessContext & {
+    req: Request;
+    res: Response;
+    outboundAction: ConnectShyftThreadOutboundAction;
+  };
+
+type ConnectShyftThreadOutboundCoreExecutor = (
+  input: ConnectShyftThreadOutboundCoreExecutionInput,
+) => Promise<void>;
+
+let connectShyftThreadOutboundCoreExecutor: ConnectShyftThreadOutboundCoreExecutor | null = null;
+
+const parseThreadIdParam = (req: Request): string => {
+  if (typeof req.params.threadId !== 'string') {
+    return '';
+  }
+
+  return req.params.threadId.trim();
+};
+
+const sendThreadViewCapabilityRefusal = (res: Response): void => {
+  sendConnectShyftRouteRefusal(res, {
+    code: 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN',
+    message: 'Thread access requires an authorized ConnectShyft role.',
+    refusalType: 'business',
+    httpStatus: 200,
+  });
+};
+
+const sendThreadOutboundCapabilityRefusal = (
+  res: Response,
+  outboundAction: ConnectShyftThreadOutboundAction,
+): void => {
+  sendConnectShyftRouteRefusal(res, {
+    code: outboundAction === 'call'
+      ? 'CONNECTSHYFT_THREAD_CALL_FORBIDDEN'
+      : 'CONNECTSHYFT_THREAD_MESSAGE_FORBIDDEN',
+    message: outboundAction === 'call'
+      ? 'Outbound call requires an authorized orgUnit role.'
+      : 'Outbound message requires an authorized orgUnit role.',
+    refusalType: 'business',
+    httpStatus: 200,
+  });
+};
+
+const sendEscalationActionMembershipRefusal = (res: Response): void => {
+  sendConnectShyftRouteRefusal(res, {
+    code: 'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+    message: 'orgUnit membership is required for this ConnectShyft route',
+    refusalType: 'business',
+    httpStatus: 200,
+  });
+};
+
+export const resolveConnectShyftThreadOutboundAccessContext = async (
+  req: Request,
+  res: Response,
+  outboundAction: ConnectShyftThreadOutboundAction,
+): Promise<ConnectShyftThreadOutboundAccessContext | null> => {
+  if (!await enforceConnectShyftCapability(req, res, 'inbox')) {
+    return null;
+  }
+
+  const contextDecision = await resolveConnectShyftRouteContextDecision(req);
+  if (!contextDecision.ok) {
+    respondWithConnectShyftContextRefusal(res, contextDecision);
+    return null;
+  }
+
+  if (!requestHasAnyCapability(req, [
+    CAPABILITIES.ORG_UNIT_THREAD_VIEW,
+    CAPABILITIES.THREAD_VIEW_ALL,
+  ], contextDecision.context)) {
+    sendThreadViewCapabilityRefusal(res);
+    return null;
+  }
+
+  if (
+    !requestHasAnyCapability(
+      req,
+      outboundAction === 'call'
+        ? [CAPABILITIES.ORG_UNIT_CALL_INITIATE, CAPABILITIES.THREAD_TAKEOVER_ALL]
+        : [CAPABILITIES.ORG_UNIT_SMS_SEND, CAPABILITIES.THREAD_TAKEOVER_ALL],
+      contextDecision.context,
+    )
+  ) {
+    sendThreadOutboundCapabilityRefusal(res, outboundAction);
+    return null;
+  }
+
+  if (
+    contextDecision.context.bypassedOrgUnitMembership
+    && !requestHasAnyCapability(req, [CAPABILITIES.THREAD_TAKEOVER_ALL], contextDecision.context)
+  ) {
+    sendEscalationActionMembershipRefusal(res);
+    return null;
+  }
+
+  const threadId = parseThreadIdParam(req);
+  if (!threadId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+      httpStatus: 400,
+    });
+    return null;
+  }
+
+  const actorUserId = resolveConnectShyftRequestedActorUserId(req);
+  const actorRoles = resolveConnectShyftActorRoles(req, contextDecision.context);
+  const lifecycleContext = await resolveConnectShyftThreadLifecycleStateContext({
+    tenantId: contextDecision.context.tenantId,
+    orgUnitId: contextDecision.context.orgUnitId,
+    threadId,
+    actorUserId,
+  });
+
+  if (!lifecycleContext.currentState) {
+    sendConnectShyftRouteRefusal(res, {
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread not found for this tenant/orgUnit context.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        context: contextDecision.context,
+        threadId,
+      },
+    });
+    return null;
+  }
+
+  return {
+    context: contextDecision.context,
+    threadId,
+    actorUserId,
+    actorRoles,
+    lifecycleContext,
+  };
+};
+
+export const registerConnectShyftThreadOutboundCoreExecutor = (
+  executor: ConnectShyftThreadOutboundCoreExecutor,
+): void => {
+  connectShyftThreadOutboundCoreExecutor = executor;
+};
+
+export const executeConnectShyftThreadOutboundAction = async (
+  req: Request,
+  res: Response,
+  outboundAction: ConnectShyftThreadOutboundAction,
+): Promise<void> => {
+  const accessContext = await resolveConnectShyftThreadOutboundAccessContext(
+    req,
+    res,
+    outboundAction,
+  );
+  if (!accessContext) {
+    return;
+  }
+
+  if (!connectShyftThreadOutboundCoreExecutor) {
+    throw new Error('ConnectShyft thread outbound core executor is not registered.');
+  }
+
+  await connectShyftThreadOutboundCoreExecutor({
+    req,
+    res,
+    outboundAction,
+    ...accessContext,
+  });
+};

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts
@@ -1,0 +1,770 @@
+// @ts-nocheck
+import request from 'supertest';
+import * as SenderNumberResolverModule from '../../../../modules/connectshyft/senderNumberResolver';
+import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
+import { resetConnectShyftCommunicationAuditLogForTests } from '../../../../modules/connectshyft/communicationAuditLog';
+import { resetConnectShyftCommunicationReliabilityStateForTests } from '../../../../modules/connectshyft/communicationReliability';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const sendSmsMock = jest.fn(async (command: {
+  threadId: string;
+  targetPhone?: string;
+  senderPhone?: string;
+  body?: string;
+}) => ({
+  providerKey: 'telnyx',
+  channel: 'message' as const,
+  providerLegId: null,
+  providerMessageId: `provider-message-${command.threadId}`,
+  providerRequestId: 'req-sms-1001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:00:00.000Z',
+}));
+
+const startOutboundCallMock = jest.fn(async (command: { threadId: string; targetPhone?: string }) => ({
+  providerKey: 'telnyx',
+  channel: 'call' as const,
+  providerLegId: command.targetPhone === '+12605550155'
+    ? `provider-leg-operator-${command.threadId}`
+    : `provider-leg-neighbor-${command.threadId}`,
+  providerMessageId: null,
+  providerRequestId: 'req-call-2001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:05:00.000Z',
+}));
+
+const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+  providerKey: 'telnyx',
+  bridgeSessionId: command.bridgeSessionId,
+  bridgeEstablished: true as const,
+  providerRequestId: 'req-bridge-3001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:06:00.000Z',
+}));
+
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const endCallMock = jest.fn(async (command: { providerLegId: string }) => ({
+  providerKey: 'telnyx',
+  providerLegId: command.providerLegId,
+  ended: true as const,
+  providerRequestId: 'req-end-call-4001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:07:00.000Z',
+}));
+
+const translateProviderEventMock = jest.fn(() => ({
+  eventType: 'SmsInbound',
+  payload: {},
+  correlation: {
+    providerLegId: null,
+    providerMessageId: null,
+    providerEventId: null,
+    providerNumber: null,
+  },
+  providerNeutral: true as const,
+  providerSpecificFieldsStripped: true as const,
+  providerBranchingInDomain: false as const,
+}));
+
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}));
+
+const TEST_TENANT_ID = 'tenant-connectshyft-f1';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-f1-east';
+const TEST_ACTOR_USER_ID = 'user-connectshyft-f1-operator';
+const CALL_SUCCESS_THREAD_ID = 'thread-f1-unclaimed-1001';
+const CALL_CLOSED_THREAD_ID = 'thread-f1-closed-1003';
+
+const buildCallHeaders = (
+  overrides: Record<string, string> = {},
+): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': TEST_ACTOR_USER_ID,
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+  ...overrides,
+});
+
+const buildVoiceSenderResolution = (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+}) => ({
+  ok: true,
+  providerNumberE164: '+12605550191',
+  mappingId: 'mapping-f1-001',
+  routingMetadata: {
+    deterministic: true,
+    channel: 'voice',
+    source: 'thread_alignment',
+    mappingLabel: 'Front Desk',
+    threadId: input.threadId,
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    preferredOutboundCsNumberId: '+12605550191',
+    lastInboundCsNumberId: '+12605550191',
+    alignedFrom: 'preferred_outbound',
+    candidateProviderNumberE164: '+12605550191',
+  },
+});
+
+const buildVoiceSenderRefusal = (input: {
+  threadId: string;
+  reason?: 'sender_mapping_missing' | 'sender_mapping_ambiguous';
+}) => ({
+  ok: false,
+  code: input.reason === 'sender_mapping_ambiguous'
+    ? 'CONNECTSHYFT_SENDER_MAPPING_AMBIGUOUS'
+    : 'CONNECTSHYFT_SENDER_MAPPING_REQUIRED',
+  message: input.reason === 'sender_mapping_ambiguous'
+    ? 'Thread sender alignment maps to multiple active provider numbers in this tenant.'
+    : 'Thread sender alignment does not map to an active provider number in this tenant.',
+  reason: input.reason || 'sender_mapping_missing',
+  routingMetadata: {
+    deterministic: true,
+    channel: 'voice',
+    source: 'thread_alignment',
+    threadId: input.threadId,
+    tenantId: TEST_TENANT_ID,
+    orgUnitId: TEST_ORG_UNIT_ID,
+    preferredOutboundCsNumberId: '+12605550191',
+    lastInboundCsNumberId: '+12605550191',
+    alignedFrom: 'preferred_outbound',
+    candidateProviderNumberE164: '+12605550191',
+  },
+});
+
+describe('connectshyft outbound call route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  let resolveSenderNumberSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sendSmsMock.mockClear();
+    startOutboundCallMock.mockClear();
+    startBridgeSessionMock.mockClear();
+    verifyWebhookMock.mockClear();
+    endCallMock.mockClear();
+    translateProviderEventMock.mockClear();
+    resetConnectShyftCanonicalEventsForTests();
+    resetConnectShyftBridgeSessionStateForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+    resetConnectShyftCommunicationAuditLogForTests();
+    resetConnectShyftCommunicationReliabilityStateForTests();
+
+    resolveSenderNumberSpy = jest.spyOn(SenderNumberResolverModule, 'resolveSenderNumber')
+      .mockImplementation(async (input) => buildVoiceSenderResolution(input));
+  });
+
+  afterEach(() => {
+    resolveSenderNumberSpy.mockRestore();
+  });
+
+  it('returns the current outbound call success envelope and bridge-session response shape', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${CALL_SUCCESS_THREAD_ID}/call`)
+      .set(buildCallHeaders())
+      .send({
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED',
+      message: 'ConnectShyft outbound call dispatched',
+      data: {
+        threadId: CALL_SUCCESS_THREAD_ID,
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+          effectiveRoles: ['ORGUNIT_MEMBER'],
+        },
+        thread: {
+          threadId: CALL_SUCCESS_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          neighborId: 'neighbor-connectshyft-f1-1001',
+          source: 'VOICE',
+          state: 'UNCLAIMED',
+          lastInboundCsNumberId: '+12605550191',
+          preferredOutboundCsNumberId: '+12605550191',
+          claimedByUserId: null,
+          claimedAtUtc: null,
+          closedByUserId: null,
+          closedAtUtc: null,
+          createdAtUtc: expect.any(String),
+          updatedAtUtc: expect.any(String),
+          escalation: {
+            stage: 0,
+            nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+          },
+        },
+        lifecycleEvent: null,
+        lifecycle: {
+          priorState: 'UNCLAIMED',
+          nextState: 'UNCLAIMED',
+          reopenedFromClosed: false,
+          reopenedByInbound: false,
+          sameThreadId: true,
+          noInboundAutoReopenSideEffects: true,
+        },
+        operatorFeedback: 'Outbound dispatched. Escalation continues until claim; no reset was applied.',
+        operatorFeedbackMeta: {
+          heading: 'Outbound dispatch completed.',
+          hiddenTransition: false,
+        },
+        uiFeedback: {
+          severity: 'success',
+          ariaLive: 'polite',
+          messageKey: 'connectshyft.outbound.call.dispatched',
+          presentation: 'contextual-action-feedback',
+          message: 'Outbound dispatched. Escalation continues until claim; no reset was applied.',
+          heading: 'Outbound dispatch completed.',
+          hiddenTransition: false,
+        },
+        chrome: {
+          persistentOperationsBannerVisible: false,
+          heavyOperationsDefaultLayout: false,
+        },
+        escalationReset: null,
+        sideEffectsPersisted: false,
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInterfaceVersion: 'v1',
+          providerBranchingInDomain: false,
+        },
+        canonicalEvent: {
+          eventId: expect.any(String),
+          aggregateId: CALL_SUCCESS_THREAD_ID,
+          aggregateType: 'Thread',
+          eventType: 'CallAttemptStarted',
+          payload: expect.objectContaining({
+            direction: 'outbound',
+            channel: 'voice',
+            actor: 'user',
+            eventName: 'connectshyft.thread.outbound_call_dispatched',
+            lifecycleEvent: 'connectshyft.thread.outbound_call_dispatched',
+            threadState: 'UNCLAIMED',
+            reopenedFromClosed: false,
+            outboundMessageArtifact: null,
+          }),
+          occurredAtUtc: expect.any(String),
+        },
+        senderResolution: {
+          source: 'thread_alignment',
+          channel: 'voice',
+          senderPhone: '+12605550191',
+          orgUnitId: TEST_ORG_UNIT_ID,
+          selectedMappingId: 'mapping-f1-001',
+          selectedMappingLabel: 'Front Desk',
+          alignedFrom: 'preferred_outbound',
+        },
+        dispatch: {
+          providerKey: 'telnyx',
+          channel: 'call',
+          providerLegId: 'provider-leg-operator-thread-f1-unclaimed-1001',
+          providerMessageId: null,
+          adapterInvoked: true,
+          providerBranchingInDomain: false,
+          requestedAt: expect.any(String),
+          dispatchContext: {
+            targetPhone: '+12605550111',
+            messageBodyProvided: false,
+          },
+        },
+        correlationMapping: {
+          deterministic: true,
+          operatorLegMapping: 'created',
+          neighborLegMapping: 'ignored',
+          error: null,
+        },
+        replaySafe: {
+          duplicate: false,
+          replayKey: null,
+        },
+        call: {
+          transport: 'bridge',
+          autoRetry: false,
+          redialPolicy: 'manual_only',
+          phases: ['initiated', 'ringing', 'connected', 'completed'],
+        },
+        autoClaimPolicy: {
+          trigger: 'CONNECTED',
+          appliesToState: 'UNCLAIMED',
+          nextState: 'CLAIMED',
+        },
+        bridgeSession: {
+          bridgeSessionId: expect.any(String),
+          status: 'operator_dialing',
+          operatorLeg: {
+            status: 'ringing',
+          },
+          neighborLeg: {
+            status: 'created',
+          },
+        },
+        audit: {
+          eventName: 'connectshyft.thread.outbound_call_dispatched',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: TEST_ACTOR_USER_ID,
+            thread_id: CALL_SUCCESS_THREAD_ID,
+            prior_state: 'UNCLAIMED',
+            new_state: 'UNCLAIMED',
+            action: 'outbound_call',
+            reason: null,
+            resolution: null,
+            thread_reopened_by_user: null,
+            lifecycle_lineage: null,
+          },
+        },
+        outbox: {
+          eventName: 'connectshyft.thread.outbound_call_dispatched',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: TEST_ACTOR_USER_ID,
+            thread_id: CALL_SUCCESS_THREAD_ID,
+            prior_state: 'UNCLAIMED',
+            new_state: 'UNCLAIMED',
+            action: 'outbound_call',
+            reason: null,
+            resolution: null,
+            thread_reopened_by_user: null,
+            lifecycle_lineage: null,
+          },
+        },
+        outboundDispatch: {
+          audit: {
+            eventName: 'connectshyft.thread.outbound_call_dispatched',
+          },
+          outbox: {
+            eventName: 'connectshyft.thread.outbound_call_dispatched',
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'audit',
+      'autoClaimPolicy',
+      'bridgeSession',
+      'call',
+      'canonicalEvent',
+      'chrome',
+      'context',
+      'correlationMapping',
+      'dispatch',
+      'escalationReset',
+      'lifecycle',
+      'lifecycleEvent',
+      'operatorFeedback',
+      'operatorFeedbackMeta',
+      'outboundDispatch',
+      'outbox',
+      'providerResolution',
+      'replaySafe',
+      'senderResolution',
+      'sideEffectsPersisted',
+      'thread',
+      'threadId',
+      'uiFeedback',
+    ].sort());
+    expect(Object.keys(response.body.data.thread).sort()).toEqual([
+      'claimedAtUtc',
+      'claimedByUserId',
+      'closedAtUtc',
+      'closedByUserId',
+      'createdAtUtc',
+      'escalation',
+      'lastInboundCsNumberId',
+      'neighborId',
+      'orgUnitId',
+      'preferredOutboundCsNumberId',
+      'source',
+      'state',
+      'tenantId',
+      'threadId',
+      'updatedAtUtc',
+    ].sort());
+    expect(response.body.data.audit).toEqual(response.body.data.outbox);
+    expect(response.body.data.outboundDispatch.audit).toEqual(response.body.data.audit);
+    expect(startOutboundCallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the current closed-thread reopen behavior for outbound calls on the same thread', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${CALL_CLOSED_THREAD_ID}/call`)
+      .set(buildCallHeaders())
+      .send({
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550118',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED',
+      message: 'ConnectShyft outbound call dispatched',
+      data: {
+        threadId: CALL_CLOSED_THREAD_ID,
+        thread: {
+          threadId: CALL_CLOSED_THREAD_ID,
+          state: 'UNCLAIMED',
+          claimedByUserId: null,
+          closedByUserId: null,
+          closedAtUtc: null,
+          escalation: {
+            stage: 0,
+            nextEvaluationAtUtc: expect.any(String),
+          },
+        },
+        lifecycleEvent: 'connectshyft.thread_reopened_by_user',
+        lifecycle: {
+          priorState: 'CLOSED',
+          nextState: 'UNCLAIMED',
+          reopenedFromClosed: true,
+          reopenedByInbound: false,
+          sameThreadId: true,
+          noInboundAutoReopenSideEffects: true,
+        },
+        operatorFeedback: 'Conversation reopened on the same thread and outbound dispatch completed. Escalation and inactivity timers were reset.',
+        operatorFeedbackMeta: {
+          heading: 'Conversation reopened and outbound dispatch completed.',
+          hiddenTransition: false,
+        },
+        uiFeedback: {
+          severity: 'success',
+          ariaLive: 'polite',
+          messageKey: 'connectshyft.thread.reopened_dispatch_success',
+          presentation: 'contextual-action-feedback',
+          message: 'Conversation reopened on the same thread and outbound dispatch completed. Escalation and inactivity timers were reset.',
+          heading: 'Conversation reopened and outbound dispatch completed.',
+          hiddenTransition: false,
+        },
+        escalationReset: {
+          stage: 0,
+          inactivityWindow: 'reset',
+        },
+        sideEffectsPersisted: false,
+        canonicalEvent: {
+          aggregateId: CALL_CLOSED_THREAD_ID,
+          eventType: 'CallAttemptStarted',
+          payload: expect.objectContaining({
+            direction: 'outbound',
+            channel: 'voice',
+            lifecycleEvent: 'connectshyft.thread.outbound_call_dispatched',
+            threadState: 'UNCLAIMED',
+            reopenedFromClosed: true,
+          }),
+        },
+        call: {
+          transport: 'bridge',
+          autoRetry: false,
+          redialPolicy: 'manual_only',
+          phases: ['initiated', 'ringing', 'connected', 'completed'],
+        },
+        autoClaimPolicy: {
+          trigger: 'CONNECTED',
+          appliesToState: 'UNCLAIMED',
+          nextState: 'CLAIMED',
+        },
+        bridgeSession: {
+          bridgeSessionId: expect.any(String),
+          status: 'operator_dialing',
+        },
+        audit: {
+          eventName: 'connectshyft.thread_reopened_by_user',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: TEST_ACTOR_USER_ID,
+            thread_id: CALL_CLOSED_THREAD_ID,
+            prior_state: 'CLOSED',
+            new_state: 'UNCLAIMED',
+            action: 'outbound_call',
+            reason: null,
+            resolution: null,
+            thread_reopened_by_user: 'connectshyft.thread_reopened_by_user',
+            lifecycle_lineage: {
+              prior_state: 'CLOSED',
+              new_state: 'UNCLAIMED',
+              thread_reopened_by_user: 'connectshyft.thread_reopened_by_user',
+            },
+          },
+        },
+        outbox: {
+          eventName: 'connectshyft.thread_reopened_by_user',
+        },
+        outboundDispatch: {
+          audit: {
+            eventName: 'connectshyft.thread.outbound_call_dispatched',
+            metadata: {
+              tenant_id: TEST_TENANT_ID,
+              org_unit_id: TEST_ORG_UNIT_ID,
+              actor_user_id: TEST_ACTOR_USER_ID,
+              thread_id: CALL_CLOSED_THREAD_ID,
+              prior_state: 'UNCLAIMED',
+              new_state: 'UNCLAIMED',
+              action: 'outbound_call',
+              reason: null,
+              resolution: null,
+              thread_reopened_by_user: 'connectshyft.thread_reopened_by_user',
+              lifecycle_lineage: {
+                prior_state: 'CLOSED',
+                new_state: 'UNCLAIMED',
+                thread_reopened_by_user: 'connectshyft.thread_reopened_by_user',
+              },
+            },
+          },
+          outbox: {
+            eventName: 'connectshyft.thread.outbound_call_dispatched',
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'audit',
+      'autoClaimPolicy',
+      'bridgeSession',
+      'call',
+      'canonicalEvent',
+      'chrome',
+      'context',
+      'correlationMapping',
+      'dispatch',
+      'escalationReset',
+      'lifecycle',
+      'lifecycleEvent',
+      'operatorFeedback',
+      'operatorFeedbackMeta',
+      'outboundDispatch',
+      'outbox',
+      'providerResolution',
+      'replaySafe',
+      'senderResolution',
+      'sideEffectsPersisted',
+      'thread',
+      'threadId',
+      'uiFeedback',
+    ].sort());
+    expect(response.body.data.audit.eventName).not.toBe(response.body.data.outboundDispatch.audit.eventName);
+    expect(startOutboundCallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the current operator-callback-required refusal shape for outbound bridge calls', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${CALL_SUCCESS_THREAD_ID}/call`)
+      .set(buildCallHeaders())
+      .send({
+        providerKey: 'telnyx',
+        targetPhone: '+12605550111',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_OPERATOR_CALLBACK_REQUIRED',
+      message: 'Outbound bridge calls require an operator callback number.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: CALL_SUCCESS_THREAD_ID,
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInterfaceVersion: 'v1',
+          providerBranchingInDomain: false,
+        },
+        sideEffects: {
+          dispatchAttempted: false,
+          lifecycleMutationApplied: false,
+          auditPersisted: false,
+        },
+      },
+    });
+    expect(startOutboundCallMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the current neighbor-phone-required refusal shape for outbound bridge calls', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${CALL_SUCCESS_THREAD_ID}/call`)
+      .set(buildCallHeaders())
+      .send({
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+      message: 'Outbound bridge calls require a dialable neighbor phone.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: CALL_SUCCESS_THREAD_ID,
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInterfaceVersion: 'v1',
+          providerBranchingInDomain: false,
+        },
+        sideEffects: {
+          dispatchAttempted: false,
+          lifecycleMutationApplied: false,
+          auditPersisted: false,
+        },
+      },
+    });
+    expect(startOutboundCallMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the current sender-resolution refusal shape before outbound call dispatch', async () => {
+    resolveSenderNumberSpy.mockResolvedValueOnce(
+      buildVoiceSenderRefusal({
+        threadId: CALL_SUCCESS_THREAD_ID,
+      }),
+    );
+
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${CALL_SUCCESS_THREAD_ID}/call`)
+      .set(buildCallHeaders())
+      .send({
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_CALL_SENDER_REQUIRED',
+      message: 'Persist one valid mapped ConnectShyft outbound line on the thread before starting a call.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: CALL_SUCCESS_THREAD_ID,
+        senderResolution: {
+          reason: 'sender_mapping_missing',
+          source: 'thread_alignment',
+          channel: 'voice',
+          orgUnitId: TEST_ORG_UNIT_ID,
+          candidateProviderNumberE164: '+12605550191',
+        },
+        chrome: {
+          persistentOperationsBannerVisible: false,
+          heavyOperationsDefaultLayout: false,
+        },
+        sideEffects: {
+          messageDispatched: false,
+          lifecycleMutationApplied: false,
+          auditPersisted: false,
+        },
+      },
+    });
+    expect(startOutboundCallMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the current client refusal when call receives a blank threadId param', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/threads/%20/call')
+      .set(buildCallHeaders())
+      .send({
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+    });
+  });
+
+  it('returns the current thread-not-found refusal when call runs outside the active tenant and orgUnit scope', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${CALL_SUCCESS_THREAD_ID}/call`)
+      .set(buildCallHeaders({
+        'x-test-connectshyft-tenant-id': 'tenant-connectshyft-f2',
+        'x-test-connectshyft-orgunit-id': 'org-connectshyft-f2-east',
+        'x-test-connectshyft-user-id': 'user-connectshyft-f2-operator',
+        'x-test-connectshyft-orgunit-memberships': JSON.stringify(['org-connectshyft-f2-east']),
+      }))
+      .send({
+        providerKey: 'telnyx',
+        operatorPhoneId: '+12605550155',
+        targetPhone: '+12605550111',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread not found for this tenant/orgUnit context.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: 'tenant-connectshyft-f2',
+          orgUnitId: 'org-connectshyft-f2-east',
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: CALL_SUCCESS_THREAD_ID,
+      },
+    });
+    expect(startOutboundCallMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts
@@ -1,0 +1,859 @@
+// @ts-nocheck
+import request from 'supertest';
+import * as SenderNumberResolverModule from '../../../../modules/connectshyft/senderNumberResolver';
+import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
+import { resetConnectShyftCommunicationAuditLogForTests } from '../../../../modules/connectshyft/communicationAuditLog';
+import { resetConnectShyftCommunicationReliabilityStateForTests } from '../../../../modules/connectshyft/communicationReliability';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import {
+  connectShyftSmsPreferenceOverrideServiceAsync,
+} from '../../../../modules/connectshyft/smsPreferenceOverrides';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const sendSmsMock = jest.fn(async (command: {
+  threadId: string;
+  targetPhone?: string;
+  senderPhone?: string;
+  body?: string;
+}) => ({
+  providerKey: 'telnyx',
+  channel: 'message' as const,
+  providerLegId: null,
+  providerMessageId: `provider-message-${command.threadId}`,
+  providerRequestId: 'req-sms-1001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:00:00.000Z',
+}));
+
+const startOutboundCallMock = jest.fn(async (command: { threadId: string; targetPhone?: string }) => ({
+  providerKey: 'telnyx',
+  channel: 'call' as const,
+  providerLegId: command.targetPhone === '+12605550155'
+    ? `provider-leg-operator-${command.threadId}`
+    : `provider-leg-neighbor-${command.threadId}`,
+  providerMessageId: null,
+  providerRequestId: 'req-call-2001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:05:00.000Z',
+}));
+
+const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+  providerKey: 'telnyx',
+  bridgeSessionId: command.bridgeSessionId,
+  bridgeEstablished: true as const,
+  providerRequestId: 'req-bridge-3001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:06:00.000Z',
+}));
+
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const endCallMock = jest.fn(async (command: { providerLegId: string }) => ({
+  providerKey: 'telnyx',
+  providerLegId: command.providerLegId,
+  ended: true as const,
+  providerRequestId: 'req-end-call-4001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:07:00.000Z',
+}));
+
+const translateProviderEventMock = jest.fn(() => ({
+  eventType: 'SmsInbound',
+  payload: {},
+  correlation: {
+    providerLegId: null,
+    providerMessageId: null,
+    providerEventId: null,
+    providerNumber: null,
+  },
+  providerNeutral: true as const,
+  providerSpecificFieldsStripped: true as const,
+  providerBranchingInDomain: false as const,
+}));
+
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}));
+
+const TEST_TENANT_ID = 'tenant-connectshyft-f2';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-f2-east';
+const TEST_ACTOR_USER_ID = 'user-connectshyft-f2-operator';
+const MESSAGE_SUCCESS_THREAD_ID = 'thread-f2-unclaimed-1001';
+const MESSAGE_CLOSED_THREAD_ID = 'thread-f2-closed-1003';
+
+const buildMessageHeaders = (
+  overrides: Record<string, string> = {},
+): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': TEST_ACTOR_USER_ID,
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+  ...overrides,
+});
+
+const buildSmsPreference = (overrides: Record<string, unknown> = {}) => ({
+  prefersTexting: 'YES',
+  neighborId: 'neighbor-connectshyft-f2-1001',
+  source: 'neighbor-record',
+  ...overrides,
+});
+
+const buildSmsSenderResolution = (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+}) => ({
+  ok: true,
+  providerNumberE164: '+12605550192',
+  mappingId: 'mapping-f2-001',
+  routingMetadata: {
+    deterministic: true,
+    channel: 'sms',
+    source: 'thread_alignment',
+    mappingLabel: 'Overflow',
+    threadId: input.threadId,
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    preferredOutboundCsNumberId: '+12605550192',
+    lastInboundCsNumberId: '+12605550192',
+    alignedFrom: 'preferred_outbound',
+    candidateProviderNumberE164: '+12605550192',
+  },
+});
+
+const buildSmsSenderRefusal = (input: {
+  threadId: string;
+}) => ({
+  ok: false,
+  code: 'CONNECTSHYFT_SENDER_MAPPING_REQUIRED',
+  message: 'Thread sender alignment does not map to an active provider number in this tenant.',
+  reason: 'sender_mapping_missing',
+  routingMetadata: {
+    deterministic: true,
+    channel: 'sms',
+    source: 'thread_alignment',
+    threadId: input.threadId,
+    tenantId: TEST_TENANT_ID,
+    orgUnitId: TEST_ORG_UNIT_ID,
+    preferredOutboundCsNumberId: '+12605550192',
+    lastInboundCsNumberId: '+12605550192',
+    alignedFrom: 'preferred_outbound',
+    candidateProviderNumberE164: '+12605550192',
+  },
+});
+
+describe('connectshyft outbound message route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  let resolvePreferenceSpy: jest.SpyInstance;
+  let resolveSenderNumberSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sendSmsMock.mockClear();
+    startOutboundCallMock.mockClear();
+    startBridgeSessionMock.mockClear();
+    verifyWebhookMock.mockClear();
+    endCallMock.mockClear();
+    translateProviderEventMock.mockClear();
+    resetConnectShyftCanonicalEventsForTests();
+    resetConnectShyftBridgeSessionStateForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+    resetConnectShyftCommunicationAuditLogForTests();
+    resetConnectShyftCommunicationReliabilityStateForTests();
+
+    resolvePreferenceSpy = jest.spyOn(
+      connectShyftSmsPreferenceOverrideServiceAsync,
+      'resolvePreference',
+    ).mockResolvedValue(buildSmsPreference());
+    resolveSenderNumberSpy = jest.spyOn(SenderNumberResolverModule, 'resolveSenderNumber')
+      .mockImplementation(async (input) => buildSmsSenderResolution(input));
+  });
+
+  afterEach(() => {
+    resolvePreferenceSpy.mockRestore();
+    resolveSenderNumberSpy.mockRestore();
+  });
+
+  it('returns the current outbound message success envelope and dispatch response shape', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${MESSAGE_SUCCESS_THREAD_ID}/messages`)
+      .set(buildMessageHeaders())
+      .send({
+        providerKey: 'telnyx',
+        body: 'Checking in about your request',
+        targetPhone: '+12605550222',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+      message: 'ConnectShyft outbound message dispatched',
+      data: {
+        threadId: MESSAGE_SUCCESS_THREAD_ID,
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+          effectiveRoles: ['ORGUNIT_MEMBER'],
+        },
+        thread: {
+          threadId: MESSAGE_SUCCESS_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          neighborId: 'neighbor-connectshyft-f2-1001',
+          source: 'VOICE',
+          state: 'UNCLAIMED',
+          lastInboundCsNumberId: '+12605550192',
+          preferredOutboundCsNumberId: '+12605550192',
+          claimedByUserId: null,
+          claimedAtUtc: null,
+          closedByUserId: null,
+          closedAtUtc: null,
+          createdAtUtc: expect.any(String),
+          updatedAtUtc: expect.any(String),
+          escalation: {
+            stage: 1,
+            nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+          },
+        },
+        lifecycleEvent: null,
+        lifecycle: {
+          priorState: 'UNCLAIMED',
+          nextState: 'UNCLAIMED',
+          reopenedFromClosed: false,
+          reopenedByInbound: false,
+          sameThreadId: true,
+          noInboundAutoReopenSideEffects: true,
+        },
+        operatorFeedback: 'Outbound dispatched. Escalation continues until claim; no reset was applied.',
+        operatorFeedbackMeta: {
+          heading: 'Outbound dispatch completed.',
+          hiddenTransition: false,
+        },
+        uiFeedback: {
+          severity: 'success',
+          ariaLive: 'polite',
+          messageKey: 'connectshyft.outbound.message.dispatched',
+          presentation: 'contextual-action-feedback',
+          message: 'Outbound dispatched. Escalation continues until claim; no reset was applied.',
+          heading: 'Outbound dispatch completed.',
+          hiddenTransition: false,
+        },
+        chrome: {
+          persistentOperationsBannerVisible: false,
+          heavyOperationsDefaultLayout: false,
+        },
+        escalationReset: null,
+        sideEffectsPersisted: false,
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInterfaceVersion: 'v1',
+          providerBranchingInDomain: false,
+        },
+        canonicalEvent: {
+          eventId: expect.any(String),
+          aggregateId: MESSAGE_SUCCESS_THREAD_ID,
+          aggregateType: 'Thread',
+          eventType: 'MessageQueued',
+          payload: {
+            direction: 'outbound',
+            channel: 'sms',
+            actor: 'user',
+            eventName: 'connectshyft.outbound.sms_appended',
+            lifecycleEvent: 'connectshyft.thread.outbound_message_dispatched',
+            threadState: 'UNCLAIMED',
+            reopenedFromClosed: false,
+            outboundMessageArtifact: {
+              channel: 'sms',
+              direction: 'outbound',
+              body: 'Checking in about your request',
+              from: '+12605550192',
+              to: '+12605550222',
+            },
+          },
+          occurredAtUtc: expect.any(String),
+        },
+        senderResolution: {
+          source: 'thread_alignment',
+          channel: 'sms',
+          senderPhone: '+12605550192',
+          orgUnitId: TEST_ORG_UNIT_ID,
+          selectedMappingId: 'mapping-f2-001',
+          selectedMappingLabel: 'Overflow',
+          alignedFrom: 'preferred_outbound',
+          threadHints: {
+            lastInboundCsNumberId: '+12605550192',
+            preferredOutboundCsNumberId: '+12605550192',
+            preferredOutboundLabel: null,
+          },
+        },
+        dispatch: {
+          providerKey: 'telnyx',
+          channel: 'message',
+          providerLegId: null,
+          providerMessageId: 'provider-message-thread-f2-unclaimed-1001',
+          providerRequestId: 'req-sms-1001',
+          adapterInvoked: true,
+          providerBranchingInDomain: false,
+          requestedAt: '2026-03-11T12:00:00.000Z',
+          dispatchContext: {
+            targetPhone: '+12605550222',
+            messageBodyProvided: true,
+          },
+        },
+        correlationMapping: {
+          deterministic: true,
+          callLegMapping: 'ignored',
+          messageMapping: 'created',
+          error: null,
+        },
+        replaySafe: {
+          duplicate: false,
+          replayKey: null,
+        },
+        preferencePolicy: {
+          prefersTexting: 'YES',
+          source: 'neighbor-record',
+          overrideRequired: false,
+          overrideAccepted: true,
+        },
+        sideEffects: {
+          messageDispatched: true,
+          lifecycleMutationApplied: false,
+          auditPersisted: false,
+        },
+        audit: {
+          eventName: 'connectshyft.thread.outbound_message_dispatched',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: TEST_ACTOR_USER_ID,
+            thread_id: MESSAGE_SUCCESS_THREAD_ID,
+            prior_state: 'UNCLAIMED',
+            new_state: 'UNCLAIMED',
+            action: 'outbound_message',
+            reason: null,
+            resolution: null,
+            thread_reopened_by_user: null,
+            lifecycle_lineage: null,
+          },
+        },
+        outbox: {
+          eventName: 'connectshyft.thread.outbound_message_dispatched',
+        },
+        outboundDispatch: {
+          audit: {
+            eventName: 'connectshyft.thread.outbound_message_dispatched',
+          },
+          outbox: {
+            eventName: 'connectshyft.thread.outbound_message_dispatched',
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'audit',
+      'canonicalEvent',
+      'chrome',
+      'context',
+      'correlationMapping',
+      'dispatch',
+      'escalationReset',
+      'lifecycle',
+      'lifecycleEvent',
+      'operatorFeedback',
+      'operatorFeedbackMeta',
+      'outboundDispatch',
+      'outbox',
+      'preferencePolicy',
+      'providerResolution',
+      'replaySafe',
+      'senderResolution',
+      'sideEffects',
+      'sideEffectsPersisted',
+      'thread',
+      'threadId',
+      'uiFeedback',
+    ].sort());
+    expect(Object.keys(response.body.data.thread).sort()).toEqual([
+      'claimedAtUtc',
+      'claimedByUserId',
+      'closedAtUtc',
+      'closedByUserId',
+      'createdAtUtc',
+      'escalation',
+      'lastInboundCsNumberId',
+      'neighborId',
+      'orgUnitId',
+      'preferredOutboundCsNumberId',
+      'source',
+      'state',
+      'tenantId',
+      'threadId',
+      'updatedAtUtc',
+    ].sort());
+    expect(response.body.data.audit).toEqual(response.body.data.outbox);
+    expect(response.body.data.outboundDispatch.audit).toEqual(response.body.data.audit);
+    expect(sendSmsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the current closed-thread reopen behavior for outbound messages on the same thread', async () => {
+    resolvePreferenceSpy.mockResolvedValueOnce(buildSmsPreference({
+      neighborId: 'neighbor-connectshyft-f2-1003',
+    }));
+
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${MESSAGE_CLOSED_THREAD_ID}/messages`)
+      .set(buildMessageHeaders())
+      .send({
+        providerKey: 'telnyx',
+        body: 'Following up on your closed conversation',
+        targetPhone: '+12605550228',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+      message: 'ConnectShyft outbound message dispatched',
+      data: {
+        threadId: MESSAGE_CLOSED_THREAD_ID,
+        thread: {
+          threadId: MESSAGE_CLOSED_THREAD_ID,
+          state: 'UNCLAIMED',
+          claimedByUserId: null,
+          closedByUserId: null,
+          closedAtUtc: null,
+          escalation: {
+            stage: 0,
+            nextEvaluationAtUtc: expect.any(String),
+          },
+        },
+        lifecycleEvent: 'connectshyft.thread_reopened_by_user',
+        lifecycle: {
+          priorState: 'CLOSED',
+          nextState: 'UNCLAIMED',
+          reopenedFromClosed: true,
+          reopenedByInbound: false,
+          sameThreadId: true,
+          noInboundAutoReopenSideEffects: true,
+        },
+        operatorFeedback: 'Conversation reopened on the same thread and outbound dispatch completed. Escalation and inactivity timers were reset.',
+        operatorFeedbackMeta: {
+          heading: 'Conversation reopened and outbound dispatch completed.',
+          hiddenTransition: false,
+        },
+        uiFeedback: {
+          severity: 'success',
+          ariaLive: 'polite',
+          messageKey: 'connectshyft.thread.reopened_dispatch_success',
+          presentation: 'contextual-action-feedback',
+          message: 'Conversation reopened on the same thread and outbound dispatch completed. Escalation and inactivity timers were reset.',
+          heading: 'Conversation reopened and outbound dispatch completed.',
+          hiddenTransition: false,
+        },
+        escalationReset: {
+          stage: 0,
+          inactivityWindow: 'reset',
+        },
+        sideEffectsPersisted: false,
+        canonicalEvent: {
+          aggregateId: MESSAGE_CLOSED_THREAD_ID,
+          eventType: 'MessageQueued',
+          payload: {
+            direction: 'outbound',
+            channel: 'sms',
+            actor: 'user',
+            eventName: 'connectshyft.outbound.sms_appended',
+            lifecycleEvent: 'connectshyft.thread.outbound_message_dispatched',
+            threadState: 'UNCLAIMED',
+            reopenedFromClosed: true,
+            outboundMessageArtifact: {
+              channel: 'sms',
+              direction: 'outbound',
+              body: 'Following up on your closed conversation',
+              from: '+12605550192',
+              to: '+12605550228',
+            },
+          },
+        },
+        preferencePolicy: {
+          prefersTexting: 'YES',
+          source: 'neighbor-record',
+          overrideRequired: false,
+          overrideAccepted: true,
+        },
+        sideEffects: {
+          messageDispatched: true,
+          lifecycleMutationApplied: true,
+          auditPersisted: false,
+        },
+        audit: {
+          eventName: 'connectshyft.thread_reopened_by_user',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            actor_user_id: TEST_ACTOR_USER_ID,
+            thread_id: MESSAGE_CLOSED_THREAD_ID,
+            prior_state: 'CLOSED',
+            new_state: 'UNCLAIMED',
+            action: 'outbound_message',
+            reason: null,
+            resolution: null,
+            thread_reopened_by_user: 'connectshyft.thread_reopened_by_user',
+            lifecycle_lineage: {
+              prior_state: 'CLOSED',
+              new_state: 'UNCLAIMED',
+              thread_reopened_by_user: 'connectshyft.thread_reopened_by_user',
+            },
+          },
+        },
+        outbox: {
+          eventName: 'connectshyft.thread_reopened_by_user',
+        },
+        outboundDispatch: {
+          audit: {
+            eventName: 'connectshyft.thread.outbound_message_dispatched',
+            metadata: {
+              tenant_id: TEST_TENANT_ID,
+              org_unit_id: TEST_ORG_UNIT_ID,
+              actor_user_id: TEST_ACTOR_USER_ID,
+              thread_id: MESSAGE_CLOSED_THREAD_ID,
+              prior_state: 'UNCLAIMED',
+              new_state: 'UNCLAIMED',
+              action: 'outbound_message',
+              reason: null,
+              resolution: null,
+              thread_reopened_by_user: 'connectshyft.thread_reopened_by_user',
+              lifecycle_lineage: {
+                prior_state: 'CLOSED',
+                new_state: 'UNCLAIMED',
+                thread_reopened_by_user: 'connectshyft.thread_reopened_by_user',
+              },
+            },
+          },
+          outbox: {
+            eventName: 'connectshyft.thread.outbound_message_dispatched',
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'audit',
+      'canonicalEvent',
+      'chrome',
+      'context',
+      'correlationMapping',
+      'dispatch',
+      'escalationReset',
+      'lifecycle',
+      'lifecycleEvent',
+      'operatorFeedback',
+      'operatorFeedbackMeta',
+      'outboundDispatch',
+      'outbox',
+      'preferencePolicy',
+      'providerResolution',
+      'replaySafe',
+      'senderResolution',
+      'sideEffects',
+      'sideEffectsPersisted',
+      'thread',
+      'threadId',
+      'uiFeedback',
+    ].sort());
+    expect(response.body.data.audit.eventName).not.toBe(response.body.data.outboundDispatch.audit.eventName);
+    expect(sendSmsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the current SMS-target-required refusal shape before outbound message dispatch', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${MESSAGE_SUCCESS_THREAD_ID}/messages`)
+      .set(buildMessageHeaders())
+      .send({
+        providerKey: 'telnyx',
+        body: 'Need assistance',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+      message: 'Add or select a valid phone number before sending SMS.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: MESSAGE_SUCCESS_THREAD_ID,
+        preferencePolicy: {
+          prefersTexting: 'YES',
+          source: 'neighbor-record',
+          overrideRequired: false,
+          overrideAccepted: true,
+        },
+        targetResolution: {
+          reason: 'missing_target',
+          source: 'neighbor_record',
+          neighborId: 'neighbor-connectshyft-f2-1001',
+          requestedTargetPhone: null,
+          candidateCount: 0,
+          candidatePhones: [],
+        },
+        uiFeedback: {
+          severity: 'warning',
+          ariaLive: 'assertive',
+          messageKey: 'connectshyft.sms_target.missing',
+          presentation: 'contextual-action-feedback',
+          requiresAction: true,
+          actionLabel: 'Select phone',
+          accessibilityHint: 'Update the neighbor profile or choose a valid phone number before sending the outbound message.',
+          message: 'Add or select a valid phone number before sending SMS.',
+        },
+        chrome: {
+          persistentOperationsBannerVisible: false,
+          heavyOperationsDefaultLayout: false,
+        },
+        sideEffects: {
+          messageDispatched: false,
+          lifecycleMutationApplied: false,
+          auditPersisted: false,
+        },
+      },
+    });
+    expect(sendSmsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the current SMS-sender-required refusal shape before outbound message dispatch', async () => {
+    resolveSenderNumberSpy.mockResolvedValueOnce(
+      buildSmsSenderRefusal({
+        threadId: MESSAGE_SUCCESS_THREAD_ID,
+      }),
+    );
+
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${MESSAGE_SUCCESS_THREAD_ID}/messages`)
+      .set(buildMessageHeaders())
+      .send({
+        providerKey: 'telnyx',
+        body: 'Need assistance',
+        targetPhone: '+12605550222',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+      message: 'Persist one valid mapped ConnectShyft sender number on the thread before sending SMS.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: MESSAGE_SUCCESS_THREAD_ID,
+        preferencePolicy: {
+          prefersTexting: 'YES',
+          source: 'neighbor-record',
+          overrideRequired: false,
+          overrideAccepted: true,
+        },
+        senderResolution: {
+          reason: 'invalid_sender_alignment',
+          source: 'thread_alignment',
+          orgUnitId: TEST_ORG_UNIT_ID,
+          activeMappingCount: 0,
+          candidateMappings: [],
+          threadHints: {
+            lastInboundCsNumberId: '+12605550192',
+            preferredOutboundCsNumberId: '+12605550192',
+            preferredOutboundLabel: null,
+          },
+        },
+        uiFeedback: {
+          severity: 'warning',
+          ariaLive: 'assertive',
+          messageKey: 'connectshyft.sms_sender.required',
+          presentation: 'contextual-action-feedback',
+          requiresAction: true,
+          actionLabel: 'Review numbers',
+          accessibilityHint: 'Persist a valid mapped provider number on the thread before retrying.',
+          message: 'Persist one valid mapped ConnectShyft sender number on the thread before sending SMS.',
+        },
+        chrome: {
+          persistentOperationsBannerVisible: false,
+          heavyOperationsDefaultLayout: false,
+        },
+        sideEffects: {
+          messageDispatched: false,
+          lifecycleMutationApplied: false,
+          auditPersisted: false,
+        },
+      },
+    });
+    expect(sendSmsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the current texting-preference override refusal shape before outbound message dispatch', async () => {
+    resolvePreferenceSpy.mockResolvedValueOnce(buildSmsPreference({
+      prefersTexting: 'NO',
+    }));
+
+    const app = buildApp();
+    const response = await request(app)
+      .post(`/api/v1/connectshyft/threads/${MESSAGE_SUCCESS_THREAD_ID}/messages`)
+      .set(buildMessageHeaders())
+      .send({
+        providerKey: 'telnyx',
+        body: 'Need assistance',
+        targetPhone: '+12605550222',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_SMS_OVERRIDE_REASON_REQUIRED',
+      message: 'Outbound SMS requires an override reason when prefers_texting=NO.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: MESSAGE_SUCCESS_THREAD_ID,
+        preferencePolicy: {
+          prefersTexting: 'NO',
+          source: 'neighbor-record',
+          overrideRequired: true,
+          overrideAccepted: false,
+          allowedOverrideReasons: [
+            'safety-follow-up',
+            'care-plan-exception',
+            'documented-consent',
+            'critical-service-update',
+          ],
+        },
+        uiFeedback: {
+          severity: 'warning',
+          ariaLive: 'assertive',
+          messageKey: 'connectshyft.override.required',
+          presentation: 'contextual-action-feedback',
+          requiresAction: true,
+          actionLabel: 'Add override reason',
+          accessibilityHint: 'Open override reason selector and resubmit the outbound message.',
+          message: 'Outbound SMS requires an override reason when prefers_texting=NO.',
+        },
+        chrome: {
+          persistentOperationsBannerVisible: false,
+          heavyOperationsDefaultLayout: false,
+        },
+        sideEffects: {
+          messageDispatched: false,
+          lifecycleMutationApplied: false,
+          auditPersisted: false,
+        },
+      },
+    });
+    expect(sendSmsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the current idempotency-conflict refusal shape for materially different outbound messages', async () => {
+    const app = buildApp();
+    const headers = buildMessageHeaders({
+      'Idempotency-Key': 'idem-message-characterization-1001',
+    });
+
+    const firstResponse = await request(app)
+      .post(`/api/v1/connectshyft/threads/${MESSAGE_SUCCESS_THREAD_ID}/messages`)
+      .set(headers)
+      .send({
+        providerKey: 'telnyx',
+        body: 'Initial outbound body',
+        targetPhone: '+12605550222',
+      });
+
+    expect(firstResponse.status).toBe(200);
+    expect(firstResponse.body.ok).toBe(true);
+
+    const conflictResponse = await request(app)
+      .post(`/api/v1/connectshyft/threads/${MESSAGE_SUCCESS_THREAD_ID}/messages`)
+      .set(headers)
+      .send({
+        providerKey: 'telnyx',
+        body: 'Changed outbound body',
+        targetPhone: '+12605550222',
+      });
+
+    expect(conflictResponse.status).toBe(200);
+    expect(conflictResponse.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD',
+      message: 'Idempotency key cannot be reused for a materially different outbound request.',
+      refusalType: 'business',
+      data: {
+        context: {
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          bypassedOrgUnitMembership: false,
+        },
+        threadId: MESSAGE_SUCCESS_THREAD_ID,
+        idempotency: {
+          duplicate: false,
+          conflict: true,
+          idempotencyKey: 'idem-message-characterization-1001',
+        },
+      },
+    });
+    expect(sendSmsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the current client refusal when message receives a blank threadId param', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/threads/%20/messages')
+      .set(buildMessageHeaders())
+      .send({
+        providerKey: 'telnyx',
+        body: 'Need assistance',
+        targetPhone: '+12605550222',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+    });
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -40,6 +40,11 @@ import {
   type ResolvedConnectShyftContext,
 } from '../../../modules/connectshyft/contextAccess';
 import {
+  executeConnectShyftThreadOutboundAction,
+  registerConnectShyftThreadOutboundCoreExecutor,
+  type ConnectShyftThreadOutboundCoreExecutionInput,
+} from '../../../modules/connectshyft/http/threadOutboundContext';
+import {
   connectShyftNumberMappingServiceAsync,
   type ConnectShyftNumberMapping,
 } from '../../../modules/connectshyft/numberMappings';
@@ -5168,44 +5173,21 @@ router.post('/threads', async (req: Request, res: Response) => {
   });
 });
 
-const performOutboundAction = async (
-  req: Request,
-  res: Response,
-  outboundAction: ConnectShyftOutboundAction,
-): Promise<void> => {
-  if (!await enforceCapability(req, res, 'inbox')) {
+const performOutboundAction = async ({
+  req,
+  res,
+  outboundAction,
+  context,
+  threadId,
+  actorUserId,
+  actorRoles,
+  lifecycleContext,
+}: ConnectShyftThreadOutboundCoreExecutionInput): Promise<void> => {
+  if (!lifecycleContext.currentState) {
     return;
   }
 
-  const context = await enforceOrgUnitContext(req, res);
-  if (!context) {
-    return;
-  }
-
-  if (!enforceThreadViewCapability(req, res, context)) {
-    return;
-  }
-
-  if (outboundAction === 'call' && !enforceThreadCallCapability(req, res, context)) {
-    return;
-  }
-  if (outboundAction === 'message' && !enforceThreadMessageCapability(req, res, context)) {
-    return;
-  }
-
-  if (!enforceEscalationActionMembership(req, res, context)) {
-    return;
-  }
-
-  const threadId = parseThreadIdParam(req);
-  if (!threadId) {
-    respondConnectShyftClientRefusal(res, {
-      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
-      message: 'threadId is required',
-    });
-    return;
-  }
-
+  const currentState = lifecycleContext.currentState;
   const outboundCallPolicyRequest = outboundAction === 'call'
     ? parseOutboundCallRequestPolicy(req)
     : null;
@@ -5253,8 +5235,6 @@ const performOutboundAction = async (
     return;
   }
 
-  const actorRoles = resolveConnectShyftActorRoles(req, context);
-  const actorUserId = resolveConnectShyftRequestedActorUserId(req);
   const actorScopeKey = buildConnectShyftActorScopeKey(actorUserId, actorRoles);
   const outboundMessagePolicy = outboundAction === 'message'
     ? parseOutboundMessagePolicyRequest(req)
@@ -5269,24 +5249,6 @@ const performOutboundAction = async (
     }
     : null;
   let outboundDispatchReplayKey: string | null = null;
-  const lifecycleContext = await resolveLifecycleContext({
-    tenantId: context.tenantId,
-    orgUnitId: context.orgUnitId,
-    threadId,
-    actorUserId,
-  });
-
-  if (!lifecycleContext.currentState) {
-    respondConnectShyftBusinessRefusal(res, {
-      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
-      message: 'Thread not found for this tenant/orgUnit context.',
-      data: {
-        context,
-        threadId,
-      },
-    });
-    return;
-  }
   const resolvedThreadNeighborId = await resolveNeighborIdForThreadCorrelation({
     tenantId: context.tenantId,
     orgUnitId: context.orgUnitId,
@@ -5294,7 +5256,7 @@ const performOutboundAction = async (
   });
 
   const outboundLifecycleAction = resolveOutboundLifecycleAction(outboundAction);
-  const priorState = lifecycleContext.currentState;
+  const priorState = currentState;
   const dispatchEventName = resolveOutboundDispatchEventName(outboundAction);
   const postDispatchWarnings: Array<{ stage: string; code: string; message: string }> = [];
 
@@ -5323,8 +5285,8 @@ const performOutboundAction = async (
       tenantId: context.tenantId,
       orgUnitId: context.orgUnitId,
       threadId,
-      currentState: lifecycleContext.currentState,
-      nextState: lifecycleContext.currentState,
+      currentState,
+      nextState: currentState,
       actorUserId,
       fallbackSummary: lifecycleContext.syntheticThread?.summary,
       fallbackNeighborId: resolvedThreadNeighborId || lifecycleContext.syntheticThread?.neighborId,
@@ -6567,6 +6529,8 @@ const performOutboundAction = async (
   });
   return;
 };
+
+registerConnectShyftThreadOutboundCoreExecutor(performOutboundAction);
 
 const handleInboundWebhook = async (
   req: Request,
@@ -8515,11 +8479,11 @@ router.post('/threads/:threadId/takeover', postConnectThreadTakeover);
 router.post('/threads/:threadId/close', postConnectThreadClose);
 
 router.post('/threads/:threadId/call', async (req: Request, res: Response) => {
-  await performOutboundAction(req, res, 'call');
+  await executeConnectShyftThreadOutboundAction(req, res, 'call');
 });
 
 router.post('/threads/:threadId/messages', async (req: Request, res: Response) => {
-  await performOutboundAction(req, res, 'message');
+  await executeConnectShyftThreadOutboundAction(req, res, 'message');
 });
 
 router.post('/webhooks/inbound', async (req: Request, res: Response) => {

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -31,7 +31,9 @@ import {
   postConnectNeighborIdentityMatch,
   postConnectNeighborMerge,
   postConnectThreadClaim,
+  postConnectThreadCall,
   postConnectThreadClose,
+  postConnectThreadMessage,
   postConnectThreadTakeover,
   putConnectNeighbor,
 } from '../../../modules/connectshyft/handlers';
@@ -40,7 +42,6 @@ import {
   type ResolvedConnectShyftContext,
 } from '../../../modules/connectshyft/contextAccess';
 import {
-  executeConnectShyftThreadOutboundAction,
   registerConnectShyftThreadOutboundCoreExecutor,
   type ConnectShyftThreadOutboundCoreExecutionInput,
 } from '../../../modules/connectshyft/http/threadOutboundContext';
@@ -8478,13 +8479,9 @@ router.post('/threads/:threadId/takeover', postConnectThreadTakeover);
 
 router.post('/threads/:threadId/close', postConnectThreadClose);
 
-router.post('/threads/:threadId/call', async (req: Request, res: Response) => {
-  await executeConnectShyftThreadOutboundAction(req, res, 'call');
-});
+router.post('/threads/:threadId/call', postConnectThreadCall);
 
-router.post('/threads/:threadId/messages', async (req: Request, res: Response) => {
-  await executeConnectShyftThreadOutboundAction(req, res, 'message');
-});
+router.post('/threads/:threadId/messages', postConnectThreadMessage);
 
 router.post('/webhooks/inbound', async (req: Request, res: Response) => {
   await handleInboundWebhook(req, res);

--- a/docs/architecture/connectshyft-router-refactor-plan.md
+++ b/docs/architecture/connectshyft-router-refactor-plan.md
@@ -1,75 +1,157 @@
-# ConnectShyft Router Refactor Plan — Add-on Update for Slice 7
+# ConnectShyft Router Refactor Plan
 
-## Current status
+## Purpose
+This document tracks the staged extraction of the ConnectShyft API router from `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` into thin-router handlers and focused helper boundaries, while preserving current behavior.
 
-### Completed
-- Slice 4 extracted the first low-risk route family:
-  - `/settings/navigation`
-  - `/availability`
-  - `/context`
-  - `/inbox`
+## Non-negotiable rules
+1. Preserve exact current response shapes during extraction slices.
+2. Preserve current behavioral semantics unless a later explicit decision changes them.
+3. Prefer characterization first, extraction second.
+4. Move route-family orchestration into handler/helper seams.
+5. Leave domain logic in existing domain/service modules until a later slice explicitly changes that.
+6. Do not mix outbound extraction with inbound/webhook extraction.
 
-- Slice 5 extracted the thread read surface:
-  - `/threads/:threadId`
-  - `/threads/:threadId/timeline`
+## Completed slices
 
-- Slice 6 extracted lifecycle actions:
-  - `/threads/:threadId/claim`
-  - `/threads/:threadId/takeover`
-  - `/threads/:threadId/close`
+### Slice 4
+Extracted first thin-router family:
+- settings/navigation
+- availability
+- context
+- inbox
 
-- Slice 7 extracted the neighbor / identity bridge route family:
-  - `POST /neighbors`
-  - `GET /neighbors`
-  - `GET /neighbors/:neighborId`
-  - `PUT /neighbors/:neighborId`
-  - `DELETE /neighbors/:neighborId`
-  - `POST /neighbors/identity-match`
-  - `POST /neighbors/merge`
+Added:
+- handler files for that route family
+- `http/accessContext.ts`
+- focused helper tests
+- handler ownership notes
 
-### Next extraction target
-- outbound actions
+### Slice 5
+Extracted thread read surface:
+- thread detail
+- thread timeline
 
-### Intentionally deferred
-- inbound/webhooks remain deferred because they still carry the heaviest telephony and provider-coupled behavior.
-- PeopleCore convergence remains future seam work; Slice 7 only extracted the ConnectShyft-local neighbor / identity bridge boundary.
+Added:
+- thread read handlers
+- `http/threadReadContext.ts`
+- thread read helper tests
+- thread read notes
 
-## Why outbound is next
+Preserved:
+- current thread detail shape
+- current timeline DTO shape
+- current single canonical thread detail payload direction for UI
 
-The next correct cut is outbound actions because the neighbor / identity seam is now explicit and pinned by characterization tests.
+### Slice 6
+Extracted lifecycle actions:
+- claim
+- takeover
+- close
 
-That keeps the extraction order low-risk:
-- neighbor CRUD and identity bridge behavior stay stable behind thin handlers
-- outbound routes can now depend on a clearer local boundary
-- inbound/webhooks can remain deferred until the telephony-coupled surfaces are addressed directly
+Added:
+- lifecycle handlers
+- `http/threadLifecycleContext.ts`
+- lifecycle helper tests
+- lifecycle notes
 
-## What Slice 7 preserved
+Preserved:
+- exact current lifecycle response shapes
+- current claim behavior where claimed threads move into My Conversations while remaining visible in Inbox and recognizable as claimed
+- current takeover and close behavior exactly
 
-Slice 7 preserved:
+### Slice 7
+Extracted neighbor and identity bridge surface:
+- neighbor create
+- neighbor list
+- neighbor detail
+- neighbor update
+- neighbor soft delete
+- identity match
+- merge
+
+Added:
+- neighbor/identity handlers
+- `http/neighborIdentityContext.ts`
+- neighbor/identity helper tests
+- neighbor identity bridge notes
+
+Preserved:
 - exact current response shapes
 - exact current merge behavior
+- ConnectShyft-local merge semantics until future PeopleCore seam work is clearer
 
-It only added:
-- thinner router boundaries
-- explicit handler ownership
-- light documentation/seam prep for future PeopleCore convergence
+Light seam prep only:
+- cleaner extraction boundary for future PeopleCore convergence
+- no convergence rewrite yet
 
-This was deliberate. The goal was route extraction and seam cleanup, not model migration.
+## Slice 8 target
 
-## Updated extraction order
+### Goal
+Extract outbound action routes into thin-router handlers with one shared outbound helper boundary, while preserving exact current outbound response shapes and exact current reopen behavior.
 
-1. settings/context/inbox/availability
-2. thread read surface
-3. lifecycle actions
-4. neighbor / identity bridge (completed in Slice 7)
-5. outbound actions (next)
-6. inbound/webhooks/telephony (intentionally deferred)
+### In scope
+- `POST /threads/:threadId/call`
+- `POST /threads/:threadId/messages`
+- outbound route characterization tests
+- outbound helper boundary
+- outbound handlers
+- router delegation
+- helper-boundary tests
+- outbound handler guardrail notes
 
-## Practical rule
+### Out of scope
+- inbound webhook extraction
+- provider architecture rewrite
+- bridge architecture rewrite
+- idempotency redesign
+- sender-number redesign
+- payload cleanup
+- reopen semantics changes
 
-Every neighbor / identity extraction must answer:
+### Planned artifacts
+- `handlers/postConnectThreadCall.ts`
+- `handlers/postConnectThreadMessage.ts`
+- `http/threadOutboundContext.ts`
+- `__tests__/handlers.threadOutboundContext.test.ts`
+- `handlers/THREAD_OUTBOUND_NOTES.md`
 
-1. what CRUD and identity behavior is pinned by characterization tests
-2. what handler boundary is introduced
-3. what response and merge behavior is preserved exactly
-4. what remains ConnectShyft-local vs future PeopleCore seam work
+### Guardrails for Slice 8
+The outbound helper boundary may centralize:
+- route-family context enforcement
+- thread id parsing
+- shared prerequisite loading
+- shared outbound route execution wrapper
+- preserved refusal/response shaping inputs
+
+The outbound helper boundary may not absorb:
+- provider adapter internals
+- bridge session internals
+- communication reliability internals
+- communication audit internals
+- SMS override internals
+- inbound/webhook logic
+
+## Next slice after Slice 8
+
+### Slice 9
+Inbound/webhooks/telephony extraction:
+- webhook entry routes
+- inbound SMS
+- inbound voice
+- voicemail handling
+- transcription callback
+- webhook correlation and receipt orchestration
+
+This is intentionally deferred until after outbound extraction because it is the most operationally tangled route family.
+
+## Extraction sequence
+1. Settings/context/inbox
+2. Thread read
+3. Lifecycle
+4. Neighbor/identity bridge
+5. Outbound actions
+6. Inbound/webhooks/telephony
+
+## Operating rule for future updates
+This file is canonical.
+Each new slice should overwrite this file with the updated current plan, not append parallel copies under the same path.

--- a/docs/architecture/connectshyft-router-refactor-plan.md
+++ b/docs/architecture/connectshyft-router-refactor-plan.md
@@ -84,54 +84,26 @@ Light seam prep only:
 - cleaner extraction boundary for future PeopleCore convergence
 - no convergence rewrite yet
 
-## Slice 8 target
-
-### Goal
-Extract outbound action routes into thin-router handlers with one shared outbound helper boundary, while preserving exact current outbound response shapes and exact current reopen behavior.
-
-### In scope
+### Slice 8
+Extracted outbound action surface:
 - `POST /threads/:threadId/call`
 - `POST /threads/:threadId/messages`
-- outbound route characterization tests
-- outbound helper boundary
+
+Added:
 - outbound handlers
-- router delegation
-- helper-boundary tests
-- outbound handler guardrail notes
-
-### Out of scope
-- inbound webhook extraction
-- provider architecture rewrite
-- bridge architecture rewrite
-- idempotency redesign
-- sender-number redesign
-- payload cleanup
-- reopen semantics changes
-
-### Planned artifacts
-- `handlers/postConnectThreadCall.ts`
-- `handlers/postConnectThreadMessage.ts`
 - `http/threadOutboundContext.ts`
-- `__tests__/handlers.threadOutboundContext.test.ts`
-- `handlers/THREAD_OUTBOUND_NOTES.md`
+- outbound characterization tests
+- outbound helper-boundary tests
 
-### Guardrails for Slice 8
-The outbound helper boundary may centralize:
-- route-family context enforcement
-- thread id parsing
-- shared prerequisite loading
-- shared outbound route execution wrapper
-- preserved refusal/response shaping inputs
+Preserved:
+- exact current outbound response shapes
+- exact current reopen behavior
 
-The outbound helper boundary may not absorb:
-- provider adapter internals
-- bridge session internals
-- communication reliability internals
-- communication audit internals
-- SMS override internals
-- inbound/webhook logic
+Guardrails preserved:
+- helper boundary stays limited to route-family context enforcement, thread id parsing, shared prerequisite loading, and shared outbound execution delegation
+- provider adapter, bridge session, reliability, audit, SMS override, and inbound/webhook internals remain outside the helper boundary
 
-## Next slice after Slice 8
+## Next slice
 
 ### Slice 9
 Inbound/webhooks/telephony extraction:

--- a/specs/codex_implementation_brief_slice_8.md
+++ b/specs/codex_implementation_brief_slice_8.md
@@ -1,0 +1,288 @@
+# Codex Implementation Brief: Slice 8
+
+## Title
+ConnectShyft Slice 8: outbound actions thin-router extraction
+
+## Objective
+Extract the outbound route family from `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` into thin-router handlers and one shared outbound helper boundary, while preserving exact current response shapes and exact current reopen behavior.
+
+## Locked rules
+1. Preserve exact current outbound response shapes for both routes.
+2. Preserve current reopen behavior exactly.
+3. Extract only the route family and helper boundary.
+4. Leave provider, bridge, idempotency, audit, SMS override, sender resolution, and webhook internals where they are.
+5. Do not redesign payloads.
+6. Do not rewrite provider/bridge architecture.
+7. Do not pull inbound/webhook logic into this slice.
+
+## In scope
+- `POST /api/v1/connectshyft/threads/:threadId/call`
+- `POST /api/v1/connectshyft/threads/:threadId/messages`
+- characterization coverage for current outbound route behavior
+- handler extraction
+- shared outbound helper boundary
+- router delegation
+- helper-boundary tests
+- docs updates
+
+## Out of scope
+- webhook or inbound extraction
+- provider architecture rewrite
+- bridge session redesign
+- sender-number redesign
+- payload cleanup
+- reopen/lifecycle behavior changes
+- PeopleCore convergence beyond light seam prep already implied by cleaner route boundaries
+
+## Target files
+### New tests
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts`
+
+### New helper boundary
+- `apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts`
+
+### New handlers
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadCall.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadMessage.ts`
+
+### Updated exports
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts`
+
+### Router update
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+
+### Docs
+- `docs/architecture/connectshyft-router-refactor-plan.md`
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md`
+
+## Design intent
+The slice should do for outbound what Slices 4 through 7 did for the other route families:
+- characterize current behavior first
+- extract helper boundary second
+- switch router to handlers third
+- add focused helper tests fourth
+- document guardrails fifth
+
+The extracted helper boundary should centralize only route-family concerns such as:
+- capability and orgUnit context enforcement
+- thread id parsing
+- loading lifecycle context or thread detail prerequisites needed by outbound routes
+- preserving current refusal shaping inputs
+- shared execution wrapper for call/message route handlers if that reduces duplication without moving domain logic out of existing modules
+
+The helper boundary must **not** absorb provider, bridge, idempotency, audit, or SMS override business logic.
+
+## Checkpoint plan
+
+---
+
+## Checkpoint 1: characterize current outbound route behavior
+
+### Goal
+Pin current route behavior for call and message dispatch before any production refactor.
+
+### Tasks
+1. Add `connectshyft.thread-call.characterization.test.ts`.
+2. Add `connectshyft.thread-message.characterization.test.ts`.
+3. Characterize current success and refusal envelopes for both routes.
+4. Capture current reopen behavior exactly for closed-thread outbound flows.
+5. Capture representative refusal surfaces without broadening coverage into inbound/webhooks.
+
+### Minimum coverage expectations
+#### Call route characterization
+- successful outbound call response shape
+- closed-thread outbound call preserves current reopen behavior and response shape
+- operator callback required refusal shape
+- neighbor phone required refusal shape
+- sender resolution refusal shape
+- thread id required refusal shape
+- thread not found / context refusal behavior as currently implemented
+
+#### Message route characterization
+- successful outbound message response shape
+- closed-thread outbound message preserves current reopen behavior and response shape
+- SMS target resolution refusal shape
+- SMS sender resolution refusal shape
+- texting-preference override refusal path shape
+- idempotency conflict or in-progress refusal shape if currently reachable in route tests
+- thread id required refusal shape
+
+### Validation commands
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts
+```
+
+### Stop rule
+Stop after Checkpoint 1. Report what changed, validation results, blockers, and wait.
+
+---
+
+## Checkpoint 2: add outbound helper boundary and handler scaffolding
+
+### Goal
+Create the new thin-router target handlers and a shared outbound helper boundary, without switching the router yet.
+
+### Tasks
+1. Add `threadOutboundContext.ts`.
+2. Add `postConnectThreadCall.ts`.
+3. Add `postConnectThreadMessage.ts`.
+4. Export the new handlers from `handlers/index.ts`.
+5. Move only route-family orchestration into the helper boundary.
+
+### Helper boundary responsibilities
+Acceptable contents for `threadOutboundContext.ts`:
+- capability gating wrappers used by both outbound routes
+- orgUnit context enforcement for outbound route family
+- thread id parsing
+- shared outbound prerequisite loading
+- shared wrapper that calls the existing outbound orchestration with `call` or `message`
+- helper methods that preserve exact response/refusal shaping for the route family
+
+Not acceptable in `threadOutboundContext.ts`:
+- provider adapter rewrites
+- bridge internals rewrites
+- sender-number algorithm rewrites
+- SMS override model rewrites
+- communication reliability redesign
+- webhook handling code
+
+### Validation commands
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts
+
+pnpm nx run connectshyft-api:test
+```
+
+### Stop rule
+Stop after Checkpoint 2. Report what changed, validation results, blockers, and wait.
+
+---
+
+## Checkpoint 3: convert outbound routes to thin router
+
+### Goal
+Switch the two outbound routes to the new handlers while preserving route order and behavior.
+
+### Tasks
+1. Update `connectshyft.ts` so:
+   - `POST /threads/:threadId/call` delegates to `postConnectThreadCall`
+   - `POST /threads/:threadId/messages` delegates to `postConnectThreadMessage`
+2. Remove only the now-unused outbound route-local wrapper logic from the router.
+3. Keep all unrelated inline router families untouched.
+4. Preserve exact current response shapes.
+5. Preserve exact current reopen behavior.
+
+### Validation commands
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts
+
+pnpm nx run connectshyft-api:test
+```
+
+### Stop rule
+Stop after Checkpoint 3. Report what changed, validation results, blockers, and wait.
+
+---
+
+## Checkpoint 4: add focused helper-boundary tests and update architecture doc
+
+### Goal
+Add direct tests for the outbound helper boundary and update the canonical router plan.
+
+### Tasks
+1. Add `handlers.threadOutboundContext.test.ts`.
+2. Cover helper-boundary behavior only.
+3. Update `docs/architecture/connectshyft-router-refactor-plan.md` to mark Slice 8 complete and set inbound/webhooks/telephony as next.
+
+### Minimum helper test coverage
+- valid outbound prerequisite resolution
+- missing thread id refusal mapping
+- thread/context prerequisite refusal mapping
+- guardrail that helper remains prerequisite/orchestration only and does not absorb provider/bridge internals
+
+### Validation commands
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts \
+  src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts
+
+pnpm nx run connectshyft-api:test
+```
+
+### Stop rule
+Stop after Checkpoint 4. Report what changed, validation results, blockers, and wait.
+
+---
+
+## Checkpoint 5: add outbound handler guardrail notes
+
+### Goal
+Document the outbound ownership boundary so later slices do not blur it.
+
+### Tasks
+1. Add `THREAD_OUTBOUND_NOTES.md` under `apps/connectshyft-api/src/modules/connectshyft/handlers/`.
+2. Document:
+   - what the outbound handlers own
+   - what `threadOutboundContext.ts` owns
+   - what remains in provider/bridge/reliability/audit modules
+   - exact response-shape preservation rule
+   - exact reopen-behavior preservation rule
+   - explicit deferral of inbound/webhooks/telephony extraction
+
+### Validation commands
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts \
+  src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts
+
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+### Stop rule
+Stop after Checkpoint 5. Report what changed, validation results, blockers, and wait.
+
+---
+
+## Implementation constraints for Codex
+- Do not change current route paths.
+- Do not change current response field names.
+- Do not normalize or clean up payload shapes in this slice.
+- Do not alter provider selection logic.
+- Do not alter bridge session start behavior.
+- Do not alter idempotency semantics.
+- Do not alter texting-preference override semantics.
+- Do not alter reopen semantics.
+- Do not fold inbound/webhook logic into the outbound helper boundary.
+- Keep route order stable in `connectshyft.ts`.
+
+## Commit guidance
+Use one commit per checkpoint.
+If the worktree already contains unrelated user changes, commit all uncommitted items exactly as instructed by the user, but do not expand implementation scope.
+
+Suggested commit messages:
+- `test(slice-8): add connectshyft outbound characterization tests`
+- `refactor(slice-8): add connectshyft outbound handlers and context scaffolding`
+- `refactor(slice-8): convert connectshyft outbound routes to thin router`
+- `docs(slice-8): update router plan and outbound helper coverage`
+- `chore(slice-8): add connectshyft outbound handler guardrails`
+
+## Definition of done
+Slice 8 is done when:
+- outbound call and message routes are delegated through thin-router handlers
+- exact current response shapes still pass characterization coverage
+- exact current reopen behavior still passes characterization coverage
+- helper-boundary tests exist
+- router plan is updated
+- outbound guardrail notes exist
+- CI remains green


### PR DESCRIPTION
## Summary
- characterize the outbound call and message routes for Slice 8
- extract thin outbound handlers and shared outbound helper boundary
- add helper-boundary tests and outbound guardrail notes

## Validation
- pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts
- pnpm nx run connectshyft-api:test
- pnpm nx run contracts:test