### PR TITLE
Refactor: extract ConnectShyft inbound webhook route family

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts
@@ -1,0 +1,411 @@
+import type { Request, Response } from 'express';
+import { postConnectWebhookInbound } from '../handlers/postConnectWebhookInbound';
+import { postConnectWebhookSms } from '../handlers/postConnectWebhookSms';
+import {
+  executeConnectShyftInboundWebhookRoute,
+  registerConnectShyftInboundWebhookCoreExecutor,
+  resolveConnectShyftInboundWebhookAccessContext,
+} from '../http/inboundWebhookContext';
+import * as inboundWebhookContextModule from '../http/inboundWebhookContext';
+import * as accessContextModule from '../http/accessContext';
+import * as providerRegistryModule from '../providerRegistry';
+import * as providerCorrelationMappingsModule from '../providerCorrelationMappings';
+import * as bridgeSessionsModule from '../bridgeSessions';
+import * as canonicalEventsModule from '../canonicalEvents';
+import * as inboundSmsModule from '../inboundSms';
+import * as inboundVoiceModule from '../inboundVoice';
+
+type MockResponse = Response & {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+const TEST_TENANT_ID = 'tenant-connectshyft-c9';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-c9-east';
+const TEST_THREAD_ID = 'thread-connectshyft-c9-1001';
+
+const createRequest = (overrides: Partial<Request> = {}): Request => {
+  const {
+    headers: overrideHeaders,
+    body: overrideBody,
+    ...restOverrides
+  } = overrides as Partial<Request> & {
+    headers?: Record<string, string>;
+  };
+  const headers = Object.entries((overrideHeaders || {}) as Record<string, string>).reduce<Record<string, string>>(
+    (acc, [key, value]) => {
+      acc[key.toLowerCase()] = value;
+      return acc;
+    },
+    {},
+  );
+
+  return {
+    path: '/api/v1/connect/webhooks/inbound',
+    url: '/api/v1/connect/webhooks/inbound',
+    originalUrl: '/api/v1/connect/webhooks/inbound',
+    protocol: 'https',
+    params: {},
+    query: {},
+    body: {
+      eventType: 'MessageReceived',
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      threadId: TEST_THREAD_ID,
+      ...(overrideBody || {}),
+    },
+    user: {
+      userId: 'user-connectshyft-c9-1001',
+      role: 'ORGUNIT_MEMBER',
+      activeTenantId: TEST_TENANT_ID,
+      activeOrgUnitId: TEST_ORG_UNIT_ID,
+      householdId: TEST_TENANT_ID,
+      email: 'inbound-webhook-context@test.local',
+    },
+    header: (name: string) => headers[name.toLowerCase()] || undefined,
+    ...restOverrides,
+  } as unknown as Request;
+};
+
+const createMockResponse = (): MockResponse => {
+  const res = {
+    locals: {
+      responseEnvelope: {
+        correlationId: 'corr-inbound-webhook-context',
+        tenantId: TEST_TENANT_ID,
+      },
+    },
+    status: jest.fn(),
+    json: jest.fn(),
+  } as unknown as MockResponse;
+
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+
+  return res;
+};
+
+const createProviderSelection = (overrides: {
+  verifyWebhookResult?: unknown;
+  canonicalTranslation?: Record<string, unknown>;
+} = {}) => {
+  const canonicalTranslation = {
+    eventType: 'message.received',
+    payload: {
+      eventType: 'MessageReceived',
+    },
+    correlation: {
+      providerLegId: null,
+      providerMessageId: 'provider-message-c9-1001',
+      providerEventId: 'provider-event-c9-1001',
+      providerNumber: '+12605550199',
+    },
+    providerNeutral: true,
+    providerSpecificFieldsStripped: true,
+    providerBranchingInDomain: false,
+    ...(overrides.canonicalTranslation || {}),
+  };
+  const adapter = {
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    verifyWebhook: jest.fn().mockReturnValue(overrides.verifyWebhookResult || { ok: true }),
+    translateProviderEvent: jest.fn().mockReturnValue(canonicalTranslation),
+  };
+  const selection = {
+    ok: true,
+    adapter,
+    providerResolution: {
+      requestedProvider: 'telnyx',
+      resolvedProvider: 'telnyx',
+      deterministic: true,
+    },
+  };
+
+  return {
+    adapter,
+    selection,
+    canonicalTranslation,
+  };
+};
+
+describe('connectshyft inbound webhook helper boundary', () => {
+  beforeEach(() => {
+    registerConnectShyftInboundWebhookCoreExecutor(async () => undefined);
+    jest.spyOn(accessContextModule, 'enforceConnectShyftCapability').mockResolvedValue(true as any);
+    jest.spyOn(accessContextModule, 'loadConnectShyftPlatformDb').mockReturnValue({
+      mocked: 'db',
+    } as any);
+    jest.spyOn(providerRegistryModule, 'resolveConnectShyftRequestedProviderKey').mockReturnValue('telnyx');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the scoped webhook prerequisites for a valid SMS webhook request', async () => {
+    const { adapter, selection, canonicalTranslation } = createProviderSelection();
+    const resolveProviderAdapterSpy = jest
+      .spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter')
+      .mockReturnValue(selection as any);
+    const correlationLookupSpy = jest
+      .spyOn(providerCorrelationMappingsModule, 'resolveConnectShyftProviderCorrelationByIdentifiers')
+      .mockResolvedValue({
+        ok: false,
+        reason: 'not-found',
+      } as any);
+    const req = createRequest({
+      path: '/api/v1/connect/webhooks/sms',
+      url: '/api/v1/connect/webhooks/sms',
+      originalUrl: '/api/v1/connect/webhooks/sms',
+    });
+    const res = createMockResponse();
+
+    const context = await resolveConnectShyftInboundWebhookAccessContext(req, res);
+
+    expect(context).toMatchObject({
+      routeKind: 'sms',
+      providerSelection: {
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+        },
+      },
+      canonicalTranslation,
+      eventType: 'message.received',
+      normalizedEventType: 'message.received',
+      correlation: {
+        source: 'metadata',
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        threadId: TEST_THREAD_ID,
+        providerLegId: null,
+        providerMessageId: 'provider-message-c9-1001',
+        providerEventId: 'provider-event-c9-1001',
+        providerNumberE164: '+12605550199',
+      },
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      threadId: TEST_THREAD_ID,
+    });
+    expect(Object.keys(context || {}).sort()).toEqual([
+      'canonicalTranslation',
+      'correlation',
+      'eventType',
+      'normalizedEventType',
+      'orgUnitId',
+      'providerSelection',
+      'routeKind',
+      'tenantId',
+      'threadId',
+    ]);
+    expect(resolveProviderAdapterSpy).toHaveBeenNthCalledWith(1, {
+      req,
+      operation: 'webhook',
+      requestedProvider: 'telnyx',
+    });
+    expect(resolveProviderAdapterSpy).toHaveBeenNthCalledWith(2, {
+      req: expect.objectContaining({
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        body: req.body,
+        url: req.url,
+        originalUrl: req.originalUrl,
+        protocol: req.protocol,
+      }),
+      operation: 'webhook',
+      requestedProvider: 'telnyx',
+    });
+    expect(adapter.verifyWebhook).toHaveBeenCalledTimes(1);
+    expect(adapter.translateProviderEvent).toHaveBeenCalledWith({
+      rawEventType: 'MessageReceived',
+      payload: req.body,
+    });
+    expect(correlationLookupSpy).toHaveBeenCalledWith({
+      providerName: 'telnyx',
+      providerLegId: null,
+      providerMessageId: 'provider-message-c9-1001',
+      tenantId: TEST_TENANT_ID,
+      db: { mocked: 'db' },
+    });
+    expect(accessContextModule.loadConnectShyftPlatformDb).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('maps missing webhook signatures to the current refusal envelope', async () => {
+    const { adapter, selection } = createProviderSelection({
+      verifyWebhookResult: {
+        ok: false,
+        refusal: {
+          code: 'WEBHOOK_SIGNATURE_MISSING',
+          message: 'Webhook signature header is required.',
+          refusalType: 'client',
+          httpStatus: 401,
+        },
+      },
+    });
+    const correlationLookupSpy = jest.spyOn(
+      providerCorrelationMappingsModule,
+      'resolveConnectShyftProviderCorrelationByIdentifiers',
+    );
+    jest.spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter').mockReturnValue(selection as any);
+    const res = createMockResponse();
+
+    const context = await resolveConnectShyftInboundWebhookAccessContext(createRequest(), res, 'inbound');
+
+    expect(context).toBeNull();
+    expect(adapter.translateProviderEvent).not.toHaveBeenCalled();
+    expect(correlationLookupSpy).not.toHaveBeenCalled();
+    expect(accessContextModule.loadConnectShyftPlatformDb).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      code: 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MISSING',
+      message: 'Webhook signature header is required.',
+      refusalType: 'client',
+      correlationId: 'corr-inbound-webhook-context',
+      tenantId: TEST_TENANT_ID,
+      data: expect.objectContaining({
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInvoked: true,
+        },
+        signatureValidation: {
+          deterministic: true,
+          verified: false,
+          provider: 'telnyx',
+        },
+        operatorFeedbackMeta: {
+          actionable: true,
+          hiddenTransition: false,
+          messageKey: 'connectshyft.webhook.signature.missing',
+          remediation: 'Ensure provider webhook signing is configured and include a valid signature.',
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
+        },
+      }),
+    }));
+  });
+
+  it('stays limited to prerequisite resolution and execution delegation without bridge or canonical side effects', async () => {
+    const { selection, canonicalTranslation } = createProviderSelection();
+    jest.spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter').mockReturnValue(selection as any);
+    jest.spyOn(
+      providerCorrelationMappingsModule,
+      'resolveConnectShyftProviderCorrelationByIdentifiers',
+    ).mockResolvedValue({
+      ok: false,
+      reason: 'not-found',
+    } as any);
+    const bridgeWebhookSpy = jest.spyOn(
+      bridgeSessionsModule,
+      'handleConnectShyftBridgeWebhookEvent',
+    ).mockImplementation(async () => {
+      throw new Error('Bridge webhook handling should not run during inbound helper preparation.');
+    });
+    const canonicalEventSpy = jest.spyOn(
+      canonicalEventsModule,
+      'recordConnectShyftCanonicalEvent',
+    ).mockImplementation(async () => {
+      throw new Error('Canonical event persistence should not run during inbound helper preparation.');
+    });
+    const inboundSmsSpy = jest.spyOn(
+      inboundSmsModule,
+      'mapConnectShyftInboundSmsWebhookToDomainEvent',
+    ).mockImplementation(() => {
+      throw new Error('Inbound SMS domain mapping should not run during inbound helper preparation.');
+    });
+    const inboundVoiceSpy = jest.spyOn(
+      inboundVoiceModule,
+      'mapConnectShyftInboundVoiceWebhookToDomainEvent',
+    ).mockImplementation(() => {
+      throw new Error('Inbound voice domain mapping should not run during inbound helper preparation.');
+    });
+    const coreExecutor = jest.fn(async (_input: unknown) => undefined);
+    const req = createRequest({
+      path: '/api/v1/connect/webhooks/sms',
+      url: '/api/v1/connect/webhooks/sms',
+      originalUrl: '/api/v1/connect/webhooks/sms',
+    });
+    const res = createMockResponse();
+
+    registerConnectShyftInboundWebhookCoreExecutor(coreExecutor);
+
+    await executeConnectShyftInboundWebhookRoute(req, res, 'sms');
+
+    expect(coreExecutor).toHaveBeenCalledTimes(1);
+
+    const executionInput = coreExecutor.mock.calls[0]?.[0];
+    if (!executionInput) {
+      throw new Error('Expected inbound webhook core executor to receive execution input.');
+    }
+
+    expect(executionInput).toMatchObject({
+      req,
+      res,
+      routeKind: 'sms',
+      providerSelection: {
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+        },
+      },
+      canonicalTranslation,
+      eventType: 'message.received',
+      normalizedEventType: 'message.received',
+      correlation: {
+        source: 'metadata',
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        threadId: TEST_THREAD_ID,
+      },
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      threadId: TEST_THREAD_ID,
+    });
+    expect(Object.keys(executionInput).sort()).toEqual([
+      'canonicalTranslation',
+      'correlation',
+      'eventType',
+      'normalizedEventType',
+      'orgUnitId',
+      'providerSelection',
+      'req',
+      'res',
+      'routeKind',
+      'tenantId',
+      'threadId',
+    ]);
+    expect(bridgeWebhookSpy).not.toHaveBeenCalled();
+    expect(canonicalEventSpy).not.toHaveBeenCalled();
+    expect(inboundSmsSpy).not.toHaveBeenCalled();
+    expect(inboundVoiceSpy).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('prepares deterministic route kinds for the thin inbound webhook handlers', async () => {
+    const executeRouteSpy = jest
+      .spyOn(inboundWebhookContextModule, 'executeConnectShyftInboundWebhookRoute')
+      .mockResolvedValue(undefined);
+    const req = createRequest();
+    const res = createMockResponse();
+
+    await postConnectWebhookInbound(req, res);
+    await postConnectWebhookSms(req, res);
+
+    expect(executeRouteSpy).toHaveBeenNthCalledWith(1, req, res, 'inbound');
+    expect(executeRouteSpy).toHaveBeenNthCalledWith(2, req, res, 'sms');
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md
@@ -1,0 +1,87 @@
+# ConnectShyft Inbound Webhook Notes
+
+## Current ownership
+
+The ConnectShyft inbound webhook surface is currently split across these files:
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+  - owns only route registration for:
+    - `POST /webhooks/inbound`
+    - `POST /webhooks/sms`
+  - owns the currently registered inbound webhook core execution path that preserves the existing inbound SMS, inbound voice, voicemail, transcription callback, and auto-claim behavior
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookInbound.ts`
+  - owns inbound-webhook route handoff and delegates execution through the shared helper boundary with deterministic `inbound` route preparation
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookSms.ts`
+  - owns SMS-webhook route handoff and delegates execution through the shared helper boundary with deterministic `sms` route preparation
+- `apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts`
+  - owns shared inbound route-entry prerequisite handling
+  - owns capability enforcement for webhook access
+  - owns provider selection and signature verification at the route-entry seam
+  - owns canonical event translation needed to prepare the existing core
+  - owns webhook correlation resolution and rollout-context validation
+  - owns prerequisite refusal mapping and the shared execution wrapper that hands the request to the existing inbound core
+
+## What remains outside the handler boundary
+
+Slice 9 intentionally did not move inbound telephony or provider internals out of their existing homes.
+
+That means the following concerns remain outside the thin handlers and outside `inboundWebhookContext.ts`:
+
+- provider internals
+  - still owned by the existing inbound core in `connectshyft.ts` and provider-facing modules such as `providerRegistry.ts`
+- correlation persistence and webhook-receipt orchestration internals
+  - still owned by the existing inbound core in `connectshyft.ts` and `providerCorrelationMappings.ts`
+- canonical event persistence and canonical payload assembly
+  - still owned by the existing inbound core in `connectshyft.ts` and `canonicalEvents.ts`
+- bridge-session webhook progression and bridge alignment behavior
+  - still owned by the existing inbound core in `connectshyft.ts` and `bridgeSessions.ts`
+- inbound SMS domain mapping and neighbor-resolution behavior
+  - still owned by the existing inbound core in `connectshyft.ts` and `inboundSms.ts`
+- inbound voice, voicemail artifact, and transcription internals
+  - still owned by the existing inbound core in `connectshyft.ts` and `inboundVoice.ts`
+
+Provider, correlation, canonical, bridge, and transcription internals remain intentionally deferred from the route-family extraction sequence.
+
+## Response shape preservation rule
+
+Slice 9 intentionally preserves the exact current inbound webhook response shapes.
+
+That means:
+
+- `POST /webhooks/inbound` still returns the existing success and refusal envelopes
+- `POST /webhooks/sms` still returns the existing success and refusal envelopes
+- existing nested provider, correlation, canonical, bridge, voicemail, transcription, auto-claim, and side-effect payload structure remains unchanged
+
+This was deliberate. The goal of this slice was thin-router extraction, helper-boundary coverage, and ownership notes, not payload cleanup or response redesign.
+
+## Behavior lock
+
+Slice 9 also intentionally locks the current operational inbound behavior.
+
+That includes:
+
+- current inbound SMS handling and neighbor-resolution semantics
+- current inbound voice behavior
+- current voice auto-claim behavior
+- current voicemail behavior
+- current transcription callback behavior
+
+Follow-up cleanup should treat these behaviors as locked unless characterization coverage and helper-boundary expectations are intentionally updated in a later slice.
+
+## Telephony and provider redesign note
+
+This slice did not redesign telephony behavior or provider behavior.
+
+It did not:
+
+- re-architect webhook routing semantics
+- redesign provider verification or translation behavior
+- redesign correlation or dedupe behavior
+- redesign bridge handling
+- redesign voicemail or transcription processing
+
+## Next step
+
+Architecture consolidation for PeopleCore / Identity Resolution / ConnectShyft model lock-in is next.
+
+That work should build on the current thin handlers and `inboundWebhookContext.ts` boundary rather than pulling deferred provider, correlation, canonical, bridge, or transcription internals into the route-family extraction seam.

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts
@@ -15,4 +15,6 @@ export { postConnectThreadCall } from './postConnectThreadCall';
 export { postConnectThreadClose } from './postConnectThreadClose';
 export { postConnectThreadMessage } from './postConnectThreadMessage';
 export { postConnectThreadTakeover } from './postConnectThreadTakeover';
+export { postConnectWebhookInbound } from './postConnectWebhookInbound';
+export { postConnectWebhookSms } from './postConnectWebhookSms';
 export { putConnectNeighbor } from './putConnectNeighbor';

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookInbound.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookInbound.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+import { executeConnectShyftInboundWebhookRoute } from '../http/inboundWebhookContext';
+
+export const postConnectWebhookInbound = async (req: Request, res: Response) =>
+  executeConnectShyftInboundWebhookRoute(req, res, 'inbound');

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookSms.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookSms.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+import { executeConnectShyftInboundWebhookRoute } from '../http/inboundWebhookContext';
+
+export const postConnectWebhookSms = async (req: Request, res: Response) =>
+  executeConnectShyftInboundWebhookRoute(req, res, 'sms');

--- a/apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts
@@ -1,0 +1,532 @@
+import { Request, Response } from 'express';
+import { refusal } from '../../../platform/envelopes/response';
+import {
+  buildConnectShyftWebhookVerificationInput,
+  mapConnectShyftWebhookVerificationResult,
+  resolveConnectShyftProviderAdapter,
+  resolveConnectShyftRequestedProviderKey,
+  type ConnectShyftProviderCanonicalEvent,
+  type ConnectShyftProviderResolutionSuccess,
+} from '../providerRegistry';
+import { connectShyftNumberMappingServiceAsync } from '../numberMappings';
+import { resolveConnectShyftProviderCorrelationByIdentifiers } from '../providerCorrelationMappings';
+import {
+  enforceConnectShyftCapability,
+  loadConnectShyftPlatformDb,
+} from './accessContext';
+
+export type ConnectShyftInboundWebhookRouteKind = 'inbound' | 'sms';
+export type ConnectShyftWebhookCorrelationSource = 'metadata' | 'provider_fallback' | 'number_mapping';
+
+export type ConnectShyftResolvedWebhookCorrelation =
+  | {
+    ok: true;
+    source: ConnectShyftWebhookCorrelationSource;
+    tenantId: string;
+    orgUnitId: string;
+    threadId: string;
+    providerLegId: string | null;
+    providerMessageId: string | null;
+    providerEventId: string | null;
+    providerNumberE164: string | null;
+  }
+  | {
+    ok: false;
+    code:
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS'
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE'
+      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT';
+    message: string;
+    reason: 'missing-identifiers' | 'not-found' | 'ambiguous' | 'unavailable' | 'conflict';
+    providerLegId: string | null;
+    providerMessageId: string | null;
+    providerEventId: string | null;
+    providerNumberE164: string | null;
+  };
+
+export type ConnectShyftInboundWebhookAccessContext = {
+  routeKind: ConnectShyftInboundWebhookRouteKind;
+  providerSelection: ConnectShyftProviderResolutionSuccess;
+  canonicalTranslation: ConnectShyftProviderCanonicalEvent;
+  eventType: string;
+  normalizedEventType: string;
+  correlation: Extract<ConnectShyftResolvedWebhookCorrelation, { ok: true }>;
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+};
+
+export type ConnectShyftInboundWebhookCoreExecutionInput =
+  ConnectShyftInboundWebhookAccessContext & {
+    req: Request;
+    res: Response;
+  };
+
+type ConnectShyftInboundWebhookCoreExecutor = (
+  input: ConnectShyftInboundWebhookCoreExecutionInput,
+) => Promise<void>;
+
+let connectShyftInboundWebhookCoreExecutor: ConnectShyftInboundWebhookCoreExecutor | null = null;
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+};
+
+const inferConnectShyftInboundWebhookRouteKind = (
+  req: Request,
+): ConnectShyftInboundWebhookRouteKind => {
+  const pathCandidates = [
+    req.path,
+    req.url,
+    req.originalUrl,
+  ]
+    .map((value) => normalizeString(value))
+    .filter((value) => value.length > 0);
+
+  return pathCandidates.some((value) => value.endsWith('/webhooks/sms') || value.endsWith('/sms'))
+    ? 'sms'
+    : 'inbound';
+};
+
+const resolveWebhookCorrelationFailure = (
+  reason: 'missing-identifiers' | 'not-found' | 'ambiguous' | 'unavailable',
+): {
+  code:
+    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
+    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
+    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS'
+    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE';
+  message: string;
+} => {
+  if (reason === 'missing-identifiers') {
+    return {
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED',
+      message: 'Inbound webhook requires correlation metadata or provider identifiers.',
+    };
+  }
+  if (reason === 'ambiguous') {
+    return {
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS',
+      message: 'Inbound webhook correlation is ambiguous across provider identifiers.',
+    };
+  }
+  if (reason === 'unavailable') {
+    return {
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE',
+      message: 'Inbound webhook correlation lookup is temporarily unavailable.',
+    };
+  }
+
+  return {
+    code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND',
+    message: 'Inbound webhook correlation mapping not found for provider identifiers.',
+  };
+};
+
+const resolveInboundWebhookCorrelation = async (input: {
+  body: unknown;
+  channelHint: 'sms' | 'voice';
+  providerName: string;
+  providerCorrelation: {
+    providerLegId: string | null;
+    providerMessageId: string | null;
+    providerEventId: string | null;
+    providerNumber: string | null;
+  };
+  tenantIdHint?: string | null;
+}): Promise<ConnectShyftResolvedWebhookCorrelation> => {
+  const payload = asRecord(input.body);
+  const tenantId = normalizeString(payload?.tenantId);
+  const orgUnitId = normalizeString(payload?.orgUnitId);
+  const threadId = normalizeString(payload?.threadId);
+  const providerIdentifiers = {
+    providerLegId: normalizeString(input.providerCorrelation.providerLegId) || null,
+    providerMessageId: normalizeString(input.providerCorrelation.providerMessageId) || null,
+    providerEventId: normalizeString(input.providerCorrelation.providerEventId) || null,
+  };
+  const providerNumberE164 = normalizeString(input.providerCorrelation.providerNumber) || null;
+  const tenantScopeHint = normalizeString(input.tenantIdHint || null);
+  const numberMappingTenantScope = tenantId
+    || (tenantScopeHint.toLowerCase() !== 'public' ? tenantScopeHint : '')
+    || null;
+  const hasCompleteMetadata = Boolean(tenantId && orgUnitId && threadId);
+  const platformDb = loadConnectShyftPlatformDb();
+
+  if (hasCompleteMetadata) {
+    const fallbackProbe = await resolveConnectShyftProviderCorrelationByIdentifiers({
+      providerName: input.providerName,
+      providerLegId: providerIdentifiers.providerLegId,
+      providerMessageId: providerIdentifiers.providerMessageId,
+      tenantId,
+      db: platformDb,
+    });
+
+    if (
+      fallbackProbe.ok
+      && (
+        fallbackProbe.correlation.tenantId !== tenantId
+        || fallbackProbe.correlation.orgUnitId !== orgUnitId
+        || fallbackProbe.correlation.threadId !== threadId
+      )
+    ) {
+      return {
+        ok: false,
+        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
+        message: 'Inbound webhook correlation metadata conflicts with provider identifier mapping.',
+        reason: 'conflict',
+        providerLegId: providerIdentifiers.providerLegId,
+        providerMessageId: providerIdentifiers.providerMessageId,
+        providerEventId: providerIdentifiers.providerEventId,
+        providerNumberE164,
+      };
+    }
+
+    return {
+      ok: true,
+      source: 'metadata',
+      tenantId,
+      orgUnitId,
+      threadId,
+      providerLegId: providerIdentifiers.providerLegId,
+      providerMessageId: providerIdentifiers.providerMessageId,
+      providerEventId: providerIdentifiers.providerEventId,
+      providerNumberE164,
+    };
+  }
+
+  const fallback = await resolveConnectShyftProviderCorrelationByIdentifiers({
+    providerName: input.providerName,
+    providerLegId: providerIdentifiers.providerLegId,
+    providerMessageId: providerIdentifiers.providerMessageId,
+    tenantId: tenantId || null,
+    db: platformDb,
+  });
+  if (!fallback.ok && providerNumberE164) {
+    try {
+      const numberMapping = await connectShyftNumberMappingServiceAsync.resolveRoutingMappingByNumber({
+        tenantId: numberMappingTenantScope,
+        twilioNumberE164: providerNumberE164,
+      });
+      if (numberMapping.status === 'found') {
+        return {
+          ok: true,
+          source: 'number_mapping',
+          tenantId: numberMapping.mapping.tenantId,
+          orgUnitId: numberMapping.mapping.orgUnitId,
+          threadId: '',
+          providerLegId: providerIdentifiers.providerLegId,
+          providerMessageId: providerIdentifiers.providerMessageId,
+          providerEventId: providerIdentifiers.providerEventId,
+          providerNumberE164: numberMapping.mapping.twilioNumberE164,
+        };
+      }
+
+      if (numberMapping.status === 'ambiguous') {
+        return {
+          ok: false,
+          code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS',
+          message: 'Inbound webhook correlation is ambiguous across provider number mappings.',
+          reason: 'ambiguous',
+          providerLegId: providerIdentifiers.providerLegId,
+          providerMessageId: providerIdentifiers.providerMessageId,
+          providerEventId: providerIdentifiers.providerEventId,
+          providerNumberE164,
+        };
+      }
+    } catch (_error) {
+      return {
+        ok: false,
+        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE',
+        message: 'Inbound webhook correlation lookup is temporarily unavailable.',
+        reason: 'unavailable',
+        providerLegId: providerIdentifiers.providerLegId,
+        providerMessageId: providerIdentifiers.providerMessageId,
+        providerEventId: providerIdentifiers.providerEventId,
+        providerNumberE164,
+      };
+    }
+
+    if (fallback.reason === 'missing-identifiers') {
+      return {
+        ok: false,
+        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND',
+        message: 'Inbound webhook correlation mapping not found for provider identifiers.',
+        reason: 'not-found',
+        providerLegId: providerIdentifiers.providerLegId,
+        providerMessageId: providerIdentifiers.providerMessageId,
+        providerEventId: providerIdentifiers.providerEventId,
+        providerNumberE164,
+      };
+    }
+  }
+
+  if (!fallback.ok) {
+    const failure = resolveWebhookCorrelationFailure(fallback.reason);
+    return {
+      ok: false,
+      code: failure.code,
+      message: failure.message,
+      reason: fallback.reason,
+      providerLegId: providerIdentifiers.providerLegId,
+      providerMessageId: providerIdentifiers.providerMessageId,
+      providerEventId: providerIdentifiers.providerEventId,
+      providerNumberE164,
+    };
+  }
+
+  if (
+    (tenantId && tenantId !== fallback.correlation.tenantId)
+    || (orgUnitId && orgUnitId !== fallback.correlation.orgUnitId)
+    || (threadId && threadId !== fallback.correlation.threadId)
+  ) {
+    return {
+      ok: false,
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
+      message: 'Inbound webhook partial metadata conflicts with provider identifier mapping.',
+      reason: 'conflict',
+      providerLegId: providerIdentifiers.providerLegId,
+      providerMessageId: providerIdentifiers.providerMessageId,
+      providerEventId: providerIdentifiers.providerEventId,
+      providerNumberE164,
+    };
+  }
+
+  return {
+    ok: true,
+    source: 'provider_fallback',
+    tenantId: fallback.correlation.tenantId,
+    orgUnitId: fallback.correlation.orgUnitId,
+    threadId: fallback.correlation.threadId,
+    providerLegId: providerIdentifiers.providerLegId,
+    providerMessageId: providerIdentifiers.providerMessageId,
+    providerEventId: providerIdentifiers.providerEventId,
+    providerNumberE164,
+  };
+};
+
+export const resolveConnectShyftInboundWebhookAccessContext = async (
+  req: Request,
+  res: Response,
+  routeKind: ConnectShyftInboundWebhookRouteKind = inferConnectShyftInboundWebhookRouteKind(req),
+): Promise<ConnectShyftInboundWebhookAccessContext | null> => {
+  if (!await enforceConnectShyftCapability(req, res, 'webhooks')) {
+    return null;
+  }
+
+  const providerSelection = resolveConnectShyftProviderAdapter({
+    req,
+    operation: 'webhook',
+    requestedProvider: resolveConnectShyftRequestedProviderKey(req),
+  });
+  if (!providerSelection.ok) {
+    refusal(res, {
+      code: providerSelection.refusal.code,
+      message: providerSelection.refusal.message,
+      refusalType: providerSelection.refusal.refusalType,
+      httpStatus: providerSelection.refusal.httpStatus,
+      data: providerSelection.refusal.data,
+    });
+    return null;
+  }
+
+  const signatureDecision = mapConnectShyftWebhookVerificationResult(
+    providerSelection.adapter.verifyWebhook(
+      buildConnectShyftWebhookVerificationInput({
+        req,
+        providerKey: providerSelection.providerResolution.resolvedProvider,
+      }),
+    ),
+  );
+  if (!signatureDecision.ok) {
+    const signatureMessageKey = signatureDecision.refusal.code === 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MISSING'
+      ? 'connectshyft.webhook.signature.missing'
+      : signatureDecision.refusal.code === 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED'
+        ? 'connectshyft.webhook.signature.not_configured'
+        : 'connectshyft.webhook.signature.invalid';
+    refusal(res, {
+      code: signatureDecision.refusal.code,
+      message: signatureDecision.refusal.message,
+      refusalType: signatureDecision.refusal.refusalType,
+      httpStatus: signatureDecision.refusal.httpStatus,
+      data: {
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        signatureValidation: {
+          deterministic: true,
+          verified: false,
+          provider: providerSelection.providerResolution.resolvedProvider,
+        },
+        operatorFeedbackMeta: {
+          actionable: true,
+          hiddenTransition: false,
+          messageKey: signatureMessageKey,
+          remediation: 'Ensure provider webhook signing is configured and include a valid signature.',
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
+        },
+      },
+    });
+    return null;
+  }
+
+  const canonicalTranslation = providerSelection.adapter.translateProviderEvent({
+    rawEventType: normalizeString(req.body?.eventType) || 'sms.inbound',
+    payload: req.body,
+  });
+  const eventType = canonicalTranslation.eventType;
+  const normalizedEventType = eventType.toLowerCase();
+  const correlation = await resolveInboundWebhookCorrelation({
+    body: req.body,
+    channelHint:
+      normalizedEventType.includes('sms') || normalizedEventType.includes('message')
+        ? 'sms'
+        : 'voice',
+    providerName: providerSelection.providerResolution.resolvedProvider,
+    providerCorrelation: canonicalTranslation.correlation,
+    tenantIdHint: req.tenantId || null,
+  });
+  if (!correlation.ok) {
+    refusal(res, {
+      code: correlation.code,
+      message: correlation.message,
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        correlation: {
+          deterministic: true,
+          metadataFirstAttempted: true,
+          fallbackLookupAttempted: true,
+          reason: correlation.reason,
+          providerLegId: correlation.providerLegId,
+          providerMessageId: correlation.providerMessageId,
+          providerEventId: correlation.providerEventId,
+          providerNumberE164: correlation.providerNumberE164,
+        },
+        operatorFeedbackMeta: {
+          actionable: true,
+          hiddenTransition: false,
+          messageKey: 'connectshyft.webhook.correlation.unresolved',
+          remediation: 'Retry with thread metadata or provider identifiers that map to a prior outbound dispatch.',
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
+        },
+      },
+    });
+    return null;
+  }
+
+  const tenantId = correlation.tenantId;
+  const orgUnitId = correlation.orgUnitId;
+  const threadId = correlation.threadId;
+  const requestWithRawBody = req as Request & { rawBody?: Buffer | string };
+  const rolloutContextValidation = resolveConnectShyftProviderAdapter({
+    req: {
+      header: (name: string) => req.header(name),
+      body: req.body,
+      rawBody: requestWithRawBody.rawBody,
+      originalUrl: req.originalUrl,
+      protocol: req.protocol,
+      url: req.url,
+      tenantId,
+      orgUnitId,
+    },
+    operation: 'webhook',
+    requestedProvider: providerSelection.providerResolution.resolvedProvider,
+  });
+  if (!rolloutContextValidation.ok) {
+    refusal(res, {
+      code: rolloutContextValidation.refusal.code,
+      message: rolloutContextValidation.refusal.message,
+      refusalType: rolloutContextValidation.refusal.refusalType,
+      httpStatus: rolloutContextValidation.refusal.httpStatus,
+      data: {
+        ...(rolloutContextValidation.refusal.data || {}),
+        correlation: {
+          source: correlation.source,
+          deterministic: true,
+          threadId,
+          tenantId,
+          orgUnitId,
+          providerLegId: correlation.providerLegId,
+          providerMessageId: correlation.providerMessageId,
+          providerEventId: correlation.providerEventId,
+          providerNumberE164: correlation.providerNumberE164,
+        },
+      },
+    });
+    return null;
+  }
+
+  return {
+    routeKind,
+    providerSelection,
+    canonicalTranslation,
+    eventType,
+    normalizedEventType,
+    correlation,
+    tenantId,
+    orgUnitId,
+    threadId,
+  };
+};
+
+export const registerConnectShyftInboundWebhookCoreExecutor = (
+  executor: ConnectShyftInboundWebhookCoreExecutor,
+): void => {
+  connectShyftInboundWebhookCoreExecutor = executor;
+};
+
+export const executeConnectShyftInboundWebhookRoute = async (
+  req: Request,
+  res: Response,
+  routeKind: ConnectShyftInboundWebhookRouteKind = inferConnectShyftInboundWebhookRouteKind(req),
+): Promise<void> => {
+  const accessContext = await resolveConnectShyftInboundWebhookAccessContext(req, res, routeKind);
+  if (!accessContext) {
+    return;
+  }
+
+  if (!connectShyftInboundWebhookCoreExecutor) {
+    throw new Error('ConnectShyft inbound webhook core executor is not registered.');
+  }
+
+  await connectShyftInboundWebhookCoreExecutor({
+    req,
+    res,
+    ...accessContext,
+  });
+};

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
@@ -1,0 +1,914 @@
+// @ts-nocheck
+import request from 'supertest';
+import db from '../../../../config/knex';
+import * as canonicalEventsModule from '../../../../modules/connectshyft/canonicalEvents';
+import * as identityResolverModule from '../../../../modules/connectshyft/identityResolver';
+import * as neighborsModule from '../../../../modules/connectshyft/neighbors';
+import { AsyncConnectShyftNeighborService } from '../../../../modules/connectshyft/neighbors';
+import {
+  connectShyftNumberMappingServiceAsync,
+  type ConnectShyftNumberMapping,
+} from '../../../../modules/connectshyft/numberMappings';
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import { AsyncConnectShyftThreadService } from '../../../../modules/connectshyft/threads';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TENANT_ID = 'tenant-connectshyft-f1';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-f1-east';
+const TEST_PROVIDER_NUMBER = '+12605550191';
+const TEST_TIMESTAMP = '2026-03-18T12:00:00.000Z';
+
+const readString = (...values: unknown[]): string | null => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+};
+
+const sendSmsMock = jest.fn();
+const startOutboundCallMock = jest.fn();
+const startBridgeSessionMock = jest.fn();
+const endCallMock = jest.fn();
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const translateProviderEventMock = jest.fn(({ rawEventType, payload }: {
+  rawEventType: string;
+  payload: unknown;
+}) => {
+  const source = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {};
+
+  return {
+    eventType: readString(rawEventType) || 'sms.inbound',
+    payload: source,
+    correlation: {
+      providerLegId: readString(source.providerLegId, source.provider_leg_id),
+      providerMessageId: readString(
+        source.providerMessageId,
+        source.provider_message_id,
+        source.messageId,
+        source.message_id,
+        source.sid,
+      ),
+      providerEventId: readString(
+        source.providerEventId,
+        source.provider_event_id,
+        source.eventId,
+        source.event_id,
+      ),
+      providerNumber: readString(source.to, source.toNumber, source.to_number),
+    },
+    providerNeutral: true as const,
+    providerSpecificFieldsStripped: true as const,
+    providerBranchingInDomain: false as const,
+  };
+});
+
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}));
+
+const buildSmsHeaders = (
+  overrides: Record<string, string> = {},
+): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-f1-operator',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+  ...overrides,
+});
+
+const buildNumberMapping = (
+  overrides: Partial<ConnectShyftNumberMapping> & Pick<
+    ConnectShyftNumberMapping,
+    'mappingId' | 'tenantId' | 'orgUnitId' | 'twilioNumberE164' | 'label'
+  >,
+): ConnectShyftNumberMapping => ({
+  mappingId: overrides.mappingId,
+  tenantId: overrides.tenantId,
+  orgUnitId: overrides.orgUnitId,
+  twilioNumberE164: overrides.twilioNumberE164,
+  label: overrides.label,
+  isActive: overrides.isActive ?? true,
+  createdAtUtc: overrides.createdAtUtc ?? TEST_TIMESTAMP,
+  updatedAtUtc: overrides.updatedAtUtc ?? TEST_TIMESTAMP,
+});
+
+const buildEnsuredThread = (overrides: Record<string, unknown> = {}) => ({
+  threadId: 'thread-sms-characterization-1001',
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  neighborId: 'neighbor-connectshyft-f1-1001',
+  source: 'SMS',
+  state: 'UNCLAIMED',
+  lastInboundCsNumberId: TEST_PROVIDER_NUMBER,
+  preferredOutboundCsNumberId: TEST_PROVIDER_NUMBER,
+  claimedByUserId: null,
+  claimedAtUtc: null,
+  closedByUserId: null,
+  closedAtUtc: null,
+  createdAtUtc: TEST_TIMESTAMP,
+  updatedAtUtc: TEST_TIMESTAMP,
+  escalation: {
+    stage: 0,
+    nextEvaluationAtUtc: null,
+  },
+  ...overrides,
+});
+
+const buildInboundSmsBody = (overrides: Record<string, unknown> = {}) => ({
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  threadId: 'thread-f1-unclaimed-1001',
+  eventType: 'sms.inbound',
+  sid: 'sms-sid-characterization-1001',
+  providerEventId: 'provider-event-sms-characterization-1001',
+  providerMessageId: 'provider-message-sms-characterization-1001',
+  from: '+12605552001',
+  to: TEST_PROVIDER_NUMBER,
+  body: 'Please call me back when you can.',
+  ...overrides,
+});
+
+const mockInboundSmsPersistence = (input?: {
+  ensuredNeighborId?: string;
+  ensuredThreadId?: string;
+  ensureThreadError?: Error;
+  canonicalEventError?: Error;
+}) => {
+  const originalTransaction = db.transaction;
+  const mockedTransaction = jest.fn(async (handler: any) =>
+    handler({
+      fn: {
+        now: () => new Date(TEST_TIMESTAMP),
+      },
+    }));
+  Object.defineProperty(db, 'transaction', {
+    value: mockedTransaction,
+  });
+
+  const ensureThreadSpy = jest.spyOn(
+    AsyncConnectShyftThreadService.prototype,
+    'ensureThread',
+  );
+  if (input?.ensureThreadError) {
+    ensureThreadSpy.mockRejectedValue(input.ensureThreadError);
+  } else {
+    ensureThreadSpy.mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_ENSURED',
+      httpStatus: 200,
+      data: {
+        thread: buildEnsuredThread({
+          threadId: input?.ensuredThreadId || 'thread-sms-characterization-1001',
+          neighborId: input?.ensuredNeighborId || 'neighbor-connectshyft-f1-1001',
+        }),
+      },
+    } as any);
+  }
+
+  const canonicalEventSpy = jest.spyOn(
+    canonicalEventsModule,
+    'recordConnectShyftCanonicalEvent',
+  );
+  if (input?.canonicalEventError) {
+    canonicalEventSpy.mockRejectedValue(input.canonicalEventError);
+  } else {
+    canonicalEventSpy.mockImplementation(async (eventInput) => ({
+      eventId: 'canonical-event-sms-characterization-1001',
+      aggregateId: eventInput.aggregateId,
+      aggregateType: eventInput.aggregateType,
+      eventType: eventInput.eventType,
+      payload: eventInput.payload,
+      occurredAtUtc: TEST_TIMESTAMP,
+    }) as any);
+  }
+
+  const textingPreferenceSpy = jest.spyOn(
+    AsyncConnectShyftNeighborService.prototype,
+    'applyInboundSmsTextingPreference',
+  ).mockResolvedValue({
+    ok: true,
+    updated: true,
+    neighbor: {
+      neighborId: input?.ensuredNeighborId || 'neighbor-connectshyft-f1-1001',
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      firstName: '',
+      lastName: '',
+      prefersTexting: 'YES',
+      phones: [],
+      createdAtUtc: TEST_TIMESTAMP,
+      updatedAtUtc: TEST_TIMESTAMP,
+    },
+  } as any);
+
+  return {
+    canonicalEventSpy,
+    ensureThreadSpy,
+    textingPreferenceSpy,
+    restore: () => {
+      textingPreferenceSpy.mockRestore();
+      canonicalEventSpy.mockRestore();
+      ensureThreadSpy.mockRestore();
+      Object.defineProperty(db, 'transaction', {
+        value: originalTransaction,
+      });
+    },
+  };
+};
+
+describe('connectshyft inbound sms webhook route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  let resolveRoutingMappingByNumberSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sendSmsMock.mockClear();
+    startOutboundCallMock.mockClear();
+    startBridgeSessionMock.mockClear();
+    endCallMock.mockClear();
+    verifyWebhookMock.mockClear();
+    translateProviderEventMock.mockClear();
+    resetConnectShyftCanonicalEventsForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+
+    resolveRoutingMappingByNumberSpy = jest.spyOn(
+      connectShyftNumberMappingServiceAsync,
+      'resolveRoutingMappingByNumber',
+    ).mockImplementation(async (input) => {
+      if (
+        input.twilioNumberE164 === TEST_PROVIDER_NUMBER
+        && (!input.tenantId || input.tenantId === TEST_TENANT_ID)
+      ) {
+        return {
+          status: 'found' as const,
+          mapping: buildNumberMapping({
+            mappingId: 'mapping-f1-001',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            twilioNumberE164: TEST_PROVIDER_NUMBER,
+            label: 'Front Desk',
+          }),
+        };
+      }
+
+      return {
+        status: 'not-found' as const,
+      };
+    });
+  });
+
+  afterEach(() => {
+    resolveRoutingMappingByNumberSpy.mockRestore();
+  });
+
+  it('returns the current inbound SMS success envelope and response payload shape on /webhooks/sms', async () => {
+    const app = buildApp();
+    const { canonicalEventSpy, restore } = mockInboundSmsPersistence({
+      ensuredThreadId: 'thread-sms-characterization-1001',
+      ensuredNeighborId: 'neighbor-connectshyft-f1-1001',
+    });
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          providerEventId: 'provider-event-sms-success-1001',
+          providerMessageId: 'provider-message-sms-success-1001',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+        message: 'Inbound webhook accepted for processing',
+        data: {
+          sid: 'sms-sid-characterization-1001',
+          from: '+12605552001',
+          to: TEST_PROVIDER_NUMBER,
+          eventType: 'sms.inbound',
+          providerResolution: {
+            requestedProvider: 'telnyx',
+            resolvedProvider: 'telnyx',
+            deterministic: true,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: 'metadata',
+            deterministic: true,
+            threadId: 'thread-sms-characterization-1001',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            neighborId: 'neighbor-connectshyft-f1-1001',
+            providerLegId: null,
+            providerMessageId: 'provider-message-sms-success-1001',
+            providerEventId: 'provider-event-sms-success-1001',
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: 'provider-event:provider-event-sms-success-1001',
+          },
+          canonicalTranslation: {
+            eventType: 'sms.inbound',
+            providerNeutral: true,
+            providerSpecificFieldsStripped: true,
+            providerBranchingInDomain: false,
+          },
+          domainHandlers: {
+            providerBranchingInDomain: false,
+          },
+          canonicalEvent: {
+            eventId: 'canonical-event-sms-characterization-1001',
+            aggregateId: 'thread-sms-characterization-1001',
+            aggregateType: 'Thread',
+            eventType: 'connectshyft.inbound.sms_appended',
+          },
+          threadId: 'thread-sms-characterization-1001',
+          threadState: 'UNCLAIMED',
+          thread: buildEnsuredThread(),
+          lifecycle: {
+            ensuredActiveThread: true,
+            createdNewThread: true,
+          },
+          inboundMessageArtifact: {
+            artifactId: 'canonical-event-sms-characterization-1001',
+            channel: 'sms',
+            direction: 'inbound',
+            providerEventId: 'provider-event-sms-success-1001',
+            providerMessageId: 'provider-message-sms-success-1001',
+            providerLegId: null,
+            body: 'Please call me back when you can.',
+            from: '+12605552001',
+            to: TEST_PROVIDER_NUMBER,
+          },
+          transaction: {
+            atomic: false,
+            auditPersisted: false,
+            outboxPersisted: false,
+          },
+          sideEffects: {
+            lifecycleMutationApplied: true,
+            canonicalEventPersisted: true,
+            auditPersisted: false,
+            outboxPersisted: false,
+          },
+          timeline: {
+            eventName: 'connectshyft.inbound.sms_appended',
+            routingDecision: 'accepted',
+            deterministicOrdering: true,
+          },
+          timelineOutcome: {
+            eventName: 'connectshyft.inbound.sms_appended',
+            routingDecision: 'accepted',
+          },
+        },
+      });
+      expect(Object.keys(response.body.data).sort()).toEqual([
+        'canonicalEvent',
+        'canonicalTranslation',
+        'correlation',
+        'domainHandlers',
+        'eventType',
+        'from',
+        'inboundMessageArtifact',
+        'lifecycle',
+        'providerResolution',
+        'replaySafe',
+        'sideEffects',
+        'sid',
+        'thread',
+        'threadId',
+        'threadState',
+        'timeline',
+        'timelineOutcome',
+        'to',
+        'transaction',
+      ].sort());
+      expect(Object.keys(response.body.data.canonicalTranslation).sort()).toEqual([
+        'correlation',
+        'eventType',
+        'payload',
+        'providerBranchingInDomain',
+        'providerNeutral',
+        'providerSpecificFieldsStripped',
+      ].sort());
+      expect(Object.keys(response.body.data.thread).sort()).toEqual([
+        'claimedAtUtc',
+        'claimedByUserId',
+        'closedAtUtc',
+        'closedByUserId',
+        'createdAtUtc',
+        'escalation',
+        'lastInboundCsNumberId',
+        'neighborId',
+        'orgUnitId',
+        'preferredOutboundCsNumberId',
+        'source',
+        'state',
+        'tenantId',
+        'threadId',
+        'updatedAtUtc',
+      ].sort());
+      expect(response.body.data).not.toHaveProperty('audit');
+      expect(response.body.data).not.toHaveProperty('outbox');
+      expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it('preserves the current duplicate-safe replay surface for inbound SMS webhooks', async () => {
+    const app = buildApp();
+    const { canonicalEventSpy, restore } = mockInboundSmsPersistence({
+      ensuredThreadId: 'thread-sms-characterization-duplicate-1002',
+      ensuredNeighborId: 'neighbor-connectshyft-f1-1001',
+    });
+
+    try {
+      const body = buildInboundSmsBody({
+        providerEventId: 'provider-event-sms-duplicate-1002',
+        providerMessageId: 'provider-message-sms-duplicate-1002',
+      });
+
+      const firstResponse = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(body);
+      const duplicateResponse = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(body);
+
+      expect(firstResponse.status).toBe(200);
+      expect(duplicateResponse.status).toBe(200);
+      expect(duplicateResponse.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+        message: 'Inbound webhook accepted (duplicate suppressed)',
+        data: {
+          sid: 'sms-sid-characterization-1001',
+          from: '+12605552001',
+          to: TEST_PROVIDER_NUMBER,
+          eventType: 'sms.inbound',
+          providerResolution: {
+            requestedProvider: 'telnyx',
+            resolvedProvider: 'telnyx',
+            deterministic: true,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: 'metadata',
+            deterministic: true,
+            threadId: 'thread-f1-unclaimed-1001',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            providerMessageId: 'provider-message-sms-duplicate-1002',
+            providerEventId: 'provider-event-sms-duplicate-1002',
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: true,
+            suppressedDomainWrites: true,
+            dedupeKey: 'provider-event:provider-event-sms-duplicate-1002',
+          },
+          sideEffects: {
+            lifecycleMutationApplied: false,
+            canonicalEventPersisted: false,
+            outboxPersisted: false,
+          },
+        },
+      });
+      expect(Object.keys(duplicateResponse.body.data).sort()).toEqual([
+        'correlation',
+        'eventType',
+        'from',
+        'providerResolution',
+        'replaySafe',
+        'sideEffects',
+        'sid',
+        'to',
+      ].sort());
+      expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+
+  it.each([
+    {
+      name: 'required',
+      body: buildInboundSmsBody({
+        threadId: undefined,
+        providerEventId: 'provider-event-sms-missing-phone-1003',
+        providerMessageId: 'provider-message-sms-missing-phone-1003',
+        from: undefined,
+      }),
+      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+      message: 'Inbound SMS processing requires a sender phone number.',
+      reason: 'sender_phone_required',
+    },
+    {
+      name: 'invalid',
+      body: buildInboundSmsBody({
+        threadId: undefined,
+        providerEventId: 'provider-event-sms-invalid-phone-1004',
+        providerMessageId: 'provider-message-sms-invalid-phone-1004',
+        from: 'not-a-phone-number',
+      }),
+      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+      message: 'Inbound SMS processing requires a valid sender phone number.',
+      reason: 'sender_phone_invalid',
+    },
+  ])('returns the current sender-phone-%s refusal shape before inbound SMS processing continues', async ({
+    body,
+    code,
+    message,
+    reason,
+  }) => {
+    const app = buildApp();
+    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint');
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(body);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code,
+        message,
+        refusalType: 'business',
+        data: {
+          providerResolution: {
+            requestedProvider: 'telnyx',
+            resolvedProvider: 'telnyx',
+            deterministic: true,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: 'number_mapping',
+            deterministic: true,
+            threadId: '',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            providerMessageId: body.providerMessageId,
+            providerEventId: body.providerEventId,
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: `provider-event:${body.providerEventId}`,
+          },
+          sideEffects: {
+            lifecycleMutationApplied: false,
+            canonicalEventPersisted: false,
+            outboxPersisted: false,
+          },
+          timelineOutcome: {
+            eventName: null,
+            routingDecision: 'refused',
+          },
+          reason,
+        },
+      });
+      expect(Object.keys(response.body.data).sort()).toEqual([
+        'correlation',
+        'providerResolution',
+        'reason',
+        'replaySafe',
+        'sideEffects',
+        'timelineOutcome',
+      ].sort());
+      expect(resolveSubjectSpy).not.toHaveBeenCalled();
+    } finally {
+      resolveSubjectSpy.mockRestore();
+    }
+  });
+
+  it('returns the current ambiguous-neighbor refusal shape when multiple active neighbors share the same sender phone', async () => {
+    const app = buildApp();
+    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+      .mockResolvedValue(null);
+    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+      .mockResolvedValue({
+        type: 'multiple_matches',
+        candidateNeighborIds: ['neighbor-a-2003', 'neighbor-b-2003'],
+        normalizedContactPoint: '+12605552003',
+      });
+    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound');
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          threadId: undefined,
+          providerEventId: 'provider-event-sms-ambiguous-2003',
+          providerMessageId: 'provider-message-sms-ambiguous-2003',
+          from: '+12605552003',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'IDENTITY_MATCH_AMBIGUOUS',
+        message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
+        refusalType: 'business',
+        data: {
+          providerResolution: {
+            requestedProvider: 'telnyx',
+            resolvedProvider: 'telnyx',
+            deterministic: true,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: 'number_mapping',
+            deterministic: true,
+            threadId: '',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            providerMessageId: 'provider-message-sms-ambiguous-2003',
+            providerEventId: 'provider-event-sms-ambiguous-2003',
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: 'provider-event:provider-event-sms-ambiguous-2003',
+          },
+          sideEffects: {
+            lifecycleMutationApplied: false,
+            canonicalEventPersisted: false,
+            outboxPersisted: false,
+          },
+          timelineOutcome: {
+            eventName: null,
+            routingDecision: 'refused',
+          },
+          senderPhone: '+12605552003',
+          candidateNeighborIds: ['neighbor-a-2003', 'neighbor-b-2003'],
+          reason: 'neighbor_ambiguous',
+        },
+      });
+      expect(Object.keys(response.body.data).sort()).toEqual([
+        'candidateNeighborIds',
+        'correlation',
+        'providerResolution',
+        'reason',
+        'replaySafe',
+        'senderPhone',
+        'sideEffects',
+        'timelineOutcome',
+      ].sort());
+      expect(createNeighborSpy).not.toHaveBeenCalled();
+    } finally {
+      createNeighborSpy.mockRestore();
+      resolveSubjectSpy.mockRestore();
+      resolveActiveSpy.mockRestore();
+    }
+  });
+
+  it('returns the current unresolved-neighbor refusal shape when inbound neighbor creation yields no reusable neighbor id', async () => {
+    const app = buildApp();
+    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+      .mockResolvedValue({
+        type: 'no_match',
+        normalizedContactPoint: '+12605552012',
+      });
+    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound')
+      .mockResolvedValue({
+        ok: true,
+        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+        httpStatus: 201,
+        data: {
+          neighbor: {
+            neighborId: '',
+          },
+        },
+      } as any);
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          threadId: undefined,
+          providerEventId: 'provider-event-sms-unresolved-2012',
+          providerMessageId: 'provider-message-sms-unresolved-2012',
+          from: '+12605552012',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'CONNECTSHYFT_WEBHOOK_NEIGHBOR_UNRESOLVED',
+        message: 'Inbound SMS processing requires a resolvable neighbor context.',
+        refusalType: 'business',
+        data: {
+          providerResolution: {
+            requestedProvider: 'telnyx',
+            resolvedProvider: 'telnyx',
+            deterministic: true,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: 'number_mapping',
+            deterministic: true,
+            threadId: '',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            providerMessageId: 'provider-message-sms-unresolved-2012',
+            providerEventId: 'provider-event-sms-unresolved-2012',
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: 'provider-event:provider-event-sms-unresolved-2012',
+          },
+          sideEffects: {
+            lifecycleMutationApplied: false,
+            canonicalEventPersisted: false,
+            outboxPersisted: false,
+          },
+          timelineOutcome: {
+            eventName: null,
+            routingDecision: 'refused',
+          },
+          senderPhone: '+12605552012',
+          reason: 'neighbor_unresolved',
+        },
+      });
+      expect(Object.keys(response.body.data).sort()).toEqual([
+        'correlation',
+        'providerResolution',
+        'reason',
+        'replaySafe',
+        'senderPhone',
+        'sideEffects',
+        'timelineOutcome',
+      ].sort());
+    } finally {
+      createNeighborSpy.mockRestore();
+      resolveSubjectSpy.mockRestore();
+    }
+  });
+
+  it('returns the current inbound SMS thread-ensure persistence refusal mapping', async () => {
+    const app = buildApp();
+    const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
+      ensureThreadError: new Error('thread-ensure-down'),
+    });
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          providerEventId: 'provider-event-sms-ensure-error-1005',
+          providerMessageId: 'provider-message-sms-ensure-error-1005',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE',
+        message: 'Inbound SMS thread ensure is temporarily unavailable.',
+        refusalType: 'business',
+        data: {
+          providerResolution: {
+            requestedProvider: 'telnyx',
+            resolvedProvider: 'telnyx',
+            deterministic: true,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: 'metadata',
+            deterministic: true,
+            threadId: 'thread-f1-unclaimed-1001',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            neighborId: 'neighbor-connectshyft-f1-1001',
+            providerMessageId: 'provider-message-sms-ensure-error-1005',
+            providerEventId: 'provider-event-sms-ensure-error-1005',
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: 'provider-event:provider-event-sms-ensure-error-1005',
+          },
+          sideEffects: {
+            lifecycleMutationApplied: false,
+            canonicalEventPersisted: false,
+            outboxPersisted: false,
+          },
+          error: 'thread-ensure-down',
+        },
+      });
+      expect(Object.keys(response.body.data).sort()).toEqual([
+        'correlation',
+        'error',
+        'providerResolution',
+        'replaySafe',
+        'sideEffects',
+      ].sort());
+      expect(ensureThreadSpy).toHaveBeenCalledTimes(1);
+      expect(canonicalEventSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it('returns the current inbound SMS canonical persistence refusal mapping', async () => {
+    const app = buildApp();
+    const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
+      canonicalEventError: new Error('canonical-down'),
+    });
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          providerEventId: 'provider-event-sms-canonical-error-1006',
+          providerMessageId: 'provider-message-sms-canonical-error-1006',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'CONNECTSHYFT_INBOUND_SMS_PERSISTENCE_UNAVAILABLE',
+        message: 'Inbound SMS processing could not persist timeline side effects.',
+        refusalType: 'business',
+        data: {
+          providerResolution: {
+            requestedProvider: 'telnyx',
+            resolvedProvider: 'telnyx',
+            deterministic: true,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: 'metadata',
+            deterministic: true,
+            threadId: 'thread-f1-unclaimed-1001',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            neighborId: 'neighbor-connectshyft-f1-1001',
+            providerMessageId: 'provider-message-sms-canonical-error-1006',
+            providerEventId: 'provider-event-sms-canonical-error-1006',
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: 'provider-event:provider-event-sms-canonical-error-1006',
+          },
+          sideEffects: {
+            lifecycleMutationApplied: false,
+            canonicalEventPersisted: false,
+            outboxPersisted: false,
+          },
+          error: 'canonical-down',
+        },
+      });
+      expect(Object.keys(response.body.data).sort()).toEqual([
+        'correlation',
+        'error',
+        'providerResolution',
+        'replaySafe',
+        'sideEffects',
+      ].sort());
+      expect(ensureThreadSpy).toHaveBeenCalledTimes(1);
+      expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts
@@ -1,0 +1,427 @@
+// @ts-nocheck
+import request from 'supertest';
+import * as canonicalEventsModule from '../../../../modules/connectshyft/canonicalEvents';
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TIMESTAMP = '2026-03-18T12:00:00.000Z';
+const TEST_TENANT_ID = 'tenant-connectshyft-f1';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-f1-east';
+const TEST_THREAD_ID = 'thread-f1-claimed-1002';
+const TEST_PROVIDER_NUMBER = '+12605550191';
+const TEST_CALLBACK_PROVIDER_EVENT_ID = 'provider-event-voice-seed-1001';
+const TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID = 'vm-thread-f1-claimed-1002-provider-event-voice-seed-1001';
+
+const readString = (...values: unknown[]): string | null => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+};
+
+const sendSmsMock = jest.fn();
+const startOutboundCallMock = jest.fn();
+const startBridgeSessionMock = jest.fn();
+const endCallMock = jest.fn();
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const translateProviderEventMock = jest.fn(({ rawEventType, payload }: {
+  rawEventType: string;
+  payload: unknown;
+}) => {
+  const source = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {};
+
+  return {
+    eventType: readString(rawEventType) || 'voice.transcription.completed',
+    payload: source,
+    correlation: {
+      providerLegId: readString(source.providerLegId, source.provider_leg_id),
+      providerMessageId: readString(
+        source.providerMessageId,
+        source.provider_message_id,
+        source.messageId,
+        source.message_id,
+      ),
+      providerEventId: readString(
+        source.providerEventId,
+        source.provider_event_id,
+        source.eventId,
+        source.event_id,
+      ),
+      providerNumber: readString(source.to, source.toNumber, source.to_number),
+    },
+    providerNeutral: true as const,
+    providerSpecificFieldsStripped: true as const,
+    providerBranchingInDomain: false as const,
+  };
+});
+
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}));
+
+const buildTranscriptionHeaders = (): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-transcription-characterization',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+});
+
+const buildTranscriptionWebhookBody = (overrides: Record<string, unknown> = {}) => ({
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  threadId: TEST_THREAD_ID,
+  eventType: 'voice.transcription.completed',
+  providerEventId: 'provider-event-transcription-callback-1001',
+  providerLegId: 'provider-leg-transcription-1001',
+  to: TEST_PROVIDER_NUMBER,
+  callbackCorrelation: {
+    tenantId: TEST_TENANT_ID,
+    orgUnitId: TEST_ORG_UNIT_ID,
+    threadId: TEST_THREAD_ID,
+    providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+    providerLegId: 'provider-leg-transcription-1001',
+    voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+  },
+  transcript: {
+    text: 'Neighbor confirmed transport coordination.',
+  },
+  ...overrides,
+});
+
+const buildPersistedVoicemailCorrelationEvent = () => ({
+  eventId: 'canonical-event-voice-seed-1001',
+  aggregateId: TEST_THREAD_ID,
+  aggregateType: 'Thread',
+  eventType: 'voice.voicemail',
+  payload: {
+    transcription: {
+      callbackCorrelation: {
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        threadId: TEST_THREAD_ID,
+        providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+        voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+      },
+    },
+  },
+  occurredAtUtc: TEST_TIMESTAMP,
+});
+
+describe('connectshyft inbound transcription callback webhook route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  let listCanonicalEventsSpy: jest.SpyInstance;
+  let recordCanonicalEventSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sendSmsMock.mockClear();
+    startOutboundCallMock.mockClear();
+    startBridgeSessionMock.mockClear();
+    endCallMock.mockClear();
+    verifyWebhookMock.mockClear();
+    translateProviderEventMock.mockClear();
+    resetConnectShyftCanonicalEventsForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+
+    listCanonicalEventsSpy = jest.spyOn(
+      canonicalEventsModule,
+      'listConnectShyftCanonicalEvents',
+    ).mockResolvedValue([
+      buildPersistedVoicemailCorrelationEvent(),
+    ] as any);
+    recordCanonicalEventSpy = jest.spyOn(
+      canonicalEventsModule,
+      'recordConnectShyftCanonicalEvent',
+    ).mockImplementation(async (eventInput) => ({
+      eventId: 'canonical-event-transcription-1001',
+      aggregateId: eventInput.aggregateId,
+      aggregateType: eventInput.aggregateType,
+      eventType: eventInput.eventType,
+      payload: eventInput.payload,
+      occurredAtUtc: TEST_TIMESTAMP,
+    }) as any);
+  });
+
+  afterEach(() => {
+    recordCanonicalEventSpy.mockRestore();
+    listCanonicalEventsSpy.mockRestore();
+  });
+
+  it('returns the current transcription callback success envelope and attachment payload shape', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildTranscriptionHeaders())
+      .send(buildTranscriptionWebhookBody());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_TRANSCRIPTION_CALLBACK_ATTACHED',
+      message: 'Transcription callback attached to voicemail artifact',
+      data: {
+        eventType: 'voice.transcription.completed',
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: 'metadata',
+          deterministic: true,
+          threadId: TEST_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+          voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: 'provider-event:provider-event-transcription-callback-1001',
+        },
+        transcriptionAttachment: {
+          applied: true,
+          transcriptText: 'Neighbor confirmed transport coordination.',
+          voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+        },
+        timeline: {
+          eventName: 'connectshyft.voicemail.transcription_attached',
+          routingDecision: 'accepted',
+        },
+        sideEffects: {
+          transcriptMutationApplied: true,
+          timelineMutationApplied: true,
+        },
+        canonicalEvent: {
+          eventId: 'canonical-event-transcription-1001',
+          aggregateId: TEST_THREAD_ID,
+          aggregateType: 'Thread',
+          eventType: 'voice.transcription.completed',
+          payload: {
+            eventName: 'connectshyft.voicemail.transcription_attached',
+            routingDecision: 'accepted',
+            voicemailArtifact: {
+              artifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+              transcription: {
+                available: true,
+                text: 'Neighbor confirmed transport coordination.',
+              },
+            },
+            transcription: {
+              available: true,
+              text: 'Neighbor confirmed transport coordination.',
+            },
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'canonicalEvent',
+      'correlation',
+      'eventType',
+      'providerResolution',
+      'replaySafe',
+      'sideEffects',
+      'timeline',
+      'transcriptionAttachment',
+    ].sort());
+    expect(recordCanonicalEventSpy).toHaveBeenCalledTimes(1);
+    expect(listCanonicalEventsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the current duplicate suppression surface for transcription callbacks', async () => {
+    const app = buildApp();
+    const body = buildTranscriptionWebhookBody({
+      providerEventId: 'provider-event-transcription-duplicate-1002',
+    });
+
+    const firstResponse = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildTranscriptionHeaders())
+      .send(body);
+    const duplicateResponse = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildTranscriptionHeaders())
+      .send(body);
+
+    expect(firstResponse.status).toBe(200);
+    expect(duplicateResponse.status).toBe(200);
+    expect(duplicateResponse.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_TRANSCRIPTION_CALLBACK_DUPLICATE_SUPPRESSED',
+      message: 'Transcription callback duplicate suppressed',
+      data: {
+        eventType: 'voice.transcription.completed',
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: 'metadata',
+          deterministic: true,
+          threadId: TEST_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          providerLegId: 'provider-leg-transcription-1001',
+          providerMessageId: null,
+          providerEventId: 'provider-event-transcription-duplicate-1002',
+          providerNumberE164: TEST_PROVIDER_NUMBER,
+        },
+        replaySafe: {
+          duplicate: true,
+          suppressedDomainWrites: true,
+          dedupeKey: 'provider-event:provider-event-transcription-duplicate-1002',
+        },
+        sideEffects: {
+          transcriptMutationApplied: false,
+          timelineMutationApplied: false,
+        },
+      },
+    });
+    expect(Object.keys(duplicateResponse.body.data).sort()).toEqual([
+      'correlation',
+      'eventType',
+      'providerResolution',
+      'replaySafe',
+      'sideEffects',
+    ].sort());
+    expect(recordCanonicalEventSpy).toHaveBeenCalledTimes(1);
+    expect(listCanonicalEventsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the current invalid-correlation refusal shape for transcription callbacks', async () => {
+    listCanonicalEventsSpy.mockResolvedValueOnce([]);
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildTranscriptionHeaders())
+      .send(buildTranscriptionWebhookBody({
+        providerEventId: 'provider-event-transcription-invalid-1003',
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_TRANSCRIPTION_CORRELATION_INVALID',
+      message: 'Transcription callback correlation is invalid or unresolved for voicemail attachment.',
+      refusalType: 'business',
+      data: {
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: 'metadata',
+          deterministic: true,
+          threadId: TEST_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+          voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: 'provider-event:provider-event-transcription-invalid-1003',
+        },
+        sideEffects: {
+          transcriptMutationApplied: false,
+          orphanTranscriptPrevented: true,
+        },
+        audit: {
+          eventName: 'connectshyft.voicemail.transcription_refused',
+          metadata: {
+            tenant_id: TEST_TENANT_ID,
+            org_unit_id: TEST_ORG_UNIT_ID,
+            thread_id: TEST_THREAD_ID,
+            provider_event_id: TEST_CALLBACK_PROVIDER_EVENT_ID,
+            voicemail_artifact_id: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+            reason: 'callback_correlation_unresolved',
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'audit',
+      'correlation',
+      'providerResolution',
+      'replaySafe',
+      'sideEffects',
+    ].sort());
+    expect(recordCanonicalEventSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the current callback-persistence failure mapping when transcription attachment persistence fails', async () => {
+    recordCanonicalEventSpy.mockRejectedValueOnce(new Error('transcription-canonical-down'));
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildTranscriptionHeaders())
+      .send(buildTranscriptionWebhookBody({
+        providerEventId: 'provider-event-transcription-error-1004',
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_TRANSCRIPTION_ATTACHMENT_UNAVAILABLE',
+      message: 'Transcription callback could not persist attachment side effects.',
+      refusalType: 'business',
+      data: {
+        correlation: {
+          source: 'metadata',
+          deterministic: true,
+          threadId: TEST_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+          voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: 'provider-event:provider-event-transcription-error-1004',
+        },
+        sideEffects: {
+          transcriptMutationApplied: false,
+          orphanTranscriptPrevented: true,
+        },
+        error: 'transcription-canonical-down',
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'correlation',
+      'error',
+      'replaySafe',
+      'sideEffects',
+    ].sort());
+    expect(listCanonicalEventsSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts
@@ -1,0 +1,629 @@
+// @ts-nocheck
+import request from 'supertest';
+import * as canonicalEventsModule from '../../../../modules/connectshyft/canonicalEvents';
+import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
+import * as providerCorrelationMappingsModule from '../../../../modules/connectshyft/providerCorrelationMappings';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TIMESTAMP = '2026-03-18T12:00:00.000Z';
+const TEST_PROVIDER_NUMBER_F1 = '+12605550191';
+const TEST_PROVIDER_NUMBER_F2 = '+12605550192';
+const CONNECTSHYFT_SYSTEM_ACTOR_USER_ID = '00000000-0000-4000-8000-000000000001';
+
+const readString = (...values: unknown[]): string | null => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+};
+
+const sendSmsMock = jest.fn();
+const startOutboundCallMock = jest.fn();
+const startBridgeSessionMock = jest.fn();
+const endCallMock = jest.fn();
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const translateProviderEventMock = jest.fn(({ rawEventType, payload }: {
+  rawEventType: string;
+  payload: unknown;
+}) => {
+  const source = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {};
+
+  return {
+    eventType: readString(rawEventType) || 'voice.voicemail',
+    payload: source,
+    correlation: {
+      providerLegId: readString(source.providerLegId, source.provider_leg_id),
+      providerMessageId: readString(
+        source.providerMessageId,
+        source.provider_message_id,
+        source.messageId,
+        source.message_id,
+      ),
+      providerEventId: readString(
+        source.providerEventId,
+        source.provider_event_id,
+        source.eventId,
+        source.event_id,
+      ),
+      providerNumber: readString(source.to, source.toNumber, source.to_number),
+    },
+    providerNeutral: true as const,
+    providerSpecificFieldsStripped: true as const,
+    providerBranchingInDomain: false as const,
+  };
+});
+
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}));
+
+const buildVoiceHeaders = (input?: {
+  tenantId?: string;
+  orgUnitId?: string;
+}): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': input?.tenantId || 'tenant-connectshyft-f1',
+  'x-test-connectshyft-orgunit-id': input?.orgUnitId || 'org-connectshyft-f1-east',
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-voice-characterization',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([
+    input?.orgUnitId || 'org-connectshyft-f1-east',
+  ]),
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+});
+
+const buildVoiceWebhookBody = (overrides: Record<string, unknown> = {}) => ({
+  tenantId: 'tenant-connectshyft-f1',
+  orgUnitId: 'org-connectshyft-f1-east',
+  threadId: 'thread-f1-unclaimed-1001',
+  eventType: 'voice.voicemail',
+  sid: 'voice-sid-characterization-1001',
+  providerEventId: 'provider-event-voice-voicemail-1001',
+  providerLegId: 'provider-leg-voice-voicemail-1001',
+  from: '+12605552021',
+  to: TEST_PROVIDER_NUMBER_F1,
+  recordingUrl: 'https://connectshyft.test/voicemail-characterization-1001.mp3',
+  voicemail_duration_seconds: 47,
+  ...overrides,
+});
+
+describe('connectshyft inbound voice webhook route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  let recordCanonicalEventSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sendSmsMock.mockClear();
+    startOutboundCallMock.mockClear();
+    startBridgeSessionMock.mockClear();
+    endCallMock.mockClear();
+    verifyWebhookMock.mockClear();
+    translateProviderEventMock.mockClear();
+    resetConnectShyftBridgeSessionStateForTests();
+    resetConnectShyftCanonicalEventsForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+
+    recordCanonicalEventSpy = jest.spyOn(
+      canonicalEventsModule,
+      'recordConnectShyftCanonicalEvent',
+    ).mockImplementation(async (eventInput) => ({
+      eventId: `canonical-event-${String(eventInput.aggregateId)}-${String(eventInput.eventType)}`,
+      aggregateId: eventInput.aggregateId,
+      aggregateType: eventInput.aggregateType,
+      eventType: eventInput.eventType,
+      payload: eventInput.payload,
+      occurredAtUtc: TEST_TIMESTAMP,
+    }) as any);
+  });
+
+  afterEach(() => {
+    recordCanonicalEventSpy.mockRestore();
+  });
+
+  it('returns the current inbound voice success envelope and voicemail routing shape', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildVoiceHeaders())
+      .send(buildVoiceWebhookBody());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      message: 'Inbound webhook accepted for processing',
+      data: {
+        sid: 'voice-sid-characterization-1001',
+        from: '+12605552021',
+        to: TEST_PROVIDER_NUMBER_F1,
+        eventType: 'voice.voicemail',
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: 'metadata',
+          deterministic: true,
+          threadId: 'thread-f1-unclaimed-1001',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          neighborId: 'neighbor-connectshyft-f1-1001',
+          providerLegId: 'provider-leg-voice-voicemail-1001',
+          providerMessageId: null,
+          providerEventId: 'provider-event-voice-voicemail-1001',
+          providerNumberE164: TEST_PROVIDER_NUMBER_F1,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: 'provider-event:provider-event-voice-voicemail-1001',
+        },
+        canonicalTranslation: {
+          eventType: 'voice.voicemail',
+          providerNeutral: true,
+          providerSpecificFieldsStripped: true,
+          providerBranchingInDomain: false,
+        },
+        domainHandlers: {
+          providerBranchingInDomain: false,
+        },
+        canonicalEvent: {
+          aggregateId: 'thread-f1-unclaimed-1001',
+          aggregateType: 'Thread',
+          eventType: 'voice.voicemail',
+        },
+        threadId: 'thread-f1-unclaimed-1001',
+        threadState: 'UNCLAIMED',
+        thread: {
+          threadId: 'thread-f1-unclaimed-1001',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          neighborId: 'neighbor-connectshyft-f1-1001',
+          source: 'VOICE',
+          state: 'UNCLAIMED',
+          lastInboundCsNumberId: TEST_PROVIDER_NUMBER_F1,
+          preferredOutboundCsNumberId: TEST_PROVIDER_NUMBER_F1,
+          claimedByUserId: null,
+          claimedAtUtc: null,
+          closedByUserId: null,
+          closedAtUtc: null,
+          createdAtUtc: expect.any(String),
+          updatedAtUtc: expect.any(String),
+          escalation: {
+            stage: 0,
+            nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+          },
+        },
+        lifecycle: {
+          ensuredActiveThread: true,
+          reusedThreadId: 'thread-f1-unclaimed-1001',
+          reopenedByInbound: false,
+          escalationResetApplied: false,
+          inactivityResetApplied: false,
+          autoClaimedByConnectedEvent: false,
+        },
+        voicemailArtifact: {
+          artifactId: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+          channel: 'voice',
+          direction: 'inbound',
+          providerEventId: 'provider-event-voice-voicemail-1001',
+          providerMessageId: null,
+          providerLegId: 'provider-leg-voice-voicemail-1001',
+          from: '+12605552021',
+          to: TEST_PROVIDER_NUMBER_F1,
+          recordingUrl: 'https://connectshyft.test/voicemail-characterization-1001.mp3',
+          durationSeconds: 47,
+        },
+        transcription: {
+          requestQueued: true,
+          queueName: 'connectshyft.voicemail.transcription',
+          callbackCorrelation: {
+            tenantId: 'tenant-connectshyft-f1',
+            orgUnitId: 'org-connectshyft-f1-east',
+            threadId: 'thread-f1-unclaimed-1001',
+            providerEventId: 'provider-event-voice-voicemail-1001',
+            correlationEventId: 'provider-event-voice-voicemail-1001',
+            providerLegId: 'provider-leg-voice-voicemail-1001',
+            voicemailArtifactId: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+          },
+        },
+        autoClaim: null,
+        callPolicy: {
+          transport: null,
+          autoRetry: false,
+          redialPolicy: 'manual_only',
+        },
+        timeline: {
+          eventName: 'connectshyft.inbound.voice_voicemail_recorded',
+          routingDecision: 'voicemail_only',
+          deterministicOrdering: true,
+        },
+        timelineOutcome: {
+          eventName: 'connectshyft.inbound.voice_voicemail_recorded',
+          routingDecision: 'voicemail_only',
+        },
+        audit: {
+          eventName: 'connectshyft.inbound.voice_voicemail_recorded',
+          metadata: {
+            tenant_id: 'tenant-connectshyft-f1',
+            org_unit_id: 'org-connectshyft-f1-east',
+            thread_id: 'thread-f1-unclaimed-1001',
+            neighbor_id: 'neighbor-connectshyft-f1-1001',
+            thread_state: 'UNCLAIMED',
+            event_type: 'voice.voicemail',
+            routing_decision: 'voicemail_only',
+            voicemail_artifact_id: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+            transcription_queue: 'connectshyft.voicemail.transcription',
+            auto_claim_attempted: false,
+            auto_claim_applied: false,
+            auto_claim_reason: null,
+            call_transport: null,
+            reopened_by_inbound: false,
+          },
+        },
+        outbox: {
+          eventName: 'connectshyft.inbound.voice_voicemail_recorded',
+        },
+        transcriptionOutbox: {
+          eventName: 'connectshyft.voicemail.transcription_requested',
+          queueName: 'connectshyft.voicemail.transcription',
+          metadata: {
+            tenant_id: 'tenant-connectshyft-f1',
+            org_unit_id: 'org-connectshyft-f1-east',
+            thread_id: 'thread-f1-unclaimed-1001',
+            voicemail_artifact_id: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+            provider_event_id: 'provider-event-voice-voicemail-1001',
+            provider_leg_id: 'provider-leg-voice-voicemail-1001',
+          },
+        },
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'audit',
+      'autoClaim',
+      'callPolicy',
+      'canonicalEvent',
+      'canonicalTranslation',
+      'correlation',
+      'domainHandlers',
+      'eventType',
+      'from',
+      'lifecycle',
+      'outbox',
+      'providerResolution',
+      'replaySafe',
+      'sid',
+      'thread',
+      'threadId',
+      'threadState',
+      'timeline',
+      'timelineOutcome',
+      'to',
+      'transcription',
+      'transcriptionOutbox',
+      'voicemailArtifact',
+    ].sort());
+    expect(Object.keys(response.body.data.thread).sort()).toEqual([
+      'claimedAtUtc',
+      'claimedByUserId',
+      'closedAtUtc',
+      'closedByUserId',
+      'createdAtUtc',
+      'escalation',
+      'lastInboundCsNumberId',
+      'neighborId',
+      'orgUnitId',
+      'preferredOutboundCsNumberId',
+      'source',
+      'state',
+      'tenantId',
+      'threadId',
+      'updatedAtUtc',
+    ].sort());
+    expect(response.body.data.audit).toEqual(response.body.data.outbox);
+  });
+
+  it('preserves the current fallback routing shape for inbound voice events', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildVoiceHeaders())
+      .send(buildVoiceWebhookBody({
+        threadId: 'thread-f1-closed-1003',
+        eventType: 'voice.fallback',
+        providerEventId: 'provider-event-voice-fallback-1002',
+        providerLegId: 'provider-leg-voice-fallback-1002',
+        recordingUrl: 'https://connectshyft.test/fallback-characterization-1002.mp3',
+        voicemail_duration_seconds: 33,
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      message: 'Inbound webhook accepted for processing',
+      data: {
+        eventType: 'voice.fallback',
+        correlation: {
+          threadId: 'thread-f1-closed-1003',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          neighborId: 'neighbor-connectshyft-f1-1003',
+          providerLegId: 'provider-leg-voice-fallback-1002',
+          providerEventId: 'provider-event-voice-fallback-1002',
+          providerNumberE164: TEST_PROVIDER_NUMBER_F1,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: 'provider-event:provider-event-voice-fallback-1002',
+        },
+        threadId: 'thread-f1-closed-1003',
+        threadState: 'CLOSED',
+        lifecycle: {
+          ensuredActiveThread: false,
+          reopenedByInbound: false,
+          escalationResetApplied: false,
+          inactivityResetApplied: false,
+          autoClaimedByConnectedEvent: false,
+        },
+        autoClaim: null,
+        callPolicy: {
+          transport: null,
+          autoRetry: false,
+          redialPolicy: 'manual_only',
+        },
+        timeline: {
+          eventName: 'connectshyft.inbound.voice_fallback_recorded',
+          routingDecision: 'intake_fallback',
+          deterministicOrdering: true,
+        },
+        timelineOutcome: {
+          eventName: 'connectshyft.inbound.voice_fallback_recorded',
+          routingDecision: 'intake_fallback',
+        },
+        audit: {
+          eventName: 'connectshyft.inbound.voice_fallback_recorded',
+          metadata: {
+            thread_state: 'CLOSED',
+            routing_decision: 'intake_fallback',
+            voicemail_artifact_id: null,
+            transcription_queue: null,
+            auto_claim_attempted: false,
+            auto_claim_applied: false,
+            auto_claim_reason: null,
+            call_transport: null,
+            reopened_by_inbound: false,
+          },
+        },
+        outbox: {
+          eventName: 'connectshyft.inbound.voice_fallback_recorded',
+        },
+      },
+    });
+    expect(response.body.data).not.toHaveProperty('voicemailArtifact');
+    expect(response.body.data).not.toHaveProperty('transcription');
+    expect(response.body.data).not.toHaveProperty('transcriptionOutbox');
+    expect(response.body.data.audit).toEqual(response.body.data.outbox);
+  });
+
+  it('preserves the current connected-call auto-claim behavior for inbound voice webhooks', async () => {
+    const app = buildApp();
+    const correlationLookupSpy = jest.spyOn(
+      providerCorrelationMappingsModule,
+      'resolveConnectShyftProviderCorrelationByIdentifiers',
+    ).mockResolvedValue({
+      ok: true,
+      correlation: {
+        tenantId: 'tenant-connectshyft-f2',
+        orgUnitId: 'org-connectshyft-f2-east',
+        threadId: 'thread-f2-unclaimed-1001',
+      },
+    } as any);
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/inbound')
+        .set(buildVoiceHeaders({
+          tenantId: 'tenant-connectshyft-f2',
+          orgUnitId: 'org-connectshyft-f2-east',
+        }))
+        .send(buildVoiceWebhookBody({
+          tenantId: 'tenant-connectshyft-f2',
+          orgUnitId: 'org-connectshyft-f2-east',
+          threadId: 'thread-f2-unclaimed-1001',
+          eventType: 'voice.connected',
+          sid: 'voice-sid-connected-2003',
+          providerEventId: 'provider-event-voice-connected-2003',
+          providerLegId: 'provider-leg-voice-connected-2003',
+          from: '+12605552023',
+          to: TEST_PROVIDER_NUMBER_F2,
+          transport: 'bridge',
+          recordingUrl: undefined,
+          voicemail_duration_seconds: undefined,
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+        message: 'Inbound webhook accepted for processing',
+        data: {
+          sid: 'voice-sid-connected-2003',
+          from: '+12605552023',
+          to: TEST_PROVIDER_NUMBER_F2,
+          eventType: 'voice.connected',
+          correlation: {
+            source: 'metadata',
+            deterministic: true,
+            threadId: 'thread-f2-unclaimed-1001',
+            tenantId: 'tenant-connectshyft-f2',
+            orgUnitId: 'org-connectshyft-f2-east',
+            neighborId: 'neighbor-connectshyft-f2-1001',
+            providerLegId: 'provider-leg-voice-connected-2003',
+            providerEventId: 'provider-event-voice-connected-2003',
+            providerNumberE164: TEST_PROVIDER_NUMBER_F2,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: 'provider-event:provider-event-voice-connected-2003',
+          },
+          threadId: 'thread-f2-unclaimed-1001',
+          threadState: 'CLAIMED',
+          thread: {
+            threadId: 'thread-f2-unclaimed-1001',
+            tenantId: 'tenant-connectshyft-f2',
+            orgUnitId: 'org-connectshyft-f2-east',
+            neighborId: 'neighbor-connectshyft-f2-1001',
+            source: 'VOICE',
+            state: 'CLAIMED',
+            lastInboundCsNumberId: TEST_PROVIDER_NUMBER_F2,
+            preferredOutboundCsNumberId: TEST_PROVIDER_NUMBER_F2,
+            claimedByUserId: CONNECTSHYFT_SYSTEM_ACTOR_USER_ID,
+            claimedAtUtc: expect.any(String),
+            closedByUserId: null,
+            closedAtUtc: null,
+            createdAtUtc: expect.any(String),
+            updatedAtUtc: expect.any(String),
+            escalation: {
+              stage: 0,
+              nextEvaluationAtUtc: null,
+            },
+          },
+          lifecycle: {
+            ensuredActiveThread: true,
+            reusedThreadId: 'thread-f2-unclaimed-1001',
+            reopenedByInbound: false,
+            escalationResetApplied: false,
+            inactivityResetApplied: false,
+            autoClaimedByConnectedEvent: true,
+          },
+          autoClaim: {
+            attempted: true,
+            applied: true,
+            reason: null,
+            lifecycleEvent: 'connectshyft.thread.claimed',
+            sideEffectsPersisted: false,
+          },
+          callPolicy: {
+            transport: 'bridge',
+            autoRetry: false,
+            redialPolicy: 'manual_only',
+          },
+          timeline: {
+            eventName: 'connectshyft.thread.claimed',
+            routingDecision: 'accepted',
+            deterministicOrdering: true,
+          },
+          timelineOutcome: {
+            eventName: 'connectshyft.thread.claimed',
+            routingDecision: 'accepted',
+          },
+          audit: {
+            eventName: 'connectshyft.thread.claimed',
+            metadata: {
+              auto_claim_attempted: true,
+              auto_claim_applied: true,
+              auto_claim_reason: null,
+              call_transport: 'bridge',
+              reopened_by_inbound: false,
+            },
+          },
+          outbox: {
+            eventName: 'connectshyft.thread.claimed',
+          },
+        },
+      });
+      expect(response.body.data).not.toHaveProperty('voicemailArtifact');
+      expect(response.body.data).not.toHaveProperty('transcription');
+      expect(response.body.data).not.toHaveProperty('transcriptionOutbox');
+      expect(response.body.data.audit).toEqual(response.body.data.outbox);
+    } finally {
+      correlationLookupSpy.mockRestore();
+    }
+  });
+
+  it('returns the current canonical-persistence refusal shape for inbound voice webhooks', async () => {
+    recordCanonicalEventSpy.mockRejectedValueOnce(new Error('voice-canonical-down'));
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildVoiceHeaders())
+      .send(buildVoiceWebhookBody({
+        providerEventId: 'provider-event-voice-error-1004',
+        providerLegId: 'provider-leg-voice-error-1004',
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_CANONICAL_EVENT_PERSISTENCE_UNAVAILABLE',
+      message: 'Inbound voice processing could not persist canonical event side effects.',
+      refusalType: 'business',
+      data: {
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: 'metadata',
+          deterministic: true,
+          threadId: 'thread-f1-unclaimed-1001',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          neighborId: 'neighbor-connectshyft-f1-1001',
+          providerLegId: 'provider-leg-voice-error-1004',
+          providerEventId: 'provider-event-voice-error-1004',
+          providerNumberE164: TEST_PROVIDER_NUMBER_F1,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: 'provider-event:provider-event-voice-error-1004',
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
+        },
+        error: 'voice-canonical-down',
+      },
+    });
+    expect(Object.keys(response.body.data).sort()).toEqual([
+      'correlation',
+      'error',
+      'providerResolution',
+      'replaySafe',
+      'sideEffects',
+      'timelineOutcome',
+    ].sort());
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -46,6 +46,12 @@ import {
   type ConnectShyftThreadOutboundCoreExecutionInput,
 } from '../../../modules/connectshyft/http/threadOutboundContext';
 import {
+  executeConnectShyftInboundWebhookRoute,
+  registerConnectShyftInboundWebhookCoreExecutor,
+  type ConnectShyftInboundWebhookCoreExecutionInput,
+  type ConnectShyftResolvedWebhookCorrelation,
+} from '../../../modules/connectshyft/http/inboundWebhookContext';
+import {
   connectShyftNumberMappingServiceAsync,
   type ConnectShyftNumberMapping,
 } from '../../../modules/connectshyft/numberMappings';
@@ -87,9 +93,7 @@ import {
   type ConnectShyftValidatedSmsOverride,
 } from '../../../modules/connectshyft/smsPreferenceOverrides';
 import {
-  buildConnectShyftWebhookVerificationInput,
   ConnectShyftProviderDispatchPolicyError,
-  mapConnectShyftWebhookVerificationResult,
   resolveConnectShyftProviderAdapter,
   resolveConnectShyftRequestedProviderKey,
   type ConnectShyftOutboundCallDispatchPolicy,
@@ -914,36 +918,6 @@ const buildProviderNeutralBridgeSessionState = (aggregate: {
   },
 });
 
-type ConnectShyftWebhookCorrelationSource = 'metadata' | 'provider_fallback' | 'number_mapping';
-
-type ConnectShyftResolvedWebhookCorrelation =
-  | {
-    ok: true;
-    source: ConnectShyftWebhookCorrelationSource;
-    tenantId: string;
-    orgUnitId: string;
-    threadId: string;
-    providerLegId: string | null;
-    providerMessageId: string | null;
-    providerEventId: string | null;
-    providerNumberE164: string | null;
-  }
-  | {
-    ok: false;
-    code:
-      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
-      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
-      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS'
-      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE'
-      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT';
-    message: string;
-    reason: 'missing-identifiers' | 'not-found' | 'ambiguous' | 'unavailable' | 'conflict';
-    providerLegId: string | null;
-    providerMessageId: string | null;
-    providerEventId: string | null;
-    providerNumberE164: string | null;
-  };
-
 type ConnectShyftBridgeCorrelationMapping = {
   deterministic: true;
   operatorLegMapping: 'created' | 'duplicate' | 'ignored' | 'error';
@@ -1117,220 +1091,6 @@ const resolveInboundAlignedProviderNumber = async (input: {
   return {
     ok: true,
     providerNumberE164: resolution.providerNumberE164,
-  };
-};
-
-const resolveWebhookCorrelationFailure = (
-  reason: 'missing-identifiers' | 'not-found' | 'ambiguous' | 'unavailable',
-): {
-  code:
-    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
-    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
-    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS'
-    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE';
-  message: string;
-} => {
-  if (reason === 'missing-identifiers') {
-    return {
-      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED',
-      message: 'Inbound webhook requires correlation metadata or provider identifiers.',
-    };
-  }
-  if (reason === 'ambiguous') {
-    return {
-      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS',
-      message: 'Inbound webhook correlation is ambiguous across provider identifiers.',
-    };
-  }
-  if (reason === 'unavailable') {
-    return {
-      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE',
-      message: 'Inbound webhook correlation lookup is temporarily unavailable.',
-    };
-  }
-  return {
-    code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND',
-    message: 'Inbound webhook correlation mapping not found for provider identifiers.',
-  };
-};
-
-const resolveInboundWebhookCorrelation = async (input: {
-  body: unknown;
-  channelHint: 'sms' | 'voice';
-  providerName: string;
-  providerCorrelation: {
-    providerLegId: string | null;
-    providerMessageId: string | null;
-    providerEventId: string | null;
-    providerNumber: string | null;
-  };
-  tenantIdHint?: string | null;
-}): Promise<ConnectShyftResolvedWebhookCorrelation> => {
-  const payload = asRecord(input.body);
-  const tenantId = normalizeLifecycleString(payload?.tenantId);
-  const orgUnitId = normalizeLifecycleString(payload?.orgUnitId);
-  const threadId = normalizeLifecycleString(payload?.threadId);
-  const providerIdentifiers = {
-    providerLegId: normalizeLifecycleString(input.providerCorrelation.providerLegId) || null,
-    providerMessageId: normalizeLifecycleString(input.providerCorrelation.providerMessageId) || null,
-    providerEventId: normalizeLifecycleString(input.providerCorrelation.providerEventId) || null,
-  };
-  const providerNumberE164 = normalizeLifecycleString(input.providerCorrelation.providerNumber) || null;
-  const tenantScopeHint = normalizeLifecycleString(input.tenantIdHint || null);
-  const numberMappingTenantScope = tenantId
-    || (tenantScopeHint.toLowerCase() !== 'public' ? tenantScopeHint : '')
-    || null;
-  const hasCompleteMetadata = Boolean(tenantId && orgUnitId && threadId);
-
-  if (hasCompleteMetadata) {
-    const fallbackProbe = await resolveConnectShyftProviderCorrelationByIdentifiers({
-      providerName: input.providerName,
-      providerLegId: providerIdentifiers.providerLegId,
-      providerMessageId: providerIdentifiers.providerMessageId,
-      tenantId,
-      db: loadPlatformDb(),
-    });
-
-    if (
-      fallbackProbe.ok
-      && (
-        fallbackProbe.correlation.tenantId !== tenantId
-        || fallbackProbe.correlation.orgUnitId !== orgUnitId
-        || fallbackProbe.correlation.threadId !== threadId
-      )
-    ) {
-      return {
-        ok: false,
-        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
-        message: 'Inbound webhook correlation metadata conflicts with provider identifier mapping.',
-        reason: 'conflict',
-        providerLegId: providerIdentifiers.providerLegId,
-        providerMessageId: providerIdentifiers.providerMessageId,
-        providerEventId: providerIdentifiers.providerEventId,
-        providerNumberE164,
-      };
-    }
-
-    return {
-      ok: true,
-      source: 'metadata',
-      tenantId,
-      orgUnitId,
-      threadId,
-      providerLegId: providerIdentifiers.providerLegId,
-      providerMessageId: providerIdentifiers.providerMessageId,
-      providerEventId: providerIdentifiers.providerEventId,
-      providerNumberE164,
-    };
-  }
-
-  const fallback = await resolveConnectShyftProviderCorrelationByIdentifiers({
-    providerName: input.providerName,
-    providerLegId: providerIdentifiers.providerLegId,
-    providerMessageId: providerIdentifiers.providerMessageId,
-    tenantId: tenantId || null,
-    db: loadPlatformDb(),
-  });
-  if (!fallback.ok && providerNumberE164) {
-    try {
-      const numberMapping = await connectShyftNumberMappingServiceAsync.resolveRoutingMappingByNumber({
-        tenantId: numberMappingTenantScope,
-        twilioNumberE164: providerNumberE164,
-      });
-      if (numberMapping.status === 'found') {
-        return {
-          ok: true,
-          source: 'number_mapping',
-          tenantId: numberMapping.mapping.tenantId,
-          orgUnitId: numberMapping.mapping.orgUnitId,
-          threadId: '',
-          providerLegId: providerIdentifiers.providerLegId,
-          providerMessageId: providerIdentifiers.providerMessageId,
-          providerEventId: providerIdentifiers.providerEventId,
-          providerNumberE164: numberMapping.mapping.twilioNumberE164,
-        };
-      }
-
-      if (numberMapping.status === 'ambiguous') {
-        return {
-          ok: false,
-          code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS',
-          message: 'Inbound webhook correlation is ambiguous across provider number mappings.',
-          reason: 'ambiguous',
-          providerLegId: providerIdentifiers.providerLegId,
-          providerMessageId: providerIdentifiers.providerMessageId,
-          providerEventId: providerIdentifiers.providerEventId,
-          providerNumberE164,
-        };
-      }
-    } catch (_error) {
-      return {
-        ok: false,
-        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE',
-        message: 'Inbound webhook correlation lookup is temporarily unavailable.',
-        reason: 'unavailable',
-        providerLegId: providerIdentifiers.providerLegId,
-        providerMessageId: providerIdentifiers.providerMessageId,
-        providerEventId: providerIdentifiers.providerEventId,
-        providerNumberE164,
-      };
-    }
-
-    if (fallback.reason === 'missing-identifiers') {
-      return {
-        ok: false,
-        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND',
-        message: 'Inbound webhook correlation mapping not found for provider identifiers.',
-        reason: 'not-found',
-        providerLegId: providerIdentifiers.providerLegId,
-        providerMessageId: providerIdentifiers.providerMessageId,
-        providerEventId: providerIdentifiers.providerEventId,
-        providerNumberE164,
-      };
-    }
-  }
-
-  if (!fallback.ok) {
-    const failure = resolveWebhookCorrelationFailure(fallback.reason);
-    return {
-      ok: false,
-      code: failure.code,
-      message: failure.message,
-      reason: fallback.reason,
-      providerLegId: providerIdentifiers.providerLegId,
-      providerMessageId: providerIdentifiers.providerMessageId,
-      providerEventId: providerIdentifiers.providerEventId,
-      providerNumberE164,
-    };
-  }
-
-  if (
-    (tenantId && tenantId !== fallback.correlation.tenantId)
-    || (orgUnitId && orgUnitId !== fallback.correlation.orgUnitId)
-    || (threadId && threadId !== fallback.correlation.threadId)
-  ) {
-    return {
-      ok: false,
-      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
-      message: 'Inbound webhook partial metadata conflicts with provider identifier mapping.',
-      reason: 'conflict',
-      providerLegId: providerIdentifiers.providerLegId,
-      providerMessageId: providerIdentifiers.providerMessageId,
-      providerEventId: providerIdentifiers.providerEventId,
-      providerNumberE164,
-    };
-  }
-
-  return {
-    ok: true,
-    source: 'provider_fallback',
-    tenantId: fallback.correlation.tenantId,
-    orgUnitId: fallback.correlation.orgUnitId,
-    threadId: fallback.correlation.threadId,
-    providerLegId: providerIdentifiers.providerLegId,
-    providerMessageId: providerIdentifiers.providerMessageId,
-    providerEventId: providerIdentifiers.providerEventId,
-    providerNumberE164,
   };
 };
 
@@ -6533,183 +6293,23 @@ const performOutboundAction = async ({
 
 registerConnectShyftThreadOutboundCoreExecutor(performOutboundAction);
 
-const handleInboundWebhook = async (
-  req: Request,
-  res: Response,
-): Promise<void> => {
-  if (!await enforceCapability(req, res, 'webhooks')) {
-    return;
-  }
-
-  const providerSelection = resolveConnectShyftProviderAdapter({
-    req,
-    operation: 'webhook',
-    requestedProvider: resolveConnectShyftRequestedProviderKey(req),
-  });
-  if (!providerSelection.ok) {
-    refusal(res, {
-      code: providerSelection.refusal.code,
-      message: providerSelection.refusal.message,
-      refusalType: providerSelection.refusal.refusalType,
-      httpStatus: providerSelection.refusal.httpStatus,
-      data: providerSelection.refusal.data,
-    });
-    return;
-  }
-
-  const signatureDecision = mapConnectShyftWebhookVerificationResult(
-    providerSelection.adapter.verifyWebhook(
-      buildConnectShyftWebhookVerificationInput({
-        req,
-        providerKey: providerSelection.providerResolution.resolvedProvider,
-      }),
-    ),
-  );
-  if (!signatureDecision.ok) {
-    const signatureMessageKey = signatureDecision.refusal.code === 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MISSING'
-      ? 'connectshyft.webhook.signature.missing'
-      : signatureDecision.refusal.code === 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED'
-        ? 'connectshyft.webhook.signature.not_configured'
-        : 'connectshyft.webhook.signature.invalid';
-    refusal(res, {
-      code: signatureDecision.refusal.code,
-      message: signatureDecision.refusal.message,
-      refusalType: signatureDecision.refusal.refusalType,
-      httpStatus: signatureDecision.refusal.httpStatus,
-      data: {
-        providerResolution: {
-          ...providerSelection.providerResolution,
-          adapterInvoked: true,
-        },
-        signatureValidation: {
-          deterministic: true,
-          verified: false,
-          provider: providerSelection.providerResolution.resolvedProvider,
-        },
-        operatorFeedbackMeta: {
-          actionable: true,
-          hiddenTransition: false,
-          messageKey: signatureMessageKey,
-          remediation: 'Ensure provider webhook signing is configured and include a valid signature.',
-        },
-        sideEffects: {
-          lifecycleMutationApplied: false,
-          canonicalEventPersisted: false,
-          outboxPersisted: false,
-        },
-        timelineOutcome: {
-          eventName: null,
-          routingDecision: 'refused',
-        },
-      },
-    });
-    return;
-  }
-
-  const canonicalTranslation = providerSelection.adapter.translateProviderEvent({
-    rawEventType: normalizeLifecycleString(req.body?.eventType) || 'sms.inbound',
-    payload: req.body,
-  });
-  const eventType = canonicalTranslation.eventType;
-  const normalizedEventType = eventType.toLowerCase();
+const performInboundWebhook = async ({
+  req,
+  res,
+  providerSelection,
+  canonicalTranslation,
+  eventType,
+  normalizedEventType,
+  correlation,
+  tenantId,
+  orgUnitId,
+  threadId,
+}: ConnectShyftInboundWebhookCoreExecutionInput): Promise<void> => {
   const isTranscriptionCallbackEvent = isConnectShyftVoicemailTranscriptionCallbackEventType(eventType);
   const isConnectedCallEvent = CONNECTSHYFT_CONNECTED_CALL_EVENT_TYPES.has(normalizedEventType);
-  const correlation = await resolveInboundWebhookCorrelation({
-    body: req.body,
-    channelHint:
-      normalizedEventType.includes('sms') || normalizedEventType.includes('message')
-        ? 'sms'
-        : 'voice',
-    providerName: providerSelection.providerResolution.resolvedProvider,
-    providerCorrelation: canonicalTranslation.correlation,
-    tenantIdHint: req.tenantId || null,
-  });
-  if (!correlation.ok) {
-    refusal(res, {
-      code: correlation.code,
-      message: correlation.message,
-      refusalType: 'business',
-      httpStatus: 200,
-      data: {
-        providerResolution: {
-          ...providerSelection.providerResolution,
-          adapterInvoked: true,
-        },
-        correlation: {
-          deterministic: true,
-          metadataFirstAttempted: true,
-          fallbackLookupAttempted: true,
-          reason: correlation.reason,
-          providerLegId: correlation.providerLegId,
-          providerMessageId: correlation.providerMessageId,
-          providerEventId: correlation.providerEventId,
-          providerNumberE164: correlation.providerNumberE164,
-        },
-        operatorFeedbackMeta: {
-          actionable: true,
-          hiddenTransition: false,
-          messageKey: 'connectshyft.webhook.correlation.unresolved',
-          remediation: 'Retry with thread metadata or provider identifiers that map to a prior outbound dispatch.',
-        },
-        sideEffects: {
-          lifecycleMutationApplied: false,
-          canonicalEventPersisted: false,
-          outboxPersisted: false,
-        },
-        timelineOutcome: {
-          eventName: null,
-          routingDecision: 'refused',
-        },
-      },
-    });
-    return;
-  }
-
-  const tenantId = correlation.tenantId;
-  const orgUnitId = correlation.orgUnitId;
-  const threadId = correlation.threadId;
   const webhookPersistenceDb = isConnectShyftTestOverrideEnabled()
     ? undefined
     : loadPlatformDb();
-  const requestWithRawBody = req as Request & { rawBody?: Buffer | string };
-
-  const rolloutContextValidation = resolveConnectShyftProviderAdapter({
-    req: {
-      header: (name: string) => req.header(name),
-      body: req.body,
-      rawBody: requestWithRawBody.rawBody,
-      originalUrl: req.originalUrl,
-      protocol: req.protocol,
-      url: req.url,
-      tenantId,
-      orgUnitId,
-    },
-    operation: 'webhook',
-    requestedProvider: providerSelection.providerResolution.resolvedProvider,
-  });
-  if (!rolloutContextValidation.ok) {
-    refusal(res, {
-      code: rolloutContextValidation.refusal.code,
-      message: rolloutContextValidation.refusal.message,
-      refusalType: rolloutContextValidation.refusal.refusalType,
-      httpStatus: rolloutContextValidation.refusal.httpStatus,
-      data: {
-        ...(rolloutContextValidation.refusal.data || {}),
-        correlation: {
-          source: correlation.source,
-          deterministic: true,
-          threadId,
-          tenantId,
-          orgUnitId,
-          providerLegId: correlation.providerLegId,
-          providerMessageId: correlation.providerMessageId,
-          providerEventId: correlation.providerEventId,
-          providerNumberE164: correlation.providerNumberE164,
-        },
-      },
-    });
-    return;
-  }
 
   if (isTranscriptionCallbackEvent) {
     const callbackPayload = extractConnectShyftVoicemailTranscriptionCallbackPayload(req.body);
@@ -8472,6 +8072,13 @@ const handleInboundWebhook = async (
   });
   return;
 };
+
+registerConnectShyftInboundWebhookCoreExecutor(performInboundWebhook);
+
+const handleInboundWebhook = async (
+  req: Request,
+  res: Response,
+): Promise<void> => executeConnectShyftInboundWebhookRoute(req, res);
 
 router.post('/threads/:threadId/claim', postConnectThreadClaim);
 

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -35,6 +35,8 @@ import {
   postConnectThreadClose,
   postConnectThreadMessage,
   postConnectThreadTakeover,
+  postConnectWebhookInbound,
+  postConnectWebhookSms,
   putConnectNeighbor,
 } from '../../../modules/connectshyft/handlers';
 import {
@@ -46,7 +48,6 @@ import {
   type ConnectShyftThreadOutboundCoreExecutionInput,
 } from '../../../modules/connectshyft/http/threadOutboundContext';
 import {
-  executeConnectShyftInboundWebhookRoute,
   registerConnectShyftInboundWebhookCoreExecutor,
   type ConnectShyftInboundWebhookCoreExecutionInput,
   type ConnectShyftResolvedWebhookCorrelation,
@@ -8075,11 +8076,6 @@ const performInboundWebhook = async ({
 
 registerConnectShyftInboundWebhookCoreExecutor(performInboundWebhook);
 
-const handleInboundWebhook = async (
-  req: Request,
-  res: Response,
-): Promise<void> => executeConnectShyftInboundWebhookRoute(req, res);
-
 router.post('/threads/:threadId/claim', postConnectThreadClaim);
 
 router.post('/threads/:threadId/takeover', postConnectThreadTakeover);
@@ -8090,12 +8086,8 @@ router.post('/threads/:threadId/call', postConnectThreadCall);
 
 router.post('/threads/:threadId/messages', postConnectThreadMessage);
 
-router.post('/webhooks/inbound', async (req: Request, res: Response) => {
-  await handleInboundWebhook(req, res);
-});
+router.post('/webhooks/inbound', postConnectWebhookInbound);
 
-router.post('/webhooks/sms', async (req: Request, res: Response) => {
-  await handleInboundWebhook(req, res);
-});
+router.post('/webhooks/sms', postConnectWebhookSms);
 
 export default router;

--- a/docs/architecture/connectshyft-router-refactor-plan.md
+++ b/docs/architecture/connectshyft-router-refactor-plan.md
@@ -103,26 +103,36 @@ Guardrails preserved:
 - helper boundary stays limited to route-family context enforcement, thread id parsing, shared prerequisite loading, and shared outbound execution delegation
 - provider adapter, bridge session, reliability, audit, SMS override, and inbound/webhook internals remain outside the helper boundary
 
-## Next slice
-
 ### Slice 9
-Inbound/webhooks/telephony extraction:
-- webhook entry routes
-- inbound SMS
-- inbound voice
-- voicemail handling
-- transcription callback
-- webhook correlation and receipt orchestration
+Extracted inbound webhook route-family seams:
+- `POST /webhooks/inbound`
+- `POST /webhooks/sms`
+- route-entry prerequisite handling for provider selection, signature verification, canonical translation, correlation resolution, and execution delegation
 
-This is intentionally deferred until after outbound extraction because it is the most operationally tangled route family.
+Added:
+- inbound webhook handlers
+- `http/inboundWebhookContext.ts`
+- inbound webhook characterization locks
+- inbound webhook helper-boundary tests
+
+Preserved:
+- exact current inbound webhook response shapes
+- exact current inbound SMS, inbound voice, voicemail, and transcription callback behavior
+
+Deferred intentionally:
+- provider / correlation / canonical / bridge internals remain intentionally deferred from the route-family extraction sequence
+- the operational inbound webhook core remains in `connectshyft.ts` pending the next consolidation step
 
 ## Extraction sequence
-1. Settings/context/inbox
-2. Thread read
-3. Lifecycle
-4. Neighbor/identity bridge
-5. Outbound actions
-6. Inbound/webhooks/telephony
+1. Settings/context/inbox complete
+2. Thread read complete
+3. Lifecycle complete
+4. Neighbor/identity bridge complete
+5. Outbound actions complete
+6. Inbound/webhooks/telephony complete
+
+## Next step
+Architecture consolidation for PeopleCore / Identity Resolution / ConnectShyft model lock-in.
 
 ## Operating rule for future updates
 This file is canonical.

--- a/specs/codex_implementation_brief_slice_9.md
+++ b/specs/codex_implementation_brief_slice_9.md
@@ -1,0 +1,445 @@
+# Codex Implementation Brief — Slice 9: ConnectShyft inbound webhooks and telephony route-family extraction
+
+## Slice goal
+
+Extract the ConnectShyft inbound webhook route family into thin handlers plus one helper boundary, while preserving exact current inbound/webhook response shapes and preserving current inbound auto-claim, voicemail, and transcription behavior exactly.
+
+This is a route extraction slice only.
+
+Do not redesign provider routing.
+Do not redesign bridge progression.
+Do not redesign provider correlation mapping.
+Do not redesign canonical event persistence.
+Do not redesign voicemail transcription behavior.
+Do not redesign inbound identity resolution behavior.
+
+## Locked constraints
+
+- Preserve exact current response shapes for:
+  - `POST /api/v1/connectshyft/webhooks/inbound`
+  - `POST /api/v1/connectshyft/webhooks/sms`
+- Preserve current inbound auto-claim behavior exactly.
+- Preserve current voicemail routing behavior exactly.
+- Preserve current transcription request and callback behavior exactly.
+- Extract only the route family and helper boundary.
+- Leave provider, bridge, correlation, canonical, and telephony internals where they are.
+- Keep router order stable.
+- Do not broaden scope into PeopleCore implementation.
+- Do not change business semantics.
+
+## Architectural intent
+
+By the end of Slice 9:
+
+- `connectshyft.ts` should delegate inbound webhook routes to thin handlers.
+- A dedicated helper boundary should centralize request-level prerequisite resolution and route-context preparation for inbound webhook handling.
+- The heavy inbound execution core can remain in router-owned or module-owned logic for now, as long as the route family itself is thin.
+- Existing provider and telephony internals stay where they are.
+
+This is the last major ConnectShyft route-family extraction before moving to architecture consolidation and implementation against the locked PeopleCore / Identity Resolution model.
+
+## Scope
+
+### In scope
+
+- Characterization tests for inbound webhook route behavior.
+- Helper boundary for inbound webhook prerequisite resolution.
+- Thin handlers for inbound webhook endpoints.
+- Router delegation swap.
+- Focused helper-boundary tests.
+- Notes/guardrails doc for future maintainers.
+- Router refactor plan update.
+
+### Out of scope
+
+- Rewriting webhook business logic.
+- Rewriting provider adapter resolution.
+- Rewriting canonical event storage.
+- Rewriting bridge session internals.
+- Rewriting provider correlation persistence.
+- Rewriting auto-claim rules.
+- Rewriting voicemail / transcription rules.
+- Rewriting sender normalization internals.
+- Any UI changes.
+- Any PeopleCore data-model implementation.
+
+## Target files
+
+### New route characterization tests
+
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts`
+
+### New helper boundary
+
+- `apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts`
+
+### New handlers
+
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookInbound.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookSms.ts`
+
+### Existing handler export surface
+
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts`
+
+### Focused helper tests
+
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts`
+
+### Guardrail notes
+
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md`
+
+### Existing router
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+
+### Existing refactor plan
+
+- `docs/architecture/connectshyft-router-refactor-plan.md`
+
+## Handler and helper design
+
+### `inboundWebhookContext.ts`
+
+This helper boundary should centralize only the route-family prerequisites and shared request preparation, not the deep execution core.
+
+It should own things like:
+
+- capability entry checks for inbound webhook route family
+- requested provider selection preconditions that are route-level
+- strict shared route parsing needed by both webhook endpoints
+- request-level normalization for route dispatch into the existing inbound core
+- any shared refusal mapping that is purely route-entry/prerequisite related
+
+It must not absorb:
+
+- provider registry internals
+- bridge progression internals
+- provider correlation persistence internals
+- canonical event persistence internals
+- inbound SMS domain mapping internals
+- inbound voice routing internals
+- voicemail transcription callback internals
+- deep neighbor resolution internals
+
+### Thin handlers
+
+`postConnectWebhookInbound.ts` and `postConnectWebhookSms.ts` should:
+
+1. call the helper boundary
+2. delegate into the existing inbound execution core
+3. preserve exact current response envelopes
+4. preserve exact current behavior
+
+These handlers should be very small.
+
+## Checkpoint plan
+
+---
+
+## Checkpoint 1 — characterization lock
+
+### Goal
+
+Pin current route behavior before any extraction.
+
+### Add
+
+- `connectshyft.webhook-sms.characterization.test.ts`
+- `connectshyft.webhook-voice.characterization.test.ts`
+- `connectshyft.webhook-transcription.characterization.test.ts`
+
+### Coverage requirements
+
+#### SMS webhook characterization
+
+Cover at least:
+
+- successful inbound SMS acceptance with current success envelope
+- duplicate-safe replay surface if currently exposed at route level
+- sender phone required / invalid refusal behavior
+- ambiguous neighbor refusal behavior
+- unresolved neighbor refusal behavior
+- inbound SMS thread ensure persistence refusal mapping
+- inbound SMS canonical persistence refusal mapping
+- exact current response payload shape for successful SMS acceptance
+
+#### Voice webhook characterization
+
+Cover at least:
+
+- successful inbound voice acceptance with current success envelope
+- current voicemail / fallback routing shape
+- current auto-claim behavior for connected call event
+- canonical persistence refusal mapping
+- exact current response payload shape including current lifecycle / routing / audit / outbox sections
+
+#### Transcription callback characterization
+
+Cover at least:
+
+- successful transcription callback acceptance with current shape
+- duplicate suppression behavior if currently surfaced
+- invalid callback correlation refusal behavior
+- callback persistence failure mapping if currently surfaced
+- preservation of current voicemail artifact / transcription fields
+
+### Validation command
+
+Run exactly:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts
+```
+
+### Stop condition
+
+Stop after Checkpoint 1 and report:
+
+- files changed
+- test results
+- blockers or deviations
+
+Commit all uncommitted items.
+
+---
+
+## Checkpoint 2 — helper boundary and thin handlers scaffolding
+
+### Goal
+
+Introduce the helper boundary and handler files without changing the route declarations yet.
+
+### Add
+
+- `http/inboundWebhookContext.ts`
+- `handlers/postConnectWebhookInbound.ts`
+- `handlers/postConnectWebhookSms.ts`
+- export both from `handlers/index.ts`
+
+### Implementation requirements
+
+- Reuse existing logic from `connectshyft.ts`; do not redesign it.
+- Keep the heavy inbound core behavior in place.
+- It is acceptable in this slice for the router-owned execution core to remain large, as long as the new helper boundary isolates route-entry logic.
+- Preserve exact response shapes.
+- Preserve exact behavior.
+
+### Validation commands
+
+Run exactly:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+### Stop condition
+
+Stop after Checkpoint 2 and report:
+
+- files changed
+- validation results
+- blockers or deviations
+
+Commit all uncommitted items.
+
+---
+
+## Checkpoint 3 — thin-router switch
+
+### Goal
+
+Switch the router endpoints to the thin handlers.
+
+### Change
+
+In `connectshyft.ts`, replace inline webhook route lambdas with delegated handlers:
+
+- `router.post('/webhooks/inbound', postConnectWebhookInbound);`
+- `router.post('/webhooks/sms', postConnectWebhookSms);`
+
+### Requirements
+
+- Preserve route order exactly.
+- Preserve response shapes exactly.
+- Preserve behavior exactly.
+- Remove only the route-local wrapper code that becomes unused because of this switch.
+- Do not expand cleanup beyond what is necessary.
+
+### Validation commands
+
+Run exactly:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+### Stop condition
+
+Stop after Checkpoint 3 and report:
+
+- files changed
+- validation results
+- blockers or deviations
+
+Commit all uncommitted items.
+
+---
+
+## Checkpoint 4 — focused helper-boundary tests and refactor-plan update
+
+### Goal
+
+Add focused tests for the helper boundary and update the refactor roadmap.
+
+### Add
+
+- `src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts`
+
+### Test coverage requirements
+
+Cover at least:
+
+- valid prerequisite resolution path
+- deterministic refusal mapping for missing or invalid route-entry prerequisites handled by the helper
+- helper remains prerequisite-only and does not absorb provider / bridge / canonical internals
+- handler-facing route preparation is deterministic
+
+### Update
+
+Update:
+
+- `docs/architecture/connectshyft-router-refactor-plan.md`
+
+Mark:
+
+- Slice 4 complete
+- Slice 5 complete
+- Slice 6 complete
+- Slice 7 complete
+- Slice 8 complete
+- Slice 9 complete
+
+And set next step to:
+
+- architecture consolidation for PeopleCore / Identity Resolution / ConnectShyft model lock-in
+
+Also explicitly state:
+
+- provider / correlation / canonical / bridge internals remain intentionally deferred from the route-family extraction sequence
+
+### Validation commands
+
+Run exactly:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+### Stop condition
+
+Stop after Checkpoint 4 and report:
+
+- files changed
+- validation results
+- blockers or deviations
+
+Commit all uncommitted items.
+
+---
+
+## Checkpoint 5 — inbound webhook guardrail notes
+
+### Goal
+
+Document ownership and deferrals for the inbound webhook route family.
+
+### Add
+
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md`
+
+### Document content requirements
+
+State clearly:
+
+- what the inbound webhook handlers own
+- what `inboundWebhookContext.ts` owns
+- what remains in provider / correlation / canonical / bridge / transcription internals
+- that exact current inbound response shapes are locked
+- that current auto-claim / voicemail / transcription behavior is locked
+- that this slice did not redesign telephony or provider behavior
+- that architecture consolidation is next
+
+### Validation commands
+
+Run exactly:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+### Stop condition
+
+Stop after Checkpoint 5 and report:
+
+- files changed
+- validation results
+- blockers or deviations
+
+Commit all uncommitted items.
+
+---
+
+## PR / CI completion step
+
+After Checkpoint 5 is complete:
+
+1. commit all remaining uncommitted items
+2. push the branch
+3. open the PR against `codex/dev`
+4. watch checks through completion
+5. do not broaden scope unless a failing check requires a tightly scoped fix
+
+Report back with:
+
+- PR number
+- check results
+- whether any follow-up patching was needed
+
+## Implementation guardrails
+
+- Do not rename existing response keys.
+- Do not normalize or “clean up” current envelopes.
+- Do not refactor provider internals into the helper.
+- Do not move bridge or canonical modules.
+- Do not re-architect webhook dedupe behavior.
+- Do not alter current webhook routing semantics.
+- Do not alter current SMS neighbor-resolution semantics.
+- Do not alter current voice auto-claim semantics.
+- Do not alter current voicemail transcription callback semantics.
+- Do not start PeopleCore implementation in this slice.
+
+## Done definition
+
+Slice 9 is done when:
+
+- inbound webhook routes are thin-router delegated
+- the helper boundary exists and is tested
+- exact current webhook response shapes remain unchanged
+- exact current auto-claim / voicemail / transcription behavior remains unchanged
+- router refactor plan is updated
+- inbound guardrail notes exist
+- local validations pass
+- CI passes
+
+## Counterpoint
+
+The biggest risk in this slice is accidental “cleanup” of the inbound core while extracting routes. That would be the wrong move. The point here is to finish structural extraction, not to make the inbound logic prettier. If the code is ugly but behavior-stable and the route family becomes thin, that is success for Slice 9.


### PR DESCRIPTION
## Summary
- add characterization locks for ConnectShyft inbound SMS, voice, and transcription webhook responses
- extract inbound webhook route-entry prerequisites into `inboundWebhookContext.ts` and switch the webhook routes to thin handlers
- add helper-boundary coverage, roadmap updates, and inbound webhook guardrail notes without redesigning provider or telephony internals

## Validation
- pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts
- pnpm nx run connectshyft-api:test
- pnpm nx run contracts:test