### PR TITLE
Slice 13: enforce PeopleCore ambiguity precedence and preserve ConnectShyft compatibility shell

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts
@@ -98,6 +98,59 @@ describe('connectshyft identity resolver', () => {
     });
   });
 
+  it('characterizes PeopleCore and legacy disagreement as multiple_matches through the resolver seam', async () => {
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-legacy-a', '+12605551218')],
+      async () => [buildNeighbor('neighbor-legacy-b', '+12605551218')],
+      {
+        listContactPointsByNormalizedValue: async () => [
+          {
+            id: 'contact-point-18',
+            tenantId: 'tenant-a',
+            type: 'phone',
+            normalizedValue: '+12605551218',
+            status: 'active_personal',
+            firstSeenAt: '2026-03-21T12:00:00.000Z',
+            lastSeenAt: '2026-03-21T12:00:00.000Z',
+            suspectedShared: false,
+            confirmedShared: false,
+            reassignmentSuspected: false,
+            createdAt: '2026-03-21T12:00:00.000Z',
+            updatedAt: '2026-03-21T12:00:00.000Z',
+          },
+        ],
+        listCurrentContactPointLinks: async () => [
+          {
+            id: 'link-18',
+            contactPointId: 'contact-point-18',
+            subjectType: 'person',
+            subjectId: 'person-18',
+            linkType: 'primary',
+            confidenceBand: 'high',
+            isCurrent: true,
+            isPrimary: true,
+            manuallyConfirmed: false,
+            firstLinkedAt: '2026-03-21T12:00:00.000Z',
+            linkedBy: 'system',
+            createdAt: '2026-03-21T12:00:00.000Z',
+            updatedAt: '2026-03-21T12:00:00.000Z',
+          },
+        ],
+      } as any,
+    );
+    const resolver = new ConnectShyftSubjectResolver(adapter);
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '(260) 555-1218',
+    })).resolves.toEqual({
+      type: 'multiple_matches',
+      candidateNeighborIds: ['neighbor-legacy-b'],
+      normalizedContactPoint: '+12605551218',
+    });
+  });
+
   it('passes hook context into the seam for inbound no-match handling', async () => {
     const evaluateMatch = jest.fn(async () => ({
       ok: true as const,

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts
@@ -151,6 +151,122 @@ describe('connectshyft identity resolver', () => {
     });
   });
 
+  it('returns multiple_matches when PeopleCore has multiple current linked people even with one legacy candidate', async () => {
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-legacy-19', '+12605551219')],
+      async () => [buildNeighbor('neighbor-legacy-19', '+12605551219')],
+      {
+        listContactPointsByNormalizedValue: async () => [
+          {
+            id: 'contact-point-19',
+            tenantId: 'tenant-a',
+            type: 'phone',
+            normalizedValue: '+12605551219',
+            status: 'active_personal',
+            firstSeenAt: '2026-03-21T12:00:00.000Z',
+            lastSeenAt: '2026-03-21T12:00:00.000Z',
+            suspectedShared: false,
+            confirmedShared: false,
+            reassignmentSuspected: false,
+            createdAt: '2026-03-21T12:00:00.000Z',
+            updatedAt: '2026-03-21T12:00:00.000Z',
+          },
+        ],
+        listCurrentContactPointLinks: async () => [
+          {
+            id: 'link-19-a',
+            contactPointId: 'contact-point-19',
+            subjectType: 'person',
+            subjectId: 'person-19-a',
+            linkType: 'primary',
+            confidenceBand: 'high',
+            isCurrent: true,
+            isPrimary: true,
+            manuallyConfirmed: false,
+            firstLinkedAt: '2026-03-21T12:00:00.000Z',
+            linkedBy: 'system',
+            createdAt: '2026-03-21T12:00:00.000Z',
+            updatedAt: '2026-03-21T12:00:00.000Z',
+          },
+          {
+            id: 'link-19-b',
+            contactPointId: 'contact-point-19',
+            subjectType: 'person',
+            subjectId: 'person-19-b',
+            linkType: 'primary',
+            confidenceBand: 'high',
+            isCurrent: true,
+            isPrimary: true,
+            manuallyConfirmed: false,
+            firstLinkedAt: '2026-03-21T12:00:00.000Z',
+            linkedBy: 'system',
+            createdAt: '2026-03-21T12:00:00.000Z',
+            updatedAt: '2026-03-21T12:00:00.000Z',
+          },
+        ],
+      } as any,
+    );
+    const resolver = new ConnectShyftSubjectResolver(adapter);
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '2605551219',
+    })).resolves.toEqual({
+      type: 'multiple_matches',
+      candidateNeighborIds: ['neighbor-legacy-19'],
+      normalizedContactPoint: '+12605551219',
+    });
+  });
+
+  it('preserves seam manual-resolution candidates when ambiguity has no legacy exact-match ids', async () => {
+    const resolver = new ConnectShyftSubjectResolver({
+      evaluateMatch: jest.fn(async () => ({
+        ok: false as const,
+        code: 'IDENTITY_MATCH_AMBIGUOUS' as const,
+        message: 'Identity match is ambiguous and requires manual resolution.',
+        data: {
+          identityMatch: {
+            decision: 'AMBIGUOUS' as const,
+            reason: 'MULTIPLE_EXACT_CONTACT_POINT_MATCHES' as const,
+            autoMergeAllowed: false,
+            contactPoint: {
+              value: '+12605551230',
+              isShared: false,
+              verificationStatus: 'verified' as const,
+            },
+            matchedNeighborId: null,
+            candidateCount: 0,
+            candidateNeighborIds: [],
+            exactMatches: [],
+          },
+          manualResolution: {
+            required: true as const,
+            reasonCode: 'IDENTITY_MATCH_AMBIGUOUS' as const,
+            nextAction: 'manual-merge' as const,
+            mergeEndpoint: '/api/v1/connectshyft/neighbors/merge' as const,
+            candidateNeighborIds: ['neighbor-b', 'neighbor-a'],
+            guidance: 'Multiple identities share this contact point. Resolve manually before any merge.',
+          },
+          idempotency: {
+            key: 'resolver-ambiguity-manual-resolution',
+            semantics: 'REPLAY_SAFE' as const,
+          },
+        },
+      })),
+    });
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '(260) 555-1230',
+    })).resolves.toEqual({
+      type: 'multiple_matches',
+      candidateNeighborIds: ['neighbor-a', 'neighbor-b'],
+      normalizedContactPoint: '+12605551230',
+    });
+  });
+
   it('passes hook context into the seam for inbound no-match handling', async () => {
     const evaluateMatch = jest.fn(async () => ({
       ok: true as const,

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts
@@ -295,6 +295,131 @@ describe('connectshyft peoplecore identity adapter', () => {
     }));
   });
 
+  it('characterizes a PeopleCore single-current-link disagreement with a different legacy neighbor as ambiguous', async () => {
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-legacy-a', '+12605551218')],
+      async () => [buildNeighbor('neighbor-legacy-b', '+12605551218')],
+      {
+        listContactPointsByNormalizedValue: async () => [
+          buildContactPoint('contact-point-18', '+12605551218'),
+        ],
+        listCurrentContactPointLinks: async () => [
+          buildContactPointLink('contact-point-18', 'person-18'),
+        ],
+        listResolverReviews: async () => [],
+        createResolverReview: jest.fn(),
+        createContactPoint: jest.fn(),
+        createPerson: jest.fn(),
+        createContactPointLink: jest.fn(),
+      } as any,
+    );
+
+    await expect(adapter.evaluateMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: {
+        label: 'mobile',
+        value: '(260) 555-1218',
+        verificationStatus: 'verified',
+      },
+      hookContext: {
+        createResolverReviewOnAmbiguous: true,
+        triggerSourceType: 'connectshyft_identity_match',
+        triggerSourceId: 'identity-match:peoplecore-disagreement',
+        requestedByUserId: 'user-1',
+      },
+    })).resolves.toMatchObject({
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      data: {
+        identityMatch: {
+          decision: 'AMBIGUOUS',
+          matchedNeighborId: null,
+        },
+        manualResolution: {
+          required: true,
+          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+        },
+      },
+    });
+  });
+
+  it('characterizes multiple PeopleCore current links as ambiguous even when legacy has a single candidate', async () => {
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-legacy-19', '+12605551219')],
+      async () => [buildNeighbor('neighbor-legacy-19', '+12605551219')],
+      {
+        listContactPointsByNormalizedValue: async () => [
+          buildContactPoint('contact-point-19', '+12605551219'),
+        ],
+        listCurrentContactPointLinks: async () => [
+          buildContactPointLink('contact-point-19', 'person-19-a'),
+          buildContactPointLink('contact-point-19', 'person-19-b'),
+        ],
+      } as any,
+    );
+
+    await expect(adapter.evaluateMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: {
+        label: 'mobile',
+        value: '2605551219',
+        verificationStatus: 'verified',
+      },
+    })).resolves.toMatchObject({
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      data: {
+        identityMatch: {
+          decision: 'AMBIGUOUS',
+          matchedNeighborId: null,
+        },
+        manualResolution: {
+          required: true,
+          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+        },
+      },
+    });
+  });
+
+  it('preserves legacy single-match fallback when PeopleCore has no current person links', async () => {
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-legacy-20', '+12605551220')],
+      async () => [buildNeighbor('neighbor-legacy-20', '+12605551220')],
+      {
+        listContactPointsByNormalizedValue: async () => [
+          buildContactPoint('contact-point-20', '+12605551220'),
+        ],
+        listCurrentContactPointLinks: async () => [],
+      } as any,
+    );
+
+    await expect(adapter.evaluateMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: {
+        label: 'mobile',
+        value: '2605551220',
+        verificationStatus: 'verified',
+      },
+    })).resolves.toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+      data: {
+        identityMatch: {
+          matchedNeighborId: 'neighbor-legacy-20',
+          contactPoint: {
+            value: '+12605551220',
+          },
+        },
+      },
+    });
+  });
+
   it('falls back cleanly when PeopleCore persistence is unavailable', async () => {
     const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
       async () => [buildNeighbor('neighbor-1', '+12605551214')],
@@ -320,6 +445,82 @@ describe('connectshyft peoplecore identity adapter', () => {
           neighborId: 'neighbor-1',
         },
       ],
+    });
+  });
+
+  it('preserves legacy single-match evaluation when PeopleCore persistence is unavailable', async () => {
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-legacy-21', '+12605551221')],
+      async () => [buildNeighbor('neighbor-legacy-21', '+12605551221')],
+      {
+        listContactPointsByNormalizedValue: async () => {
+          throw new PeopleCorePersistenceUnavailableError(new Error('people schema missing'));
+        },
+        listCurrentContactPointLinks: jest.fn(),
+      } as any,
+    );
+
+    await expect(adapter.evaluateMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: {
+        label: 'mobile',
+        value: '2605551221',
+        verificationStatus: 'verified',
+      },
+    })).resolves.toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+      data: {
+        identityMatch: {
+          matchedNeighborId: 'neighbor-legacy-21',
+          contactPoint: {
+            value: '+12605551221',
+          },
+        },
+      },
+    });
+  });
+
+  it('preserves shared-contact no-auto-merge guardrails when PeopleCore has a single current link', async () => {
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-legacy-22', '+12605551222')],
+      async () => [buildNeighbor('neighbor-legacy-22', '+12605551222')],
+      {
+        listContactPointsByNormalizedValue: async () => [
+          buildContactPoint('contact-point-22', '+12605551222'),
+        ],
+        listCurrentContactPointLinks: async () => [
+          buildContactPointLink('contact-point-22', 'person-22'),
+        ],
+      } as any,
+    );
+
+    await expect(adapter.evaluateMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: {
+        label: 'mobile',
+        value: '2605551222',
+        isShared: true,
+        verificationStatus: 'verified',
+      },
+    })).resolves.toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+      data: {
+        identityMatch: {
+          matchedNeighborId: 'neighbor-legacy-22',
+          decision: 'NO_AUTO_MERGE',
+          autoMergeAllowed: false,
+          contactPoint: {
+            value: '+12605551222',
+            isShared: true,
+          },
+        },
+      },
     });
   });
 });

--- a/apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts
@@ -6,6 +6,10 @@ import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from './peoplecore
 
 const SYSTEM_RESOLVER_ACTOR_ROLES = ['SYSTEM_ADMIN'];
 
+const uniqueSortedStrings = (values: string[]): string[] =>
+  Array.from(new Set(values.filter((value) => value.trim().length > 0))).sort((left, right) =>
+    left.localeCompare(right));
+
 export type ResolveSubjectByContactPointInput = {
   tenantId: string;
   orgUnitId: string;
@@ -70,11 +74,10 @@ export class ConnectShyftSubjectResolver implements ConnectShyftSubjectResolverB
       if (result.code === 'IDENTITY_MATCH_AMBIGUOUS') {
         return {
           type: 'multiple_matches',
-          candidateNeighborIds: [
-            ...(result.data?.identityMatch?.candidateNeighborIds
-              || result.data?.manualResolution?.candidateNeighborIds
-              || []),
-          ].sort(),
+          candidateNeighborIds: uniqueSortedStrings([
+            ...(result.data?.identityMatch?.candidateNeighborIds || []),
+            ...(result.data?.manualResolution?.candidateNeighborIds || []),
+          ]),
           normalizedContactPoint,
         };
       }

--- a/apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts
@@ -4,8 +4,9 @@ import {
   peopleCoreServiceAsync,
 } from '../peoplecore/service';
 import {
-  AsyncInProcessConnectShyftIdentityBoundaryAdapter,
-  type ConnectShyftIdentityBoundaryAdapter,
+  evaluateConnectShyftIdentityBoundary,
+  type ConnectShyftIdentityBoundaryDecision,
+  type ConnectShyftIdentityBoundaryManualResolutionContext,
   type ConnectShyftIdentityBoundaryNeighbor,
   type ConnectShyftIdentityBoundaryRequest,
   type ConnectShyftIdentityBoundaryResult,
@@ -28,7 +29,14 @@ type PeopleCoreIdentityLookupService = Pick<
 >;
 
 export type ConnectShyftPeopleCoreIdentityCandidateLookup =
-  ConnectShyftPeopleCoreIdentityLookupSnapshot;
+  ConnectShyftPeopleCoreIdentityLookupSnapshot & {
+    tenantNeighbors: ConnectShyftIdentityBoundaryNeighbor[];
+  };
+
+type ConnectShyftPeopleCoreLookupData = Pick<
+  ConnectShyftPeopleCoreIdentityCandidateLookup,
+  'peopleCoreAvailable' | 'peopleCoreContactPoints' | 'peopleCoreCurrentLinks'
+>;
 
 const normalizeContactPointValue = (contactPointValue: string): string | null => {
   const resolved = normalizePhone(
@@ -39,15 +47,99 @@ const normalizeContactPointValue = (contactPointValue: string): string | null =>
   return resolved.ok ? resolved.phone.normalizedE164 : null;
 };
 
-const emptyPeopleCoreLookup = () => ({
+const emptyPeopleCoreLookup = (): ConnectShyftPeopleCoreLookupData => ({
   peopleCoreAvailable: false,
   peopleCoreContactPoints: [] as ConnectShyftPeopleCoreIdentityCandidateLookup['peopleCoreContactPoints'],
   peopleCoreCurrentLinks: [] as ConnectShyftPeopleCoreIdentityCandidateLookup['peopleCoreCurrentLinks'],
 });
 
+const AMBIGUOUS_IDENTITY_MATCH_MESSAGE =
+  'Identity match is ambiguous and requires manual resolution.';
+const AMBIGUOUS_IDENTITY_MATCH_GUIDANCE =
+  'Multiple identities share this contact point. Resolve manually before any merge.';
+
+const uniqueSortedStrings = (values: string[]): string[] =>
+  Array.from(new Set(values.filter((value) => value.trim().length > 0))).sort((left, right) =>
+    left.localeCompare(right));
+
+const collectDistinctCurrentPersonIds = (
+  lookup: ConnectShyftPeopleCoreIdentityCandidateLookup,
+): string[] =>
+  uniqueSortedStrings(
+    lookup.peopleCoreCurrentLinks
+      .filter((link) => link.subjectType === 'person' && link.isCurrent !== false)
+      .map((link) => link.subjectId),
+  );
+
+const buildManualResolutionContext = (
+  candidateNeighborIds: string[],
+): ConnectShyftIdentityBoundaryManualResolutionContext => ({
+  required: true,
+  reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+  nextAction: 'manual-merge',
+  mergeEndpoint: '/api/v1/connectshyft/neighbors/merge',
+  candidateNeighborIds,
+  guidance: AMBIGUOUS_IDENTITY_MATCH_GUIDANCE,
+});
+
+const buildForcedAmbiguousDecision = (
+  legacyDecision: ConnectShyftIdentityBoundaryDecision,
+): ConnectShyftIdentityBoundaryDecision => {
+  const candidateNeighborIds = uniqueSortedStrings([
+    ...legacyDecision.candidateNeighborIds,
+    ...(legacyDecision.manualResolution?.candidateNeighborIds || []),
+  ]);
+  const manualResolution = buildManualResolutionContext(candidateNeighborIds);
+
+  return {
+    decision: 'AMBIGUOUS',
+    reason: 'MULTIPLE_EXACT_CONTACT_POINT_MATCHES',
+    autoMergeAllowed: false,
+    contactPoint: legacyDecision.contactPoint,
+    matchedNeighborId: null,
+    candidateCount: candidateNeighborIds.length,
+    candidateNeighborIds,
+    exactMatches: legacyDecision.exactMatches,
+    manualResolution,
+  };
+};
+
+const collectExactMatchNeighborIds = (
+  neighbors: ConnectShyftIdentityBoundaryNeighbor[],
+  normalizedContactPointValue: string | null,
+): string[] => {
+  if (!normalizedContactPointValue) {
+    return [];
+  }
+
+  return uniqueSortedStrings(
+    neighbors
+      .filter((neighbor) =>
+        neighbor.phones.some((phone) => phone.value === normalizedContactPointValue))
+      .map((neighbor) => neighbor.neighborId),
+  );
+};
+
+const hasLegacySameSubjectProof = (
+  lookup: ConnectShyftPeopleCoreIdentityCandidateLookup,
+  legacyDecision: ConnectShyftIdentityBoundaryDecision,
+): boolean => {
+  const legacyCandidateNeighborIds = uniqueSortedStrings(legacyDecision.candidateNeighborIds);
+  if (legacyCandidateNeighborIds.length !== 1) {
+    return false;
+  }
+
+  const tenantExactMatchNeighborIds = collectExactMatchNeighborIds(
+    lookup.tenantNeighbors,
+    lookup.normalizedContactPointValue,
+  );
+
+  return tenantExactMatchNeighborIds.length === 1
+    && tenantExactMatchNeighborIds[0] === legacyCandidateNeighborIds[0];
+};
+
 export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
-  implements ConnectShyftIdentityBoundaryAdapter {
-  private readonly boundaryAdapter: ConnectShyftIdentityBoundaryAdapter;
+{
   private readonly hooks: ConnectShyftPeopleCoreIdentityHooks;
 
   constructor(
@@ -61,16 +153,6 @@ export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
     private readonly peopleCoreService: PeopleCoreIdentityLookupService = peopleCoreServiceAsync,
   ) {
     this.hooks = new ConnectShyftPeopleCoreIdentityHooks(this.peopleCoreService);
-    this.boundaryAdapter = new AsyncInProcessConnectShyftIdentityBoundaryAdapter(
-      async (tenantId) => this.loadNeighborsByTenant(tenantId),
-      async (tenantId, normalizedContactPointValue) =>
-        (
-          await this.evaluateIdentityCandidatesByNormalizedContactPoint({
-            tenantId,
-            normalizedContactPointValue,
-          })
-        ).candidateNeighbors,
-    );
   }
 
   private async loadFallbackCandidates(
@@ -87,7 +169,7 @@ export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
   private async loadPeopleCoreLookup(input: {
     tenantId: string;
     normalizedContactPointValue: string;
-  }): Promise<Omit<ConnectShyftPeopleCoreIdentityCandidateLookup, 'normalizedContactPointValue' | 'candidateNeighbors'>> {
+  }): Promise<ConnectShyftPeopleCoreLookupData> {
     try {
       const peopleCoreContactPoints = await this.peopleCoreService.listContactPointsByNormalizedValue({
         tenantId: input.tenantId,
@@ -129,6 +211,7 @@ export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
       return {
         normalizedContactPointValue: null,
         ...emptyPeopleCoreLookup(),
+        tenantNeighbors: [],
         candidateNeighbors: [],
       };
     }
@@ -144,6 +227,7 @@ export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
     normalizedContactPointValue: string;
   }): Promise<ConnectShyftPeopleCoreIdentityCandidateLookup> {
     const peopleCoreLookup = await this.loadPeopleCoreLookup(input);
+    const tenantNeighbors = await this.loadNeighborsByTenant(input.tenantId);
     const candidateNeighbors = await this.loadFallbackCandidates(
       input.tenantId,
       input.normalizedContactPointValue,
@@ -152,6 +236,7 @@ export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
     return {
       normalizedContactPointValue: input.normalizedContactPointValue,
       ...peopleCoreLookup,
+      tenantNeighbors,
       candidateNeighbors,
     };
   }
@@ -166,7 +251,11 @@ export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
         normalizedContactPointValue,
       })
       : null;
-    const result = await Promise.resolve(this.boundaryAdapter.evaluateMatch(input));
+    const legacyResult = evaluateConnectShyftIdentityBoundary(
+      input,
+      lookup?.candidateNeighbors || [],
+    );
+    const result = this.applyPeopleCoreAuthorityPolicy(lookup, legacyResult);
 
     if (lookup) {
       try {
@@ -177,5 +266,56 @@ export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
     }
 
     return result;
+  }
+
+  private applyPeopleCoreAuthorityPolicy(
+    lookup: ConnectShyftPeopleCoreIdentityCandidateLookup | null,
+    legacyResult: ConnectShyftIdentityBoundaryResult,
+  ): ConnectShyftIdentityBoundaryResult {
+    if (!lookup?.peopleCoreAvailable) {
+      return legacyResult;
+    }
+
+    const currentPersonIds = collectDistinctCurrentPersonIds(lookup);
+    if (currentPersonIds.length === 0) {
+      return legacyResult;
+    }
+
+    if (currentPersonIds.length > 1) {
+      return this.forceLegacyResultToAmbiguous(legacyResult);
+    }
+
+    if (
+      legacyResult.ok
+      && legacyResult.code === 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED'
+      && !hasLegacySameSubjectProof(lookup, legacyResult.data.identityMatch)
+    ) {
+      // Checkpoint 2 intentionally treats current PeopleCore evidence as sufficient to block
+      // a silent legacy winner until a real same-subject proof exists.
+      return this.forceLegacyResultToAmbiguous(legacyResult);
+    }
+
+    return legacyResult;
+  }
+
+  private forceLegacyResultToAmbiguous(
+    legacyResult: ConnectShyftIdentityBoundaryResult,
+  ): ConnectShyftIdentityBoundaryResult {
+    if (!legacyResult.data?.idempotency || !legacyResult.data.identityMatch) {
+      return legacyResult;
+    }
+
+    const identityMatch = buildForcedAmbiguousDecision(legacyResult.data.identityMatch);
+
+    return {
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      message: AMBIGUOUS_IDENTITY_MATCH_MESSAGE,
+      data: {
+        identityMatch,
+        manualResolution: identityMatch.manualResolution,
+        idempotency: legacyResult.data.idempotency,
+      },
+    };
   }
 }

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
@@ -283,6 +283,97 @@ describe('connectshyft identity-match route', () => {
     });
   });
 
+  it('returns IDENTITY_MATCH_AMBIGUOUS with deterministic manual resolution for PeopleCore disagreement', async () => {
+    jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      message: 'Identity match is ambiguous and requires manual resolution.',
+      data: {
+        identityMatch: {
+          decision: 'AMBIGUOUS',
+          reason: 'MULTIPLE_EXACT_CONTACT_POINT_MATCHES',
+          autoMergeAllowed: false,
+          contactPoint: {
+            value: '+12605550997',
+            isShared: false,
+            verificationStatus: 'verified',
+          },
+          matchedNeighborId: null,
+          candidateCount: 1,
+          candidateNeighborIds: ['neighbor-legacy-conflict'],
+          exactMatches: [
+            {
+              neighborId: 'neighbor-legacy-conflict',
+              phoneId: 'phone-legacy-conflict',
+              isShared: false,
+              verificationStatus: 'verified',
+            },
+          ],
+          manualResolution: {
+            required: true,
+            reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+            nextAction: 'manual-merge',
+            mergeEndpoint: '/api/v1/connectshyft/neighbors/merge',
+            candidateNeighborIds: ['neighbor-legacy-conflict'],
+            guidance: 'Multiple identities share this contact point. Resolve manually before any merge.',
+          },
+        },
+        manualResolution: {
+          required: true,
+          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+          nextAction: 'manual-merge',
+          mergeEndpoint: '/api/v1/connectshyft/neighbors/merge',
+          candidateNeighborIds: ['neighbor-legacy-conflict'],
+          guidance: 'Multiple identities share this contact point. Resolve manually before any merge.',
+        },
+        idempotency: {
+          key: 'identity-replay-key-peoplecore-disagreement',
+          semantics: 'REPLAY_SAFE',
+        },
+      },
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/neighbors/identity-match')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: TEST_ORG_UNIT_ID,
+        contactPoint: {
+          label: 'mobile',
+          value: '(260) 555-0997',
+          isShared: false,
+          verificationStatus: 'verified',
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      data: {
+        identityMatch: {
+          decision: 'AMBIGUOUS',
+          matchedNeighborId: null,
+          candidateCount: 1,
+          candidateNeighborIds: ['neighbor-legacy-conflict'],
+          contactPoint: {
+            value: '+12605550997',
+          },
+        },
+        manualResolution: {
+          required: true,
+          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+          candidateNeighborIds: ['neighbor-legacy-conflict'],
+        },
+        idempotency: {
+          key: 'identity-replay-key-peoplecore-disagreement',
+          semantics: 'REPLAY_SAFE',
+        },
+      },
+    });
+  });
+
   it('records identity-match audit hash as keyed hmac output', async () => {
     jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
       ok: true,

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts
@@ -1097,7 +1097,7 @@ describe('connectshyft provider adapter registry route integration - dispatch an
     });
   });
 
-  it('derives provider-neutral thread detail timeline from canonical events with deterministic ordering', async () => {
+  it('returns the current thread-not-found refusal for canonical-event synthetic thread ids without thread-detail backing', async () => {
     const app = buildApp();
     const headers = buildHeaders({
       'x-test-connectshyft-tenant-id': 'tenant-connectshyft-f2',
@@ -1112,22 +1112,15 @@ describe('connectshyft provider adapter registry route integration - dispatch an
 
     expect(response.status).toBe(200);
     expect(response.body).toMatchObject({
-      ok: true,
-      code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
       data: {
-        thread: {
-          threadId: 'thread-f2-unclaimed-1001',
-          providerNeutral: true,
-          statusDerivedFromCanonicalEvents: true,
-          timeline: expect.any(Array),
+        context: {
+          tenantId: 'tenant-connectshyft-f2',
+          orgUnitId: 'org-connectshyft-f2-east',
+          bypassedOrgUnitMembership: false,
         },
       },
-    });
-
-    const timeline = response.body.data.thread.timeline as CanonicalEventRecord[];
-    expect(timeline).toEqual(sortCanonical(timeline));
-    timeline.forEach((event) => {
-      expectProviderSpecificLeakageRemoved(event.payload);
     });
   });
 });

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
@@ -752,6 +752,64 @@ describe('connectshyft inbound sms webhook route characterization', () => {
     }
   });
 
+  it('preserves the ambiguity refusal path for PeopleCore multi-link ambiguity without creating a neighbor', async () => {
+    const app = buildApp();
+    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+      .mockResolvedValue(null);
+    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+      .mockResolvedValue({
+        type: 'multiple_matches',
+        candidateNeighborIds: ['neighbor-peoplecore-multi-2005'],
+        normalizedContactPoint: '+12605552005',
+      });
+    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound');
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          threadId: undefined,
+          providerEventId: 'provider-event-sms-peoplecore-multi-2005',
+          providerMessageId: 'provider-message-sms-peoplecore-multi-2005',
+          from: '+12605552005',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'IDENTITY_MATCH_AMBIGUOUS',
+        message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
+        refusalType: 'business',
+        data: {
+          correlation: {
+            source: 'number_mapping',
+            deterministic: true,
+            threadId: '',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            providerMessageId: 'provider-message-sms-peoplecore-multi-2005',
+            providerEventId: 'provider-event-sms-peoplecore-multi-2005',
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: 'provider-event:provider-event-sms-peoplecore-multi-2005',
+          },
+          senderPhone: '+12605552005',
+          candidateNeighborIds: ['neighbor-peoplecore-multi-2005'],
+          reason: 'neighbor_ambiguous',
+        },
+      });
+      expect(createNeighborSpy).not.toHaveBeenCalled();
+    } finally {
+      createNeighborSpy.mockRestore();
+      resolveSubjectSpy.mockRestore();
+      resolveActiveSpy.mockRestore();
+    }
+  });
+
   it('returns the current inbound SMS success shape when subject resolution finds a single reusable neighbor', async () => {
     const app = buildApp();
     const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
@@ -923,6 +981,124 @@ describe('connectshyft inbound sms webhook route characterization', () => {
         tenantId: TEST_TENANT_ID,
         orgUnitId: TEST_ORG_UNIT_ID,
         phone: '+12605552011',
+      }));
+      expect(ensureThreadSpy).toHaveBeenCalledTimes(1);
+      expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      createNeighborSpy.mockRestore();
+      resolveSubjectSpy.mockRestore();
+      restore();
+    }
+  });
+
+  it('preserves the create-new flow when PeopleCore has no current link and legacy resolution stays no_match', async () => {
+    const app = buildApp();
+    const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
+      ensuredThreadId: 'thread-sms-characterization-created-2014',
+      ensuredNeighborId: 'neighbor-connectshyft-f1-2014',
+    });
+    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+      .mockResolvedValue({
+        type: 'no_match',
+        normalizedContactPoint: '+12605552014',
+      });
+    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound')
+      .mockResolvedValue({
+        ok: true,
+        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+        httpStatus: 201,
+        data: {
+          neighbor: {
+            neighborId: 'neighbor-connectshyft-f1-2014',
+          },
+        },
+      } as any);
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          threadId: undefined,
+          providerEventId: 'provider-event-sms-no-current-link-2014',
+          providerMessageId: 'provider-message-sms-no-current-link-2014',
+          from: '+12605552014',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+        data: {
+          correlation: {
+            neighborId: 'neighbor-connectshyft-f1-2014',
+          },
+          threadId: 'thread-sms-characterization-created-2014',
+        },
+      });
+      expect(createNeighborSpy).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        phone: '+12605552014',
+      }));
+      expect(ensureThreadSpy).toHaveBeenCalledTimes(1);
+      expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      createNeighborSpy.mockRestore();
+      resolveSubjectSpy.mockRestore();
+      restore();
+    }
+  });
+
+  it('preserves the fallback create-new flow when PeopleCore is unavailable and legacy resolution stays no_match', async () => {
+    const app = buildApp();
+    const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
+      ensuredThreadId: 'thread-sms-characterization-created-2015',
+      ensuredNeighborId: 'neighbor-connectshyft-f1-2015',
+    });
+    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+      .mockResolvedValue({
+        type: 'no_match',
+        normalizedContactPoint: '+12605552015',
+      });
+    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound')
+      .mockResolvedValue({
+        ok: true,
+        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+        httpStatus: 201,
+        data: {
+          neighbor: {
+            neighborId: 'neighbor-connectshyft-f1-2015',
+          },
+        },
+      } as any);
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          threadId: undefined,
+          providerEventId: 'provider-event-sms-peoplecore-unavailable-2015',
+          providerMessageId: 'provider-message-sms-peoplecore-unavailable-2015',
+          from: '+12605552015',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+        data: {
+          correlation: {
+            neighborId: 'neighbor-connectshyft-f1-2015',
+          },
+          threadId: 'thread-sms-characterization-created-2015',
+        },
+      });
+      expect(createNeighborSpy).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        phone: '+12605552015',
       }));
       expect(ensureThreadSpy).toHaveBeenCalledTimes(1);
       expect(canonicalEventSpy).toHaveBeenCalledTimes(1);

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
@@ -694,6 +694,64 @@ describe('connectshyft inbound sms webhook route characterization', () => {
     }
   });
 
+  it('preserves the ambiguity refusal path for PeopleCore and legacy disagreement without attaching or creating a neighbor', async () => {
+    const app = buildApp();
+    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+      .mockResolvedValue(null);
+    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+      .mockResolvedValue({
+        type: 'multiple_matches',
+        candidateNeighborIds: ['neighbor-conflict-2004'],
+        normalizedContactPoint: '+12605552004',
+      });
+    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound');
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          threadId: undefined,
+          providerEventId: 'provider-event-sms-conflict-2004',
+          providerMessageId: 'provider-message-sms-conflict-2004',
+          from: '+12605552004',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: false,
+        code: 'IDENTITY_MATCH_AMBIGUOUS',
+        message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
+        refusalType: 'business',
+        data: {
+          correlation: {
+            source: 'number_mapping',
+            deterministic: true,
+            threadId: '',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            providerMessageId: 'provider-message-sms-conflict-2004',
+            providerEventId: 'provider-event-sms-conflict-2004',
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: 'provider-event:provider-event-sms-conflict-2004',
+          },
+          senderPhone: '+12605552004',
+          candidateNeighborIds: ['neighbor-conflict-2004'],
+          reason: 'neighbor_ambiguous',
+        },
+      });
+      expect(createNeighborSpy).not.toHaveBeenCalled();
+    } finally {
+      createNeighborSpy.mockRestore();
+      resolveSubjectSpy.mockRestore();
+      resolveActiveSpy.mockRestore();
+    }
+  });
+
   it('returns the current inbound SMS success shape when subject resolution finds a single reusable neighbor', async () => {
     const app = buildApp();
     const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
@@ -769,6 +827,103 @@ describe('connectshyft inbound sms webhook route characterization', () => {
         contactPoint: '+12605552002',
       });
       expect(createNeighborSpy).not.toHaveBeenCalled();
+      expect(ensureThreadSpy).toHaveBeenCalledTimes(1);
+      expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      createNeighborSpy.mockRestore();
+      resolveSubjectSpy.mockRestore();
+      restore();
+    }
+  });
+
+  it('preserves the create-new flow when subject resolution reports no reusable neighbor', async () => {
+    const app = buildApp();
+    const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
+      ensuredThreadId: 'thread-sms-characterization-created-2011',
+      ensuredNeighborId: 'neighbor-connectshyft-f1-2011',
+    });
+    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+      .mockResolvedValue({
+        type: 'no_match',
+        normalizedContactPoint: '+12605552011',
+      });
+    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound')
+      .mockResolvedValue({
+        ok: true,
+        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+        httpStatus: 201,
+        data: {
+          neighbor: {
+            neighborId: 'neighbor-connectshyft-f1-2011',
+          },
+        },
+      } as any);
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          threadId: undefined,
+          providerEventId: 'provider-event-sms-created-2011',
+          providerMessageId: 'provider-message-sms-created-2011',
+          from: '+12605552011',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+        message: 'Inbound webhook accepted for processing',
+        data: {
+          from: '+12605552011',
+          to: TEST_PROVIDER_NUMBER,
+          eventType: 'sms.inbound',
+          correlation: {
+            source: 'number_mapping',
+            deterministic: true,
+            threadId: 'thread-sms-characterization-created-2011',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            neighborId: 'neighbor-connectshyft-f1-2011',
+            providerMessageId: 'provider-message-sms-created-2011',
+            providerEventId: 'provider-event-sms-created-2011',
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: 'provider-event:provider-event-sms-created-2011',
+          },
+          threadId: 'thread-sms-characterization-created-2011',
+          threadState: 'UNCLAIMED',
+          thread: buildEnsuredThread({
+            threadId: 'thread-sms-characterization-created-2011',
+            neighborId: 'neighbor-connectshyft-f1-2011',
+          }),
+          lifecycle: {
+            ensuredActiveThread: true,
+            createdNewThread: true,
+          },
+          inboundMessageArtifact: {
+            body: 'Please call me back when you can.',
+            from: '+12605552011',
+            to: TEST_PROVIDER_NUMBER,
+            providerEventId: 'provider-event-sms-created-2011',
+            providerMessageId: 'provider-message-sms-created-2011',
+          },
+        },
+      });
+      expect(resolveSubjectSpy).toHaveBeenCalledWith({
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        contactPoint: '+12605552011',
+      });
+      expect(createNeighborSpy).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        phone: '+12605552011',
+      }));
       expect(ensureThreadSpy).toHaveBeenCalledTimes(1);
       expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
     } finally {

--- a/docs/architecture/connectshyft-router-refactor-plan.md
+++ b/docs/architecture/connectshyft-router-refactor-plan.md
@@ -6,12 +6,13 @@
 - ConnectShyft route-family extraction sequence complete.
 - Frontend build/test surface separation completed in Slice 11.
 - Slice 12 PeopleCore persistence foundation and identity seam complete.
+- Slice 13 PeopleCore ambiguity precedence documentation and handler-preservation rules complete.
 
 ## Purpose
 
 This document records the completed extraction of `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` into a thin route-registration shell with module-owned handlers and helper boundaries.
 
-It also captures the post-Slice 12 stop point so future work does not treat the extraction sequence as still in progress.
+It also captures the post-Slice 13 stop point so future work does not treat the extraction sequence as still in progress.
 
 ## Non-negotiable rules
 
@@ -22,6 +23,7 @@ It also captures the post-Slice 12 stop point so future work does not treat the 
 5. Keep provider, bridge, canonical-event, and correlation internals in their existing domain/infrastructure modules unless a later intentional slice changes ownership.
 6. Treat Slice 11 as stabilization and architecture lock, not behavior redesign.
 7. Treat Slice 12 seam work as identity foundation behind the extracted handlers, not as a reason to re-thicken `connectshyft.ts`.
+8. Treat Slice 13 as authority refinement behind the seam, not as reconciliation or router redesign.
 
 ## Completed sequence
 
@@ -216,6 +218,32 @@ Completed:
 - identity convergence foundation without undoing the thin-router extraction
 - a future-safe seam for later identity authority migration
 
+### Slice 13
+
+Documented and locked the PeopleCore ambiguity-precedence rule behind the extracted handlers:
+
+- PeopleCore is consulted first for identity read authority
+- PeopleCore can invalidate certainty, but cannot assert person-to-neighbor equivalence
+- no current PeopleCore link or unavailable PeopleCore -> preserve legacy behavior
+- multiple current PeopleCore links -> ambiguous
+- single PeopleCore link plus legacy disagreement -> ambiguous
+- single aligned winner -> preserve current exact-match behavior
+- inbound SMS create-new remains blocked under ambiguity and unchanged for true `no_match`
+
+Preserved:
+
+- exact current route envelopes
+- current thin-router and handler ownership boundaries
+- current provider, bridge, canonical-event, and correlation ownership
+
+Did not add:
+
+- reconciliation
+- crosswalk infrastructure
+- auto-linking
+- merge engine behavior
+- scoring engine behavior
+
 ## Route-family extraction result
 
 The ConnectShyft route-family extraction sequence is complete:
@@ -242,13 +270,15 @@ Slice 11 was stabilization and architecture lock, not a behavior redesign slice.
 
 Slice 12 adds the identity convergence foundation behind that extracted surface, not a router redesign.
 
+Slice 13 adds ambiguity precedence behind that extracted surface, not a router redesign.
+
 ## Next intentional work
 
-Next work after Slice 12 should be:
+Next work after Slice 13 should be:
 
-- ConnectShyft identity refinement behind the PeopleCore seam
-- controlled migration of more identity authority away from ConnectShyft-local neighbor lookup
+- operationalization of ambiguity and resolver handling behind the PeopleCore seam
 - continued model-alignment work without changing current route envelopes lightly
+- not reconciliation or crosswalk implementation by default
 - not Application Shell by default
 
 ## Operating rule for future updates

--- a/docs/architecture/identity-resolution-model.md
+++ b/docs/architecture/identity-resolution-model.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Authoritative for the Slice 12 identity-resolution architecture and seam behavior.
+Authoritative for the Slice 13 identity-resolution architecture and seam behavior.
 
 ---
 
@@ -20,6 +20,12 @@ Current Slice 12 behavior also requires:
 - preserving existing ConnectShyft route and module outcomes
 - introducing a seam before replacing ConnectShyft-local ownership
 - allowing work to continue when identity is unresolved
+
+Slice 13 adds the governing precedence rule:
+
+- PeopleCore can block certainty
+- PeopleCore cannot assert person-to-neighbor identity equivalence in this slice
+- disagreement becomes explicit ambiguity
 
 ---
 
@@ -67,15 +73,40 @@ Current Slice 12 behavior also requires:
 
 ## 5. Current ConnectShyft Seam Outcomes
 
-The Slice 12 seam preserves these ConnectShyft outcomes for exact contact-point resolution:
+The Slice 13 seam preserves these ConnectShyft outcomes for exact contact-point resolution:
 
-- verified non-shared exact match -> auto-merge allowed
-- no exact match -> no match
+- verified non-shared exact match -> auto-merge allowed only when the legacy winner stays aligned with the PeopleCore-backed read path
+- no exact match -> no match when PeopleCore is unavailable, has no current person link, or has one current person link and legacy resolution still has no winner
 - multiple exact matches -> ambiguous with manual-resolution context
+- PeopleCore multi-person current-link result -> ambiguous with manual-resolution context
+- cross-system disagreement between a single current PeopleCore person and a different legacy concrete winner -> ambiguous with manual-resolution context
 - shared or unverified conditions -> no-auto-merge
 - deleted-only lookup exclusion where characterized
 
 The seam does not redesign these outputs. It routes identity consultation through PeopleCore-backed lookup and hook foundations while keeping the current ConnectShyft outward behavior stable.
+
+### 5.1 Ambiguity categories
+
+Slice 13 documents three distinct ambiguity categories:
+
+- legacy multi-neighbor ambiguity
+- PeopleCore multi-person ambiguity
+- cross-system disagreement ambiguity
+
+### 5.2 Decision flow
+
+```text
+PeopleCore available?
+  NO -> preserve legacy behavior
+  YES -> current person links?
+    0 -> preserve legacy behavior
+    >1 -> ambiguous
+    1 -> legacy outcome?
+      multiple -> ambiguous
+      single aligned -> preserve current exact-match behavior
+      single disagreement -> ambiguous
+      none -> no-match (unchanged in Slice 13)
+```
 
 ---
 
@@ -156,7 +187,7 @@ Slice 12 now persists `ResolverReview` records in PeopleCore and can create them
 - fully usable
 - subject to later resolution
 
-Slice 12 now includes best-effort provisional-person creation hooks behind the seam for safe inbound `no_match` flows. These hooks do not replace ConnectShyft neighbor creation at the API boundary.
+Slice 12 now includes best-effort provisional-person creation hooks behind the seam for safe inbound `no_match` flows. These hooks do not replace ConnectShyft neighbor creation at the API boundary and do not auto-link a PeopleCore person to a ConnectShyft neighbor.
 
 ---
 
@@ -191,13 +222,15 @@ ContactPoint states influence confidence:
 
 ## 13. Deferred Work
 
-Still deferred beyond Slice 12:
+Still deferred beyond Slice 13:
 
 - broad PeopleCore-driven candidate scoring inside ConnectShyft flows
 - resolver UI
 - full rebinding mechanics
 - replacement of ConnectShyft neighbor APIs with PeopleCore person APIs
 - Application Shell work
+- reconciliation or crosswalk infrastructure between PeopleCore persons and ConnectShyft neighbors
+- automated merge or scoring engines for cross-system identity decisions
 
 ---
 
@@ -206,9 +239,16 @@ Still deferred beyond Slice 12:
 - full automation
 - silent identity decisions
 - blocking work until resolved
+- reconciliation
+- crosswalk
+- automatic PeopleCore-to-neighbor linking
+- merge engine
+- scoring engine
 
 ---
 
-## 15. Slice 13 Target
+## 15. Slice 14 Handoff
 
-Slice 13 should focus on ConnectShyft identity refinement and a controlled migration of more identity authority behind the seam while preserving current route contracts.
+The next logical slice after Slice 13 is operationalization of ambiguity and resolver handling while preserving current route contracts.
+
+It is not reconciliation, cross-system equivalence solving, or automatic PeopleCore-to-neighbor linking.

--- a/docs/architecture/peoplecore-connectshyft-boundary-matrix.md
+++ b/docs/architecture/peoplecore-connectshyft-boundary-matrix.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Authoritative for the Slice 12 ownership boundary.
+Authoritative for the Slice 13 ownership boundary.
 
-| Object | Current Owner | Slice 12 Persistence Owner | Rebind Class | Current Note |
+`Rebind Class` is a future planning label. In Slice 13, it does not mean automatic PeopleCore-to-ConnectShyft linking, solved cross-system equivalence, or active reconciliation behavior.
+
+| Object | Current Owner | Slice 13 Persistence Owner | Rebind Class | Current Note |
 | --- | --- | --- | --- | --- |
 | Person | PeopleCore | PeopleCore | auto_rebind | Persisted in `people.persons` |
 | Household | PeopleCore | PeopleCore | review_rebind | Persisted in `people.households` |
@@ -26,10 +28,33 @@ Authoritative for the Slice 12 ownership boundary.
 | TimelineEvent | ConnectShyft | ConnectShyft | derived_projection | Timeline remains a ConnectShyft projection |
 | WorkIntent | ConnectShyft | ConnectShyft | review_rebind | Temporary bridge object remains ConnectShyft-owned |
 
-## Slice 12 Boundary Rule
+## Slice 13 Boundary Rule
 
 PeopleCore now owns persistence truth for person/contact-point/household/resolver-review concepts.
 
 ConnectShyft still owns communication objects and current neighbor-facing APIs.
 
-The seam is the integration point between them. Slice 12 does not bypass that seam by replacing ConnectShyft ownership everywhere at once.
+The seam is the integration point between them. Slice 13 does not bypass that seam by replacing ConnectShyft ownership everywhere at once.
+
+Slice 13 read-authority rule:
+
+- PeopleCore can block certainty
+- PeopleCore cannot assert person-to-neighbor equivalence
+- no current PeopleCore link or unavailable PeopleCore preserves legacy ConnectShyft behavior
+- multiple current PeopleCore links produce ambiguity
+- single current PeopleCore link plus a different legacy concrete winner produces ambiguity
+- single current PeopleCore link plus legacy no-match remains no-match in this slice
+
+Explicit non-goals for this boundary in Slice 13:
+
+- no reconciliation
+- no crosswalk
+- no auto-linking
+- no merge engine
+- no scoring engine
+
+## Slice 14 Handoff
+
+The next logical slice is operationalization of ambiguity and resolver handling at this boundary.
+
+It is not a reconciliation or automatic convergence slice.

--- a/docs/architecture/peoplecore-identity-seam.md
+++ b/docs/architecture/peoplecore-identity-seam.md
@@ -2,11 +2,17 @@
 
 ## Status
 
-Authoritative for the Slice 12 ConnectShyft-to-PeopleCore identity seam.
+Authoritative for the Slice 13 ConnectShyft-to-PeopleCore identity seam.
 
 ## Purpose
 
 The seam lets ConnectShyft consult PeopleCore-owned identity persistence without changing current ConnectShyft route envelopes or immediately replacing ConnectShyft neighbor ownership.
+
+In Slice 13, the seam follows this rule:
+
+- PeopleCore can block certainty
+- PeopleCore cannot assert person-to-neighbor identity equivalence
+- disagreement becomes ambiguity instead of a silent winner selection
 
 Current implementation lives in:
 
@@ -21,7 +27,7 @@ The seam currently supports:
 - resolving subject candidates by normalized contact point
 - loading PeopleCore contact points and current links first
 - preserving deterministic ConnectShyft outcomes for:
-  - auto-merge allowed
+  - auto-merge allowed when a single aligned winner still exists
   - no match
   - no-auto-merge for shared or unverified contact points
   - ambiguous/manual-resolution outcomes
@@ -29,13 +35,26 @@ The seam currently supports:
 - exposing the normalized contact-point value back to ConnectShyft callers
 - running best-effort internal hook writes for provisional identity and resolver review creation where enabled
 
+Slice 13 explicitly recognizes these ambiguity categories:
+
+- legacy multi-neighbor ambiguity
+- PeopleCore multi-person ambiguity
+- cross-system disagreement ambiguity
+
 ## Current Flow
 
 1. ConnectShyft normalizes the inbound phone value.
 2. The seam loads PeopleCore `ContactPoint` and current `ContactPointLink` records for that normalized value.
-3. The seam also loads the current ConnectShyft neighbor candidates needed to preserve existing route/module behavior.
-4. The existing ConnectShyft identity boundary still produces the outward decision shape and refusal semantics.
-5. If hook context is enabled, the seam may best-effort:
+3. If PeopleCore is unavailable, the seam preserves legacy ConnectShyft behavior.
+4. If PeopleCore is available but has no current person link, the seam preserves legacy ConnectShyft behavior.
+5. If PeopleCore has multiple current person links, the seam returns ambiguity.
+6. If PeopleCore has one current person link, the seam also loads the current ConnectShyft neighbor candidates needed to preserve existing route/module behavior:
+   - legacy multiple -> ambiguity
+   - legacy single aligned winner -> preserve current exact-match behavior
+   - legacy single disagreement -> ambiguity
+   - legacy no winner -> no-match unchanged in Slice 13
+7. The existing ConnectShyft identity boundary still produces the outward decision shape and refusal semantics.
+8. If hook context is enabled, the seam may best-effort:
    - create provisional PeopleCore person foundation on safe `no_match` flows
    - create resolver-review foundation on ambiguous flows
 
@@ -66,18 +85,21 @@ The seam does not:
 - rebind conversations or timelines directly to PeopleCore persons
 - move provider, webhook, bridge, or canonical-event ownership
 - implement the Application Shell
+- add reconciliation or crosswalk infrastructure
+- auto-link PeopleCore persons to ConnectShyft neighbors
+- add a merge engine or scoring engine for cross-system identity
 
 ## Deferred Work
 
-Still deferred beyond Slice 12:
+Still deferred beyond Slice 13:
 
-- controlled migration of more identity authority away from ConnectShyft neighbor lookup
+- explicit operational handling for ambiguity and resolver workflows
 - explicit neighbor-to-person convergence strategy
 - conversation rebinding mechanics
 - resolver UI and broader PeopleCore operational workflows
 
-## Slice 13 Target
+## Slice 14 Handoff
 
-Slice 13 should focus on ConnectShyft identity refinement and a controlled migration of more identity authority behind this seam.
+The next logical slice after Slice 13 is operationalization of ambiguity and resolver handling behind this seam.
 
-It should not default to Application Shell work.
+It should not default to reconciliation, crosswalk implementation, or Application Shell work.

--- a/slice13-discovery.txt
+++ b/slice13-discovery.txt
@@ -1,0 +1,2433 @@
+=== PEOPLECORE / SEAM / HOOKS ===
+domains/people/resolver/resolverReviewMemoryStore.ts:78:export function createResolverReview(input: CreateResolverReviewInput): ResolverReview {
+domains/people/contact-points/contactPointMemoryStore.ts:72:export function createContactPoint(input: CreateContactPointInput): ContactPoint {
+domains/people/contact-points/contactPointMemoryStore.ts:90:export function createContactPointLink(input: CreateContactPointLinkInput): ContactPointLink {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:390:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:370:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:411:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:510:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:562:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:650:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:724:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:767:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint');
+apps/connectshyft-api/src/app.ts:14:  createContactPoint,
+apps/connectshyft-api/src/app.ts:15:  createContactPointLink,
+apps/connectshyft-api/src/app.ts:16:  createResolverReview,
+apps/connectshyft-api/src/app.ts:130:  const contactPoint = createContactPoint({
+apps/connectshyft-api/src/app.ts:149:  const contactPointLink = createContactPointLink({
+apps/connectshyft-api/src/app.ts:177:  const resolverReview = createResolverReview({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:427:        createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/modules/peoplecore/store.ts:179:  createContactPoint(input: CreateContactPointInput): Promise<ContactPoint>;
+apps/connectshyft-api/src/modules/peoplecore/store.ts:184:  createContactPointLink(input: CreateContactPointLinkInput): Promise<ContactPointLink>;
+apps/connectshyft-api/src/modules/peoplecore/store.ts:190:  createResolverReview(input: CreateResolverReviewInput): Promise<ResolverReview>;
+apps/connectshyft-api/src/modules/peoplecore/store.ts:782:  async createContactPoint(input: CreateContactPointInput): Promise<ContactPoint> {
+apps/connectshyft-api/src/modules/peoplecore/store.ts:839:  async createContactPointLink(input: CreateContactPointLinkInput): Promise<ContactPointLink> {
+apps/connectshyft-api/src/modules/peoplecore/store.ts:949:  async createResolverReview(input: CreateResolverReviewInput): Promise<ResolverReview> {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:129:import { resolveSubjectByContactPoint } from '../../../modules/connectshyft/identityResolver';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6279:        const subjectResolution = await resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/peoplecore/service.ts:91:  createContactPoint(input: CreateContactPointInput) {
+apps/connectshyft-api/src/modules/peoplecore/service.ts:92:    return this.execute(() => this.store.createContactPoint(input));
+apps/connectshyft-api/src/modules/peoplecore/service.ts:103:  createContactPointLink(input: CreateContactPointLinkInput) {
+apps/connectshyft-api/src/modules/peoplecore/service.ts:104:    return this.execute(() => this.store.createContactPointLink(input));
+apps/connectshyft-api/src/modules/peoplecore/service.ts:119:  createResolverReview(input: CreateResolverReviewInput) {
+apps/connectshyft-api/src/modules/peoplecore/service.ts:120:    return this.execute(() => this.store.createResolverReview(input));
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:552:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:618:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:703:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:783:    const resolveSubjectSpy = jest.spyOn(identityResolverModule, 'resolveSubjectByContactPoint')
+apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts:301:    const contactPoint = await store.createContactPoint({
+apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts:322:    const link = await store.createContactPointLink({
+apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts:406:    const created = await store.createResolverReview({
+apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts:454:      store.createContactPointLink({
+apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts:56:      createContactPoint: jest.fn(async () => ({ id: 'contact-point-1' })),
+apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts:68:    await expect(service.createContactPoint(CONTACT_POINT_INPUT))
+apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts:96:    ['createContactPoint', (service: AsyncPeopleCoreService) => service.createContactPoint(CONTACT_POINT_INPUT), 'createContactPoint'],
+apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts:103:    ['createContactPointLink', (service: AsyncPeopleCoreService) => service.createContactPointLink({
+apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts:115:    }), 'createContactPointLink'],
+apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts:124:    ['createResolverReview', (service: AsyncPeopleCoreService) => service.createResolverReview(RESOLVER_REVIEW_INPUT), 'createResolverReview'],
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:15:  | 'createContactPoint'
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:16:  | 'createContactPointLink'
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:18:  | 'createResolverReview'
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:133:  async createProvisionalPersonHook(
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:157:        contactPoint = await this.peopleCoreService.createContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:208:    const link = await this.peopleCoreService.createContactPointLink({
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:230:  async createResolverReviewHook(
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:274:    const review = await this.peopleCoreService.createResolverReview({
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:313:      && input.hookContext?.createProvisionalOnNoMatch
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:315:      await this.createProvisionalPersonHook({
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:332:      && input.hookContext?.createResolverReviewOnAmbiguous
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:334:      await this.createResolverReviewHook({
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:52:  createProvisionalOnNoMatch?: boolean;
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:53:  createResolverReviewOnAmbiguous?: boolean;
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:5:import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from './peoplecoreIdentityAdapter';
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:32:  resolveSubjectByContactPoint(
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:42:  async resolveSubjectByContactPoint(
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:57:        createProvisionalOnNoMatch: true,
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:58:        createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:114:export const resolveSubjectByContactPoint = (
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:117:  defaultSubjectResolver.resolveSubjectByContactPoint(input);
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts:16:} from './peoplecoreIdentityHooks';
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts:21:  | 'createContactPoint'
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts:22:  | 'createContactPointLink'
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts:24:  | 'createResolverReview'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:22:import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from './peoplecoreIdentityAdapter';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:1:import { ConnectShyftPeopleCoreIdentityHooks } from '../peoplecoreIdentityHooks';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:41:      createContactPoint: jest.fn(async () => buildContactPoint('contact-point-1', '+12605551230')),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:52:      createContactPointLink: jest.fn(async () => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:68:      createResolverReview: jest.fn(),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:72:    const result = await hooks.createProvisionalPersonHook({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:90:    expect(service.createContactPoint).toHaveBeenCalledWith(expect.objectContaining({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:107:      createResolverReview: jest.fn(async () => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:124:      createContactPoint: jest.fn(),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:126:      createContactPointLink: jest.fn(),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:130:    const result = await hooks.createResolverReviewHook({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:150:    expect(service.createResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborIdentityMatch.ts:27:      createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:6:import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from '../peoplecoreIdentityAdapter';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:84:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:131:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:144:        createProvisionalOnNoMatch: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:145:        createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:159:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:177:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:195:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:213:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:238:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:257:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:285:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:304:    await expect(resolver.resolveSubjectByContactPoint({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:2:import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from '../peoplecoreIdentityAdapter';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:60:      createContactPoint: jest.fn(async () => buildContactPoint('contact-point-3', '+12605551220')),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:71:      createContactPointLink: jest.fn(async () => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:87:      createResolverReview: jest.fn(),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:105:        createProvisionalOnNoMatch: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:126:    expect(peopleCoreService.createContactPointLink).toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:217:    const createResolverReview = jest.fn(async () => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:252:        createResolverReview,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:253:        createContactPoint: jest.fn(),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:255:        createContactPointLink: jest.fn(),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:269:        createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:289:    expect(createResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+
+=== NEIGHBOR DEPENDENCIES ===
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:70:  connectShyftNeighborServiceAsync,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:71:  createNeighborFromInbound,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:72:  resolveActiveNeighborForInbound,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3422:    const resolvedNeighbor = await connectShyftNeighborServiceAsync.resolveNeighbor({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3756:  const resolvedNeighbor = await resolveActiveNeighborForInbound({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4478:      const resolvedNeighbor = await connectShyftNeighborServiceAsync.resolveNeighbor({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6289:          const createdNeighbor = await createNeighborFromInbound({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:8:  connectShyftNeighborServiceAsync,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:224:    jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:309:    jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:376:    jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:471:    jest.spyOn(AsyncConnectShyftNeighborService.prototype, 'mergeNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:555:    jest.spyOn(AsyncConnectShyftNeighborService.prototype, 'mergeNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:597:    const mergeSpy = jest.spyOn(AsyncConnectShyftNeighborService.prototype, 'mergeNeighbor');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:285:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:387:    const createInboundSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:388:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborCreate.ts:9:import { connectShyftNeighborServiceAsync } from '../neighbors';
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborCreate.ts:17:  const created = await connectShyftNeighborServiceAsync.createNeighbor({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:7:import { connectShyftNeighborServiceAsync } from '../../../../modules/connectshyft/neighbors';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:115:    jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:171:    jest.spyOn(connectShyftNeighborServiceAsync, 'updateNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:229:    jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:308:    const softDeleteSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'softDeleteNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:403:    jest.spyOn(connectShyftNeighborServiceAsync, 'softDeleteNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:436:    const softDeleteSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'softDeleteNeighbor');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:460:    const softDeleteSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'softDeleteNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:498:    const listSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'listNeighbors').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:549:    const resolveSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:601:    const resolveSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:6:import { connectShyftNeighborServiceAsync } from '../../../../modules/connectshyft/neighbors';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:123:    jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:204:    jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:287:    jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:370:    const evaluateSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'evaluateIdentityMatch').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:8:  connectShyftNeighborServiceAsync,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:224:    const updateSpy = jest.spyOn(AsyncConnectShyftNeighborService.prototype, 'updateNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:319:    const updateSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'updateNeighbor');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:354:    jest.spyOn(AsyncConnectShyftNeighborService.prototype, 'updateNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:444:    const softDeleteSpy = jest.spyOn(AsyncConnectShyftNeighborService.prototype, 'softDeleteNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:523:    const softDeleteSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'softDeleteNeighbor');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:547:    jest.spyOn(AsyncConnectShyftNeighborService.prototype, 'softDeleteNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborIdentityMatch.ts:11:import { connectShyftNeighborServiceAsync } from '../neighbors';
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborIdentityMatch.ts:19:  const matched = await connectShyftNeighborServiceAsync.evaluateIdentityMatch({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:616:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:624:    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:709:    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:788:    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:5:import { connectShyftNeighborServiceAsync } from '../../../../modules/connectshyft/neighbors';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:220:    const createSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:286:    jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:340:    jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:397:    const createSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:428:    const createSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'createNeighbor');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:366:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:410:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:508:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:516:    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:560:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:567:    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:647:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:655:    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:722:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:765:    const resolveActiveSpy = jest.spyOn(neighborsModule, 'resolveActiveNeighborForInbound')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:5:import { connectShyftNeighborServiceAsync } from '../../../../modules/connectshyft/neighbors';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:210:    const listSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'listNeighbors').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:264:    const resolveSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:325:    jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:354:    const resolveSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:15:  connectShyftNeighborServiceAsync,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:471:    const resolveNeighborSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:570:    jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue(
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:605:    jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue(
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:643:    jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue(
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:687:    jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:997:  updateNeighbor(input: NeighborStoreUpdateInput): NeighborPersistenceResult {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:1043:  softDeleteNeighbor(input: {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:1091:  mergeNeighbors(input: NeighborStoreMergeInput): NeighborMergePersistenceResult {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:1288:  listActiveIdentityBoundaryNeighborsByTenant(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:1363:  listActiveIdentityBoundaryNeighborsByPhoneValue(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:1655:  async softDeleteNeighbor(input: {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:1835:  async listActiveIdentityBoundaryNeighborsByTenant(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:1934:  async listActiveIdentityBoundaryNeighborsByPhoneValue(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2053:  async updateNeighbor(input: NeighborStoreUpdateInput): Promise<NeighborPersistenceResult> {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2148:  async mergeNeighbors(input: NeighborStoreMergeInput): Promise<NeighborMergePersistenceResult> {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2309:        listActiveIdentityBoundaryNeighborsByTenant?: (
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2312:      listActiveIdentityBoundaryNeighborsByPhoneValue?: (
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2319:        (tenantId) => activeStore.listActiveIdentityBoundaryNeighborsByTenant
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2320:          ? activeStore.listActiveIdentityBoundaryNeighborsByTenant(tenantId)
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2333:          activeStore.listActiveIdentityBoundaryNeighborsByPhoneValue
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2334:            ? activeStore.listActiveIdentityBoundaryNeighborsByPhoneValue(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2443:  createNeighborFromInbound(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2522:  softDeleteNeighbor(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2532:    const deleted = this.store.softDeleteNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2553:  updateNeighbor(input: ConnectShyftUpdateNeighborCommand): ConnectShyftUpdateNeighborResult {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2575:    const updated = this.store.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2611:  mergeNeighbor(input: ConnectShyftMergeNeighborCommand): ConnectShyftMergeNeighborResult {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2626:    const merged = this.store.mergeNeighbors({
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2654:  async (tenantId) => defaultKnexNeighborStore.listActiveIdentityBoundaryNeighborsByTenant(tenantId),
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2656:    defaultKnexNeighborStore.listActiveIdentityBoundaryNeighborsByPhoneValue(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2672:      listActiveIdentityBoundaryNeighborsByTenant?: (
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2675:      listActiveIdentityBoundaryNeighborsByPhoneValue?: (
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2682:        async (tenantId) => activeStore.listActiveIdentityBoundaryNeighborsByTenant
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2683:          ? activeStore.listActiveIdentityBoundaryNeighborsByTenant(tenantId)
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2696:          activeStore.listActiveIdentityBoundaryNeighborsByPhoneValue
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2697:            ? activeStore.listActiveIdentityBoundaryNeighborsByPhoneValue(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2840:  async createNeighborFromInbound(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2956:  async softDeleteNeighbor(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2967:      const deleted = await this.store.softDeleteNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2995:  async updateNeighbor(input: ConnectShyftUpdateNeighborCommand): Promise<ConnectShyftUpdateNeighborResult> {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3018:      const updated = await this.store.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3068:  async mergeNeighbor(input: ConnectShyftMergeNeighborCommand): Promise<ConnectShyftMergeNeighborResult> {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3084:      const merged = await this.store.mergeNeighbors({
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3116:export const connectShyftNeighborServiceAsync = new AsyncConnectShyftNeighborService(
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3121:export const resolveActiveNeighborForInbound = (
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3124:  connectShyftNeighborServiceAsync.resolveActiveNeighbor(input);
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3126:export const createNeighborFromInbound = async (input: ConnectShyftCreateInboundNeighborCommand & {
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3132:  const created = await connectShyftNeighborServiceAsync.createNeighborFromInbound(input);
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3169:  connectShyftNeighborServiceAsync.applyInboundSmsTextingPreference(input);
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectNeighborDetail.ts:10:import { connectShyftNeighborServiceAsync } from '../neighbors';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectNeighborDetail.ts:18:  const resolved = await connectShyftNeighborServiceAsync.resolveNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectNeighbors.ts:9:import { connectShyftNeighborServiceAsync } from '../neighbors';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectNeighbors.ts:17:  const resolved = await connectShyftNeighborServiceAsync.listNeighbors({
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:12:  connectShyftNeighborServiceAsync,
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:800:    const updated = await connectShyftNeighborServiceAsync.updateNeighbor(command);
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:825:        const updated = await txNeighborService.updateNeighbor(command);
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:907:    const deleted = await connectShyftNeighborServiceAsync.softDeleteNeighbor(command);
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:943:        const deletedResult = await txNeighborService.softDeleteNeighbor(command);
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1091:        const mergedResult = await txNeighborService.mergeNeighbor(command);
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:4:import { KnexConnectShyftNeighborStore } from './neighbors';
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:104:  async (tenantId) => defaultNeighborStore.listActiveIdentityBoundaryNeighborsByTenant(tenantId),
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:106:    defaultNeighborStore.listActiveIdentityBoundaryNeighborsByPhoneValue(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:160:    const result = service.createNeighborFromInbound({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:207:    const inboundDuplicate = service.createNeighborFromInbound({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:337:    const duplicateUpdate = service.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:424:    const updated = service.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:618:    const forbidden = service.softDeleteNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:630:    const confirmationRequired = service.softDeleteNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:642:    const deleted = service.softDeleteNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:714:    const repeated = service.softDeleteNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:755:    const deleted = service.softDeleteNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:766:    const inboundCreated = service.createNeighborFromInbound({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:840:    const unknownNeighbor = service.createNeighborFromInbound({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1109:    const updated = service.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1153:    const updatedToUnknown = service.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1183:    const updatedBackToYes = service.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1248:    const updated = service.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1299:    const crossTenantUpdated = service.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1354:    const merged = service.mergeNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1409:    const merged = service.mergeNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1429:    const merged = service.mergeNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1449:    const merged = service.mergeNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1796:      updateNeighbor: jest.fn(async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1801:      softDeleteNeighbor: jest.fn(async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1847:    const updated = await service.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1866:    const deleted = await service.softDeleteNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1907:      updateNeighbor: jest.fn(async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1935:    const updated = await service.updateNeighbor({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:11:import { connectShyftNeighborServiceAsync } from '../neighbors';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:286:      connectShyftNeighborServiceAsync,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:289:    const mergeNeighborSpy = jest.spyOn(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:290:      connectShyftNeighborServiceAsync,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:291:      'mergeNeighbor',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:292:    ).mockRejectedValue(new Error('mergeNeighbor should not run during access-context resolution'));
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:325:    expect(mergeNeighborSpy).not.toHaveBeenCalled();
+
+=== RESOLVER TRIGGERS ===
+domains/people/resolver/resolverReviewMemoryStore.ts:5:  | 'shared_contact_ambiguity'
+domains/people/resolver/resolverReviewMemoryStore.ts:6:  | 'contact_point_reassignment'
+domains/people/resolver/resolverReviewMemoryStore.ts:8:  | 'subject_reassignment_review'
+domains/people/resolver/resolverReviewMemoryStore.ts:9:  | 'identity_conflict'
+domains/people/resolver/resolverReviewMemoryStore.ts:18:  | 'resolved_shared_contact'
+domains/people/resolver/resolverReviewMemoryStore.ts:26:  | 'mark_shared_contact'
+domains/people/resolver/resolverReviewMemoryStore.ts:33:  | 'shared_contact_possible'
+domains/people/resolver/resolverReviewMemoryStore.ts:34:  | 'shared_contact_confirmed'
+domains/people/resolver/resolverReviewMemoryStore.ts:70:const resolverReviews: ResolverReview[] = []
+domains/people/resolver/resolverReviewMemoryStore.ts:72:let resolverReviewSequence = 0
+domains/people/resolver/resolverReviewMemoryStore.ts:75:  return resolverReviews.map((resolverReview) => ({ ...resolverReview }))
+domains/people/resolver/resolverReviewMemoryStore.ts:78:export function createResolverReview(input: CreateResolverReviewInput): ResolverReview {
+domains/people/resolver/resolverReviewMemoryStore.ts:79:  const resolverReview: ResolverReview = {
+domains/people/resolver/resolverReviewMemoryStore.ts:81:    id: `rr_${++resolverReviewSequence}`,
+domains/people/resolver/resolverReviewMemoryStore.ts:84:  resolverReviews.push(resolverReview)
+domains/people/resolver/resolverReviewMemoryStore.ts:86:  return { ...resolverReview }
+domains/people/contact-points/contactPointMemoryStore.ts:10:  | 'reassignment_suspected'
+domains/people/contact-points/contactPointMemoryStore.ts:26:  reassignmentSuspected: boolean
+domains/people/contact-points/contactPointState.ts:12:  'reassignment_suspected',
+domains/people/contact-points/contactPointState.ts:23:export function requiresResolverReview(status: ContactPointStatus): boolean {
+domains/people/index.ts:5:export * from './resolver/resolverReviewMemoryStore'
+libs/contracts/src/people/events.ts:24:  resolverReviewId?: string;
+libs/contracts/src/people/events.ts:33:  'id' | 'normalizedValue' | 'status' | 'reassignmentSuspected'
+libs/contracts/src/people/events.ts:42:    type: 'contact_point.reassignment_suspected';
+libs/contracts/src/people/contact-point.ts:8:  | 'reassignment_suspected'
+libs/contracts/src/people/contact-point.ts:24:  reassignmentSuspected: boolean;
+libs/contracts/src/people/contact-point.ts:64:  | 'reassignment_suspected'
+libs/contracts/src/people/resolver-review.ts:5:  | 'shared_contact_ambiguity'
+libs/contracts/src/people/resolver-review.ts:6:  | 'contact_point_reassignment'
+libs/contracts/src/people/resolver-review.ts:8:  | 'subject_reassignment_review'
+libs/contracts/src/people/resolver-review.ts:9:  | 'identity_conflict';
+libs/contracts/src/people/resolver-review.ts:18:  | 'resolved_shared_contact'
+libs/contracts/src/people/resolver-review.ts:26:  | 'mark_shared_contact'
+libs/contracts/src/people/resolver-review.ts:33:  | 'shared_contact_possible'
+libs/contracts/src/people/resolver-review.ts:34:  | 'shared_contact_confirmed'
+tests/integration/peoplecore/resolver-reviews.test.ts:6:    const createResolverReviewResponse = await (request as any)(app).post('/people/resolver-reviews').send({
+tests/integration/peoplecore/resolver-reviews.test.ts:7:      reviewType: 'identity_conflict',
+tests/integration/peoplecore/resolver-reviews.test.ts:17:    expect(createResolverReviewResponse.status).toBe(200);
+tests/integration/peoplecore/resolver-reviews.test.ts:18:    expect(createResolverReviewResponse.body.reviewType).toBe('identity_conflict');
+tests/integration/peoplecore/resolver-reviews.test.ts:19:    expect(createResolverReviewResponse.body.reviewStatus).toBe('pending');
+tests/integration/peoplecore/resolver-reviews.test.ts:20:    expect(createResolverReviewResponse.body.priority).toBe('normal');
+tests/integration/peoplecore/resolver-reviews.test.ts:21:    expect(createResolverReviewResponse.body.candidatePersonIds).toEqual(['person_1', 'person_2']);
+tests/integration/peoplecore/resolver-reviews.test.ts:29:          id: createResolverReviewResponse.body.id,
+tests/integration/peoplecore/resolver-reviews.test.ts:30:          reviewType: 'identity_conflict',
+libs/contracts/tests/people/contact-point.test.ts:15:      reassignmentSuspected: false,
+tests/integration/peoplecore/contact-points.test.ts:18:    expect(createContactPointResponse.body.reassignmentSuspected).toBe(false);
+libs/contracts/tests/people/events.test.ts:49:    const reassignmentSuspected: ContactPointReassignmentSuspectedEvent = {
+libs/contracts/tests/people/events.test.ts:51:      type: 'contact_point.reassignment_suspected',
+libs/contracts/tests/people/events.test.ts:60:        status: 'reassignment_suspected',
+libs/contracts/tests/people/events.test.ts:61:        reassignmentSuspected: true,
+libs/contracts/tests/people/events.test.ts:66:    const resolverReviewCreated: ResolverReviewCreatedEvent = {
+libs/contracts/tests/people/events.test.ts:78:        reviewType: 'identity_conflict',
+libs/contracts/tests/people/events.test.ts:93:    expect(reassignmentSuspected.payload.reassignmentSuspected).toBe(true);
+libs/contracts/tests/people/events.test.ts:94:    expect(resolverReviewCreated.type).toBe('resolver_review.created');
+libs/contracts/tests/people/resolver-review.test.ts:9:      reviewType: 'identity_conflict',
+libs/contracts/tests/people/resolver-review.test.ts:22:    expect(review.reviewType).toBe('identity_conflict');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:378:      code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:408:        manualResolution: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:410:          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:443:      code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:452:        manualResolution: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:453:          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:413:        code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:113:  it('preserves IDENTITY_MATCH_AMBIGUOUS even when audit side-effects cannot persist', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:114:    const manualResolution = {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:116:      reasonCode: 'IDENTITY_MATCH_AMBIGUOUS' as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:125:      code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:154:          manualResolution,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:156:        manualResolution,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:185:      code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:190:        manualResolution: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:191:          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:206:      code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:236:        manualResolution: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:238:          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:268:      code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:278:        manualResolution: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:279:          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:427:        createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:640:        code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/app.ts:16:  createResolverReview,
+apps/connectshyft-api/src/app.ts:140:    reassignmentSuspected: false,
+apps/connectshyft-api/src/app.ts:177:  const resolverReview = createResolverReview({
+apps/connectshyft-api/src/app.ts:202:  res.json(resolverReview);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:184:const IDENTITY_MATCH_AMBIGUOUS_CODE = 'IDENTITY_MATCH_AMBIGUOUS';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6359:            code: IDENTITY_MATCH_AMBIGUOUS_CODE,
+apps/connectshyft-api/src/modules/peoplecore/store.ts:190:  createResolverReview(input: CreateResolverReviewInput): Promise<ResolverReview>;
+apps/connectshyft-api/src/modules/peoplecore/store.ts:243:  reassignment_suspected: boolean;
+apps/connectshyft-api/src/modules/peoplecore/store.ts:374:    reassignmentSuspected: row.reassignment_suspected,
+apps/connectshyft-api/src/modules/peoplecore/store.ts:513:      'reassignment_suspected',
+apps/connectshyft-api/src/modules/peoplecore/store.ts:556:  private resolverReviewColumns(): string[] {
+apps/connectshyft-api/src/modules/peoplecore/store.ts:799:        reassignment_suspected: input.reassignmentSuspected,
+apps/connectshyft-api/src/modules/peoplecore/store.ts:949:  async createResolverReview(input: CreateResolverReviewInput): Promise<ResolverReview> {
+apps/connectshyft-api/src/modules/peoplecore/store.ts:978:      .returning<DbResolverReviewRow[]>(this.resolverReviewColumns());
+apps/connectshyft-api/src/modules/peoplecore/store.ts:991:      .first<DbResolverReviewRow>(this.resolverReviewColumns());
+apps/connectshyft-api/src/modules/peoplecore/store.ts:1013:      .select<DbResolverReviewRow[]>(this.resolverReviewColumns());
+apps/connectshyft-api/src/modules/peoplecore/service.ts:119:  createResolverReview(input: CreateResolverReviewInput) {
+apps/connectshyft-api/src/modules/peoplecore/service.ts:120:    return this.execute(() => this.store.createResolverReview(input));
+apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts:31:  reassignmentSuspected: false,
+apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts:37:  reviewType: 'identity_conflict' as const,
+apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts:124:    ['createResolverReview', (service: AsyncPeopleCoreService) => service.createResolverReview(RESOLVER_REVIEW_INPUT), 'createResolverReview'],
+apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts:249:      reassignment_suspected: false,
+apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts:311:      reassignmentSuspected: false,
+apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts:376:      review_type: 'identity_conflict',
+apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts:406:    const created = await store.createResolverReview({
+apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts:409:      reviewType: 'identity_conflict',
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:18:  | 'createResolverReview'
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:167:          reassignmentSuspected: false,
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:230:  async createResolverReviewHook(
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:274:    const review = await this.peopleCoreService.createResolverReview({
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:277:      reviewType: 'shared_contact_ambiguity',
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:289:      riskFlags: ['shared_contact_possible'],
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:331:      && result.code === 'IDENTITY_MATCH_AMBIGUOUS'
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:332:      && input.hookContext?.createResolverReviewOnAmbiguous
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:334:      await this.createResolverReviewHook({
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts:24:  | 'createResolverReview'
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborIdentityMatch.ts:27:      createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborIdentityMatch.ts:35:    : matched.code === 'IDENTITY_MATCH_AMBIGUOUS' && matched.data?.identityMatch
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:58:        createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:70:      if (result.code === 'IDENTITY_MATCH_AMBIGUOUS') {
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:75:              || result.data?.manualResolution?.candidateNeighborIds
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:215:  manualResolution?: ConnectShyftIdentityManualResolutionContext;
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:273:    | 'IDENTITY_MATCH_AMBIGUOUS'
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:38:const IDENTITY_MATCH_AMBIGUOUS_CODE = 'IDENTITY_MATCH_AMBIGUOUS';
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:102:    manualResolution?: unknown;
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:644:  manual_resolution_required: input.decision.manualResolution?.required === true,
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:645:  manual_resolution_reason_code: input.decision.manualResolution?.reasonCode || null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:15:  reassignmentSuspected: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:68:      createResolverReview: jest.fn(),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:107:      createResolverReview: jest.fn(async () => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:111:        reviewType: 'shared_contact_ambiguity',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:120:        riskFlags: ['shared_contact_possible'],
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:130:    const result = await hooks.createResolverReviewHook({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts:150:    expect(service.createResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1649:      code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1657:        manualResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1659:          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:54:          reassignmentSuspected: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:145:        createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts:95:      code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts:102:        manualResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts:104:          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:34:  reassignmentSuspected: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:87:      createResolverReview: jest.fn(),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:217:    const createResolverReview = jest.fn(async () => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:221:      reviewType: 'shared_contact_ambiguity',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:230:      riskFlags: ['shared_contact_possible'],
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:252:        createResolverReview,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:269:        createResolverReviewOnAmbiguous: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:276:      code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:282:        manualResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:284:          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:289:    expect(createResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:53:  createResolverReviewOnAmbiguous?: boolean;
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:99:  reasonCode: 'IDENTITY_MATCH_AMBIGUOUS';
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:119:  manualResolution?: ConnectShyftIdentityBoundaryManualResolutionContext;
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:140:      | 'IDENTITY_MATCH_AMBIGUOUS'
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:146:      manualResolution?: ConnectShyftIdentityBoundaryManualResolutionContext;
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:186:  reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:234:      manualResolution: buildManualResolutionContext(candidateNeighborIds),
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:385:  code: 'IDENTITY_MATCH_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:389:    manualResolution: decision.manualResolution,
+apps/connectshyft-api/src/modules/connectshyft/PEOPLECORE_IDENTITY_HOOKS_NOTES.md:7:- inbound subject resolution enables resolver-review creation on seam-level `IDENTITY_MATCH_AMBIGUOUS`
+apps/connectshyft-api/src/modules/connectshyft/PEOPLECORE_IDENTITY_HOOKS_NOTES.md:8:- the neighbor identity-match handler enables resolver-review creation on seam-level `IDENTITY_MATCH_AMBIGUOUS`
+
+=== PERFORMANCE / LATENCY ===
+apps/connectshyft-api/src/services/CategoryService.ts:306:    const allocationCount = await knex('budget_allocations')
+apps/connectshyft-api/src/services/CategoryService.ts:312:      throw new BadRequestError('Cannot delete category with existing budget allocations.');
+apps/connectshyft-api/src/services/TransactionService.ts:96:      const budgetMonth = await BudgetService.getOrCreateBudgetMonth(householdId, monthDate, trx);
+apps/connectshyft-api/src/services/TransactionService.ts:98:      const allocation = await trx('budget_allocations')
+apps/connectshyft-api/src/services/TransactionService.ts:100:          budget_month_id: budgetMonth.id,
+apps/connectshyft-api/src/services/TransactionService.ts:110:          await trx('budget_allocations')
+apps/connectshyft-api/src/services/TransactionService.ts:316:        if (!sourceAccount.is_on_budget) {
+apps/connectshyft-api/src/services/TransactionService.ts:317:          throw new BadRequestError('Goal-linked transactions must use an on-budget source account');
+apps/connectshyft-api/src/services/TransactionService.ts:531:        if (!fromAccount.is_on_budget) {
+apps/connectshyft-api/src/services/TransactionService.ts:532:          throw new BadRequestError('Goal-linked transfers must use an on-budget source account');
+docs/architecture/connectshyft-router-refactor-plan.md:250:- controlled migration of more identity authority away from ConnectShyft-local neighbor lookup
+apps/connectshyft-api/src/services/ExtraMoneyService.ts:91:  'performance bonus'
+apps/connectshyft-api/src/services/ExtraMoneyService.ts:561:      // 5. Update budget allocations for current month (category assignments only)
+apps/connectshyft-api/src/services/ExtraMoneyService.ts:563:      const budgetMonth = await BudgetService.getOrCreateBudgetMonth(householdId, month, trx);
+apps/connectshyft-api/src/services/ExtraMoneyService.ts:567:        await trx('budget_allocations')
+apps/connectshyft-api/src/services/ExtraMoneyService.ts:569:            budget_month_id: budgetMonth.id,
+specs/026-sender-number-architecture/plan.md:18:**Performance Goals**: No separate performance acceptance target is introduced in this slice.  
+apps/connectshyft-api/src/services/AssignmentService.ts:63:  // Gross budget inflows that can fund RTA:
+apps/connectshyft-api/src/services/AssignmentService.ts:64:  // - direct positive transactions in on-budget accounts
+apps/connectshyft-api/src/services/AssignmentService.ts:65:  // - transfer inflows from off-budget -> on-budget
+apps/connectshyft-api/src/services/AssignmentService.ts:83:                WHEN a.is_on_budget = false THEN 0
+apps/connectshyft-api/src/services/AssignmentService.ts:95:                WHEN a.is_on_budget = true AND COALESCE(ta.is_on_budget, false) = false
+apps/connectshyft-api/src/services/AssignmentService.ts:107:  // Outflows from on-budget -> off-budget should immediately reduce RTA.
+apps/connectshyft-api/src/services/AssignmentService.ts:122:            WHEN a.is_on_budget = true AND COALESCE(ta.is_on_budget, false) = false AND t.amount < 0
+apps/connectshyft-api/src/services/AssignmentService.ts:168:        knex.raw('a.is_on_budget as account_is_on_budget'),
+apps/connectshyft-api/src/services/AssignmentService.ts:169:        knex.raw('ta.is_on_budget as counterpart_is_on_budget'),
+apps/connectshyft-api/src/services/AssignmentService.ts:180:      Boolean(transaction.account_is_on_budget) &&
+apps/connectshyft-api/src/services/AssignmentService.ts:188:        !Boolean(transaction.counterpart_is_on_budget)
+apps/connectshyft-api/src/services/AssignmentService.ts:294:    const budgetMonth = await BudgetService.getOrCreateBudgetMonth(householdId, monthDate, trx);
+apps/connectshyft-api/src/services/AssignmentService.ts:296:    const whereClause: any = { budget_month_id: budgetMonth.id };
+apps/connectshyft-api/src/services/AssignmentService.ts:304:    let allocation = await trx('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:310:      await trx('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:312:          budget_month_id: budgetMonth.id,
+apps/connectshyft-api/src/services/AssignmentService.ts:325:    await trx('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:335:   * Prioritizes categories with budgets that have low assigned amounts
+apps/connectshyft-api/src/services/AssignmentService.ts:368:    // Get budget allocations that need funding (allocated > assigned)
+apps/connectshyft-api/src/services/AssignmentService.ts:371:    const budgetMonth = await BudgetService.getOrCreateBudgetMonth(householdId, monthDate);
+apps/connectshyft-api/src/services/AssignmentService.ts:373:    const allocations = await knex('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:374:      .where({ budget_month_id: budgetMonth.id })
+apps/connectshyft-api/src/services/AssignmentService.ts:377:        { column: 'allocated_amount', order: 'desc' }, // Prioritize larger budgets
+apps/connectshyft-api/src/services/AssignmentService.ts:509:    // Get budget month
+apps/connectshyft-api/src/services/AssignmentService.ts:512:    const budgetMonth = await BudgetService.getOrCreateBudgetMonth(householdId, monthDate);
+apps/connectshyft-api/src/services/AssignmentService.ts:515:    const sourceWhere: any = { budget_month_id: budgetMonth.id };
+apps/connectshyft-api/src/services/AssignmentService.ts:525:    const sourceAllocation = await knex('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:540:    const destWhere: any = { budget_month_id: budgetMonth.id };
+apps/connectshyft-api/src/services/AssignmentService.ts:550:    let destAllocation = await knex('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:556:      const [newAllocation] = await knex('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:558:          budget_month_id: budgetMonth.id,
+apps/connectshyft-api/src/services/AssignmentService.ts:572:      await trx('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:580:      await trx('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:616:    // - direct inflows to on-budget accounts
+apps/connectshyft-api/src/services/AssignmentService.ts:617:    // - transfer inflows from off-budget -> on-budget
+apps/connectshyft-api/src/services/AssignmentService.ts:627:        a.is_on_budget = true
+apps/connectshyft-api/src/services/AssignmentService.ts:630:          OR COALESCE(ta.is_on_budget, false) = false
+apps/connectshyft-api/src/services/AssignmentService.ts:817:   * Used by inline "Assigned" editing in the budget grid.
+apps/connectshyft-api/src/services/AssignmentService.ts:837:      const budgetMonth = await BudgetService.getOrCreateBudgetMonth(householdId, monthDate, trx);
+apps/connectshyft-api/src/services/AssignmentService.ts:839:      const whereClause: any = { budget_month_id: budgetMonth.id };
+apps/connectshyft-api/src/services/AssignmentService.ts:847:      let allocation = await trx('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:852:        [allocation] = await trx('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:854:            budget_month_id: budgetMonth.id,
+apps/connectshyft-api/src/services/AssignmentService.ts:881:      await trx('budget_allocations')
+apps/connectshyft-api/src/services/AssignmentService.ts:899:    // 1. Get budget summary
+docs/architecture/identity-resolution-model.md:78:The seam does not redesign these outputs. It routes identity consultation through PeopleCore-backed lookup and hook foundations while keeping the current ConnectShyft outward behavior stable.
+apps/connectshyft-api/src/services/__tests__/TransactionLinking.test.ts:51:    const budgetAllocation = {
+apps/connectshyft-api/src/services/__tests__/TransactionLinking.test.ts:60:      if (tableName === 'budget_allocations') {
+apps/connectshyft-api/src/services/__tests__/TransactionLinking.test.ts:68:            if (wherePayload?.budget_month_id === 'bm-1' && wherePayload?.category_id === 'cat-goal') {
+apps/connectshyft-api/src/services/__tests__/TransactionLinking.test.ts:69:              return budgetAllocation;
+apps/connectshyft-api/src/services/__tests__/TransactionLinking.test.ts:110:  it('rejects goal-linked transfer when source account is off-budget', async () => {
+apps/connectshyft-api/src/services/__tests__/TransactionLinking.test.ts:115:      .mockResolvedValueOnce({ id: 'acct-from', is_on_budget: false } as any)
+apps/connectshyft-api/src/services/__tests__/TransactionLinking.test.ts:116:      .mockResolvedValueOnce({ id: 'acct-to', is_on_budget: true } as any);
+apps/connectshyft-api/src/services/__tests__/TransactionLinking.test.ts:126:    ).rejects.toThrow('Goal-linked transfers must use an on-budget source account');
+apps/connectshyft-api/src/services/__tests__/TransactionLinking.test.ts:134:      .mockResolvedValue({ id: 'acct-1', is_on_budget: true } as any);
+apps/connectshyft-api/src/services/__tests__/BudgetFundingRules.test.ts:159:  it('rejects manual assignment from on-budget to on-budget transfer inflow', async () => {
+apps/connectshyft-api/src/services/__tests__/BudgetFundingRules.test.ts:167:      account_is_on_budget: true,
+apps/connectshyft-api/src/services/__tests__/BudgetFundingRules.test.ts:168:      counterpart_is_on_budget: true,
+apps/connectshyft-api/src/services/__tests__/BudgetFundingRules.test.ts:189:      account_is_on_budget: true,
+apps/connectshyft-api/src/services/__tests__/BudgetFundingRules.test.ts:190:      counterpart_is_on_budget: null,
+apps/connectshyft-api/src/services/__tests__/BudgetFundingRules.test.ts:212:      is_on_budget: true,
+apps/connectshyft-api/src/services/__tests__/BudgetFundingRules.test.ts:217:    expect(accountInsertPayload?.is_on_budget).toBe(true);
+docs/architecture/adr-007-provisional-identity.md:15:- slow down volunteers
+apps/connectshyft-api/src/services/__tests__/BudgetCarryover.test.ts:1:const budgetMonths = [
+apps/connectshyft-api/src/services/__tests__/BudgetCarryover.test.ts:13:    budget_month_id: 'bm-prev',
+apps/connectshyft-api/src/services/__tests__/BudgetCarryover.test.ts:26:  if (tableName === 'budget_months') {
+apps/connectshyft-api/src/services/__tests__/BudgetCarryover.test.ts:34:        return budgetMonths.find((m) =>
+apps/connectshyft-api/src/services/__tests__/BudgetCarryover.test.ts:45:        budgetMonths.push(newMonth);
+apps/connectshyft-api/src/services/__tests__/BudgetCarryover.test.ts:53:  if (tableName === 'budget_allocations') {
+apps/connectshyft-api/src/services/__tests__/BudgetCarryover.test.ts:66:        const rows = previousAllocations.filter((r) => r.budget_month_id === whereCriteria.budget_month_id);
+apps/connectshyft-api/src/services/__tests__/BudgetCarryover.test.ts:125:    const budgetMonth = await BudgetService.getOrCreateBudgetMonth('house-1', month, fakeKnex);
+apps/connectshyft-api/src/services/__tests__/BudgetCarryover.test.ts:127:    expect(budgetMonth.id).toBe('bm-new');
+docs/architecture/peoplecore-identity-seam.md:74:- controlled migration of more identity authority away from ConnectShyft neighbor lookup
+apps/connectshyft-api/src/services/__tests__/AccountService.tenancy.test.ts:23:            is_on_budget: true,
+specs/007-migration-runner/plan.md:27:**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+apps/connectshyft-api/src/services/AnalyticsService.ts:7:  | 'budget_month_created'
+apps/connectshyft-api/src/services/AccountService.ts:14:  is_on_budget: boolean;
+apps/connectshyft-api/src/services/AccountService.ts:26:  is_on_budget?: boolean;
+apps/connectshyft-api/src/services/AccountService.ts:32:  is_on_budget?: boolean;
+apps/connectshyft-api/src/services/AccountService.ts:78:    const { name, type, starting_balance = 0, is_on_budget = true, is_active = true } = data;
+apps/connectshyft-api/src/services/AccountService.ts:95:          is_on_budget,
+apps/connectshyft-api/src/services/DebtService.ts:80:  monthly_payment_budget: number;
+apps/connectshyft-api/src/services/DebtService.ts:433:        `Monthly payment budget ($${monthlyPaymentBudget}) is less than total minimum payments ($${totalMinimumPayments})`
+apps/connectshyft-api/src/services/DebtService.ts:456:      monthly_payment_budget: monthlyPaymentBudget,
+apps/connectshyft-api/src/services/DebtService.ts:588:   * This creates a payment plan and schedule that updates the budget
+apps/connectshyft-api/src/services/DebtService.ts:632:      // 4. Update budget allocation for debt section
+apps/connectshyft-api/src/services/DebtService.ts:633:      // Get or create the current month's budget
+apps/connectshyft-api/src/services/DebtService.ts:635:      const budgetMonth = await BudgetService.getOrCreateBudgetMonth(householdId, currentMonth);
+apps/connectshyft-api/src/services/DebtService.ts:646:        const existingAllocation = await trx('budget_allocations')
+apps/connectshyft-api/src/services/DebtService.ts:648:            budget_month_id: budgetMonth.id,
+apps/connectshyft-api/src/services/DebtService.ts:655:          await trx('budget_allocations')
+apps/connectshyft-api/src/services/DebtService.ts:664:          await trx('budget_allocations').insert({
+apps/connectshyft-api/src/services/DebtService.ts:665:            budget_month_id: budgetMonth.id,
+specs/022-inbound-sms-identity-resolution-and-raw-body-capture/data-model.md:64:Represents the replaceable phone-based identity lookup boundary for inbound SMS.
+apps/connectshyft-api/src/services/BudgetService.ts:21:  budget_month_id: string;
+apps/connectshyft-api/src/services/BudgetService.ts:47:  remaining: number;      // allocated - spent (budget tracking)
+apps/connectshyft-api/src/services/BudgetService.ts:61:  remaining: number;      // allocated - spent (budget tracking)
+apps/connectshyft-api/src/services/BudgetService.ts:109:                WHEN a.is_on_budget = false THEN 0
+apps/connectshyft-api/src/services/BudgetService.ts:121:                WHEN a.is_on_budget = true AND COALESCE(ta.is_on_budget, false) = false
+apps/connectshyft-api/src/services/BudgetService.ts:147:            WHEN a.is_on_budget = true AND COALESCE(ta.is_on_budget, false) = false AND t.amount < 0
+apps/connectshyft-api/src/services/BudgetService.ts:159:   * Get or create budget month
+apps/connectshyft-api/src/services/BudgetService.ts:170:    let budgetMonth = await trx('budget_months')
+apps/connectshyft-api/src/services/BudgetService.ts:177:    if (!budgetMonth) {
+apps/connectshyft-api/src/services/BudgetService.ts:182:      // Check if previous month's budget exists
+apps/connectshyft-api/src/services/BudgetService.ts:183:      const previousBudget = await trx('budget_months')
+apps/connectshyft-api/src/services/BudgetService.ts:190:      // Create new budget month
+apps/connectshyft-api/src/services/BudgetService.ts:191:      [budgetMonth] = await trx('budget_months')
+apps/connectshyft-api/src/services/BudgetService.ts:199:        'budget_month_created',
+apps/connectshyft-api/src/services/BudgetService.ts:211:        const previousAllocations = await trx('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:212:          .where({ budget_month_id: previousBudget.id });
+apps/connectshyft-api/src/services/BudgetService.ts:266:            budget_month_id: budgetMonth.id,
+apps/connectshyft-api/src/services/BudgetService.ts:276:          await trx('budget_allocations').insert(newAllocations);
+apps/connectshyft-api/src/services/BudgetService.ts:287:    return budgetMonth;
+apps/connectshyft-api/src/services/BudgetService.ts:291:   * Update budget month notes
+apps/connectshyft-api/src/services/BudgetService.ts:298:    const budgetMonth = await this.getOrCreateBudgetMonth(householdId, month);
+apps/connectshyft-api/src/services/BudgetService.ts:300:    const [updated] = await knex('budget_months')
+apps/connectshyft-api/src/services/BudgetService.ts:301:      .where({ id: budgetMonth.id })
+apps/connectshyft-api/src/services/BudgetService.ts:312:   * Set a single budget allocation (category or section level)
+apps/connectshyft-api/src/services/BudgetService.ts:319:    const budgetMonth = await this.getOrCreateBudgetMonth(householdId, month);
+apps/connectshyft-api/src/services/BudgetService.ts:372:    const existingAllocation = await knex('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:374:        budget_month_id: budgetMonth.id,
+apps/connectshyft-api/src/services/BudgetService.ts:382:      const [updated] = await knex('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:394:      const [allocation] = await knex('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:396:          budget_month_id: budgetMonth.id,
+apps/connectshyft-api/src/services/BudgetService.ts:410:   * Bulk set allocations (useful for setting entire budget at once)
+apps/connectshyft-api/src/services/BudgetService.ts:427:   * Get budget summary with spending for a month
+apps/connectshyft-api/src/services/BudgetService.ts:433:    const budgetMonth = await this.getOrCreateBudgetMonth(householdId, month);
+apps/connectshyft-api/src/services/BudgetService.ts:436:    const allocations = await knex('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:437:      .where({ budget_month_id: budgetMonth.id });
+apps/connectshyft-api/src/services/BudgetService.ts:496:    // Build section summaries (exclude Income section from budget)
+apps/connectshyft-api/src/services/BudgetService.ts:611:    // Gross inflow into the on-budget world.
+apps/connectshyft-api/src/services/BudgetService.ts:712:      month: budgetMonth.month,
+apps/connectshyft-api/src/services/BudgetService.ts:713:      month_notes: budgetMonth.notes,
+apps/connectshyft-api/src/services/BudgetService.ts:750:    const allocation = await knex('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:759:    const budgetMonth = await knex('budget_months')
+apps/connectshyft-api/src/services/BudgetService.ts:760:      .where({ id: allocation.budget_month_id })
+apps/connectshyft-api/src/services/BudgetService.ts:763:    if (!budgetMonth || budgetMonth.household_id !== householdId) {
+apps/connectshyft-api/src/services/BudgetService.ts:767:    await knex('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:779:    const budgetMonth = await this.getOrCreateBudgetMonth(householdId, month);
+apps/connectshyft-api/src/services/BudgetService.ts:781:    const allocations = await knex('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:782:      .where({ budget_month_id: budgetMonth.id });
+apps/connectshyft-api/src/services/BudgetService.ts:804:    const budgetMonth = await this.getOrCreateBudgetMonth(householdId, monthDate);
+apps/connectshyft-api/src/services/BudgetService.ts:805:    const monthString = data.month || new Date(budgetMonth.month).toISOString().slice(0, 7);
+apps/connectshyft-api/src/services/BudgetService.ts:833:    // 2. Find or create budget allocation for this category
+apps/connectshyft-api/src/services/BudgetService.ts:834:    const whereClause: any = { budget_month_id: budgetMonth.id };
+apps/connectshyft-api/src/services/BudgetService.ts:842:    let allocation = await knex('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:848:      [allocation] = await knex('budget_allocations')
+apps/connectshyft-api/src/services/BudgetService.ts:850:          budget_month_id: budgetMonth.id,
+apps/connectshyft-api/src/services/BudgetService.ts:863:      [allocation] = await knex('budget_allocations')
+apps/connectshyft-api/src/services/CreditCardService.ts:13:  new_charges_covered_by_budget: number;
+apps/connectshyft-api/src/services/CreditCardService.ts:59:    // New charges are "covered" by the budget because spending on credit
+apps/connectshyft-api/src/services/CreditCardService.ts:60:    // reduces category budgets immediately
+apps/connectshyft-api/src/services/CreditCardService.ts:82:      new_charges_covered_by_budget: newChargesCoveredByBudget,
+apps/connectshyft-api/src/services/CreditCardService.ts:141:      successMessage = `✅ You're current on this card! You have $${newChargesThisMonth.toFixed(2)} in new charges from this month's budget.`;
+apps/connectshyft-api/src/services/CreditCardService.ts:170:          warningMessage = `Your payment of $${paymentsThisMonth.toFixed(2)} was applied to your previous balance. You still have $${newChargesThisMonth.toFixed(2)} in new charges from this month's budget.`;
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:349:      latencyBudgetsMs: {
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:350:        p95: CONNECTSHYFT_INBOX_P95_BUDGET_MS,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:351:        p99: CONNECTSHYFT_INBOX_P99_BUDGET_MS,
+apps/connectshyft-api/src/services/ScenarioService.ts:161:     * Applies scenario items to the current month's budget to create a 'Shadow Budget'
+apps/connectshyft-api/src/services/ScenarioService.ts:171:        // We get the full budget summary which includes income, allocations, spending, etc.
+apps/connectshyft-api/src/migrations/20260209090000_add_account_budget_scope_and_initial_funding.ts:4:  const hasIsOnBudget = await knex.schema.hasColumn('accounts', 'is_on_budget');
+apps/connectshyft-api/src/migrations/20260209090000_add_account_budget_scope_and_initial_funding.ts:8:      table.boolean('is_on_budget').notNullable().defaultTo(true);
+apps/connectshyft-api/src/migrations/20260209090000_add_account_budget_scope_and_initial_funding.ts:9:      table.index(['household_id', 'is_on_budget']);
+apps/connectshyft-api/src/migrations/20260209090000_add_account_budget_scope_and_initial_funding.ts:85:  const hasIsOnBudget = await knex.schema.hasColumn('accounts', 'is_on_budget');
+apps/connectshyft-api/src/migrations/20260209090000_add_account_budget_scope_and_initial_funding.ts:88:      table.dropIndex(['household_id', 'is_on_budget']);
+apps/connectshyft-api/src/migrations/20260209090000_add_account_budget_scope_and_initial_funding.ts:89:      table.dropColumn('is_on_budget');
+apps/connectshyft-api/src/migrations/20260131170000_add_month_to_account_balance_assignments.ts:28:  // Recalculate assigned_amount for all budget allocations based on month-specific assignments
+apps/connectshyft-api/src/migrations/20260131170000_add_month_to_account_balance_assignments.ts:30:    UPDATE budget_allocations AS ba
+apps/connectshyft-api/src/migrations/20260131170000_add_month_to_account_balance_assignments.ts:35:        JOIN budget_months bm ON bm.id = ba.budget_month_id
+apps/connectshyft-api/src/migrations/20260131170000_add_month_to_account_balance_assignments.ts:43:        JOIN budget_months bm ON bm.id = ba.budget_month_id
+apps/connectshyft-api/src/migrations/20260131170000_add_month_to_account_balance_assignments.ts:53:    UPDATE budget_allocations AS ba
+apps/connectshyft-api/src/migrations/20260131170000_add_month_to_account_balance_assignments.ts:58:        JOIN budget_months bm ON bm.id = ba.budget_month_id
+apps/connectshyft-api/src/migrations/20260131170000_add_month_to_account_balance_assignments.ts:66:        JOIN budget_months bm ON bm.id = ba.budget_month_id
+apps/connectshyft-api/src/validators/budget.validators.ts:4: * Validator for creating a budget month
+apps/connectshyft-api/src/validators/budget.validators.ts:19: * Validator for updating a budget month
+apps/connectshyft-api/src/validators/budget.validators.ts:29: * Validator for creating/updating budget allocations
+apps/connectshyft-api/src/migrations/001_initial_schema.ts:135:  await knex.schema.createTable('budget_months', (table) => {
+apps/connectshyft-api/src/migrations/001_initial_schema.ts:146:  await knex.schema.createTable('budget_allocations', (table) => {
+apps/connectshyft-api/src/migrations/001_initial_schema.ts:148:    table.uuid('budget_month_id').notNullable().references('id').inTable('budget_months').onDelete('CASCADE');
+apps/connectshyft-api/src/migrations/001_initial_schema.ts:157:    table.index('budget_month_id');
+apps/connectshyft-api/src/migrations/001_initial_schema.ts:202:  await knex.schema.dropTableIfExists('budget_allocations');
+apps/connectshyft-api/src/migrations/001_initial_schema.ts:203:  await knex.schema.dropTableIfExists('budget_months');
+apps/connectshyft-api/src/validators/account.validators.ts:24:  is_on_budget: Joi.boolean().default(true),
+apps/connectshyft-api/src/validators/account.validators.ts:36:  is_on_budget: Joi.boolean(),
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:98:      latencyBudgetsMs: {
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:99:        p95: CONNECTSHYFT_INBOX_P95_BUDGET_MS,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:100:        p99: CONNECTSHYFT_INBOX_P99_BUDGET_MS,
+apps/connectshyft-api/src/validators/debt.validators.ts:122:  monthly_payment_budget: Joi.number().positive().required()
+apps/connectshyft-api/src/validators/debt.validators.ts:124:      'number.base': 'Monthly payment budget must be a number',
+apps/connectshyft-api/src/validators/debt.validators.ts:125:      'number.positive': 'Monthly payment budget must be positive',
+apps/connectshyft-api/src/validators/debt.validators.ts:126:      'any.required': 'Monthly payment budget is required',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:285:        latencyBudgetsMs: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:286:          p95: 750,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:287:          p99: 1500,
+apps/connectshyft-api/src/migrations/20260210120000_repair_assigned_with_carryover_plus_month_activity.ts:11:  budget_month_id: string;
+apps/connectshyft-api/src/migrations/20260210120000_repair_assigned_with_carryover_plus_month_activity.ts:40:    const months = await trx('budget_months')
+apps/connectshyft-api/src/migrations/20260210120000_repair_assigned_with_carryover_plus_month_activity.ts:67:        const prevAllocations = await trx('budget_allocations')
+apps/connectshyft-api/src/migrations/20260210120000_repair_assigned_with_carryover_plus_month_activity.ts:68:          .where({ budget_month_id: prevMonth.id }) as AllocationRow[];
+apps/connectshyft-api/src/migrations/20260210120000_repair_assigned_with_carryover_plus_month_activity.ts:71:        const currentAllocations = await trx('budget_allocations')
+apps/connectshyft-api/src/migrations/20260210120000_repair_assigned_with_carryover_plus_month_activity.ts:72:          .where({ budget_month_id: currentMonth.id }) as AllocationRow[];
+apps/connectshyft-api/src/migrations/20260210120000_repair_assigned_with_carryover_plus_month_activity.ts:182:          await trx('budget_allocations')
+apps/connectshyft-api/src/migrations/004_add_debt_tracking.ts:21:    table.uuid('category_id').references('id').inTable('categories').onDelete('SET NULL'); // Link to budget category
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:143:        latencyBudgetsMs: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:144:          p95: expect.any(Number),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:145:          p99: expect.any(Number),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:185:      'latencyBudgetsMs',
+specs/002-phone-identity/plan.md:18:**Performance Goals**: Synchronous parse/normalize/format operations with no network calls, negligible request-path overhead for neighbor create/update/identity-match flows, and indexed lookup on canonical E.164 values  
+specs/013-admin-leftovers-cleanup/research.md:14:- **Rationale**: The current admin-web layout still contains MoneyShyft navigation items such as `/accounts`, `/budget`, and `/transactions`, even though the admin router no longer mounts those routes. Removing stale views without cleaning those references would preserve a broken navigation experience and undermine the slice’s safety goal.
+specs/013-admin-leftovers-cleanup/research.md:64:- No router mounts exist for `/accounts`, `/transactions`, `/budget`, `/extra-money`, `/debts`, `/goals`, or the named stale view groups.
+specs/013-admin-leftovers-cleanup/research.md:72:  - `/budget`
+specs/013-admin-leftovers-cleanup/research.md:79:  - `/budget`
+specs/002-phone-identity/tasks.md:59:**Goal**: Identity-boundary matching resolves by canonical phone identity instead of ConnectShyft-local regex normalization, using the same shared-domain contract and canonical lookup path introduced in US1.
+specs/002-phone-identity/tasks.md:61:**Independent Test**: Evaluate identity matching with differently formatted equivalents of the same number and confirm exact-match, no-match, ambiguous, and shared-phone decisions are computed from canonical identity data and canonical lookup columns.
+specs/002-phone-identity/tasks.md:173:3. After US1 passes, identity-boundary logic and lookup-index work for US2 can be split across engineers.
+specs/003-telnyx-outbound-adapter/plan.md:18:**Performance Goals**: Constant-time provider resolution, no additional route/deployment hops, truthful outbound dispatch within existing ConnectShyft request latency envelopes, and no duplicate provider side effects for idempotent retries  
+specs/023-duplicate-handling-and-phone-uniqueness-enforcement/spec.md:67:3. **Given** an upstream workflow depends on phone-based identity resolution and the lookup is ambiguous, **When** the workflow completes, **Then** it returns the ambiguity refusal without creating a new identity, merging records, or attaching the action to any neighbor.
+specs/023-duplicate-handling-and-phone-uniqueness-enforcement/spec.md:141:- **SC-003**: In regression validation, 100% of formatting variants for the same phone value are treated as the same canonical identity for both duplicate enforcement and lookup behavior.
+specs/023-duplicate-handling-and-phone-uniqueness-enforcement/spec.md:142:- **SC-004**: In regression validation, 100% of phone-based identity lookups with exactly one current eligible match return that match, and 100% of lookups with multiple current eligible matches return ambiguity refusal with zero arbitrary selections.
+specs/slice-12-codex-ready-implementation-brief.md:607:The seam-first approach is slower by one slice and safer by an order of magnitude.
+specs/023-duplicate-handling-and-phone-uniqueness-enforcement/plan.md:18:**Performance Goals**: Keep duplicate refusal within the same request that performs the write, preserve indexed canonical phone lookups, add no network calls, and keep identity resolution deterministic in one lookup pass  
+specs/008-connectshyft-texting-preference/plan.md:20:**Performance Goals**: Preserve existing neighbor CRUD latency and query shape; no additional cross-service hops  
+specs/023-duplicate-handling-and-phone-uniqueness-enforcement/data-model.md:40:Represents one persisted canonical phone value attached to a neighbor and evaluated for current ownership, duplicate prevention, and identity lookup.
+specs/023-duplicate-handling-and-phone-uniqueness-enforcement/data-model.md:58:- `normalizedE164` is the only value allowed for duplicate comparison and identity lookup.
+specs/006-migration-authority-convergence/plan.md:28:**Performance Goals**: Deterministic inventory and classification across the current 60 unique migrations with negligible added deploy latency outside a single manifest comparison pass  
+specs/006-migration-authority-convergence/research.md:29:- Decision: Keep `20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity` as the only verified manual-hotfix override initially, and treat `20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index` as a required inspection target that is not auto-verified.
+apps/connectshyft-api/src/migrations/013_add_account_balance_assignments.ts:7: * assigned to budget categories. This is separate from regular income-based assignments
+apps/connectshyft-api/src/migrations/013_add_account_balance_assignments.ts:8: * and represents "initial capital" or "found money" being allocated to the budget.
+apps/connectshyft-api/src/migrations/013_add_account_balance_assignments.ts:12: * - Adding new account later: User assigns spouse's account balance to budget
+specs/006-migration-authority-convergence/tasks.md:36:**Independent Test**: Run `node scripts/reconcile-shared-migrations.js --format table` and `node scripts/reconcile-shared-migrations.js --format json` from the repo root and verify that the full 60-migration shared authority is inventoried, `.ts` and `.js` names resolve to the same logical IDs, `20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity` is surfaced as a verified manual-hotfix candidate when unrecorded, and `20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index` remains `blocked` as inspection-required until operator review resolves it.
+specs/006-migration-authority-convergence/tasks.md:44:- [X] T009 [P] [US1] Update `/Users/jeremiahotis/projects/connectshyft/shared/database/reconciliation/migration-manifest-overrides.json` so `20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.js` remains verified and `20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.js` is represented as inspection-required under canonical production naming
+specs/006-migration-authority-convergence/tasks.md:147:Task: "T009 Update /Users/jeremiahotis/projects/connectshyft/shared/database/reconciliation/migration-manifest-overrides.json so 20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.js remains verified and 20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.js is inspection-required under canonical production naming"
+specs/024-neighbor-soft-delete-admin-controls/tasks.md:99:- [X] T023 [US3] Ensure deleted-neighbor and inactive-phone exclusion remains enforced in active identity lookups and inbound helper paths in `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/neighbors.ts` and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+specs/006-migration-authority-convergence/quickstart.md:187:    - `004_add_envelope_budgeting.js`
+specs/012-platform-lane-separation/spec.md:77:- budgeting
+specs/012-platform-lane-separation/spec.md:119:- budgeting/finance logic
+specs/025-message-timeline-persistence-and-projection/02-plan.md:64:- performance on large threads
+apps/connectshyft-api/src/migrations/009_add_envelope_budgeting.ts:4:  // 1. Add assigned_amount to budget_allocations
+apps/connectshyft-api/src/migrations/009_add_envelope_budgeting.ts:6:  const hasAssignedAmount = await knex.schema.hasColumn('budget_allocations', 'assigned_amount');
+apps/connectshyft-api/src/migrations/009_add_envelope_budgeting.ts:8:    await knex.schema.table('budget_allocations', (table) => {
+apps/connectshyft-api/src/migrations/009_add_envelope_budgeting.ts:25:      // Either category OR section (same pattern as budget_allocations)
+apps/connectshyft-api/src/migrations/009_add_envelope_budgeting.ts:96:  const hasAssignedAmount = await knex.schema.hasColumn('budget_allocations', 'assigned_amount');
+apps/connectshyft-api/src/migrations/009_add_envelope_budgeting.ts:98:    await knex.schema.table('budget_allocations', (table) => {
+apps/connectshyft-api/src/migrations/20260131121500_move_variable_expenses.ts:75:        await trx('budget_allocations')
+specs/012-platform-lane-separation/remediation-map.md:68:| `apps/admin-api/src/routes/api/v1/accounts.ts`, `budgets.ts`, `transactions.ts`, and the rest of the money route tree | unmounted stale mirror | `admin-api` only mounts platform/admin/auth. These finance routes are wrong-lane baggage, not admin ownership. |
+apps/connectshyft-api/src/migrations/20260210113000_backfill_overwritten_assigned_amounts.ts:11:  budget_month_id: string;
+apps/connectshyft-api/src/migrations/20260210113000_backfill_overwritten_assigned_amounts.ts:40:    const months = await trx('budget_months')
+apps/connectshyft-api/src/migrations/20260210113000_backfill_overwritten_assigned_amounts.ts:69:        const prevAllocations = await trx('budget_allocations')
+apps/connectshyft-api/src/migrations/20260210113000_backfill_overwritten_assigned_amounts.ts:70:          .where({ budget_month_id: prevMonth.id }) as AllocationRow[];
+apps/connectshyft-api/src/migrations/20260210113000_backfill_overwritten_assigned_amounts.ts:74:        const currentAllocations = await trx('budget_allocations')
+apps/connectshyft-api/src/migrations/20260210113000_backfill_overwritten_assigned_amounts.ts:75:          .where({ budget_month_id: currentMonth.id }) as AllocationRow[];
+apps/connectshyft-api/src/migrations/20260210113000_backfill_overwritten_assigned_amounts.ts:171:          await trx('budget_allocations')
+specs/025-message-timeline-persistence-and-projection/research.md:68:  - Remove any read cap and load unbounded event history: rejected because large threads would raise unnecessary performance risk.
+specs/012-platform-lane-separation/research.md:74:- Build every app after every patch in arbitrary order: rejected because it slows convergence and hides causal dependency failures.
+specs/012-platform-lane-separation/implementation-plan.md:316:| Admin money route mirrors | `apps/admin-api/src/routes/api/v1/accounts.ts`, `transactions.ts`, `budgets.ts`, `categories.ts`, `goals.ts`, `debts.ts`, `income.ts`, `scenarios.ts`, `tags.ts`, `extra-money.ts`, `recurring-transactions.ts`, `splits.ts`, `settings.ts`, `households.ts`, `assignments.ts` | Delete after MoneyShyft remains the sole money runtime owner. |
+apps/connectshyft-api/src/migrations/20260210100000_backfill_missing_assigned_carryover.ts:11:  budget_month_id: string;
+apps/connectshyft-api/src/migrations/20260210100000_backfill_missing_assigned_carryover.ts:40:    const months = await trx('budget_months')
+apps/connectshyft-api/src/migrations/20260210100000_backfill_missing_assigned_carryover.ts:84:        const prevAllocations = await trx('budget_allocations')
+apps/connectshyft-api/src/migrations/20260210100000_backfill_missing_assigned_carryover.ts:85:          .where({ budget_month_id: prev.id }) as AllocationRow[];
+apps/connectshyft-api/src/migrations/20260210100000_backfill_missing_assigned_carryover.ts:89:        const currentAllocations = await trx('budget_allocations')
+apps/connectshyft-api/src/migrations/20260210100000_backfill_missing_assigned_carryover.ts:90:          .where({ budget_month_id: current.id }) as AllocationRow[];
+apps/connectshyft-api/src/migrations/20260210100000_backfill_missing_assigned_carryover.ts:141:          await trx('budget_allocations')
+apps/connectshyft-api/src/migrations/004_add_envelope_budgeting.ts:4:// The actual schema changes now live in 009_add_envelope_budgeting.ts.
+specs/012-platform-lane-separation/tasks.md:160:- [X] T061 [P] [US8] Delete only inventory-approved `dead_stale` backend non-canonical mirrors listed in `/Users/jeremiahotis/projects/connectshyft/architecture/LANE_INVENTORY.md` from `/Users/jeremiahotis/projects/connectshyft/apps/admin-api/src/routes/api/v1/accounts.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/admin-api/src/routes/api/v1/budgets.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/admin-api/src/routes/api/v1/transactions.ts`, `/Users/jeremiahotis/projects/connectshyft/apps/admin-api/src/modules/route/**`, and `/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/services/**`
+specs/011-platform-lane-authority-convergence-audit/plan.md:27:**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+specs/011-platform-lane-authority-convergence-audit/duplication-divergence-map.md:21:- `budget.validators.ts`
+specs/011-platform-lane-authority-convergence-audit/file-surface-inventory.md:10:| Money-domain routes | `apps/moneyshyft-api/src/routes/api/v1/accounts.ts`, `transactions.ts`, `splits.ts`, `categories.ts`, `goals.ts`, `budgets.ts`, `income.ts`, `debts.ts`, `assignments.ts`, `households.ts`, `recurring-transactions.ts`, `extra-money.ts`, `settings.ts`, `scenarios.ts`, `tags.ts` |
+specs/011-platform-lane-authority-convergence-audit/file-surface-inventory.md:20:| Money views | `apps/moneyshyft-web/src/views/DashboardView.vue` and lane-specific feature views mounted under `/`, `/accounts`, `/transactions`, `/budget`, `/goals`, `/debts`, `/extra-money`, `/settings`, `/scenarios` |
+specs/011-platform-lane-authority-convergence-audit/file-surface-inventory.md:56:- `budget.validators.ts`
+specs/spec-input/01-moneyshyft-pwa/07-specify-context.md:35:Individuals managing personal budgets.
+specs/spec-input/01-moneyshyft-pwa/01-feature-summary.md:25:- individuals managing their personal budget
+specs/spec-input/01-moneyshyft-pwa/01-feature-summary.md:28:- household partners sharing budgeting visibility
+specs/spec-input/01-moneyshyft-pwa/01-feature-summary.md:38:5. use the budgeting interface without broken refresh or login issues
+specs/spec-input/RUN_ORDER.md:14:| 01 | MoneyShyft PWA | Installable budgeting app and PWA foundation | planned | | | PWA/mobile helpers, smoke path, state persistence tests | affected-quality, frontend-smoke, release-validation | Live-user retention priority |
+specs/spec-input/00-testing-ci-architecture/01-feature-summary.md:29:- CI will become noisy, slow, and uneven
+specs/spec-input/_shared/shyftunity_speckit_packaging_guide_v1.md:63:- performance/security constraints
+specs/001-tighten-deployment-contracts/ADR-00X_Communication_Infrastructure_Contract.md:302:- too slow for the current remediation need
+specs/spec-input/00-testing-ci-architecture/07-specify-context.md:108:- performance budgets
+specs/spec-input/_shared/deferred-quality-roadmap.md:61:Prevents gradual performance degradation in user-critical flows.
+specs/spec-input/_shared/deferred-quality-roadmap.md:64:Yes. Define metrics early, but do not enforce hard repo-wide budgets immediately.
+specs/spec-input/_shared/deferred-quality-roadmap.md:95:- release validation is slowed by repeated reruns
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:35:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/components/budget/AddCategoryModal.vue
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:36:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/components/budget/AddSectionModal.vue
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:37:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/components/budget/AssignmentModal.vue
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:38:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/components/budget/BudgetMonthSelector.vue
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:39:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/components/budget/BudgetSection.vue
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:40:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/components/budget/EditCategoryModal.vue
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:41:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/components/budget/EditSectionModal.vue
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:42:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/components/budget/ManageIncomeModal.vue
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:43:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/components/budget/TransferModal.vue
+specs/001-tighten-deployment-contracts/issues/cs-001-lane-convergence/artifacts/pre-migration-inventory.txt:107:/Users/jeremiahotis/projects/connectshyft/apps/moneyshyft-web/src/stores/budgets.ts
+
+=== peoplecoreIdentityAdapter.ts ===
+import { normalizePhone } from '../../../../../domains/communication';
+import {
+  AsyncPeopleCoreService,
+  peopleCoreServiceAsync,
+} from '../peoplecore/service';
+import {
+  AsyncInProcessConnectShyftIdentityBoundaryAdapter,
+  type ConnectShyftIdentityBoundaryAdapter,
+  type ConnectShyftIdentityBoundaryNeighbor,
+  type ConnectShyftIdentityBoundaryRequest,
+  type ConnectShyftIdentityBoundaryResult,
+} from './identityBoundary';
+import {
+  ConnectShyftPeopleCoreIdentityHooks,
+  type ConnectShyftPeopleCoreIdentityLookupSnapshot,
+} from './peoplecoreIdentityHooks';
+import { resolveConnectShyftPhoneNormalizationContext } from './phoneIdentityContext';
+
+type PeopleCoreIdentityLookupService = Pick<
+  AsyncPeopleCoreService,
+  | 'createContactPoint'
+  | 'createContactPointLink'
+  | 'createPerson'
+  | 'createResolverReview'
+  | 'listContactPointsByNormalizedValue'
+  | 'listCurrentContactPointLinks'
+  | 'listResolverReviews'
+>;
+
+export type ConnectShyftPeopleCoreIdentityCandidateLookup =
+  ConnectShyftPeopleCoreIdentityLookupSnapshot;
+
+const normalizeContactPointValue = (contactPointValue: string): string | null => {
+  const resolved = normalizePhone(
+    contactPointValue.trim(),
+    resolveConnectShyftPhoneNormalizationContext('user_entered'),
+  );
+
+  return resolved.ok ? resolved.phone.normalizedE164 : null;
+};
+
+const emptyPeopleCoreLookup = () => ({
+  peopleCoreAvailable: false,
+  peopleCoreContactPoints: [] as ConnectShyftPeopleCoreIdentityCandidateLookup['peopleCoreContactPoints'],
+  peopleCoreCurrentLinks: [] as ConnectShyftPeopleCoreIdentityCandidateLookup['peopleCoreCurrentLinks'],
+});
+
+export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
+  implements ConnectShyftIdentityBoundaryAdapter {
+  private readonly boundaryAdapter: ConnectShyftIdentityBoundaryAdapter;
+  private readonly hooks: ConnectShyftPeopleCoreIdentityHooks;
+
+  constructor(
+    private readonly loadNeighborsByTenant: (
+      tenantId: string,
+    ) => Promise<ConnectShyftIdentityBoundaryNeighbor[]>,
+    private readonly loadNeighborsByNormalizedContactPoint?: (
+      tenantId: string,
+      normalizedContactPointValue: string,
+    ) => Promise<ConnectShyftIdentityBoundaryNeighbor[]>,
+    private readonly peopleCoreService: PeopleCoreIdentityLookupService = peopleCoreServiceAsync,
+  ) {
+    this.hooks = new ConnectShyftPeopleCoreIdentityHooks(this.peopleCoreService);
+    this.boundaryAdapter = new AsyncInProcessConnectShyftIdentityBoundaryAdapter(
+      async (tenantId) => this.loadNeighborsByTenant(tenantId),
+      async (tenantId, normalizedContactPointValue) =>
+        (
+          await this.evaluateIdentityCandidatesByNormalizedContactPoint({
+            tenantId,
+            normalizedContactPointValue,
+          })
+        ).candidateNeighbors,
+    );
+  }
+
+  private async loadFallbackCandidates(
+    tenantId: string,
+    normalizedContactPointValue: string,
+  ): Promise<ConnectShyftIdentityBoundaryNeighbor[]> {
+    if (this.loadNeighborsByNormalizedContactPoint) {
+      return this.loadNeighborsByNormalizedContactPoint(tenantId, normalizedContactPointValue);
+    }
+
+    return this.loadNeighborsByTenant(tenantId);
+  }
+
+  private async loadPeopleCoreLookup(input: {
+    tenantId: string;
+    normalizedContactPointValue: string;
+  }): Promise<Omit<ConnectShyftPeopleCoreIdentityCandidateLookup, 'normalizedContactPointValue' | 'candidateNeighbors'>> {
+    try {
+      const peopleCoreContactPoints = await this.peopleCoreService.listContactPointsByNormalizedValue({
+        tenantId: input.tenantId,
+        type: 'phone',
+        normalizedValue: input.normalizedContactPointValue,
+      });
+
+      const peopleCoreCurrentLinks = (
+        await Promise.all(
+          peopleCoreContactPoints.map((contactPoint) =>
+            this.peopleCoreService.listCurrentContactPointLinks({
+              tenantId: input.tenantId,
+              contactPointId: contactPoint.id,
+            })),
+        )
+      ).flat();
+
+      return {
+        peopleCoreAvailable: true,
+        peopleCoreContactPoints,
+        peopleCoreCurrentLinks,
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        return emptyPeopleCoreLookup();
+      }
+
+      throw error;
+    }
+  }
+
+  async evaluateIdentityCandidatesForContactPoint(input: {
+    tenantId: string;
+    contactPointValue: string;
+  }): Promise<ConnectShyftPeopleCoreIdentityCandidateLookup> {
+    const normalizedContactPointValue = normalizeContactPointValue(input.contactPointValue);
+
+    if (!normalizedContactPointValue) {
+      return {
+        normalizedContactPointValue: null,
+        ...emptyPeopleCoreLookup(),
+        candidateNeighbors: [],
+      };
+    }
+
+    return this.evaluateIdentityCandidatesByNormalizedContactPoint({
+      tenantId: input.tenantId,
+      normalizedContactPointValue,
+    });
+  }
+
+  async evaluateIdentityCandidatesByNormalizedContactPoint(input: {
+    tenantId: string;
+    normalizedContactPointValue: string;
+  }): Promise<ConnectShyftPeopleCoreIdentityCandidateLookup> {
+    const peopleCoreLookup = await this.loadPeopleCoreLookup(input);
+    const candidateNeighbors = await this.loadFallbackCandidates(
+      input.tenantId,
+      input.normalizedContactPointValue,
+    );
+
+    return {
+      normalizedContactPointValue: input.normalizedContactPointValue,
+      ...peopleCoreLookup,
+      candidateNeighbors,
+    };
+  }
+
+  async evaluateMatch(
+    input: ConnectShyftIdentityBoundaryRequest,
+  ): Promise<ConnectShyftIdentityBoundaryResult> {
+    const normalizedContactPointValue = normalizeContactPointValue(input.contactPoint.value);
+    const lookup = normalizedContactPointValue
+      ? await this.evaluateIdentityCandidatesByNormalizedContactPoint({
+        tenantId: input.tenantId,
+        normalizedContactPointValue,
+      })
+      : null;
+    const result = await Promise.resolve(this.boundaryAdapter.evaluateMatch(input));
+
+    if (lookup) {
+      try {
+        await this.hooks.applyIdentityHooks(input, result, lookup);
+      } catch (_error) {
+        // Hook writes are intentionally best-effort so current ConnectShyft behavior remains stable.
+      }
+    }
+
+    return result;
+  }
+}
+
+=== peoplecoreIdentityHooks.ts ===
+import type { ContactPoint, ContactPointLink } from '@shyft/contracts';
+import {
+  AsyncPeopleCoreService,
+  peopleCoreServiceAsync,
+} from '../peoplecore/service';
+import type {
+  ConnectShyftIdentityBoundaryNeighbor,
+  ConnectShyftIdentityBoundaryRequest,
+  ConnectShyftIdentityBoundaryResult,
+  ConnectShyftPeopleCoreIdentityHookContext,
+} from './identityBoundary';
+
+type PeopleCoreIdentityHookService = Pick<
+  AsyncPeopleCoreService,
+  | 'createContactPoint'
+  | 'createContactPointLink'
+  | 'createPerson'
+  | 'createResolverReview'
+  | 'listContactPointsByNormalizedValue'
+  | 'listCurrentContactPointLinks'
+  | 'listResolverReviews'
+>;
+
+export type ConnectShyftPeopleCoreIdentityLookupSnapshot = {
+  normalizedContactPointValue: string | null;
+  peopleCoreAvailable: boolean;
+  peopleCoreContactPoints: ContactPoint[];
+  peopleCoreCurrentLinks: ContactPointLink[];
+  candidateNeighbors: ConnectShyftIdentityBoundaryNeighbor[];
+};
+
+export type ConnectShyftProvisionalIdentityHookInput = {
+  tenantId: string;
+  orgUnitId: string;
+  normalizedContactPointValue: string;
+  rawContactPointValue?: string;
+  hookContext?: ConnectShyftPeopleCoreIdentityHookContext;
+  lookup?: ConnectShyftPeopleCoreIdentityLookupSnapshot;
+};
+
+export type ConnectShyftResolverReviewHookInput = {
+  tenantId: string;
+  orgUnitId: string;
+  normalizedContactPointValue: string;
+  hookContext?: ConnectShyftPeopleCoreIdentityHookContext;
+  lookup?: ConnectShyftPeopleCoreIdentityLookupSnapshot;
+};
+
+export type ConnectShyftProvisionalIdentityHookResult =
+  | {
+    created: true;
+    personId: string;
+    contactPointId: string;
+    linkId: string;
+  }
+  | {
+    created: false;
+    reason:
+      | 'peoplecore_unavailable'
+      | 'contact_point_already_linked'
+      | 'missing_org_unit';
+    contactPointId?: string;
+  };
+
+export type ConnectShyftResolverReviewHookResult =
+  | {
+    created: true;
+    reviewId: string;
+    contactPointId?: string;
+  }
+  | {
+    created: false;
+    reason:
+      | 'peoplecore_unavailable'
+      | 'duplicate_trigger'
+      | 'missing_org_unit';
+    contactPointId?: string;
+  };
+
+const DEFAULT_HOOK_REQUESTED_BY = 'system-connectshyft-identity-seam';
+const DEFAULT_PROVISIONAL_FIRST_NAME = 'Unknown';
+const DEFAULT_PROVISIONAL_LAST_NAME = 'Contact';
+const UNIQUE_VIOLATION_CODE = '23505';
+
+const buildHookTimestamp = (): string => new Date().toISOString();
+
+const uniqueSortedStrings = (values: string[]): string[] =>
+  Array.from(new Set(values.filter((value) => value.trim().length > 0))).sort((left, right) =>
+    left.localeCompare(right));
+
+const isUniqueViolation = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  return (error as { code?: string }).code === UNIQUE_VIOLATION_CODE;
+};
+
+export class ConnectShyftPeopleCoreIdentityHooks {
+  constructor(
+    private readonly peopleCoreService: PeopleCoreIdentityHookService = peopleCoreServiceAsync,
+  ) {}
+
+  private async loadLookup(
+    tenantId: string,
+    normalizedContactPointValue: string,
+  ): Promise<ConnectShyftPeopleCoreIdentityLookupSnapshot> {
+    const peopleCoreContactPoints = await this.peopleCoreService.listContactPointsByNormalizedValue({
+      tenantId,
+      type: 'phone',
+      normalizedValue: normalizedContactPointValue,
+    });
+
+    const peopleCoreCurrentLinks = (
+      await Promise.all(
+        peopleCoreContactPoints.map((contactPoint) =>
+          this.peopleCoreService.listCurrentContactPointLinks({
+            tenantId,
+            contactPointId: contactPoint.id,
+          })),
+      )
+    ).flat();
+
+    return {
+      normalizedContactPointValue,
+      peopleCoreAvailable: true,
+      peopleCoreContactPoints,
+      peopleCoreCurrentLinks,
+      candidateNeighbors: [],
+    };
+  }
+
+  async createProvisionalPersonHook(
+    input: ConnectShyftProvisionalIdentityHookInput,
+  ): Promise<ConnectShyftProvisionalIdentityHookResult> {
+    if (!input.orgUnitId.trim()) {
+      return {
+        created: false,
+        reason: 'missing_org_unit',
+      };
+    }
+
+    const lookup = input.lookup
+      || await this.loadLookup(input.tenantId, input.normalizedContactPointValue);
+
+    if (!lookup.peopleCoreAvailable) {
+      return {
+        created: false,
+        reason: 'peoplecore_unavailable',
+      };
+    }
+
+    let contactPoint = lookup.peopleCoreContactPoints[0];
+    if (!contactPoint) {
+      try {
+        const now = buildHookTimestamp();
+        contactPoint = await this.peopleCoreService.createContactPoint({
+          tenantId: input.tenantId,
+          type: 'phone',
+          normalizedValue: input.normalizedContactPointValue,
+          rawValue: input.rawContactPointValue,
+          status: 'active_personal',
+          firstSeenAt: now,
+          lastSeenAt: now,
+          suspectedShared: false,
+          confirmedShared: false,
+          reassignmentSuspected: false,
+        });
+      } catch (error) {
+        if (!isUniqueViolation(error)) {
+          throw error;
+        }
+
+        const reloaded = await this.loadLookup(input.tenantId, input.normalizedContactPointValue);
+        contactPoint = reloaded.peopleCoreContactPoints[0];
+      }
+    }
+
+    if (!contactPoint) {
+      return {
+        created: false,
+        reason: 'peoplecore_unavailable',
+      };
+    }
+
+    const currentLinks = await this.peopleCoreService.listCurrentContactPointLinks({
+      tenantId: input.tenantId,
+      contactPointId: contactPoint.id,
+    });
+
+    if (currentLinks.some((link) => link.subjectType === 'person')) {
+      return {
+        created: false,
+        reason: 'contact_point_already_linked',
+        contactPointId: contactPoint.id,
+      };
+    }
+
+    const person = await this.peopleCoreService.createPerson({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      firstName: DEFAULT_PROVISIONAL_FIRST_NAME,
+      lastName: DEFAULT_PROVISIONAL_LAST_NAME,
+      status: 'active_provisional',
+    });
+
+    const firstLinkedAt = buildHookTimestamp();
+    const link = await this.peopleCoreService.createContactPointLink({
+      tenantId: input.tenantId,
+      contactPointId: contactPoint.id,
+      subjectType: 'person',
+      subjectId: person.id,
+      linkType: 'unknown',
+      confidenceBand: 'low',
+      isCurrent: true,
+      isPrimary: true,
+      manuallyConfirmed: false,
+      firstLinkedAt,
+      linkedBy: 'system',
+    });
+
+    return {
+      created: true,
+      personId: person.id,
+      contactPointId: contactPoint.id,
+      linkId: link.id,
+    };
+  }
+
+  async createResolverReviewHook(
+    input: ConnectShyftResolverReviewHookInput,
+  ): Promise<ConnectShyftResolverReviewHookResult> {
+    if (!input.orgUnitId.trim()) {
+      return {
+        created: false,
+        reason: 'missing_org_unit',
+      };
+    }
+
+    const lookup = input.lookup
+      || await this.loadLookup(input.tenantId, input.normalizedContactPointValue);
+
+    if (!lookup.peopleCoreAvailable) {
+      return {
+        created: false,
+        reason: 'peoplecore_unavailable',
+      };
+    }
+
+    const triggerSourceType = input.hookContext?.triggerSourceType || 'connectshyft_identity_seam';
+    const triggerSourceId = input.hookContext?.triggerSourceId
+      || `${triggerSourceType}:${input.tenantId}:${input.orgUnitId}:${input.normalizedContactPointValue}`;
+    const existingReviews = await this.peopleCoreService.listResolverReviews({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+    });
+
+    if (existingReviews.some((review) =>
+      review.triggerSourceType === triggerSourceType
+      && review.triggerSourceId === triggerSourceId)) {
+      return {
+        created: false,
+        reason: 'duplicate_trigger',
+        contactPointId: lookup.peopleCoreContactPoints[0]?.id,
+      };
+    }
+
+    const candidatePersonIds = uniqueSortedStrings(
+      lookup.peopleCoreCurrentLinks
+        .filter((link) => link.subjectType === 'person')
+        .map((link) => link.subjectId),
+    );
+
+    const review = await this.peopleCoreService.createResolverReview({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      reviewType: 'shared_contact_ambiguity',
+      reviewStatus: 'pending',
+      priority: 'high',
+      triggerSourceType,
+      triggerSourceId,
+      conversationId: input.hookContext?.conversationId,
+      candidatePersonIds,
+      contactPointId: lookup.peopleCoreContactPoints[0]?.id,
+      confidenceBand: 'high',
+      confidenceReasons: [
+        'Multiple exact contact-point matches require resolver review.',
+      ],
+      riskFlags: ['shared_contact_possible'],
+      requestedByUserId: input.hookContext?.requestedByUserId || DEFAULT_HOOK_REQUESTED_BY,
+      requestedAt: buildHookTimestamp(),
+    });
+
+    return {
+      created: true,
+      reviewId: review.id,
+      contactPointId: review.contactPointId,
+    };
+  }
+
+  async applyIdentityHooks(
+    input: ConnectShyftIdentityBoundaryRequest,
+    result: ConnectShyftIdentityBoundaryResult,
+    lookup: ConnectShyftPeopleCoreIdentityLookupSnapshot | null,
+  ): Promise<void> {
+    if (!input.orgUnitId?.trim() || !lookup?.normalizedContactPointValue) {
+      return;
+    }
+
+    if (
+      result.ok
+      && result.code === 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH'
+      && input.hookContext?.createProvisionalOnNoMatch
+    ) {
+      await this.createProvisionalPersonHook({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        normalizedContactPointValue: lookup.normalizedContactPointValue,
+        rawContactPointValue: input.contactPoint.value,
+        hookContext: {
+
+=== identityResolver.ts ===
+import {
+  type ConnectShyftIdentityBoundaryAdapter,
+} from './identityBoundary';
+import { KnexConnectShyftNeighborStore } from './neighbors';
+import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from './peoplecoreIdentityAdapter';
+
+const SYSTEM_RESOLVER_ACTOR_ROLES = ['SYSTEM_ADMIN'];
+
+export type ResolveSubjectByContactPointInput = {
+  tenantId: string;
+  orgUnitId: string;
+  contactPoint: string;
+};
+
+export type ResolveSubjectByContactPointResult =
+  | {
+    type: 'single_match';
+    neighborId: string;
+    normalizedContactPoint: string;
+  }
+  | {
+    type: 'no_match';
+    normalizedContactPoint: string;
+  }
+  | {
+    type: 'multiple_matches';
+    candidateNeighborIds: string[];
+    normalizedContactPoint: string;
+  };
+
+export interface ConnectShyftSubjectResolverBoundary {
+  resolveSubjectByContactPoint(
+    input: ResolveSubjectByContactPointInput,
+  ): Promise<ResolveSubjectByContactPointResult>;
+}
+
+export class ConnectShyftSubjectResolver implements ConnectShyftSubjectResolverBoundary {
+  constructor(
+    private readonly identityBoundary: ConnectShyftIdentityBoundaryAdapter,
+  ) {}
+
+  async resolveSubjectByContactPoint(
+    input: ResolveSubjectByContactPointInput,
+  ): Promise<ResolveSubjectByContactPointResult> {
+    const result = await this.identityBoundary.evaluateMatch({
+      actorRoles: SYSTEM_RESOLVER_ACTOR_ROLES,
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      idempotencyKey: `inbound-subject:${input.tenantId}:${input.orgUnitId}:${input.contactPoint}`,
+      contactPoint: {
+        label: 'mobile',
+        value: input.contactPoint,
+        isShared: false,
+        verificationStatus: 'verified',
+      },
+      hookContext: {
+        createProvisionalOnNoMatch: true,
+        createResolverReviewOnAmbiguous: true,
+        triggerSourceType: 'connectshyft_inbound_subject_resolution',
+        requestedByUserId: 'system-connectshyft-identity-seam',
+      },
+    });
+
+    const normalizedContactPoint = result.ok
+      ? result.data.identityMatch.contactPoint.value
+      : result.data?.identityMatch?.contactPoint.value
+        || input.contactPoint;
+
+    if (!result.ok) {
+      if (result.code === 'IDENTITY_MATCH_AMBIGUOUS') {
+        return {
+          type: 'multiple_matches',
+          candidateNeighborIds: [
+            ...(result.data?.identityMatch?.candidateNeighborIds
+              || result.data?.manualResolution?.candidateNeighborIds
+              || []),
+          ].sort(),
+          normalizedContactPoint,
+        };
+      }
+
+      throw new Error(`Identity resolver failed with ${result.code}`);
+    }
+
+    const matchedNeighborId = result.data.identityMatch.matchedNeighborId;
+    if (matchedNeighborId) {
+      return {
+        type: 'single_match',
+        neighborId: matchedNeighborId,
+        normalizedContactPoint,
+      };
+    }
+
+    return {
+      type: 'no_match',
+      normalizedContactPoint,
+    };
+  }
+}
+
+const defaultNeighborStore = new KnexConnectShyftNeighborStore();
+
+const defaultIdentityBoundary = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+  async (tenantId) => defaultNeighborStore.listActiveIdentityBoundaryNeighborsByTenant(tenantId),
+  async (tenantId, normalizedContactPointValue) =>
+    defaultNeighborStore.listActiveIdentityBoundaryNeighborsByPhoneValue(
+      tenantId,
+      normalizedContactPointValue,
+    ),
+);
+
+const defaultSubjectResolver = new ConnectShyftSubjectResolver(defaultIdentityBoundary);
+
+export const resolveSubjectByContactPoint = (
+  input: ResolveSubjectByContactPointInput,
+): Promise<ResolveSubjectByContactPointResult> =>
+  defaultSubjectResolver.resolveSubjectByContactPoint(input);
+
+=== peoplecore/store.ts ===
+import type {
+  ContactPoint,
+  ContactPointEvent,
+  ContactPointLink,
+  ContactPointLinkSubjectType,
+  ContactPointType,
+  Household,
+  HouseholdMembership,
+  Person,
+  ResolverReview,
+} from '@shyft/contracts';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+
+const PEOPLE_SCHEMA = 'people';
+const DEFAULT_CONTACT_POINT_EVENT_LIMIT = 50;
+const MAX_CONTACT_POINT_EVENT_LIMIT = 200;
+
+const toIsoUtc = (value: unknown, fallbackIsoUtc: string): string => {
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.valueOf())) {
+      return parsed.toISOString();
+    }
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.valueOf())) {
+    return value.toISOString();
+  }
+
+  return fallbackIsoUtc;
+};
+
+const normalizeOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => normalizeOptionalString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+};
+
+const normalizeEventLimit = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_CONTACT_POINT_EVENT_LIMIT;
+  }
+
+  const normalized = Math.trunc(value);
+  if (normalized <= 0) {
+    return DEFAULT_CONTACT_POINT_EVENT_LIMIT;
+  }
+
+  return Math.min(normalized, MAX_CONTACT_POINT_EVENT_LIMIT);
+};
+
+export class PeopleCoreScopeViolationError extends Error {
+  readonly code = 'PEOPLECORE_SCOPE_VIOLATION';
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'PeopleCoreScopeViolationError';
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export type CreatePersonInput = Omit<Person, 'id' | 'createdAt' | 'updatedAt'> & {
+  personId?: string;
+};
+
+export type GetPersonInput = {
+  tenantId: string;
+  personId: string;
+};
+
+export type ListPersonsInput = {
+  tenantId: string;
+  orgUnitId?: string;
+};
+
+export type CreateHouseholdInput = Omit<Household, 'id' | 'createdAt' | 'updatedAt'> & {
+  householdId?: string;
+};
+
+export type GetHouseholdInput = {
+  tenantId: string;
+  householdId: string;
+};
+
+export type CreateHouseholdMembershipInput = Omit<
+  HouseholdMembership,
+  'id' | 'createdAt' | 'updatedAt'
+> & {
+  membershipId?: string;
+  tenantId: string;
+};
+
+export type ListHouseholdMembershipsInput = {
+  tenantId: string;
+  householdId?: string;
+  personId?: string;
+  isCurrent?: boolean;
+};
+
+export type CreateContactPointInput = Omit<ContactPoint, 'id' | 'createdAt' | 'updatedAt'> & {
+  contactPointId?: string;
+};
+
+export type GetContactPointInput = {
+  tenantId: string;
+  contactPointId: string;
+};
+
+export type ListContactPointsByNormalizedValueInput = {
+  tenantId: string;
+  type: ContactPointType;
+  normalizedValue: string;
+};
+
+export type CreateContactPointLinkInput = Omit<
+  ContactPointLink,
+  'id' | 'createdAt' | 'updatedAt'
+> & {
+  linkId?: string;
+  tenantId: string;
+};
+
+export type ListCurrentContactPointLinksInput = {
+  tenantId: string;
+  contactPointId?: string;
+  subjectType?: ContactPointLinkSubjectType;
+  subjectId?: string;
+};
+
+export type AppendContactPointEventInput = Omit<ContactPointEvent, 'id' | 'createdAt'> & {
+  eventId?: string;
+  createdAt?: string;
+};
+
+export type ListContactPointEventsInput = {
+  tenantId: string;
+  contactPointId: string;
+  limit?: number;
+};
+
+export type CreateResolverReviewInput = Omit<ResolverReview, 'id'> & {
+  reviewId?: string;
+};
+
+export type GetResolverReviewInput = {
+  tenantId: string;
+  reviewId: string;
+};
+
+export type ListResolverReviewsInput = {
+  tenantId: string;
+  orgUnitId?: string;
+};
+
+export interface PeopleCoreStore {
+  createPerson(input: CreatePersonInput): Promise<Person>;
+  getPerson(input: GetPersonInput): Promise<Person | null>;
+  listPersons(input: ListPersonsInput): Promise<Person[]>;
+  createHousehold(input: CreateHouseholdInput): Promise<Household>;
+  getHousehold(input: GetHouseholdInput): Promise<Household | null>;
+  createHouseholdMembership(input: CreateHouseholdMembershipInput): Promise<HouseholdMembership>;
+  listHouseholdMemberships(input: ListHouseholdMembershipsInput): Promise<HouseholdMembership[]>;
+  createContactPoint(input: CreateContactPointInput): Promise<ContactPoint>;
+  getContactPoint(input: GetContactPointInput): Promise<ContactPoint | null>;
+  listContactPointsByNormalizedValue(
+    input: ListContactPointsByNormalizedValueInput,
+  ): Promise<ContactPoint[]>;
+  createContactPointLink(input: CreateContactPointLinkInput): Promise<ContactPointLink>;
+  listCurrentContactPointLinks(
+    input: ListCurrentContactPointLinksInput,
+  ): Promise<ContactPointLink[]>;
+  appendContactPointEvent(input: AppendContactPointEventInput): Promise<ContactPointEvent>;
+  listContactPointEvents(input: ListContactPointEventsInput): Promise<ContactPointEvent[]>;
+  createResolverReview(input: CreateResolverReviewInput): Promise<ResolverReview>;
+  getResolverReview(input: GetResolverReviewInput): Promise<ResolverReview | null>;
+  listResolverReviews(input: ListResolverReviewsInput): Promise<ResolverReview[]>;
+}
+
+type DbPersonRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  first_name: string;
+  last_name: string;
+  preferred_name: string | null;
+  status: Person['status'];
+  merged_into_person_id: string | null;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+type DbHouseholdRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  name: string | null;
+  status: Household['status'];
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+type DbHouseholdMembershipRow = {
+  id: string;
+  household_id: string;
+  person_id: string;
+  role: HouseholdMembership['role'];
+  is_current: boolean;
+  start_at_utc: string | Date | null;
+  end_at_utc: string | Date | null;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+type DbContactPointRow = {
+  id: string;
+  tenant_id: string;
+  type: ContactPoint['type'];
+  normalized_value: string;
+  raw_value: string | null;
+  status: ContactPoint['status'];
+  first_seen_at_utc: string | Date;
+  last_seen_at_utc: string | Date;
+  last_inbound_at_utc: string | Date | null;
+  last_outbound_at_utc: string | Date | null;
+  suspected_shared: boolean;
+  confirmed_shared: boolean;
+  reassignment_suspected: boolean;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+type DbContactPointLinkRow = {
+  id: string;
+  contact_point_id: string;
+  subject_type: ContactPointLink['subjectType'];
+  subject_id: string;
+  link_type: ContactPointLink['linkType'];
+  confidence_band: ContactPointLink['confidenceBand'];
+  is_current: boolean;
+  is_primary: boolean;
+  manually_confirmed: boolean;
+  confirmation_source: ContactPointLink['confirmationSource'] | null;
+  first_linked_at_utc: string | Date;
+  last_confirmed_at_utc: string | Date | null;
+  last_used_at_utc: string | Date | null;
+  linked_by: ContactPointLink['linkedBy'];
+  linked_by_user_id: string | null;
+  unlink_reason: string | null;
+  unlinked_at_utc: string | Date | null;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+type DbContactPointEventRow = {
+  id: string;
+  tenant_id: string;
+  contact_point_id: string;
+  event_type: ContactPointEvent['eventType'];
+  event_source: string;
+  related_object_type: string | null;
+  related_object_id: string | null;
+  created_at_utc: string | Date;
+};
+
+type DbResolverReviewRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  review_type: ResolverReview['reviewType'];
+  review_status: ResolverReview['reviewStatus'];
+  priority: ResolverReview['priority'];
+  trigger_source_type: string;
+  trigger_source_id: string;
+  conversation_id: string | null;
+  provisional_person_id: string | null;
+  candidate_person_ids: unknown;
+  contact_point_id: string | null;
+  confidence_band: ResolverReview['confidenceBand'];
+  confidence_reasons: unknown;
+  risk_flags: unknown;
+  requested_by_user_id: string;
+  assigned_resolver_user_id: string | null;
+  requested_at_utc: string | Date;
+  started_at_utc: string | Date | null;
+  resolved_at_utc: string | Date | null;
+  resolution_type: ResolverReview['resolutionType'] | null;
+  resolution_reason: string | null;
+  resolution_notes: string | null;
+};
+
+const mapPersonRow = (row: DbPersonRow): Person => {
+  const fallbackIsoUtc = new Date().toISOString();
+
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    orgUnitId: row.org_unit_id,
+    firstName: row.first_name,
+    lastName: row.last_name,
+    preferredName: normalizeOptionalString(row.preferred_name),
+    status: row.status,
+    mergedIntoPersonId: normalizeOptionalString(row.merged_into_person_id),
+    createdAt: toIsoUtc(row.created_at_utc, fallbackIsoUtc),
+    updatedAt: toIsoUtc(row.updated_at_utc, fallbackIsoUtc),
+  };
+};
+
+const mapHouseholdRow = (row: DbHouseholdRow): Household => {
+  const fallbackIsoUtc = new Date().toISOString();
+
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    orgUnitId: row.org_unit_id,
+    name: normalizeOptionalString(row.name),
+    status: row.status,
+    createdAt: toIsoUtc(row.created_at_utc, fallbackIsoUtc),
+    updatedAt: toIsoUtc(row.updated_at_utc, fallbackIsoUtc),
+  };
+};
+
+const mapHouseholdMembershipRow = (row: DbHouseholdMembershipRow): HouseholdMembership => {
+  const fallbackIsoUtc = new Date().toISOString();
+
+  return {
+    id: row.id,
+    householdId: row.household_id,
+    personId: row.person_id,
+    role: row.role,
+    isCurrent: row.is_current,
+    startAt: row.start_at_utc ? toIsoUtc(row.start_at_utc, fallbackIsoUtc) : undefined,
+    endAt: row.end_at_utc ? toIsoUtc(row.end_at_utc, fallbackIsoUtc) : undefined,
+    createdAt: toIsoUtc(row.created_at_utc, fallbackIsoUtc),
+    updatedAt: toIsoUtc(row.updated_at_utc, fallbackIsoUtc),
+  };
+};
+
+const mapContactPointRow = (row: DbContactPointRow): ContactPoint => {
+  const fallbackIsoUtc = new Date().toISOString();
+
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    type: row.type,
+    normalizedValue: row.normalized_value,
+    rawValue: normalizeOptionalString(row.raw_value),
+    status: row.status,
+    firstSeenAt: toIsoUtc(row.first_seen_at_utc, fallbackIsoUtc),
+    lastSeenAt: toIsoUtc(row.last_seen_at_utc, fallbackIsoUtc),
+    lastInboundAt: row.last_inbound_at_utc
+      ? toIsoUtc(row.last_inbound_at_utc, fallbackIsoUtc)
+      : undefined,
+    lastOutboundAt: row.last_outbound_at_utc
+      ? toIsoUtc(row.last_outbound_at_utc, fallbackIsoUtc)
+      : undefined,
+    suspectedShared: row.suspected_shared,
+    confirmedShared: row.confirmed_shared,
+    reassignmentSuspected: row.reassignment_suspected,
+    createdAt: toIsoUtc(row.created_at_utc, fallbackIsoUtc),
+    updatedAt: toIsoUtc(row.updated_at_utc, fallbackIsoUtc),
+  };
+};
+
+const mapContactPointLinkRow = (row: DbContactPointLinkRow): ContactPointLink => {
+  const fallbackIsoUtc = new Date().toISOString();
+
+  return {
+    id: row.id,
+    contactPointId: row.contact_point_id,
+    subjectType: row.subject_type,
+    subjectId: row.subject_id,
+    linkType: row.link_type,
+    confidenceBand: row.confidence_band,
+    isCurrent: row.is_current,
+    isPrimary: row.is_primary,
+    manuallyConfirmed: row.manually_confirmed,
+    confirmationSource: row.confirmation_source || undefined,
+    firstLinkedAt: toIsoUtc(row.first_linked_at_utc, fallbackIsoUtc),
+    lastConfirmedAt: row.last_confirmed_at_utc
+      ? toIsoUtc(row.last_confirmed_at_utc, fallbackIsoUtc)
+      : undefined,
+    lastUsedAt: row.last_used_at_utc
+      ? toIsoUtc(row.last_used_at_utc, fallbackIsoUtc)
+      : undefined,
+    linkedBy: row.linked_by,
+    linkedByUserId: normalizeOptionalString(row.linked_by_user_id),
+    unlinkReason: normalizeOptionalString(row.unlink_reason),
+    unlinkedAt: row.unlinked_at_utc ? toIsoUtc(row.unlinked_at_utc, fallbackIsoUtc) : undefined,
+    createdAt: toIsoUtc(row.created_at_utc, fallbackIsoUtc),
+    updatedAt: toIsoUtc(row.updated_at_utc, fallbackIsoUtc),
+  };
+};
+
+const mapContactPointEventRow = (row: DbContactPointEventRow): ContactPointEvent => {
+  const fallbackIsoUtc = new Date().toISOString();
+
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    contactPointId: row.contact_point_id,
+    eventType: row.event_type,
+    eventSource: row.event_source,
+    relatedObjectType: normalizeOptionalString(row.related_object_type),
+    relatedObjectId: normalizeOptionalString(row.related_object_id),
+
+=== identity seam tests ===
+import { PeopleCorePersistenceUnavailableError } from '../../peoplecore/service';
+import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from '../peoplecoreIdentityAdapter';
+import type { ConnectShyftIdentityBoundaryNeighbor } from '../identityBoundary';
+
+const TIMESTAMP = '2026-03-21T12:00:00.000Z';
+
+const buildNeighbor = (
+  neighborId: string,
+  value: string,
+  overrides: Partial<ConnectShyftIdentityBoundaryNeighbor['phones'][number]> = {},
+): ConnectShyftIdentityBoundaryNeighbor => ({
+  neighborId,
+  phones: [
+    {
+      phoneId: `${neighborId}-phone-1`,
+      value,
+      isShared: false,
+      verificationStatus: 'verified',
+      ...overrides,
+    },
+  ],
+});
+
+const buildContactPoint = (contactPointId: string, normalizedValue: string) => ({
+  id: contactPointId,
+  tenantId: 'tenant-a',
+  type: 'phone' as const,
+  normalizedValue,
+  status: 'active_personal' as const,
+  firstSeenAt: TIMESTAMP,
+  lastSeenAt: TIMESTAMP,
+  suspectedShared: false,
+  confirmedShared: false,
+  reassignmentSuspected: false,
+  createdAt: TIMESTAMP,
+  updatedAt: TIMESTAMP,
+});
+
+const buildContactPointLink = (contactPointId: string, subjectId: string) => ({
+  id: `${contactPointId}-link-1`,
+  contactPointId,
+  subjectType: 'person' as const,
+  subjectId,
+  linkType: 'primary' as const,
+  confidenceBand: 'high' as const,
+  isCurrent: true,
+  isPrimary: true,
+  manuallyConfirmed: false,
+  firstLinkedAt: TIMESTAMP,
+  linkedBy: 'system' as const,
+  createdAt: TIMESTAMP,
+  updatedAt: TIMESTAMP,
+});
+
+describe('connectshyft peoplecore identity adapter', () => {
+  it('creates provisional PeopleCore foundation on no-match without changing the ConnectShyft result', async () => {
+    const peopleCoreService = {
+      listContactPointsByNormalizedValue: jest.fn(async () => []),
+      listCurrentContactPointLinks: jest.fn(async () => []),
+      createContactPoint: jest.fn(async () => buildContactPoint('contact-point-3', '+12605551220')),
+      createPerson: jest.fn(async () => ({
+        id: 'person-3',
+        tenantId: 'tenant-a',
+        orgUnitId: 'org-a',
+        firstName: 'Unknown',
+        lastName: 'Contact',
+        status: 'active_provisional',
+        createdAt: TIMESTAMP,
+        updatedAt: TIMESTAMP,
+      })),
+      createContactPointLink: jest.fn(async () => ({
+        id: 'link-3',
+        contactPointId: 'contact-point-3',
+        subjectType: 'person',
+        subjectId: 'person-3',
+        linkType: 'unknown',
+        confidenceBand: 'low',
+        isCurrent: true,
+        isPrimary: true,
+        manuallyConfirmed: false,
+        firstLinkedAt: TIMESTAMP,
+        linkedBy: 'system',
+        createdAt: TIMESTAMP,
+        updatedAt: TIMESTAMP,
+      })),
+      listResolverReviews: jest.fn(async () => []),
+      createResolverReview: jest.fn(),
+    };
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [],
+      async () => [],
+      peopleCoreService as any,
+    );
+
+    await expect(adapter.evaluateMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: {
+        label: 'mobile',
+        value: '2605551220',
+        verificationStatus: 'verified',
+      },
+      hookContext: {
+        createProvisionalOnNoMatch: true,
+        triggerSourceType: 'connectshyft_inbound_subject_resolution',
+      },
+    })).resolves.toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+      data: {
+        identityMatch: {
+          matchedNeighborId: null,
+          contactPoint: {
+            value: '+12605551220',
+          },
+        },
+      },
+    });
+
+    expect(peopleCoreService.createPerson).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      status: 'active_provisional',
+    }));
+    expect(peopleCoreService.createContactPointLink).toHaveBeenCalled();
+  });
+
+  it('evaluates normalized contact-point candidates through the PeopleCore lookup path before preserving current ConnectShyft candidates', async () => {
+    const peopleCoreService = {
+      listContactPointsByNormalizedValue: jest.fn(async () => [
+        buildContactPoint('contact-point-1', '+12605551212'),
+      ]),
+      listCurrentContactPointLinks: jest.fn(async () => [
+        buildContactPointLink('contact-point-1', 'person-1'),
+      ]),
+    };
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-1', '+12605551212')],
+      async () => [buildNeighbor('neighbor-1', '+12605551212')],
+      peopleCoreService as any,
+    );
+
+    const lookup = await adapter.evaluateIdentityCandidatesForContactPoint({
+      tenantId: 'tenant-a',
+      contactPointValue: '(260) 555-1212',
+    });
+
+    expect(peopleCoreService.listContactPointsByNormalizedValue).toHaveBeenCalledWith({
+      tenantId: 'tenant-a',
+      type: 'phone',
+      normalizedValue: '+12605551212',
+    });
+    expect(peopleCoreService.listCurrentContactPointLinks).toHaveBeenCalledWith({
+      tenantId: 'tenant-a',
+      contactPointId: 'contact-point-1',
+    });
+    expect(lookup).toMatchObject({
+      normalizedContactPointValue: '+12605551212',
+      peopleCoreAvailable: true,
+      peopleCoreContactPoints: [
+        {
+          id: 'contact-point-1',
+        },
+      ],
+      peopleCoreCurrentLinks: [
+        {
+          id: 'contact-point-1-link-1',
+          subjectId: 'person-1',
+        },
+      ],
+      candidateNeighbors: [
+        {
+          neighborId: 'neighbor-1',
+        },
+      ],
+    });
+  });
+
+  it('preserves current auto-merge behavior while consulting the PeopleCore seam', async () => {
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-1', '+12605551212')],
+      async () => [buildNeighbor('neighbor-1', '+12605551212')],
+      {
+        listContactPointsByNormalizedValue: async () => [
+          buildContactPoint('contact-point-1', '+12605551212'),
+        ],
+        listCurrentContactPointLinks: async () => [
+          buildContactPointLink('contact-point-1', 'person-1'),
+        ],
+      } as any,
+    );
+
+    await expect(adapter.evaluateMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-a',
+      contactPoint: {
+        label: 'mobile',
+        value: '260-555-1212',
+        verificationStatus: 'verified',
+      },
+    })).resolves.toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+      data: {
+        identityMatch: {
+          matchedNeighborId: 'neighbor-1',
+          contactPoint: {
+            value: '+12605551212',
+          },
+        },
+      },
+    });
+  });
+
+  it('preserves current ambiguous/manual-resolution behavior when fallback candidates remain ambiguous', async () => {
+    const createResolverReview = jest.fn(async () => ({
+      id: 'resolver-review-ambiguous',
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      reviewType: 'shared_contact_ambiguity',
+      reviewStatus: 'pending',
+      priority: 'high',
+      triggerSourceType: 'connectshyft_identity_match',
+      triggerSourceId: 'identity-match:ambiguous',
+      candidatePersonIds: ['person-1', 'person-2'],
+      contactPointId: 'contact-point-2',
+      confidenceBand: 'high',
+      confidenceReasons: ['Multiple exact contact-point matches require resolver review.'],
+      riskFlags: ['shared_contact_possible'],
+      requestedByUserId: 'user-1',
+      requestedAt: TIMESTAMP,
+    }));
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [
+        buildNeighbor('neighbor-1', '+12605551213'),
+        buildNeighbor('neighbor-2', '+12605551213'),
+      ],
+      async () => [
+        buildNeighbor('neighbor-1', '+12605551213'),
+        buildNeighbor('neighbor-2', '+12605551213'),
+      ],
+      {
+        listContactPointsByNormalizedValue: async () => [
+          buildContactPoint('contact-point-2', '+12605551213'),
+        ],
+        listCurrentContactPointLinks: async () => [
+          buildContactPointLink('contact-point-2', 'person-1'),
+          buildContactPointLink('contact-point-2', 'person-2'),
+        ],
+        listResolverReviews: async () => [],
+        createResolverReview,
+        createContactPoint: jest.fn(),
+        createPerson: jest.fn(),
+        createContactPointLink: jest.fn(),
+      } as any,
+    );
+
+    await expect(adapter.evaluateMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: {
+        label: 'mobile',
+        value: '+1 (260) 555-1213',
+        verificationStatus: 'verified',
+      },
+      hookContext: {
+        createResolverReviewOnAmbiguous: true,
+        triggerSourceType: 'connectshyft_identity_match',
+        triggerSourceId: 'identity-match:ambiguous',
+        requestedByUserId: 'user-1',
+      },
+    })).resolves.toMatchObject({
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      data: {
+        identityMatch: {
+          decision: 'AMBIGUOUS',
+          candidateNeighborIds: ['neighbor-1', 'neighbor-2'],
+        },
+        manualResolution: {
+          required: true,
+          reasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+        },
+      },
+    });
+
+    expect(createResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      triggerSourceType: 'connectshyft_identity_match',
+      triggerSourceId: 'identity-match:ambiguous',
+      requestedByUserId: 'user-1',
+    }));
+  });
+
+  it('falls back cleanly when PeopleCore persistence is unavailable', async () => {
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-1', '+12605551214')],
+      async () => [buildNeighbor('neighbor-1', '+12605551214')],
+      {
+        listContactPointsByNormalizedValue: async () => {
+          throw new PeopleCorePersistenceUnavailableError(new Error('people schema missing'));
+        },
+        listCurrentContactPointLinks: jest.fn(),
+      } as any,
+    );
+
+    await expect(adapter.evaluateIdentityCandidatesForContactPoint({
+      tenantId: 'tenant-a',
+      contactPointValue: '2605551214',
+    })).resolves.toMatchObject({
+      normalizedContactPointValue: '+12605551214',
+      peopleCoreAvailable: false,
+      peopleCoreContactPoints: [],
+      peopleCoreCurrentLinks: [],
+      candidateNeighbors: [
+        {
+          neighborId: 'neighbor-1',
+import {
+  AsyncInProcessConnectShyftIdentityBoundaryAdapter,
+  type ConnectShyftIdentityBoundaryNeighbor,
+} from '../identityBoundary';
+import { ConnectShyftSubjectResolver } from '../identityResolver';
+import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from '../peoplecoreIdentityAdapter';
+
+const buildNeighbor = (
+  neighborId: string,
+  value: string,
+  overrides: Partial<ConnectShyftIdentityBoundaryNeighbor['phones'][number]> = {},
+): ConnectShyftIdentityBoundaryNeighbor => ({
+  neighborId,
+  phones: [
+    {
+      phoneId: `${neighborId}-phone-1`,
+      value,
+      isShared: false,
+      verificationStatus: 'verified',
+      ...overrides,
+    },
+  ],
+});
+
+const buildResolver = (
+  neighborsByTenant: Record<string, ConnectShyftIdentityBoundaryNeighbor[]>,
+  lookupByTenantAndPhone: Record<string, Record<string, ConnectShyftIdentityBoundaryNeighbor[]>> = {},
+): ConnectShyftSubjectResolver => {
+  const adapter = new AsyncInProcessConnectShyftIdentityBoundaryAdapter(
+    async (tenantId) => neighborsByTenant[tenantId] || [],
+    async (tenantId, normalizedContactPointValue) =>
+      lookupByTenantAndPhone[tenantId]?.[normalizedContactPointValue]
+      || (neighborsByTenant[tenantId] || []).filter((neighbor) =>
+        neighbor.phones.some((phone) => phone.value === normalizedContactPointValue)),
+  );
+
+  return new ConnectShyftSubjectResolver(adapter);
+};
+
+describe('connectshyft identity resolver', () => {
+  it('returns single_match through the PeopleCore seam while preserving current resolver behavior', async () => {
+    const peopleCoreService = {
+      listContactPointsByNormalizedValue: jest.fn(async () => [
+        {
+          id: 'contact-point-1',
+          tenantId: 'tenant-a',
+          type: 'phone',
+          normalizedValue: '+12605551216',
+          status: 'active_personal',
+          firstSeenAt: '2026-03-21T12:00:00.000Z',
+          lastSeenAt: '2026-03-21T12:00:00.000Z',
+          suspectedShared: false,
+          confirmedShared: false,
+          reassignmentSuspected: false,
+          createdAt: '2026-03-21T12:00:00.000Z',
+          updatedAt: '2026-03-21T12:00:00.000Z',
+        },
+      ]),
+      listCurrentContactPointLinks: jest.fn(async () => [
+        {
+          id: 'link-1',
+          contactPointId: 'contact-point-1',
+          subjectType: 'person',
+          subjectId: 'person-1',
+          linkType: 'primary',
+          confidenceBand: 'high',
+          isCurrent: true,
+          isPrimary: true,
+          manuallyConfirmed: false,
+          firstLinkedAt: '2026-03-21T12:00:00.000Z',
+          linkedBy: 'system',
+          createdAt: '2026-03-21T12:00:00.000Z',
+          updatedAt: '2026-03-21T12:00:00.000Z',
+        },
+      ]),
+    };
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-1', '+12605551216')],
+      async () => [buildNeighbor('neighbor-1', '+12605551216')],
+      peopleCoreService as any,
+    );
+    const resolver = new ConnectShyftSubjectResolver(adapter);
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '(260) 555-1216',
+    })).resolves.toEqual({
+      type: 'single_match',
+      neighborId: 'neighbor-1',
+      normalizedContactPoint: '+12605551216',
+    });
+
+    expect(peopleCoreService.listContactPointsByNormalizedValue).toHaveBeenCalledWith({
+      tenantId: 'tenant-a',
+      type: 'phone',
+      normalizedValue: '+12605551216',
+    });
+  });
+
+  it('passes hook context into the seam for inbound no-match handling', async () => {
+    const evaluateMatch = jest.fn(async () => ({
+      ok: true as const,
+      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH' as const,
+      httpStatus: 200 as const,
+      data: {
+        identityMatch: {
+          decision: 'NO_AUTO_MERGE' as const,
+          reason: 'NO_EXACT_CONTACT_POINT_MATCH' as const,
+          autoMergeAllowed: false,
+          contactPoint: {
+            value: '+12605551217',
+            isShared: false,
+            verificationStatus: 'verified' as const,
+          },
+          matchedNeighborId: null,
+          candidateCount: 0,
+          candidateNeighborIds: [],
+          exactMatches: [],
+        },
+        idempotency: {
+          key: 'inbound-subject:tenant-a:org-a:(260)555-1217',
+          semantics: 'REPLAY_SAFE' as const,
+        },
+      },
+    }));
+    const resolver = new ConnectShyftSubjectResolver({
+      evaluateMatch,
+    });
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '(260) 555-1217',
+    })).resolves.toEqual({
+      type: 'no_match',
+      normalizedContactPoint: '+12605551217',
+    });
+
+    expect(evaluateMatch).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      hookContext: {
+        createProvisionalOnNoMatch: true,
+        createResolverReviewOnAmbiguous: true,
+        triggerSourceType: 'connectshyft_inbound_subject_resolution',
+        requestedByUserId: 'system-connectshyft-identity-seam',
+      },
+    }));
+  });
+
+  it('returns single_match for a unique tenant-scoped phone match', async () => {
+    const resolver = buildResolver({
+      'tenant-a': [
+        buildNeighbor('neighbor-1', '+12605551212'),
+      ],
+    });
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '+12605551212',
+    })).resolves.toEqual({
+      type: 'single_match',
+      neighborId: 'neighbor-1',
+      normalizedContactPoint: '+12605551212',
+    });
+  });
+
+  it('normalizes canonical formatting variants before resolving a unique phone match', async () => {
+    const resolver = buildResolver({
+      'tenant-a': [
+        buildNeighbor('neighbor-1', '+12605551212'),
+      ],
+    });
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '(260) 555-1212',
+    })).resolves.toEqual({
+      type: 'single_match',
+      neighborId: 'neighbor-1',
+      normalizedContactPoint: '+12605551212',
+    });
+  });
+
+  it('returns no_match when the current tenant has no exact phone match', async () => {
+    const resolver = buildResolver({
+      'tenant-a': [
+        buildNeighbor('neighbor-1', '+12605550000'),
+      ],
+    });
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '+12605551212',
+    })).resolves.toEqual({
+      type: 'no_match',
+      normalizedContactPoint: '+12605551212',
+    });
+  });
+
+  it('returns multiple_matches when multiple neighbors share the same phone', async () => {
+    const resolver = buildResolver({
+      'tenant-a': [
+        buildNeighbor('neighbor-1', '+12605551212'),
+        buildNeighbor('neighbor-2', '+12605551212'),
+      ],
+    });
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '+12605551212',
+    })).resolves.toEqual({
+      type: 'multiple_matches',
+      candidateNeighborIds: ['neighbor-1', 'neighbor-2'],
+      normalizedContactPoint: '+12605551212',
+    });
+  });
+
+  it('returns no_match when deleted-only phone rows are excluded from active lookup', async () => {
+    const resolver = buildResolver(
+      {
+        'tenant-a': [
+          buildNeighbor('neighbor-deleted-shadow', '+12605551213'),
+        ],
+      },
+      {
+        'tenant-a': {
+          '+12605551213': [],
+        },
+      },
+    );
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '+1 (260) 555-1213',
+    })).resolves.toEqual({
+      type: 'no_match',
+      normalizedContactPoint: '+12605551213',
+    });
+  });
+
+  it('returns single_match for a unique shared contact even when auto-merge remains blocked', async () => {
+    const resolver = buildResolver({
+      'tenant-a': [
+        buildNeighbor('neighbor-1', '+12605551215', {
+          isShared: true,
+        }),
+      ],
+    });
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '(260) 555-1215',
+    })).resolves.toEqual({
+      type: 'single_match',
+      neighborId: 'neighbor-1',
+      normalizedContactPoint: '+12605551215',
+    });
+  });
+
+  it('returns single_match when active lookup excludes deleted duplicates and keeps the current owner', async () => {
+    const currentOwner = buildNeighbor('neighbor-current', '+12605551214');
+    const deletedShadow = buildNeighbor('neighbor-deleted-shadow', '+12605551214');
+    const resolver = buildResolver(
+      {
+        'tenant-a': [
+          currentOwner,
+          deletedShadow,
+        ],
+      },
+      {
+        'tenant-a': {
+          '+12605551214': [currentOwner],
+        },
+      },
+    );
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '260.555.1214',
+    })).resolves.toEqual({
+      type: 'single_match',
+      neighborId: 'neighbor-current',
+      normalizedContactPoint: '+12605551214',
+    });
+  });
+
+  it('treats other-tenant-only matches as no_match for the current tenant', async () => {
+    const resolver = buildResolver({
+      'tenant-a': [],
+      'tenant-b': [
+        buildNeighbor('neighbor-foreign', '+12605551212'),
+      ],
+    });
+
+    await expect(resolver.resolveSubjectByContactPoint({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      contactPoint: '+12605551212',
+    })).resolves.toEqual({
+      type: 'no_match',
+      normalizedContactPoint: '+12605551212',
+    });
+  });
+});

--- a/specs/slice-13-codex-ready-implementation-brief.md
+++ b/specs/slice-13-codex-ready-implementation-brief.md
@@ -1,0 +1,725 @@
+# Slice 13 Codex-Ready Implementation Brief
+
+## Title
+
+PeopleCore identity read authority and ConnectShyft compatibility shell
+
+## Branch
+
+`codex/slice-13-peoplecore-read-authority-and-compat-shell`
+
+## Objective
+
+Make PeopleCore the first authoritative source for phone identity resolution while preserving existing ConnectShyft route contracts and keeping `neighbors.ts` as the operational compatibility shell for current CRUD and inbound workflows.
+
+## Locked Policy
+
+When PeopleCore and legacy ConnectShyft neighbor resolution disagree, Slice 13 MUST return ambiguity/manual resolution and MUST NOT silently prefer either side.
+
+---
+
+## Why this slice exists
+
+Slice 12 established:
+
+- PeopleCore persistence foundation
+- a PeopleCore identity seam
+- best-effort provisional identity hooks
+- best-effort resolver review hooks
+- preserved ConnectShyft outward behavior
+
+But Slice 12 still leaves candidate authority with ConnectShyft neighbor lookup in practical terms. Slice 13 is the controlled authority shift:
+
+- PeopleCore becomes first read authority for phone identity
+- ConnectShyft neighbor lookup remains fallback only when PeopleCore has no current person link
+- disagreement becomes an explicit ambiguity outcome, never a hidden winner
+- neighbor CRUD remains intact for now as a compatibility shell
+
+This is not the bulk-migration slice, not the resolver-UI slice, and not the application-shell slice.
+
+---
+
+## Non-negotiable constraints
+
+1. Preserve existing route paths, route order, refusal envelope shape, and HTTP status behavior unless this brief explicitly says otherwise.
+2. Do not redesign ConnectShyft neighbor CRUD contracts in this slice.
+3. Do not remove `neighbors.ts` or the existing async service exports in this slice.
+4. Do not bulk-backfill all ConnectShyft neighbors into PeopleCore in this slice.
+5. Do not add broad new resolver workflows beyond the narrow cases defined here.
+6. Do not silently choose a winner when PeopleCore and legacy neighbor lookup disagree.
+7. All new PeopleCore-first authority logic must remain tenant-scoped and org-unit-safe.
+8. All new behavior must be characterized before refactor or authority shift.
+9. Preserve current inbound SMS operational continuity.
+10. Keep the current seam best-effort posture for write hooks. Request-path failures in PeopleCore hook writes must not break current ConnectShyft route outcomes.
+
+---
+
+## Authority rules to implement
+
+For normalized phone identity lookup:
+
+### Rule A: PeopleCore exact single current person link wins
+
+If PeopleCore returns exactly one current person link for the normalized phone value:
+
+- resolution outcome is single match
+- use that PeopleCore person identity as the authoritative identity answer
+- if a legacy ConnectShyft neighbor candidate exists and aligns cleanly, continue normally
+- if legacy data disagrees, return ambiguity/manual resolution instead of selecting either side
+
+### Rule B: PeopleCore multiple current person links is ambiguous
+
+If PeopleCore returns more than one current person link for the normalized phone value:
+
+- return ambiguity/manual resolution
+- do not fall through to legacy neighbor winner selection
+- create or reuse narrow resolver-review hooks as already allowed by the seam
+
+### Rule C: PeopleCore no current person links falls back
+
+If PeopleCore returns no current person links:
+
+- preserve current legacy ConnectShyft neighbor lookup behavior
+- preserve current single_match / no_match / multiple_matches outcomes from the legacy path
+- preserve current inbound no-match create flow
+
+### Rule D: Disagreement is explicit ambiguity
+
+If PeopleCore yields a single current person link but the legacy ConnectShyft candidate layer disagrees in identity ownership:
+
+- return ambiguity/manual resolution
+- do not auto-merge
+- do not choose PeopleCore silently
+- do not choose legacy silently
+- optionally create a resolver review using a narrow mismatch trigger defined in this slice
+
+### Rule E: Shared-contact and unverified guardrails still apply
+
+If the current exact-match safety rules would block auto-merge because of shared or unverified conditions:
+
+- preserve the current blocked/no-auto-merge behavior
+- do not let PeopleCore-first authority erase those safety rules
+
+---
+
+## In scope
+
+- PeopleCore-first read authority for phone identity
+- disagreement detection between PeopleCore authority and legacy neighbor candidates
+- preserved fallback when PeopleCore has no current person link
+- narrow resolver-review creation for disagreement if specified below
+- telemetry / audit / shadow comparison for lookup outcomes
+- characterization coverage
+- architecture note updates
+
+## Out of scope
+
+- bulk backfill
+- replacing neighbor CRUD routes with PeopleCore person CRUD
+- application shell
+- resolver UI / queue UI
+- full rebinding engine
+- PeopleCore-first timeline ownership
+- household-based identity scoring expansion
+- ML scoring
+- hard performance budget enforcement beyond the current repo conventions
+
+---
+
+## Source-of-truth files to work in
+
+Primary likely files:
+
+- `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- `apps/connectshyft-api/src/modules/peoplecore/store.ts`
+- `apps/connectshyft-api/src/modules/peoplecore/service.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts`
+- `docs/architecture/identity-resolution-model.md`
+- `docs/architecture/peoplecore-identity-seam.md`
+- `docs/architecture/connectshyft-router-refactor-plan.md`
+
+Potential supporting file if needed:
+
+- `apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts`
+
+---
+
+## Required telemetry / comparison model
+
+Add a narrow internal comparison record for identity lookup execution. This does not need a database migration in this slice unless truly necessary. Start with audit/event emission if possible.
+
+For each PeopleCore-aware lookup attempt, capture:
+
+- tenantId
+- orgUnitId if present
+- normalizedContactPointValue
+- peopleCoreOutcome: `single_match | no_match | multiple_matches | unavailable`
+- peopleCoreSubjectIds
+- legacyOutcome: `single_match | no_match | multiple_matches | unavailable`
+- legacyNeighborIds
+- finalOutcome: `single_match | no_match | multiple_matches | no_auto_merge | ambiguous`
+- fallbackUsed: boolean
+- disagreementDetected: boolean
+- hookWriteAttempted: boolean
+- hookWriteSucceeded: boolean
+
+This is for safe migration visibility, not user-facing UI.
+
+---
+
+## Narrow resolver-review expansion allowed in this slice
+
+Allowed:
+
+- existing ambiguous shared-contact review creation
+- a new narrow review trigger for **PeopleCore / legacy identity disagreement** if implemented minimally and deterministically
+
+If added, use:
+
+- `reviewType`: `identity_conflict`
+- confidence band: `high`
+- risk flag must include: `conflicting_name_dob` only if actually true, otherwise use `duplicate_creation_attempt` only if that is what happened, otherwise introduce no fake flag
+- trigger source should be deterministic and idempotent
+
+Default recommendation:
+
+- reuse `identity_conflict`
+- do not expand contract enums unless existing values are insufficient
+
+---
+
+## Data / contract expectations
+
+Do not break existing contracts in `libs/contracts` unless a narrowly justified addition is required.
+
+Default assumption:
+
+- Slice 13 should avoid new contract enums
+- Slice 13 should work with current `ResolverReview`, `ContactPoint`, and current identity outputs
+- only update docs if code can remain within current contract surface
+
+---
+
+## Implementation plan
+
+### Checkpoint 1: Characterize current and new authority cases before changing logic
+
+Add or extend characterization tests that lock:
+
+1. PeopleCore single current link + legacy same neighbor result
+   - final result stays single_match / current allowed outcome
+
+2. PeopleCore single current link + legacy different neighbor result
+   - final result becomes ambiguity/manual resolution
+   - no silent winner
+
+3. PeopleCore multiple current links + legacy single candidate
+   - final result is ambiguity/manual resolution
+   - no legacy override
+
+4. PeopleCore no current links + legacy single candidate
+   - legacy single_match preserved
+
+5. PeopleCore unavailable + legacy single candidate
+   - current fallback preserved
+
+6. Inbound SMS path:
+   - PeopleCore single current link + legacy aligned -> do not create new neighbor
+   - PeopleCore no current link + legacy no_match -> current create-new flow preserved
+   - PeopleCore / legacy disagreement -> ambiguity path preserved, no arbitrary attach, no create-new
+
+7. Identity-match route:
+   - disagreement returns `IDENTITY_MATCH_AMBIGUOUS`
+   - current manualResolution payload remains deterministic
+
+8. Shared-contact case:
+   - PeopleCore single current link with shared conditions still blocks auto-merge if current rules block it
+
+Validation commands:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/identityBoundary.test.ts \
+  src/modules/connectshyft/__tests__/identityResolver.test.ts \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+Commit:
+
+```bash
+git add .
+git commit -m "test(slice-13): lock peoplecore authority and disagreement characterization"
+```
+
+Stop after Checkpoint 1.
+
+---
+
+## Checkpoint 2 — Implement PeopleCore-vs-legacy precedence and ambiguity policy
+
+### Objective
+
+Refactor the PeopleCore seam so it no longer treats PeopleCore lookup as observational-only when PeopleCore has current-link evidence. Preserve all locked route/result shapes, but change the seam decision policy so current PeopleCore evidence can force ambiguity instead of silently deferring to a legacy single winner.
+
+### Scope
+
+Edit only the minimum code necessary in:
+
+- `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts` only if required by type fallout or dead-simple normalization of adapter outputs
+- related unit tests only as required to satisfy the locked Checkpoint 1 characterization expectations
+
+Do not edit route handlers, HTTP envelopes, contracts, migrations, or PeopleCore store/service APIs in this checkpoint.
+
+### Locked policy to implement
+
+Treat these as hard rules:
+
+1. **Legacy-only remains legacy-owned**
+   - If PeopleCore is unavailable, has no contact point for the normalized value, or has no current person links for that contact point, preserve existing ConnectShyft legacy candidate behavior unchanged.
+   - This means:
+     - legacy single eligible neighbor stays single-match / current legacy result
+     - legacy no-match stays no-match
+     - legacy ambiguous stays ambiguous
+
+2. **PeopleCore current-link evidence is authoritative enough to block a silent winner**
+   - If PeopleCore returns one or more current person links for the normalized contact point, the seam must no longer silently trust a conflicting legacy single winner.
+
+3. **Single PeopleCore current person + single legacy neighbor disagreement => ambiguous**
+   - If PeopleCore has exactly one distinct current linked person for the normalized contact point, and legacy fallback resolves exactly one candidate neighbor, but the seam cannot prove they are the same underlying subject, return ambiguity.
+   - Do not return single_match in this situation.
+   - Do not invent a mapping.
+   - Do not auto-merge.
+   - Do not create a provisional identity.
+   - This ambiguity must preserve the existing `IDENTITY_MATCH_AMBIGUOUS` result shape and manual-resolution context.
+
+4. **Multiple PeopleCore current linked people => ambiguous**
+   - If PeopleCore has more than one distinct current linked person for the normalized contact point, return ambiguity even if legacy fallback has exactly one candidate neighbor.
+   - This is a hard stop.
+
+5. **Shared/unverified legacy guardrails still apply**
+   - If legacy candidate behavior already yields no-auto-merge due to shared or unverified conditions, preserve that.
+   - Do not weaken existing shared-contact safety rules.
+
+6. **No new neighbor<->person mapping layer in this checkpoint**
+   - Do not add a person-to-neighbor crosswalk table.
+   - Do not infer equivalence from names or other heuristics.
+   - Do not join PeopleCore persons to ConnectShyft neighbors.
+   - This checkpoint is precedence and refusal policy only.
+
+7. **Hook side effects remain best-effort**
+   - Existing best-effort hook behavior stays best-effort.
+   - Resolver-review creation on ambiguous flows may continue.
+   - No-match provisional creation must not fire when the seam now returns ambiguity.
+
+### Implementation guidance
+
+Refactor `peoplecoreIdentityAdapter.ts` to introduce an explicit intermediate decision layer before returning the final boundary result.
+
+Recommended shape:
+
+- Add small internal helpers for:
+  - collecting distinct current linked PeopleCore person IDs from `peopleCoreCurrentLinks`
+  - determining whether PeopleCore has authoritative current-link evidence
+  - determining whether fallback legacy candidates are:
+    - none
+    - single
+    - multiple
+  - deciding whether the seam must override legacy single-winner behavior to ambiguity
+
+- Keep the existing normalized lookup loading path.
+- Keep existing fallback candidate loading path.
+- Keep existing call into the legacy boundary logic where appropriate.
+- Add a seam-level override step after lookup and before final return:
+  - if PeopleCore has no authoritative current-link evidence, return the legacy boundary result unchanged
+  - if PeopleCore has multiple distinct current person IDs, force ambiguous result
+  - if PeopleCore has one distinct current person ID and legacy result is a single-match winner, force ambiguous result unless a same-subject proof exists
+  - since there is currently no same-subject proof mechanism, this case is ambiguous by policy
+
+### Important constraint on result construction
+
+Do **not** create a new route/result shape.
+
+Use the same result family already used by `identityBoundary.ts`:
+
+- ambiguous must still be `ok: false`
+- code must still be `IDENTITY_MATCH_AMBIGUOUS`
+- manualResolution payload must still exist
+- `candidateNeighborIds` must remain deterministic and sorted from the legacy candidate side when present
+
+For the resolver seam:
+
+- the resolver should continue translating ambiguous boundary results into:
+  - `type: 'multiple_matches'`
+  - sorted `candidateNeighborIds`
+  - normalized contact point
+
+### Candidate-neighbor rules for forced ambiguity
+
+When ambiguity is forced due to PeopleCore evidence:
+
+- If legacy fallback produced one or more candidate neighbors, use those neighbor IDs as the `candidateNeighborIds`
+- If legacy fallback produced multiple candidate neighbors, preserve that full set
+- If legacy fallback produced exactly one candidate neighbor, return that one candidate in the ambiguity payload
+- If legacy fallback produced zero candidate neighbors but PeopleCore has multiple current people, still return ambiguity, with an empty `candidateNeighborIds` array if necessary rather than inventing fake neighbor IDs
+
+### Non-goals
+
+Do not do any of the following in this checkpoint:
+
+- no PeopleCore-to-neighbor reconciliation model
+- no resolver UI work
+- no contract changes
+- no route handler changes
+- no webhook orchestration rewrites
+- no inbound create-new flow redesign
+- no scoring/ranking engine
+
+### Required validation
+
+Run exactly these commands after implementation:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  src/modules/connectshyft/__tests__/identityResolver.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+
+pnpm nx run connectshyft-api:test
+```
+
+### Completion criteria
+
+Checkpoint 2 is complete only when all of the following are true:
+
+- the three current blocker tests now pass
+- no Checkpoint 1 characterization expectations were weakened
+- route response shapes remain unchanged
+- ambiguous/manual-resolution payloads remain deterministic
+- no production code outside the seam was changed except truly minimal fallout
+
+### Commit rule
+
+If validation passes and there are no blockers, commit all uncommitted changes for this checkpoint as:
+
+```bash
+refactor(slice-13): enforce peoplecore identity precedence ambiguity policy
+```
+
+If blockers remain, do not commit. Report:
+
+- what failed
+- why
+- the smallest next change required
+
+---
+
+### Checkpoint 3: Enforce PeopleCore-first authority rules in final identity decisions
+
+Wire the new comparison rules into final outcome determination.
+
+Required outcomes:
+
+- PeopleCore single + legacy same => current single-match outcome
+- PeopleCore single + legacy none => single-match outcome still allowed
+- PeopleCore single + legacy different => ambiguity/manual resolution
+- PeopleCore multi => ambiguity/manual resolution
+- PeopleCore none => legacy path preserved
+- PeopleCore unavailable => legacy path preserved
+
+Important:
+
+- preserve current `IDENTITY_MATCH_AMBIGUOUS` route code where that is the current external behavior
+- preserve current manualResolution structure
+- preserve current no-auto-merge behavior when shared/unverified safety conditions apply
+
+This checkpoint may require narrow changes in:
+
+- `identityBoundary.ts`
+- `identityResolver.ts`
+- `neighbors.ts`
+
+But do not broaden beyond authority logic.
+
+Validation commands:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/identityBoundary.test.ts \
+  src/modules/connectshyft/__tests__/identityResolver.test.ts \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+Commit:
+
+```bash
+git add .
+git commit -m "feat(slice-13): enforce peoplecore-first identity authority with explicit disagreement ambiguity"
+```
+
+Stop after Checkpoint 3.
+
+---
+
+### Checkpoint 4: Add narrow disagreement telemetry / audit
+
+Add internal telemetry or audit emission for authority comparison outcomes.
+
+Requirements:
+
+- no user-facing contract change required
+- keep implementation minimal
+- prefer existing audit/event infrastructure over new schema
+- no migration unless absolutely necessary
+
+Telemetry must capture:
+
+- normalized phone
+- peopleCore outcome
+- legacy outcome
+- final outcome
+- fallbackUsed
+- disagreementDetected
+
+Add focused tests proving:
+
+- disagreement records are emitted
+- fallback path records fallbackUsed=true
+- PeopleCore unavailable records peopleCoreOutcome=unavailable
+- no duplicate noisy emissions for one evaluation path
+
+Validation commands:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  src/modules/connectshyft/__tests__/identityResolver.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+Commit:
+
+```bash
+git add .
+git commit -m "feat(slice-13): add authority comparison telemetry for peoplecore identity seam"
+```
+
+Stop after Checkpoint 4.
+
+---
+
+### Checkpoint 5: Add narrow resolver-review creation for disagreement only if needed
+
+Only do this if the checkpoint 1-4 implementation leaves unresolved disagreement without durable review signal.
+
+If implemented:
+
+- trigger only on PeopleCore single-vs-legacy conflicting identity ownership
+- use deterministic triggerSourceType and triggerSourceId
+- keep best-effort behavior
+- avoid duplicate review creation for the same trigger
+
+Recommended trigger source:
+
+- `connectshyft_identity_authority_disagreement`
+
+Recommended review type:
+
+- `identity_conflict`
+
+Do not add this if telemetry plus ambiguity is already sufficient and tests/documents show it is deferred. Choose the minimal safe path.
+
+Validation commands:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+Commit:
+
+```bash
+git add .
+git commit -m "feat(slice-13): add narrow resolver review hook for identity authority disagreement"
+```
+
+Stop after Checkpoint 5.
+
+---
+
+### Checkpoint 6: Lock docs and roadmap
+
+Update architecture docs to reflect the new reality:
+
+Required doc updates:
+
+- `docs/architecture/identity-resolution-model.md`
+- `docs/architecture/peoplecore-identity-seam.md`
+- `docs/architecture/peoplecore-connectshyft-boundary-matrix.md`
+- `docs/architecture/connectshyft-router-refactor-plan.md`
+
+Required content:
+
+- PeopleCore is now first read authority for phone identity when current links exist
+- ConnectShyft neighbor remains compatibility shell for CRUD and fallback
+- disagreement policy is explicit ambiguity, never silent preference
+- bulk migration remains deferred
+- Slice 14 should likely target compatibility-shell reduction or application-shell groundwork, depending repo state at that point
+
+Also add one narrow note file if needed:
+
+- `apps/connectshyft-api/src/modules/connectshyft/PEOPLECORE_AUTHORITY_NOTES.md`
+
+Validation commands:
+
+```bash
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+cd apps/connectshyft-web && npm run build
+cd apps/connectshyft-web && npm run test
+```
+
+Commit:
+
+```bash
+git add .
+git commit -m "docs(slice-13): lock peoplecore read authority and connectshyft compatibility shell"
+```
+
+Stop after Checkpoint 6.
+
+---
+
+## Testing obligations
+
+You must preserve or extend characterization coverage for:
+
+- identity ambiguity
+- inbound SMS no-match create flow
+- inbound SMS single-match no-create flow
+- PeopleCore unavailable fallback
+- shared-contact no-auto-merge behavior
+- deleted-only legacy exclusions where already characterized
+- disagreement ambiguity behavior
+
+You must not remove existing characterization tests to make the slice pass.
+
+---
+
+## Required acceptance criteria
+
+1. PeopleCore exact single current person link is first authority for phone identity resolution.
+2. PeopleCore multiple current person links always produce ambiguity/manual resolution.
+3. PeopleCore absence preserves current legacy fallback behavior.
+4. PeopleCore and legacy disagreement never results in silent winner selection.
+5. Existing ConnectShyft route contracts remain intact.
+6. Inbound SMS still functions for aligned single-match and no-match create paths.
+7. Telemetry or audit captures comparison outcomes.
+8. Neighbor CRUD remains operational and unchanged at route-contract level.
+9. All tests pass.
+10. PR CI is green.
+
+---
+
+## Commands for final validation
+
+Run all of the following before opening PR:
+
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/identityBoundary.test.ts \
+  src/modules/connectshyft/__tests__/identityResolver.test.ts \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+cd apps/connectshyft-web && npm run build
+cd apps/connectshyft-web && npm run test
+```
+
+If any workspace lock or dependency metadata changed:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+If that fails because lockfiles need sync, update the workspace lock properly before opening PR.
+
+---
+
+## PR instructions
+
+Branch name:
+
+```bash
+git checkout -b codex/slice-13-peoplecore-read-authority-and-compat-shell
+```
+
+PR title:
+
+```text
+feat(slice-13): make peoplecore first read authority for connectshyft identity
+```
+
+PR summary must state:
+
+- PeopleCore-first identity read authority is now enforced where current links exist
+- disagreement is explicit ambiguity
+- legacy neighbor lookup remains fallback and compatibility shell
+- no bulk migration was attempted
+- route contracts were preserved
+
+---
+
+## Done definition
+
+Slice 13 is done only when:
+
+- authority precedence is implemented
+- disagreement is explicit ambiguity
+- current route contracts remain stable
+- telemetry exists
+- docs are updated
+- CI is green
+
+---
+
+## Explicitly deferred to later slice
+
+- full PeopleCore-backed candidate scoring across additional signals
+- rebinding engine
+- person-first CRUD cutover
+- deprecating `neighbors.ts`
+- resolver UI / queue experience
+- application shell
+- bulk backfill / migration tooling
+
+---
+
+## Counterpoint
+
+The tempting move is to make PeopleCore authoritative and simultaneously collapse `neighbors.ts` into a much smaller shell. Do not do that in this slice. The repo still shows broad direct neighbor dependencies across routes, handlers, inbound flows, and tests. Combining read-authority shift with major shell reduction would be unnecessary blast radius.
+
+The right move here is authority shift first, shell reduction later.

--- a/specs/slice-13-codex-ready-implementation-brief.md
+++ b/specs/slice-13-codex-ready-implementation-brief.md
@@ -1,19 +1,25 @@
 # Slice 13 Codex-Ready Implementation Brief
+
 ## Title
+
 PeopleCore identity read authority with ambiguity precedence and ConnectShyft compatibility shell
 
 ## Branch
+
 `codex/slice-13-peoplecore-read-authority-and-ambiguity-precedence`
 
 ## Objective
+
 Shift ConnectShyft phone identity lookup to a PeopleCore-first read model where PeopleCore can invalidate certainty but cannot assert identity equivalence across systems. Preserve current ConnectShyft route contracts, keep `neighbors.ts` as the compatibility shell for current CRUD and inbound workflows, and prevent incorrect identity attachment or create-new behavior under disagreement.
 
 ## Locked Policy
+
 For Slice 13, the precedence rule is:
 
 **PeopleCore can invalidate certainty, but cannot assert identity equivalence.**
 
 That means:
+
 - If PeopleCore has **no current person link**, preserve legacy ConnectShyft behavior.
 - If PeopleCore has **multiple current person links**, final outcome is ambiguity.
 - If PeopleCore has **one current person link** and legacy ConnectShyft yields a different concrete winner, final outcome is ambiguity.
@@ -26,7 +32,9 @@ This is a safety slice, not a reconciliation slice.
 ---
 
 ## Why this slice exists
+
 Slice 12 established:
+
 - PeopleCore persistence foundation
 - a PeopleCore identity seam
 - best-effort provisional identity hooks
@@ -36,6 +44,7 @@ Slice 12 established:
 But Slice 12 still leaves practical winner selection with the legacy ConnectShyft neighbor candidate layer. That is exactly why the new Checkpoint 1 tests fail: the current adapter still lets legacy single-winner logic collapse cases that should now be treated as disagreement ambiguity.
 
 Slice 13 is the controlled authority refinement:
+
 - PeopleCore becomes the first source consulted for phone identity read authority
 - legacy neighbor lookup remains fallback only when PeopleCore has no current linked person authority
 - disagreement becomes explicit ambiguity
@@ -44,6 +53,7 @@ Slice 13 is the controlled authority refinement:
 - neighbor CRUD remains intact as a compatibility shell
 
 This is **not**:
+
 - a neighbor-to-person migration slice
 - a resolver UI slice
 - a merge engine slice
@@ -53,6 +63,7 @@ This is **not**:
 ---
 
 ## Non-negotiable constraints
+
 1. Preserve existing route paths, route order, refusal envelope shape, and HTTP status behavior unless this brief explicitly says otherwise.
 2. Do not redesign ConnectShyft neighbor CRUD contracts in this slice.
 3. Do not remove `neighbors.ts` or existing async service exports in this slice.
@@ -69,9 +80,11 @@ This is **not**:
 ---
 
 ## Hard deferrals for Slice 13
+
 The attached Checkpoints 3 to 6 block is skeletal because it states policy but not repo-executable implementation detail. It correctly names the deferrals, but not the actual work package. The corrected version below makes those deferrals explicit and enforceable.
 
 Deferred beyond Slice 13:
+
 - neighbor ↔ person reconciliation
 - identity crosswalk table
 - inferred equivalence logic
@@ -84,6 +97,7 @@ Deferred beyond Slice 13:
 - timeline ownership migration
 
 Allowed in Slice 13:
+
 - comments marking future reconciliation
 - notes explicitly labeled `Deferred beyond Slice 13`
 - narrow ambiguity telemetry and resolver-review creation where already permitted
@@ -91,7 +105,9 @@ Allowed in Slice 13:
 ---
 
 ## Source-of-truth files
+
 Primary code files:
+
 - `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
@@ -102,6 +118,7 @@ Primary code files:
 - `apps/connectshyft-api/src/modules/peoplecore/service.ts`
 
 Primary test files:
+
 - `apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts`
@@ -109,6 +126,7 @@ Primary test files:
 - `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts`
 
 Documentation files:
+
 - `docs/architecture/identity-resolution-model.md`
 - `docs/architecture/peoplecore-identity-seam.md`
 - `docs/architecture/connectshyft-router-refactor-plan.md`
@@ -119,13 +137,17 @@ Documentation files:
 ## Required behavior model
 
 ### Rule A — PeopleCore unavailable
+
 If PeopleCore read persistence is unavailable:
+
 - keep current fallback behavior
 - preserve legacy outcome from current neighbor lookup
 - do not produce new ambiguity solely because PeopleCore is unavailable
 
 ### Rule B — PeopleCore no current person links
+
 If PeopleCore returns zero current person links for the normalized phone:
+
 - preserve legacy ConnectShyft behavior unchanged
 - legacy single current neighbor stays single_match
 - legacy multiple current neighbors stays ambiguity
@@ -133,14 +155,18 @@ If PeopleCore returns zero current person links for the normalized phone:
 - inbound no-match create-new path remains available
 
 ### Rule C — PeopleCore multiple current person links
+
 If PeopleCore returns more than one current person link:
+
 - final result is ambiguity
 - no legacy override allowed
 - no create-new allowed
 - current route envelope must remain deterministic
 
 ### Rule D — PeopleCore single current person link plus legacy disagreement
+
 If PeopleCore returns exactly one current person link and the legacy ConnectShyft candidate layer yields a different concrete current owner path:
+
 - final result is ambiguity
 - no silent winner
 - no attach to legacy winner
@@ -148,38 +174,47 @@ If PeopleCore returns exactly one current person link and the legacy ConnectShyf
 - no create-new
 
 For this slice, “disagreement” includes at minimum:
+
 - PeopleCore single current person link and legacy `single_match` with a different winner path than the seam’s PeopleCore-backed authority posture
 - PeopleCore single current person link and route-facing result would otherwise arbitrarily pick a legacy winner
 
 ### Rule E — PeopleCore single current person link plus legacy none
+
 If PeopleCore returns exactly one current person link and legacy ConnectShyft yields no current neighbor candidate:
+
 - final result remains no_match in Slice 13
 - PeopleCore cannot assert equivalence and force attach
 - inbound create-new shell may still proceed only if the overall result remains no_match and there is no ambiguity
 
 ### Rule F — Shared/unverified guardrails remain stronger than authority
+
 If a current exact-match path is blocked by shared-contact or verification rules:
+
 - preserve the current blocked / no-auto-merge behavior
 - PeopleCore cannot erase that safety condition
 
 ---
 
 ## Internal implementation recommendation
+
 Best practice recommendation: **keep `identityBoundary.ts` as the outward decision engine and refactor `peoplecoreIdentityAdapter.ts` into a comparison layer that can force ambiguity before the legacy winner reaches outward callers.**
 
 Why:
+
 - route and service contracts already depend on `ConnectShyftIdentityBoundaryResult`
 - tests already characterize existing outward behavior there
 - the current failure is not a route problem, it is a seam-precedence problem
 - this avoids unnecessary route churn
 
 Recommended internal types in `peoplecoreIdentityAdapter.ts`:
+
 - `PeopleCoreAuthorityOutcome`
 - `LegacyAuthorityOutcome`
 - `IdentityAuthorityComparison`
 - `ForcedAmbiguityReason`
 
 Recommended internal outcome enums:
+
 - PeopleCore outcome: `unavailable | no_current_links | single_current_link | multiple_current_links`
 - Legacy outcome: `no_match | single_match | multiple_matches`
 - Comparison outcome: `fallback_to_legacy | preserve_legacy | force_ambiguity`
@@ -189,10 +224,13 @@ Do **not** export these unless tests truly need them. Keep them local if possibl
 ---
 
 ## Checkpoint 1 — Characterization lock
+
 Status intent: characterize first, no production behavior changes.
 
 ### Required test coverage
+
 Add or finish characterization coverage for:
+
 1. PeopleCore single current link + legacy aligned single candidate → preserved current single-match behavior.
 2. PeopleCore single current link + legacy disagreement → ambiguity.
 3. PeopleCore multiple current links + legacy single candidate → ambiguity.
@@ -206,6 +244,7 @@ Add or finish characterization coverage for:
    - no arbitrary attach on disagreement
 
 ### Validation
+
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
   src/modules/connectshyft/__tests__/identityBoundary.test.ts \
@@ -217,6 +256,7 @@ pnpm nx run connectshyft-api:test
 ```
 
 ### Commit
+
 ```bash
 git add .
 git commit -m "test(slice-13): lock peoplecore ambiguity precedence characterization"
@@ -227,12 +267,15 @@ Stop after Checkpoint 1.
 ---
 
 ## Checkpoint 2 — Refactor seam precedence logic
+
 Status intent: fix the three known blockers by moving disagreement and multi-link authority handling into the seam.
 
 ### Required production changes
+
 Refactor `peoplecoreIdentityAdapter.ts` so it does **not** simply collect PeopleCore lookup data and then hand legacy candidates through unchanged.
 
 Instead:
+
 1. Normalize contact point value.
 2. Load PeopleCore contact points and current links.
 3. Derive PeopleCore authority outcome.
@@ -244,6 +287,7 @@ Instead:
 9. Run best-effort hooks after final result determination.
 
 ### Required logic
+
 - `multiple_current_links` => force ambiguity
 - `single_current_link + legacy_single_match_disagreement` => force ambiguity
 - `single_current_link + legacy_no_match` => preserve no_match for Slice 13
@@ -251,19 +295,23 @@ Instead:
 - `unavailable` => preserve legacy outcome
 
 ### Allowed implementation technique
+
 Either of these is acceptable:
+
 - build a forced ambiguity result directly inside the adapter using existing `ConnectShyftIdentityBoundaryResult` shape
 - or refactor a small shared helper in `identityBoundary.ts` for building ambiguity results, then call it from the adapter
 
 Default recommendation: build a small non-exported helper in the adapter if it keeps churn lower.
 
 ### Prohibitions
+
 - Do not add DB tables.
 - Do not add person↔neighbor mapping persistence.
 - Do not alter route response schema.
 - Do not inject PeopleCore-only fields into route payloads.
 
 ### Validation
+
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
   src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
@@ -273,6 +321,7 @@ pnpm nx run connectshyft-api:test
 ```
 
 ### Commit
+
 ```bash
 git add .
 git commit -m "refactor(slice-13): enforce peoplecore ambiguity precedence in seam"
@@ -283,13 +332,17 @@ Stop after Checkpoint 2.
 ---
 
 ## Checkpoint 3 — Resolver and route integrity
+
 The attached uploaded file reduces this to policy bullets, but the repo needs executable guidance. fileciteturn14file0
 
 ### System rule
+
 If ambiguity is produced at the seam, it is terminal for Slice 13.
 
 ### Required code behavior
+
 In `identityResolver.ts`:
+
 - preserve existing resolver contract
 - if seam returns `IDENTITY_MATCH_AMBIGUOUS`, resolver must return:
   - `type: 'multiple_matches'`
@@ -299,18 +352,21 @@ In `identityResolver.ts`:
 - do not transform seam ambiguity into no_match
 
 In route-facing identity-match flows:
+
 - existing ambiguity envelope must remain unchanged
 - `manualResolution` block remains deterministic
 - success / refusal status behavior remains unchanged
 - no PeopleCore-specific fields in outward response
 
 ### Files in scope
+
 - `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
 - `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborIdentityMatch.ts`
 - tests already covering route envelopes
 
 ### Required tests
+
 - Resolver disagreement case returns `multiple_matches`
 - Resolver PeopleCore multi-link case returns `multiple_matches`
 - Identity-match route disagreement case returns existing ambiguity refusal shape
@@ -318,6 +374,7 @@ In route-facing identity-match flows:
 - No legacy fallback path overrides seam ambiguity
 
 ### Validation
+
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
   src/modules/connectshyft/__tests__/identityResolver.test.ts \
@@ -327,6 +384,7 @@ pnpm nx run connectshyft-api:test
 ```
 
 ### Commit
+
 ```bash
 git add .
 git commit -m "refactor(slice-13): preserve seam ambiguity through resolver and routes"
@@ -337,13 +395,17 @@ Stop after Checkpoint 3.
 ---
 
 ## Checkpoint 4 — Hard deferral of reconciliation
+
 This checkpoint is mainly negative scope enforcement, but it still needs concrete repo verification.
 
 ### System rule
+
 There is no identity reconciliation in Slice 13.
 
 ### Absolute prohibitions
+
 Do not add:
+
 - mapping tables
 - identity crosswalk persistence
 - person↔neighbor join service
@@ -354,17 +416,22 @@ Do not add:
 - background reconciliation job
 
 ### Allowed
+
 - internal comments noting `Deferred beyond Slice 13`
 - documentation clarifying why ambiguity increases in this slice
 
 ### Required code review checks
+
 Search and verify there are no new:
+
 - migrations for identity mapping
 - new peoplecore services for reconciliation
 - new contract enums solely for mapping infrastructure
 
 ### Validation
+
 Run these search checks after implementation:
+
 ```bash
 rg -n "crosswalk|reconcil|equivalen|heuristic|similarity|score|link.*neighbor|neighbor.*person.*map|mapping table" apps/connectshyft-api/src libs/contracts shared/database/migrations docs
 rg -n "createTable\(|ALTER TABLE|ADD COLUMN" shared/database/migrations apps/connectshyft-api/src/migrations | rg -i "person|neighbor|identity|mapping|crosswalk"
@@ -373,6 +440,7 @@ pnpm nx run contracts:test
 ```
 
 ### Commit
+
 ```bash
 git add docs apps/connectshyft-api/src/modules/connectshyft apps/connectshyft-api/src/modules/peoplecore libs/contracts
 # only if there are actual changes from this checkpoint
@@ -385,48 +453,64 @@ Stop after Checkpoint 4.
 ---
 
 ## Checkpoint 5 — Creation guard and inbound SMS flow control
+
 The uploaded block states the policy correctly, but it needs repo-specific implementation instructions. fileciteturn14file0
 
 ### System rule
+
 Ambiguity blocks creation.
 
 ### Required behavior
+
 If the final seam/resolver outcome is ambiguity:
+
 - inbound SMS must not create a new neighbor
 - webhook path must preserve current ambiguity refusal behavior
 - no attach to an arbitrary existing neighbor
 - no retry-based create on same ambiguous event
 
 If the final outcome is no_match:
+
 - preserve current create-new shell behavior
 - preserve idempotency behavior already in place
 
 ### Files in scope
+
 - `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
 - `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
 - `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts`
 - provider-registry inbound dispatch tests if touched indirectly
 
 ### Required tests
+
 - disagreement path through inbound SMS does not call `createNeighborFromInbound`
 - PeopleCore multi-link ambiguity does not call `createNeighborFromInbound`
 - PeopleCore no-current-link + legacy no_match still does call `createNeighborFromInbound`
 - PeopleCore unavailable still preserves current fallback create path when legacy no_match applies
 
 ### Idempotency requirement
+
 Do not add new idempotency semantics. Preserve current dedupe and create behavior. The key rule is only:
+
 - ambiguity must never create
 
-### Validation
+### Validation:
+
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
   src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts \
-  src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts \
   src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts
+
 pnpm nx run connectshyft-api:test
 ```
 
+Known unrelated validation issue:
+
+- src/routes/api/v1/**tests**/connectshyft.provider-registry.dispatch-events.test.ts contains a pre-existing failing characterization at line 1097 expecting CONNECTSHYFT_THREAD_DETAIL_LOADED while current route behavior returns CONNECTSHYFT_THREAD_NOT_FOUND for thread-f2-unclaimed-1001.
+- This failure is unrelated to Checkpoint 5 ambiguity/create-new behavior and did not regress from this checkpoint.
+
 ### Commit
+
 ```bash
 git add .
 git commit -m "fix(slice-13): block create-new under peoplecore ambiguity"
@@ -437,23 +521,29 @@ Stop after Checkpoint 5.
 ---
 
 ## Checkpoint 6 — Documentation alignment
+
 The uploaded block names the right doc themes, but not the repo-facing edits. fileciteturn14file0
 
 ### Must document
 
 #### 1. Precedence rule
+
 Add explicit wording:
+
 - PeopleCore can block certainty
 - PeopleCore cannot assert identity equivalence in Slice 13
 - disagreement becomes ambiguity
 
 #### 2. Ambiguity categories
+
 Document these explicitly:
+
 - legacy multi-neighbor ambiguity
 - PeopleCore multi-person ambiguity
 - cross-system disagreement ambiguity
 
 #### 3. Decision flow
+
 Document this exact logic in prose or diagram form:
 
 ```text
@@ -470,7 +560,9 @@ PeopleCore available?
 ```
 
 #### 4. Non-goals
+
 Explicitly state:
+
 - no reconciliation
 - no crosswalk
 - no auto-linking
@@ -478,22 +570,27 @@ Explicitly state:
 - no scoring engine
 
 #### 5. Slice 14 handoff note
+
 Document that the next logical slice is operationalization of ambiguity and resolver handling, not reconciliation.
 
 ### Files to update
+
 - `docs/architecture/identity-resolution-model.md`
 - `docs/architecture/peoplecore-identity-seam.md`
 - `docs/architecture/connectshyft-router-refactor-plan.md`
 - `docs/architecture/peoplecore-connectshyft-boundary-matrix.md`
 
 ### Prohibited documentation language
+
 Do not imply Slice 13 already does:
+
 - future merge logic in present tense
 - automatic PeopleCore/neighbor linking
 - eventual consistency already established
 - person↔neighbor equivalence as a solved problem
 
 ### Validation
+
 ```bash
 rg -n "auto-link|crosswalk|equivalence|reconciliation|merge engine|scoring" docs/architecture
 pnpm nx run connectshyft-api:test
@@ -501,6 +598,7 @@ pnpm nx run contracts:test
 ```
 
 ### Commit
+
 ```bash
 git add docs/architecture
 git commit -m "docs(slice-13): align architecture to peoplecore ambiguity precedence"
@@ -511,7 +609,9 @@ Stop after Checkpoint 6.
 ---
 
 ## Final validation sweep
+
 Run at the end of the slice:
+
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
   src/modules/connectshyft/__tests__/identityBoundary.test.ts \
@@ -527,6 +627,7 @@ pnpm nx run contracts:test
 ```
 
 Optional broader safety pass if already normal for your branch:
+
 ```bash
 pnpm nx run admin-api:test
 pnpm nx run moneyshyft-api:test
@@ -535,6 +636,7 @@ pnpm nx run moneyshyft-api:test
 ---
 
 ## Expected commit sequence
+
 1. `test(slice-13): lock peoplecore ambiguity precedence characterization`
 2. `refactor(slice-13): enforce peoplecore ambiguity precedence in seam`
 3. `refactor(slice-13): preserve seam ambiguity through resolver and routes`
@@ -547,13 +649,16 @@ If you prefer a single squashed codex branch before PR, use the checkpoint commi
 ---
 
 ## PR target
+
 - Base: `codex/dev`
 - Branch: `codex/slice-13-peoplecore-read-authority-and-ambiguity-precedence`
 
 ## PR title
+
 `Slice 13: enforce PeopleCore ambiguity precedence and preserve ConnectShyft compatibility shell`
 
 ## PR summary bullets
+
 - makes PeopleCore first read authority for identity invalidation
 - forces ambiguity on cross-system disagreement and multi-link PeopleCore cases
 - preserves legacy fallback when PeopleCore has no current links or is unavailable
@@ -564,6 +669,7 @@ If you prefer a single squashed codex branch before PR, use the checkpoint commi
 ---
 
 ## Codex execution note
+
 Do not improvise beyond this slice.
 
 The correct behavior for Slice 13 is to increase ambiguity in unsafe disagreement cases. That is intentional. A noisier but safer ambiguity result is better than a cleaner but wrong identity winner.

--- a/specs/slice-13-codex-ready-implementation-brief.md
+++ b/specs/slice-13-codex-ready-implementation-brief.md
@@ -1,250 +1,211 @@
 # Slice 13 Codex-Ready Implementation Brief
-
 ## Title
-
-PeopleCore identity read authority and ConnectShyft compatibility shell
+PeopleCore identity read authority with ambiguity precedence and ConnectShyft compatibility shell
 
 ## Branch
-
-`codex/slice-13-peoplecore-read-authority-and-compat-shell`
+`codex/slice-13-peoplecore-read-authority-and-ambiguity-precedence`
 
 ## Objective
-
-Make PeopleCore the first authoritative source for phone identity resolution while preserving existing ConnectShyft route contracts and keeping `neighbors.ts` as the operational compatibility shell for current CRUD and inbound workflows.
+Shift ConnectShyft phone identity lookup to a PeopleCore-first read model where PeopleCore can invalidate certainty but cannot assert identity equivalence across systems. Preserve current ConnectShyft route contracts, keep `neighbors.ts` as the compatibility shell for current CRUD and inbound workflows, and prevent incorrect identity attachment or create-new behavior under disagreement.
 
 ## Locked Policy
+For Slice 13, the precedence rule is:
 
-When PeopleCore and legacy ConnectShyft neighbor resolution disagree, Slice 13 MUST return ambiguity/manual resolution and MUST NOT silently prefer either side.
+**PeopleCore can invalidate certainty, but cannot assert identity equivalence.**
+
+That means:
+- If PeopleCore has **no current person link**, preserve legacy ConnectShyft behavior.
+- If PeopleCore has **multiple current person links**, final outcome is ambiguity.
+- If PeopleCore has **one current person link** and legacy ConnectShyft yields a different concrete winner, final outcome is ambiguity.
+- If PeopleCore has **one current person link** and legacy ConnectShyft yields no current winner, final outcome remains no-match for this slice.
+- If PeopleCore has **one current person link** and legacy ConnectShyft aligns cleanly on the same practical ownership path, current single-match behavior may continue.
+- PeopleCore must **not** silently replace the legacy neighbor identifier returned by existing ConnectShyft flows in this slice.
+
+This is a safety slice, not a reconciliation slice.
 
 ---
 
 ## Why this slice exists
-
 Slice 12 established:
-
 - PeopleCore persistence foundation
 - a PeopleCore identity seam
 - best-effort provisional identity hooks
 - best-effort resolver review hooks
 - preserved ConnectShyft outward behavior
 
-But Slice 12 still leaves candidate authority with ConnectShyft neighbor lookup in practical terms. Slice 13 is the controlled authority shift:
+But Slice 12 still leaves practical winner selection with the legacy ConnectShyft neighbor candidate layer. That is exactly why the new Checkpoint 1 tests fail: the current adapter still lets legacy single-winner logic collapse cases that should now be treated as disagreement ambiguity.
 
-- PeopleCore becomes first read authority for phone identity
-- ConnectShyft neighbor lookup remains fallback only when PeopleCore has no current person link
-- disagreement becomes an explicit ambiguity outcome, never a hidden winner
-- neighbor CRUD remains intact for now as a compatibility shell
+Slice 13 is the controlled authority refinement:
+- PeopleCore becomes the first source consulted for phone identity read authority
+- legacy neighbor lookup remains fallback only when PeopleCore has no current linked person authority
+- disagreement becomes explicit ambiguity
+- create-new remains blocked under ambiguity
+- existing route envelopes remain stable
+- neighbor CRUD remains intact as a compatibility shell
 
-This is not the bulk-migration slice, not the resolver-UI slice, and not the application-shell slice.
+This is **not**:
+- a neighbor-to-person migration slice
+- a resolver UI slice
+- a merge engine slice
+- a crosswalk or reconciliation slice
+- an application-shell slice
 
 ---
 
 ## Non-negotiable constraints
-
 1. Preserve existing route paths, route order, refusal envelope shape, and HTTP status behavior unless this brief explicitly says otherwise.
 2. Do not redesign ConnectShyft neighbor CRUD contracts in this slice.
-3. Do not remove `neighbors.ts` or the existing async service exports in this slice.
-4. Do not bulk-backfill all ConnectShyft neighbors into PeopleCore in this slice.
-5. Do not add broad new resolver workflows beyond the narrow cases defined here.
-6. Do not silently choose a winner when PeopleCore and legacy neighbor lookup disagree.
-7. All new PeopleCore-first authority logic must remain tenant-scoped and org-unit-safe.
-8. All new behavior must be characterized before refactor or authority shift.
-9. Preserve current inbound SMS operational continuity.
-10. Keep the current seam best-effort posture for write hooks. Request-path failures in PeopleCore hook writes must not break current ConnectShyft route outcomes.
+3. Do not remove `neighbors.ts` or existing async service exports in this slice.
+4. Do not add a cross-system identity mapping table, join table, or equivalence cache in this slice.
+5. Do not bulk-backfill ConnectShyft neighbors into PeopleCore in this slice.
+6. Do not silently choose a winner when PeopleCore and legacy ConnectShyft disagree.
+7. Do not let ambiguity collapse into `single_match` or `no_match` except where explicitly allowed by the locked rules.
+8. Do not let ambiguity trigger neighbor creation.
+9. Keep write hooks best-effort. Hook failure must not break existing ConnectShyft request-path outcomes.
+10. All new logic must remain tenant-scoped and org-unit-safe.
+11. Characterize before refactor.
+12. Keep current shared-contact and verification guardrails intact.
 
 ---
 
-## Authority rules to implement
+## Hard deferrals for Slice 13
+The attached Checkpoints 3 to 6 block is skeletal because it states policy but not repo-executable implementation detail. It correctly names the deferrals, but not the actual work package. The corrected version below makes those deferrals explicit and enforceable.
 
-For normalized phone identity lookup:
+Deferred beyond Slice 13:
+- neighbor ↔ person reconciliation
+- identity crosswalk table
+- inferred equivalence logic
+- similarity scoring
+- household-assisted ranking
+- merge automation
+- PeopleCore-first person CRUD replacement for ConnectShyft routes
+- resolver UI / inbox / queue
+- broad event-driven rebinding
+- timeline ownership migration
 
-### Rule A: PeopleCore exact single current person link wins
-
-If PeopleCore returns exactly one current person link for the normalized phone value:
-
-- resolution outcome is single match
-- use that PeopleCore person identity as the authoritative identity answer
-- if a legacy ConnectShyft neighbor candidate exists and aligns cleanly, continue normally
-- if legacy data disagrees, return ambiguity/manual resolution instead of selecting either side
-
-### Rule B: PeopleCore multiple current person links is ambiguous
-
-If PeopleCore returns more than one current person link for the normalized phone value:
-
-- return ambiguity/manual resolution
-- do not fall through to legacy neighbor winner selection
-- create or reuse narrow resolver-review hooks as already allowed by the seam
-
-### Rule C: PeopleCore no current person links falls back
-
-If PeopleCore returns no current person links:
-
-- preserve current legacy ConnectShyft neighbor lookup behavior
-- preserve current single_match / no_match / multiple_matches outcomes from the legacy path
-- preserve current inbound no-match create flow
-
-### Rule D: Disagreement is explicit ambiguity
-
-If PeopleCore yields a single current person link but the legacy ConnectShyft candidate layer disagrees in identity ownership:
-
-- return ambiguity/manual resolution
-- do not auto-merge
-- do not choose PeopleCore silently
-- do not choose legacy silently
-- optionally create a resolver review using a narrow mismatch trigger defined in this slice
-
-### Rule E: Shared-contact and unverified guardrails still apply
-
-If the current exact-match safety rules would block auto-merge because of shared or unverified conditions:
-
-- preserve the current blocked/no-auto-merge behavior
-- do not let PeopleCore-first authority erase those safety rules
+Allowed in Slice 13:
+- comments marking future reconciliation
+- notes explicitly labeled `Deferred beyond Slice 13`
+- narrow ambiguity telemetry and resolver-review creation where already permitted
 
 ---
 
-## In scope
-
-- PeopleCore-first read authority for phone identity
-- disagreement detection between PeopleCore authority and legacy neighbor candidates
-- preserved fallback when PeopleCore has no current person link
-- narrow resolver-review creation for disagreement if specified below
-- telemetry / audit / shadow comparison for lookup outcomes
-- characterization coverage
-- architecture note updates
-
-## Out of scope
-
-- bulk backfill
-- replacing neighbor CRUD routes with PeopleCore person CRUD
-- application shell
-- resolver UI / queue UI
-- full rebinding engine
-- PeopleCore-first timeline ownership
-- household-based identity scoring expansion
-- ML scoring
-- hard performance budget enforcement beyond the current repo conventions
-
----
-
-## Source-of-truth files to work in
-
-Primary likely files:
-
+## Source-of-truth files
+Primary code files:
 - `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
 - `apps/connectshyft-api/src/modules/peoplecore/store.ts`
 - `apps/connectshyft-api/src/modules/peoplecore/service.ts`
-- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts`
-- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts`
+
+Primary test files:
 - `apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`
 - `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts`
+
+Documentation files:
 - `docs/architecture/identity-resolution-model.md`
 - `docs/architecture/peoplecore-identity-seam.md`
 - `docs/architecture/connectshyft-router-refactor-plan.md`
-
-Potential supporting file if needed:
-
-- `apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts`
+- `docs/architecture/peoplecore-connectshyft-boundary-matrix.md`
 
 ---
 
-## Required telemetry / comparison model
+## Required behavior model
 
-Add a narrow internal comparison record for identity lookup execution. This does not need a database migration in this slice unless truly necessary. Start with audit/event emission if possible.
+### Rule A — PeopleCore unavailable
+If PeopleCore read persistence is unavailable:
+- keep current fallback behavior
+- preserve legacy outcome from current neighbor lookup
+- do not produce new ambiguity solely because PeopleCore is unavailable
 
-For each PeopleCore-aware lookup attempt, capture:
+### Rule B — PeopleCore no current person links
+If PeopleCore returns zero current person links for the normalized phone:
+- preserve legacy ConnectShyft behavior unchanged
+- legacy single current neighbor stays single_match
+- legacy multiple current neighbors stays ambiguity
+- legacy no current neighbors stays no_match
+- inbound no-match create-new path remains available
 
-- tenantId
-- orgUnitId if present
-- normalizedContactPointValue
-- peopleCoreOutcome: `single_match | no_match | multiple_matches | unavailable`
-- peopleCoreSubjectIds
-- legacyOutcome: `single_match | no_match | multiple_matches | unavailable`
-- legacyNeighborIds
-- finalOutcome: `single_match | no_match | multiple_matches | no_auto_merge | ambiguous`
-- fallbackUsed: boolean
-- disagreementDetected: boolean
-- hookWriteAttempted: boolean
-- hookWriteSucceeded: boolean
+### Rule C — PeopleCore multiple current person links
+If PeopleCore returns more than one current person link:
+- final result is ambiguity
+- no legacy override allowed
+- no create-new allowed
+- current route envelope must remain deterministic
 
-This is for safe migration visibility, not user-facing UI.
+### Rule D — PeopleCore single current person link plus legacy disagreement
+If PeopleCore returns exactly one current person link and the legacy ConnectShyft candidate layer yields a different concrete current owner path:
+- final result is ambiguity
+- no silent winner
+- no attach to legacy winner
+- no attach to hypothetical PeopleCore winner
+- no create-new
 
----
+For this slice, “disagreement” includes at minimum:
+- PeopleCore single current person link and legacy `single_match` with a different winner path than the seam’s PeopleCore-backed authority posture
+- PeopleCore single current person link and route-facing result would otherwise arbitrarily pick a legacy winner
 
-## Narrow resolver-review expansion allowed in this slice
+### Rule E — PeopleCore single current person link plus legacy none
+If PeopleCore returns exactly one current person link and legacy ConnectShyft yields no current neighbor candidate:
+- final result remains no_match in Slice 13
+- PeopleCore cannot assert equivalence and force attach
+- inbound create-new shell may still proceed only if the overall result remains no_match and there is no ambiguity
 
-Allowed:
-
-- existing ambiguous shared-contact review creation
-- a new narrow review trigger for **PeopleCore / legacy identity disagreement** if implemented minimally and deterministically
-
-If added, use:
-
-- `reviewType`: `identity_conflict`
-- confidence band: `high`
-- risk flag must include: `conflicting_name_dob` only if actually true, otherwise use `duplicate_creation_attempt` only if that is what happened, otherwise introduce no fake flag
-- trigger source should be deterministic and idempotent
-
-Default recommendation:
-
-- reuse `identity_conflict`
-- do not expand contract enums unless existing values are insufficient
-
----
-
-## Data / contract expectations
-
-Do not break existing contracts in `libs/contracts` unless a narrowly justified addition is required.
-
-Default assumption:
-
-- Slice 13 should avoid new contract enums
-- Slice 13 should work with current `ResolverReview`, `ContactPoint`, and current identity outputs
-- only update docs if code can remain within current contract surface
+### Rule F — Shared/unverified guardrails remain stronger than authority
+If a current exact-match path is blocked by shared-contact or verification rules:
+- preserve the current blocked / no-auto-merge behavior
+- PeopleCore cannot erase that safety condition
 
 ---
 
-## Implementation plan
+## Internal implementation recommendation
+Best practice recommendation: **keep `identityBoundary.ts` as the outward decision engine and refactor `peoplecoreIdentityAdapter.ts` into a comparison layer that can force ambiguity before the legacy winner reaches outward callers.**
 
-### Checkpoint 1: Characterize current and new authority cases before changing logic
+Why:
+- route and service contracts already depend on `ConnectShyftIdentityBoundaryResult`
+- tests already characterize existing outward behavior there
+- the current failure is not a route problem, it is a seam-precedence problem
+- this avoids unnecessary route churn
 
-Add or extend characterization tests that lock:
+Recommended internal types in `peoplecoreIdentityAdapter.ts`:
+- `PeopleCoreAuthorityOutcome`
+- `LegacyAuthorityOutcome`
+- `IdentityAuthorityComparison`
+- `ForcedAmbiguityReason`
 
-1. PeopleCore single current link + legacy same neighbor result
-   - final result stays single_match / current allowed outcome
+Recommended internal outcome enums:
+- PeopleCore outcome: `unavailable | no_current_links | single_current_link | multiple_current_links`
+- Legacy outcome: `no_match | single_match | multiple_matches`
+- Comparison outcome: `fallback_to_legacy | preserve_legacy | force_ambiguity`
 
-2. PeopleCore single current link + legacy different neighbor result
-   - final result becomes ambiguity/manual resolution
-   - no silent winner
+Do **not** export these unless tests truly need them. Keep them local if possible.
 
-3. PeopleCore multiple current links + legacy single candidate
-   - final result is ambiguity/manual resolution
-   - no legacy override
+---
 
-4. PeopleCore no current links + legacy single candidate
-   - legacy single_match preserved
+## Checkpoint 1 — Characterization lock
+Status intent: characterize first, no production behavior changes.
 
-5. PeopleCore unavailable + legacy single candidate
-   - current fallback preserved
+### Required test coverage
+Add or finish characterization coverage for:
+1. PeopleCore single current link + legacy aligned single candidate → preserved current single-match behavior.
+2. PeopleCore single current link + legacy disagreement → ambiguity.
+3. PeopleCore multiple current links + legacy single candidate → ambiguity.
+4. PeopleCore no current links + legacy single candidate → preserved legacy single_match.
+5. PeopleCore unavailable + legacy single candidate → preserved legacy single_match.
+6. Shared-contact case under PeopleCore-first lookup still blocks auto-merge.
+7. Identity-match route keeps current ambiguity envelope and deterministic manualResolution shape.
+8. Inbound SMS preserves:
+   - no create-new on ambiguity
+   - current create-new shell only on no_match
+   - no arbitrary attach on disagreement
 
-6. Inbound SMS path:
-   - PeopleCore single current link + legacy aligned -> do not create new neighbor
-   - PeopleCore no current link + legacy no_match -> current create-new flow preserved
-   - PeopleCore / legacy disagreement -> ambiguity path preserved, no arbitrary attach, no create-new
-
-7. Identity-match route:
-   - disagreement returns `IDENTITY_MATCH_AMBIGUOUS`
-   - current manualResolution payload remains deterministic
-
-8. Shared-contact case:
-   - PeopleCore single current link with shared conditions still blocks auto-merge if current rules block it
-
-Validation commands:
-
+### Validation
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
   src/modules/connectshyft/__tests__/identityBoundary.test.ts \
@@ -255,471 +216,354 @@ pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js -
 pnpm nx run connectshyft-api:test
 ```
 
-Commit:
-
+### Commit
 ```bash
 git add .
-git commit -m "test(slice-13): lock peoplecore authority and disagreement characterization"
+git commit -m "test(slice-13): lock peoplecore ambiguity precedence characterization"
 ```
 
 Stop after Checkpoint 1.
 
 ---
 
-## Checkpoint 2 — Implement PeopleCore-vs-legacy precedence and ambiguity policy
+## Checkpoint 2 — Refactor seam precedence logic
+Status intent: fix the three known blockers by moving disagreement and multi-link authority handling into the seam.
 
-### Objective
+### Required production changes
+Refactor `peoplecoreIdentityAdapter.ts` so it does **not** simply collect PeopleCore lookup data and then hand legacy candidates through unchanged.
 
-Refactor the PeopleCore seam so it no longer treats PeopleCore lookup as observational-only when PeopleCore has current-link evidence. Preserve all locked route/result shapes, but change the seam decision policy so current PeopleCore evidence can force ambiguity instead of silently deferring to a legacy single winner.
+Instead:
+1. Normalize contact point value.
+2. Load PeopleCore contact points and current links.
+3. Derive PeopleCore authority outcome.
+4. Load legacy active neighbor candidates.
+5. Derive legacy outcome.
+6. Compare the two.
+7. If comparison requires ambiguity, return an ambiguity-shaped `ConnectShyftIdentityBoundaryResult` before legacy winner selection leaks outward.
+8. If comparison permits fallback or preservation, continue existing boundary evaluation.
+9. Run best-effort hooks after final result determination.
 
-### Scope
+### Required logic
+- `multiple_current_links` => force ambiguity
+- `single_current_link + legacy_single_match_disagreement` => force ambiguity
+- `single_current_link + legacy_no_match` => preserve no_match for Slice 13
+- `no_current_links` => preserve legacy outcome
+- `unavailable` => preserve legacy outcome
 
-Edit only the minimum code necessary in:
+### Allowed implementation technique
+Either of these is acceptable:
+- build a forced ambiguity result directly inside the adapter using existing `ConnectShyftIdentityBoundaryResult` shape
+- or refactor a small shared helper in `identityBoundary.ts` for building ambiguity results, then call it from the adapter
 
-- `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts`
-- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts` only if required by type fallout or dead-simple normalization of adapter outputs
-- related unit tests only as required to satisfy the locked Checkpoint 1 characterization expectations
+Default recommendation: build a small non-exported helper in the adapter if it keeps churn lower.
 
-Do not edit route handlers, HTTP envelopes, contracts, migrations, or PeopleCore store/service APIs in this checkpoint.
+### Prohibitions
+- Do not add DB tables.
+- Do not add person↔neighbor mapping persistence.
+- Do not alter route response schema.
+- Do not inject PeopleCore-only fields into route payloads.
 
-### Locked policy to implement
-
-Treat these as hard rules:
-
-1. **Legacy-only remains legacy-owned**
-   - If PeopleCore is unavailable, has no contact point for the normalized value, or has no current person links for that contact point, preserve existing ConnectShyft legacy candidate behavior unchanged.
-   - This means:
-     - legacy single eligible neighbor stays single-match / current legacy result
-     - legacy no-match stays no-match
-     - legacy ambiguous stays ambiguous
-
-2. **PeopleCore current-link evidence is authoritative enough to block a silent winner**
-   - If PeopleCore returns one or more current person links for the normalized contact point, the seam must no longer silently trust a conflicting legacy single winner.
-
-3. **Single PeopleCore current person + single legacy neighbor disagreement => ambiguous**
-   - If PeopleCore has exactly one distinct current linked person for the normalized contact point, and legacy fallback resolves exactly one candidate neighbor, but the seam cannot prove they are the same underlying subject, return ambiguity.
-   - Do not return single_match in this situation.
-   - Do not invent a mapping.
-   - Do not auto-merge.
-   - Do not create a provisional identity.
-   - This ambiguity must preserve the existing `IDENTITY_MATCH_AMBIGUOUS` result shape and manual-resolution context.
-
-4. **Multiple PeopleCore current linked people => ambiguous**
-   - If PeopleCore has more than one distinct current linked person for the normalized contact point, return ambiguity even if legacy fallback has exactly one candidate neighbor.
-   - This is a hard stop.
-
-5. **Shared/unverified legacy guardrails still apply**
-   - If legacy candidate behavior already yields no-auto-merge due to shared or unverified conditions, preserve that.
-   - Do not weaken existing shared-contact safety rules.
-
-6. **No new neighbor<->person mapping layer in this checkpoint**
-   - Do not add a person-to-neighbor crosswalk table.
-   - Do not infer equivalence from names or other heuristics.
-   - Do not join PeopleCore persons to ConnectShyft neighbors.
-   - This checkpoint is precedence and refusal policy only.
-
-7. **Hook side effects remain best-effort**
-   - Existing best-effort hook behavior stays best-effort.
-   - Resolver-review creation on ambiguous flows may continue.
-   - No-match provisional creation must not fire when the seam now returns ambiguity.
-
-### Implementation guidance
-
-Refactor `peoplecoreIdentityAdapter.ts` to introduce an explicit intermediate decision layer before returning the final boundary result.
-
-Recommended shape:
-
-- Add small internal helpers for:
-  - collecting distinct current linked PeopleCore person IDs from `peopleCoreCurrentLinks`
-  - determining whether PeopleCore has authoritative current-link evidence
-  - determining whether fallback legacy candidates are:
-    - none
-    - single
-    - multiple
-  - deciding whether the seam must override legacy single-winner behavior to ambiguity
-
-- Keep the existing normalized lookup loading path.
-- Keep existing fallback candidate loading path.
-- Keep existing call into the legacy boundary logic where appropriate.
-- Add a seam-level override step after lookup and before final return:
-  - if PeopleCore has no authoritative current-link evidence, return the legacy boundary result unchanged
-  - if PeopleCore has multiple distinct current person IDs, force ambiguous result
-  - if PeopleCore has one distinct current person ID and legacy result is a single-match winner, force ambiguous result unless a same-subject proof exists
-  - since there is currently no same-subject proof mechanism, this case is ambiguous by policy
-
-### Important constraint on result construction
-
-Do **not** create a new route/result shape.
-
-Use the same result family already used by `identityBoundary.ts`:
-
-- ambiguous must still be `ok: false`
-- code must still be `IDENTITY_MATCH_AMBIGUOUS`
-- manualResolution payload must still exist
-- `candidateNeighborIds` must remain deterministic and sorted from the legacy candidate side when present
-
-For the resolver seam:
-
-- the resolver should continue translating ambiguous boundary results into:
-  - `type: 'multiple_matches'`
-  - sorted `candidateNeighborIds`
-  - normalized contact point
-
-### Candidate-neighbor rules for forced ambiguity
-
-When ambiguity is forced due to PeopleCore evidence:
-
-- If legacy fallback produced one or more candidate neighbors, use those neighbor IDs as the `candidateNeighborIds`
-- If legacy fallback produced multiple candidate neighbors, preserve that full set
-- If legacy fallback produced exactly one candidate neighbor, return that one candidate in the ambiguity payload
-- If legacy fallback produced zero candidate neighbors but PeopleCore has multiple current people, still return ambiguity, with an empty `candidateNeighborIds` array if necessary rather than inventing fake neighbor IDs
-
-### Non-goals
-
-Do not do any of the following in this checkpoint:
-
-- no PeopleCore-to-neighbor reconciliation model
-- no resolver UI work
-- no contract changes
-- no route handler changes
-- no webhook orchestration rewrites
-- no inbound create-new flow redesign
-- no scoring/ranking engine
-
-### Required validation
-
-Run exactly these commands after implementation:
-
+### Validation
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
   src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
   src/modules/connectshyft/__tests__/identityResolver.test.ts \
-  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
-  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
-
+  src/modules/connectshyft/__tests__/identityBoundary.test.ts
 pnpm nx run connectshyft-api:test
 ```
 
-### Completion criteria
-
-Checkpoint 2 is complete only when all of the following are true:
-
-- the three current blocker tests now pass
-- no Checkpoint 1 characterization expectations were weakened
-- route response shapes remain unchanged
-- ambiguous/manual-resolution payloads remain deterministic
-- no production code outside the seam was changed except truly minimal fallout
-
-### Commit rule
-
-If validation passes and there are no blockers, commit all uncommitted changes for this checkpoint as:
-
+### Commit
 ```bash
-refactor(slice-13): enforce peoplecore identity precedence ambiguity policy
+git add .
+git commit -m "refactor(slice-13): enforce peoplecore ambiguity precedence in seam"
 ```
 
-If blockers remain, do not commit. Report:
-
-- what failed
-- why
-- the smallest next change required
+Stop after Checkpoint 2.
 
 ---
 
-### Checkpoint 3: Enforce PeopleCore-first authority rules in final identity decisions
+## Checkpoint 3 — Resolver and route integrity
+The attached uploaded file reduces this to policy bullets, but the repo needs executable guidance. fileciteturn14file0
 
-Wire the new comparison rules into final outcome determination.
+### System rule
+If ambiguity is produced at the seam, it is terminal for Slice 13.
 
-Required outcomes:
+### Required code behavior
+In `identityResolver.ts`:
+- preserve existing resolver contract
+- if seam returns `IDENTITY_MATCH_AMBIGUOUS`, resolver must return:
+  - `type: 'multiple_matches'`
+  - `candidateNeighborIds` from the seam/manualResolution payload
+  - same normalized contact point returned by current logic
+- do not transform seam ambiguity into single_match
+- do not transform seam ambiguity into no_match
 
-- PeopleCore single + legacy same => current single-match outcome
-- PeopleCore single + legacy none => single-match outcome still allowed
-- PeopleCore single + legacy different => ambiguity/manual resolution
-- PeopleCore multi => ambiguity/manual resolution
-- PeopleCore none => legacy path preserved
-- PeopleCore unavailable => legacy path preserved
+In route-facing identity-match flows:
+- existing ambiguity envelope must remain unchanged
+- `manualResolution` block remains deterministic
+- success / refusal status behavior remains unchanged
+- no PeopleCore-specific fields in outward response
 
-Important:
+### Files in scope
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborIdentityMatch.ts`
+- tests already covering route envelopes
 
-- preserve current `IDENTITY_MATCH_AMBIGUOUS` route code where that is the current external behavior
-- preserve current manualResolution structure
-- preserve current no-auto-merge behavior when shared/unverified safety conditions apply
+### Required tests
+- Resolver disagreement case returns `multiple_matches`
+- Resolver PeopleCore multi-link case returns `multiple_matches`
+- Identity-match route disagreement case returns existing ambiguity refusal shape
+- Manual resolution payload stays deterministic
+- No legacy fallback path overrides seam ambiguity
 
-This checkpoint may require narrow changes in:
-
-- `identityBoundary.ts`
-- `identityResolver.ts`
-- `neighbors.ts`
-
-But do not broaden beyond authority logic.
-
-Validation commands:
-
+### Validation
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
-  src/modules/connectshyft/__tests__/identityBoundary.test.ts \
   src/modules/connectshyft/__tests__/identityResolver.test.ts \
-  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
-  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
+  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts
 pnpm nx run connectshyft-api:test
-pnpm nx run contracts:test
 ```
 
-Commit:
-
+### Commit
 ```bash
 git add .
-git commit -m "feat(slice-13): enforce peoplecore-first identity authority with explicit disagreement ambiguity"
+git commit -m "refactor(slice-13): preserve seam ambiguity through resolver and routes"
 ```
 
 Stop after Checkpoint 3.
 
 ---
 
-### Checkpoint 4: Add narrow disagreement telemetry / audit
+## Checkpoint 4 — Hard deferral of reconciliation
+This checkpoint is mainly negative scope enforcement, but it still needs concrete repo verification.
 
-Add internal telemetry or audit emission for authority comparison outcomes.
+### System rule
+There is no identity reconciliation in Slice 13.
 
-Requirements:
+### Absolute prohibitions
+Do not add:
+- mapping tables
+- identity crosswalk persistence
+- person↔neighbor join service
+- merge logic between person and neighbor records
+- heuristic matching
+- similarity scoring
+- inferred equivalence
+- background reconciliation job
 
-- no user-facing contract change required
-- keep implementation minimal
-- prefer existing audit/event infrastructure over new schema
-- no migration unless absolutely necessary
+### Allowed
+- internal comments noting `Deferred beyond Slice 13`
+- documentation clarifying why ambiguity increases in this slice
 
-Telemetry must capture:
+### Required code review checks
+Search and verify there are no new:
+- migrations for identity mapping
+- new peoplecore services for reconciliation
+- new contract enums solely for mapping infrastructure
 
-- normalized phone
-- peopleCore outcome
-- legacy outcome
-- final outcome
-- fallbackUsed
-- disagreementDetected
-
-Add focused tests proving:
-
-- disagreement records are emitted
-- fallback path records fallbackUsed=true
-- PeopleCore unavailable records peopleCoreOutcome=unavailable
-- no duplicate noisy emissions for one evaluation path
-
-Validation commands:
-
+### Validation
+Run these search checks after implementation:
 ```bash
-pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
-  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
-  src/modules/connectshyft/__tests__/identityResolver.test.ts
+rg -n "crosswalk|reconcil|equivalen|heuristic|similarity|score|link.*neighbor|neighbor.*person.*map|mapping table" apps/connectshyft-api/src libs/contracts shared/database/migrations docs
+rg -n "createTable\(|ALTER TABLE|ADD COLUMN" shared/database/migrations apps/connectshyft-api/src/migrations | rg -i "person|neighbor|identity|mapping|crosswalk"
 pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
 ```
 
-Commit:
-
+### Commit
 ```bash
-git add .
-git commit -m "feat(slice-13): add authority comparison telemetry for peoplecore identity seam"
+git add docs apps/connectshyft-api/src/modules/connectshyft apps/connectshyft-api/src/modules/peoplecore libs/contracts
+# only if there are actual changes from this checkpoint
 ```
+
+Use no-op commit only if needed by your branch discipline. Otherwise skip commit if there are truly no file changes.
 
 Stop after Checkpoint 4.
 
 ---
 
-### Checkpoint 5: Add narrow resolver-review creation for disagreement only if needed
+## Checkpoint 5 — Creation guard and inbound SMS flow control
+The uploaded block states the policy correctly, but it needs repo-specific implementation instructions. fileciteturn14file0
 
-Only do this if the checkpoint 1-4 implementation leaves unresolved disagreement without durable review signal.
+### System rule
+Ambiguity blocks creation.
 
-If implemented:
+### Required behavior
+If the final seam/resolver outcome is ambiguity:
+- inbound SMS must not create a new neighbor
+- webhook path must preserve current ambiguity refusal behavior
+- no attach to an arbitrary existing neighbor
+- no retry-based create on same ambiguous event
 
-- trigger only on PeopleCore single-vs-legacy conflicting identity ownership
-- use deterministic triggerSourceType and triggerSourceId
-- keep best-effort behavior
-- avoid duplicate review creation for the same trigger
+If the final outcome is no_match:
+- preserve current create-new shell behavior
+- preserve idempotency behavior already in place
 
-Recommended trigger source:
+### Files in scope
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts`
+- provider-registry inbound dispatch tests if touched indirectly
 
-- `connectshyft_identity_authority_disagreement`
+### Required tests
+- disagreement path through inbound SMS does not call `createNeighborFromInbound`
+- PeopleCore multi-link ambiguity does not call `createNeighborFromInbound`
+- PeopleCore no-current-link + legacy no_match still does call `createNeighborFromInbound`
+- PeopleCore unavailable still preserves current fallback create path when legacy no_match applies
 
-Recommended review type:
+### Idempotency requirement
+Do not add new idempotency semantics. Preserve current dedupe and create behavior. The key rule is only:
+- ambiguity must never create
 
-- `identity_conflict`
-
-Do not add this if telemetry plus ambiguity is already sufficient and tests/documents show it is deferred. Choose the minimal safe path.
-
-Validation commands:
-
+### Validation
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
-  src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts \
-  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
-  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts
 pnpm nx run connectshyft-api:test
-pnpm nx run contracts:test
 ```
 
-Commit:
-
+### Commit
 ```bash
 git add .
-git commit -m "feat(slice-13): add narrow resolver review hook for identity authority disagreement"
+git commit -m "fix(slice-13): block create-new under peoplecore ambiguity"
 ```
 
 Stop after Checkpoint 5.
 
 ---
 
-### Checkpoint 6: Lock docs and roadmap
+## Checkpoint 6 — Documentation alignment
+The uploaded block names the right doc themes, but not the repo-facing edits. fileciteturn14file0
 
-Update architecture docs to reflect the new reality:
+### Must document
 
-Required doc updates:
+#### 1. Precedence rule
+Add explicit wording:
+- PeopleCore can block certainty
+- PeopleCore cannot assert identity equivalence in Slice 13
+- disagreement becomes ambiguity
 
-- `docs/architecture/identity-resolution-model.md`
-- `docs/architecture/peoplecore-identity-seam.md`
-- `docs/architecture/peoplecore-connectshyft-boundary-matrix.md`
-- `docs/architecture/connectshyft-router-refactor-plan.md`
+#### 2. Ambiguity categories
+Document these explicitly:
+- legacy multi-neighbor ambiguity
+- PeopleCore multi-person ambiguity
+- cross-system disagreement ambiguity
 
-Required content:
+#### 3. Decision flow
+Document this exact logic in prose or diagram form:
 
-- PeopleCore is now first read authority for phone identity when current links exist
-- ConnectShyft neighbor remains compatibility shell for CRUD and fallback
-- disagreement policy is explicit ambiguity, never silent preference
-- bulk migration remains deferred
-- Slice 14 should likely target compatibility-shell reduction or application-shell groundwork, depending repo state at that point
-
-Also add one narrow note file if needed:
-
-- `apps/connectshyft-api/src/modules/connectshyft/PEOPLECORE_AUTHORITY_NOTES.md`
-
-Validation commands:
-
-```bash
-pnpm nx run connectshyft-api:test
-pnpm nx run contracts:test
-cd apps/connectshyft-web && npm run build
-cd apps/connectshyft-web && npm run test
+```text
+PeopleCore available?
+  NO -> preserve legacy behavior
+  YES -> current person links?
+    0 -> preserve legacy behavior
+    >1 -> ambiguous
+    1 -> legacy outcome?
+      multiple -> ambiguous
+      single aligned -> preserve current exact-match behavior
+      single disagreement -> ambiguous
+      none -> no-match (unchanged in Slice 13)
 ```
 
-Commit:
+#### 4. Non-goals
+Explicitly state:
+- no reconciliation
+- no crosswalk
+- no auto-linking
+- no merge engine
+- no scoring engine
 
+#### 5. Slice 14 handoff note
+Document that the next logical slice is operationalization of ambiguity and resolver handling, not reconciliation.
+
+### Files to update
+- `docs/architecture/identity-resolution-model.md`
+- `docs/architecture/peoplecore-identity-seam.md`
+- `docs/architecture/connectshyft-router-refactor-plan.md`
+- `docs/architecture/peoplecore-connectshyft-boundary-matrix.md`
+
+### Prohibited documentation language
+Do not imply Slice 13 already does:
+- future merge logic in present tense
+- automatic PeopleCore/neighbor linking
+- eventual consistency already established
+- person↔neighbor equivalence as a solved problem
+
+### Validation
 ```bash
-git add .
-git commit -m "docs(slice-13): lock peoplecore read authority and connectshyft compatibility shell"
+rg -n "auto-link|crosswalk|equivalence|reconciliation|merge engine|scoring" docs/architecture
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+### Commit
+```bash
+git add docs/architecture
+git commit -m "docs(slice-13): align architecture to peoplecore ambiguity precedence"
 ```
 
 Stop after Checkpoint 6.
 
 ---
 
-## Testing obligations
-
-You must preserve or extend characterization coverage for:
-
-- identity ambiguity
-- inbound SMS no-match create flow
-- inbound SMS single-match no-create flow
-- PeopleCore unavailable fallback
-- shared-contact no-auto-merge behavior
-- deleted-only legacy exclusions where already characterized
-- disagreement ambiguity behavior
-
-You must not remove existing characterization tests to make the slice pass.
-
----
-
-## Required acceptance criteria
-
-1. PeopleCore exact single current person link is first authority for phone identity resolution.
-2. PeopleCore multiple current person links always produce ambiguity/manual resolution.
-3. PeopleCore absence preserves current legacy fallback behavior.
-4. PeopleCore and legacy disagreement never results in silent winner selection.
-5. Existing ConnectShyft route contracts remain intact.
-6. Inbound SMS still functions for aligned single-match and no-match create paths.
-7. Telemetry or audit captures comparison outcomes.
-8. Neighbor CRUD remains operational and unchanged at route-contract level.
-9. All tests pass.
-10. PR CI is green.
-
----
-
-## Commands for final validation
-
-Run all of the following before opening PR:
-
+## Final validation sweep
+Run at the end of the slice:
 ```bash
 pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
   src/modules/connectshyft/__tests__/identityBoundary.test.ts \
   src/modules/connectshyft/__tests__/identityResolver.test.ts \
   src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
-  src/modules/connectshyft/__tests__/peoplecoreIdentityHooks.test.ts \
   src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
-  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
-
+  src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts
 pnpm nx run connectshyft-api:test
 pnpm nx run contracts:test
-cd apps/connectshyft-web && npm run build
-cd apps/connectshyft-web && npm run test
 ```
 
-If any workspace lock or dependency metadata changed:
-
+Optional broader safety pass if already normal for your branch:
 ```bash
-pnpm install --frozen-lockfile
+pnpm nx run admin-api:test
+pnpm nx run moneyshyft-api:test
 ```
 
-If that fails because lockfiles need sync, update the workspace lock properly before opening PR.
+---
+
+## Expected commit sequence
+1. `test(slice-13): lock peoplecore ambiguity precedence characterization`
+2. `refactor(slice-13): enforce peoplecore ambiguity precedence in seam`
+3. `refactor(slice-13): preserve seam ambiguity through resolver and routes`
+4. optional no-op or skip if Checkpoint 4 has no file diffs
+5. `fix(slice-13): block create-new under peoplecore ambiguity`
+6. `docs(slice-13): align architecture to peoplecore ambiguity precedence`
+
+If you prefer a single squashed codex branch before PR, use the checkpoint commits locally anyway, then squash at PR time only if your repo policy allows it.
 
 ---
 
-## PR instructions
+## PR target
+- Base: `codex/dev`
+- Branch: `codex/slice-13-peoplecore-read-authority-and-ambiguity-precedence`
 
-Branch name:
+## PR title
+`Slice 13: enforce PeopleCore ambiguity precedence and preserve ConnectShyft compatibility shell`
 
-```bash
-git checkout -b codex/slice-13-peoplecore-read-authority-and-compat-shell
-```
-
-PR title:
-
-```text
-feat(slice-13): make peoplecore first read authority for connectshyft identity
-```
-
-PR summary must state:
-
-- PeopleCore-first identity read authority is now enforced where current links exist
-- disagreement is explicit ambiguity
-- legacy neighbor lookup remains fallback and compatibility shell
-- no bulk migration was attempted
-- route contracts were preserved
+## PR summary bullets
+- makes PeopleCore first read authority for identity invalidation
+- forces ambiguity on cross-system disagreement and multi-link PeopleCore cases
+- preserves legacy fallback when PeopleCore has no current links or is unavailable
+- blocks create-new under ambiguity in inbound SMS flows
+- keeps current route envelopes stable
+- documents Slice 13 as a safety slice, not a reconciliation slice
 
 ---
 
-## Done definition
+## Codex execution note
+Do not improvise beyond this slice.
 
-Slice 13 is done only when:
-
-- authority precedence is implemented
-- disagreement is explicit ambiguity
-- current route contracts remain stable
-- telemetry exists
-- docs are updated
-- CI is green
-
----
-
-## Explicitly deferred to later slice
-
-- full PeopleCore-backed candidate scoring across additional signals
-- rebinding engine
-- person-first CRUD cutover
-- deprecating `neighbors.ts`
-- resolver UI / queue experience
-- application shell
-- bulk backfill / migration tooling
-
----
-
-## Counterpoint
-
-The tempting move is to make PeopleCore authoritative and simultaneously collapse `neighbors.ts` into a much smaller shell. Do not do that in this slice. The repo still shows broad direct neighbor dependencies across routes, handlers, inbound flows, and tests. Combining read-authority shift with major shell reduction would be unnecessary blast radius.
-
-The right move here is authority shift first, shell reduction later.
+The correct behavior for Slice 13 is to increase ambiguity in unsafe disagreement cases. That is intentional. A noisier but safer ambiguity result is better than a cleaner but wrong identity winner.

--- a/specs/slice-14-codex-ready-implementation-brief.md
+++ b/specs/slice-14-codex-ready-implementation-brief.md
@@ -1,0 +1,550 @@
+# Slice 14 Codex-Ready Implementation Brief
+## Title
+Ops ambiguity path for PeopleCore-first identity conflicts
+
+## Repo target path
+`specs/slice-14-codex-ready-implementation-brief.md`
+
+## Branch
+`codex/slice-14-ops-ambiguity-path`
+
+## Objective
+Add an operational ambiguity path for PeopleCore-first identity conflicts so the system preserves current ConnectShyft request behavior, persists a durable ops-facing record of ambiguity, and exposes a narrow admin read/review surface without introducing reconciliation, merge, relinking, scoring redesign, or PeopleCore-driven winner selection.
+
+## Locked recommendations
+1. **Append-only ambiguity event log, not a work queue.** This slice should persist ambiguity events and allow a minimal review-state change only.
+2. **Persist from the request path as best-effort side effect.** Failure to persist ambiguity events must never alter the identity result returned to existing ConnectShyft callers.
+3. **Use ConnectShyft-local ops surfaces in this slice.** Do not build a PeopleCore resolver UI yet.
+4. **Keep current outward ambiguity contracts stable.** Existing route response shapes remain authoritative.
+5. **No reconciliation behavior in Slice 14.** No merge, relink, attach, suppress, or winner selection.
+
+## Locked policy
+### Core authority rule
+PeopleCore can invalidate certainty and force ambiguity.
+
+PeopleCore cannot, in Slice 14, silently assert equivalence between a PeopleCore person and a ConnectShyft neighbor when there is disagreement or unresolved mapping.
+
+### Ops rule
+Slice 14 exists to make ambiguity visible and reviewable by staff without changing the live identity decision semantics already locked in Slice 13.
+
+### Non-negotiable constraints
+1. Do not change existing ConnectShyft route paths.
+2. Do not change existing route success/refusal envelope shapes unless this brief explicitly says so.
+3. Do not redesign `neighbors.ts` CRUD ownership in this slice.
+4. Do not create any resolver action that mutates identity ownership.
+5. Do not introduce background jobs, polling workers, or automations in this slice.
+6. Do not add automatic deduplication of ambiguity events.
+7. Do not mutate candidate ordering coming from the ambiguity result.
+8. Do not let ambiguity persistence failure break the request path.
+9. Do not build reconciliation UI.
+10. Do not introduce PeopleCore-to-neighbor winner mapping tables in this slice.
+
+---
+
+## Why this slice exists
+Slice 13 makes PeopleCore-first identity authority viable, but ambiguity is still mostly ephemeral at request time. Staff need an operational record that:
+- preserves the exact ambiguity result returned to the caller
+- records what was ambiguous
+- records where it happened
+- supports basic reviewed/unreviewed tracking
+- stays strictly observational
+
+This slice is the operational visibility layer for ambiguity.
+
+This slice is **not** a resolver workflow engine.
+
+---
+
+## In scope
+- durable ambiguity-event persistence
+- best-effort request-path write on ambiguity outcomes
+- narrow admin/API read surface for ambiguity events
+- narrow reviewed-state update
+- characterization and regression coverage
+- architecture/docs updates
+
+## Out of scope
+- merge actions
+- attach/rebind actions
+- PeopleCore person detail UI
+- ConnectShyft neighbor replacement
+- household matching
+- candidate scoring redesign
+- notification workflows
+- assignment queues
+- SLA engines
+- bulk migration/backfill of historical ambiguity from old logs
+
+---
+
+## Exact repo surfaces to use
+Primary files likely involved:
+- `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/config/knex.ts`
+- `shared/database/migrations/<timestamp>_create_connectshyft_identity_ambiguity_events.ts`
+- `apps/connectshyft-api/src/migrations/<timestamp>_create_connectshyft_identity_ambiguity_events.ts`
+- `apps/admin-api/src/migrations/<timestamp>_create_connectshyft_identity_ambiguity_events.ts`
+- `apps/moneyshyft-api/src/migrations/<timestamp>_create_connectshyft_identity_ambiguity_events.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts`
+- `docs/architecture/peoplecore-identity-seam.md`
+- `docs/architecture/identity-resolution-model.md`
+- `docs/architecture/connectshyft-router-refactor-plan.md`
+
+Recommended new files:
+- `apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts`
+
+Note: follow the repo’s shared-migration mirror pattern exactly.
+
+---
+
+## Data model to add
+Create a new ConnectShyft-local table under the `connectshyft` schema.
+
+### Recommended table
+`connectshyft.cs_identity_ambiguity_events`
+
+### Recommended columns
+- `id UUID PRIMARY KEY`
+- `tenant_id UUID NOT NULL`
+- `org_unit_id UUID NULL`
+- `source_context TEXT NOT NULL`
+- `source_context_id TEXT NULL`
+- `normalized_contact_point TEXT NOT NULL`
+- `contact_point_type TEXT NOT NULL DEFAULT 'phone'`
+- `candidate_neighbor_ids JSONB NOT NULL`
+- `candidate_count INTEGER NOT NULL`
+- `ambiguity_reason_code TEXT NOT NULL`
+- `status TEXT NOT NULL DEFAULT 'pending'`
+- `requested_by_user_id TEXT NULL`
+- `correlation_id TEXT NULL`
+- `idempotency_key TEXT NULL`
+- `created_at_utc TIMESTAMPTZ NOT NULL DEFAULT now()`
+- `updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT now()`
+
+### Locked constraints
+- `contact_point_type` allowed values: `('phone')`
+- `status` allowed values: `('pending','reviewed')`
+- `ambiguity_reason_code` initially allowed values:
+  - `'IDENTITY_MATCH_AMBIGUOUS'`
+  - `'PEOPLECORE_LEGACY_DISAGREEMENT'`
+  - `'PEOPLECORE_MULTI_CURRENT_LINKS'`
+
+### Locked indexes
+Create indexes for:
+- `(tenant_id, created_at_utc desc)`
+- `(tenant_id, status, created_at_utc desc)`
+- `(tenant_id, normalized_contact_point)`
+- `(tenant_id, source_context, created_at_utc desc)`
+
+### Storage rules
+1. Store `candidate_neighbor_ids` exactly in the order surfaced by the evaluated ambiguity decision.
+2. Store `candidate_count` redundantly for cheap filtering.
+3. Do not store enriched PeopleCore person projections in this table.
+4. Do not store neighbor snapshots in this table.
+5. Do not dedupe on insert.
+6. This is append-only except for status changes and `updated_at_utc`.
+
+---
+
+## Behavior rules
+### When to persist an ambiguity event
+Persist only when the final decision returned by the PeopleCore-aware identity path is ambiguous.
+
+That includes:
+1. current legacy-style ambiguity where multiple current neighbor candidates remain ambiguous
+2. PeopleCore single-current-link vs legacy-neighbor disagreement
+3. PeopleCore multiple current links forcing ambiguity even if legacy had a single candidate
+
+### When not to persist
+Do not persist ambiguity events for:
+- no-match
+- single-match
+- no-auto-merge due only to shared/unverified guardrails
+- invalid-format refusals
+- forbidden refusals
+- persistence-unavailable refusals unrelated to ambiguity result generation
+
+### Request-path semantics
+The write is best-effort.
+
+If ambiguity-event persistence fails:
+- log it
+- do not alter the route response
+- do not convert the result into a persistence error
+- do not retry in-process
+
+---
+
+## API surface to add
+Use the existing repo/API structure. Keep it narrow.
+
+### Read endpoint
+Recommended route under ConnectShyft admin/runtime API surface:
+`GET /api/v1/connectshyft/identity-ambiguities`
+
+If there is already a more appropriate admin-only route family in the repo, keep it in the same API app but use the existing guard style consistently.
+
+### Allowed query params
+- `tenantId` required through resolved access context, not as free client override
+- `orgUnitId` optional filter
+- `status` optional: `pending | reviewed`
+- `normalizedContactPoint` optional exact filter
+- `sourceContext` optional exact filter
+- `limit` optional, default `50`, max `200`
+- `cursor` optional for keyset pagination or existing repo pagination style
+
+### Read response shape
+Keep it simple and explicit:
+
+```json
+{
+  "ok": true,
+  "code": "CONNECTSHYFT_IDENTITY_AMBIGUITIES_RESOLVED",
+  "httpStatus": 200,
+  "data": {
+    "events": [
+      {
+        "id": "uuid",
+        "tenantId": "uuid",
+        "orgUnitId": "uuid|null",
+        "sourceContext": "connectshyft_identity_match",
+        "sourceContextId": "identity-match:peoplecore-disagreement",
+        "normalizedContactPoint": "+12605551218",
+        "contactPointType": "phone",
+        "candidateNeighborIds": ["neighbor-a", "neighbor-b"],
+        "candidateCount": 2,
+        "ambiguityReasonCode": "PEOPLECORE_LEGACY_DISAGREEMENT",
+        "status": "pending",
+        "requestedByUserId": "user-1",
+        "correlationId": "corr-123",
+        "idempotencyKey": "identity-match:...",
+        "createdAtUtc": "2026-03-21T12:00:00.000Z",
+        "updatedAtUtc": "2026-03-21T12:00:00.000Z"
+      }
+    ],
+    "nextCursor": null
+  }
+}
+```
+
+### Status-update endpoint
+`PATCH /api/v1/connectshyft/identity-ambiguities/:ambiguityEventId`
+
+Allowed body:
+```json
+{ "status": "reviewed" }
+```
+
+### Status-update rules
+- allow only `pending -> reviewed`
+- treat repeated `reviewed -> reviewed` as idempotent success if that matches current repo style, otherwise use a deterministic business refusal
+- do not allow any other transitions
+- do not trigger reconciliation side effects
+- do not change PeopleCore records
+- do not change neighbor records
+
+---
+
+## Access and policy recommendation
+### Recommendation
+Gate both endpoints behind the same tenant-scoped privileged ConnectShyft identity capabilities already used for sensitive neighbor/identity operations.
+
+Default:
+- read requires tenant-privileged or identity-resolution-capable role
+- status update requires tenant-privileged role
+
+### Why
+This is operational ambiguity metadata tied to identity decisions. It should not be broadly visible to every thread viewer.
+
+### Counterpoint:
+Reusing overly broad read permissions would be faster, but it weakens identity governance and will age badly once real resolver workflows arrive.
+
+---
+
+## Implementation plan
+
+### Checkpoint 1 — Characterize ops ambiguity expectations before production edits
+Add failing characterization tests only. No production logic changes.
+
+Lock these cases:
+1. PeopleCore / legacy disagreement persists current ambiguous route result and records an ops ambiguity event target shape.
+2. Multiple current PeopleCore links persist current ambiguous route result and record an ops ambiguity event target shape.
+3. No-match and single-match do not create ambiguity events.
+4. Shared/unverified no-auto-merge does not create ambiguity events.
+5. Inbound SMS ambiguity keeps current refusal behavior and does not create a neighbor.
+6. Status update surface is not present yet or is explicitly characterized as missing before implementation if needed.
+
+Validation commands:
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  src/modules/connectshyft/__tests__/identityResolver.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+Commit:
+```bash
+git add apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+git commit -m "test(slice-14): lock ops ambiguity path behavior"
+```
+
+### Checkpoint 2 — Add ambiguity-event persistence foundation
+Add the migration and store/service module for ambiguity events.
+
+Required work:
+- add shared migration
+- add mirror migration wrappers in app migration directories that follow the existing pattern
+- add a focused module for create/list/update-status operations
+- add focused store/service tests
+
+Recommended module surface in `ambiguityEvents.ts`:
+- `createIdentityAmbiguityEvent(input)`
+- `listIdentityAmbiguityEvents(input)`
+- `markIdentityAmbiguityEventReviewed(input)`
+
+Validation commands:
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/ambiguityEvents.test.ts \
+  src/migrations/__tests__/connectshyftIdentityAmbiguityEventsMigration.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+Commit:
+```bash
+git add shared/database/migrations \
+  apps/connectshyft-api/src/migrations \
+  apps/admin-api/src/migrations \
+  apps/moneyshyft-api/src/migrations \
+  apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts \
+  apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts \
+  apps/connectshyft-api/src/migrations/__tests__/connectshyftIdentityAmbiguityEventsMigration.test.ts
+git commit -m "feat(slice-14): add connectshyft ambiguity event persistence"
+```
+
+### Checkpoint 3 — Persist ambiguity events from the PeopleCore-aware seam as best-effort side effect
+Wire the ambiguity write at the seam boundary where final ambiguity is known.
+
+Recommendation:
+- keep persistence close to the PeopleCore-aware adapter path, not spread across every route
+- allow route-level context such as correlation/idempotency/source context to flow in from the existing inputs
+
+Required behavior:
+1. On final ambiguity result, write one ambiguity event.
+2. On non-ambiguity result, write none.
+3. On write failure, log and continue.
+4. Preserve exact returned ambiguity result.
+
+Important:
+Do not let both seam-level and route-level code create duplicate records for the same request. Pick one write location and keep it authoritative.
+
+Best-practice default:
+- seam writes the event
+- routes consume the unchanged ambiguity result
+- route-level audit remains route-level only if it already exists
+
+Validation commands:
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  src/modules/connectshyft/__tests__/identityResolver.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts \
+  src/modules/connectshyft/__tests__/ambiguityEvents.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+Commit:
+```bash
+git add apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts \
+  apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts \
+  apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+git commit -m "feat(slice-14): persist ops ambiguity events from identity seam"
+```
+
+### Checkpoint 4 — Add narrow read endpoint for ops visibility
+Add the read route and tests.
+
+Required behavior:
+- tenant-scoped only
+- optional org unit/status/contact filters
+- deterministic ordering newest first
+- limit capped
+- no enrichment joins beyond what is needed to return the event object
+- no hidden mutation side effects
+
+Validation commands:
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+Commit:
+```bash
+git add apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts \
+  apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+git commit -m "feat(slice-14): add identity ambiguity ops read endpoint"
+```
+
+### Checkpoint 5 — Add reviewed-status update endpoint
+Add the narrow mutation surface.
+
+Required behavior:
+- only allows `reviewed`
+- idempotent handling is acceptable and recommended
+- no reconciliation behavior
+- no identity writes
+
+Validation commands:
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
+pnpm nx run connectshyft-api:test
+```
+
+Commit:
+```bash
+git add apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts \
+  apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+git commit -m "feat(slice-14): add identity ambiguity reviewed status update"
+```
+
+### Checkpoint 6 — Documentation and lock
+Update docs to reflect the new ops ambiguity layer.
+
+Required docs updates:
+- `docs/architecture/peoplecore-identity-seam.md`
+- `docs/architecture/identity-resolution-model.md`
+- `docs/architecture/connectshyft-router-refactor-plan.md`
+
+Doc points to lock:
+- ambiguity persistence is observational only
+- reviewed status is operational only
+- no reconciliation exists yet
+- Slice 15 or later is where true resolver operations may begin
+
+Validation commands:
+```bash
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+Commit:
+```bash
+git add docs/architecture/peoplecore-identity-seam.md \
+  docs/architecture/identity-resolution-model.md \
+  docs/architecture/connectshyft-router-refactor-plan.md
+git commit -m "docs(slice-14): lock ops ambiguity path architecture"
+```
+
+---
+
+## Recommended implementation details
+### Recommended ambiguity reason mapping
+Map final ambiguity causes like this:
+- legacy multi-neighbor ambiguity -> `IDENTITY_MATCH_AMBIGUOUS`
+- PeopleCore single-link / legacy disagreement -> `PEOPLECORE_LEGACY_DISAGREEMENT`
+- PeopleCore multiple current links -> `PEOPLECORE_MULTI_CURRENT_LINKS`
+
+### Recommended source-context values
+Use deterministic source context strings already flowing through seam input where possible:
+- `connectshyft_identity_match`
+- `connectshyft_inbound_subject_resolution`
+- future-safe values only if they already exist in this slice’s path
+
+### Recommended idempotency posture
+Do not add database uniqueness for ambiguity events in Slice 14.
+
+Reason:
+- this is an operational log
+- repeated ambiguous requests are themselves meaningful
+- dedupe policy is business logic, not persistence-foundation logic
+
+Counterpoint:
+This can create repeated records for repeated retries, but that is preferable right now to silently collapsing operational evidence.
+
+### Recommended logging
+On ambiguity-event write failure, log at warn/error with:
+- tenantId
+- orgUnitId
+- normalizedContactPoint
+- ambiguityReasonCode
+- sourceContext
+- correlationId
+- idempotencyKey
+
+Do not leak raw contact values outside the repo’s existing logging conventions if those are masked elsewhere.
+
+---
+
+## Test expectations
+At minimum, final green state should include:
+- disagreement ambiguity characterization
+- multi-current-link ambiguity characterization
+- fallback preservation when PeopleCore is unavailable
+- no-write on no-match/single-match/no-auto-merge
+- ops read endpoint coverage
+- reviewed-status endpoint coverage
+- migration test coverage
+- full `connectshyft-api:test` pass
+
+Recommended focused command bundle:
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts \
+  src/modules/connectshyft/__tests__/identityResolver.test.ts \
+  src/modules/connectshyft/__tests__/ambiguityEvents.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts \
+  src/migrations/__tests__/connectshyftIdentityAmbiguityEventsMigration.test.ts
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+---
+
+## Done means
+Slice 14 is done when all of the following are true:
+1. Final ambiguity results produce a durable ambiguity-event record.
+2. Non-ambiguity identity results do not.
+3. Persistence failure does not change existing route behavior.
+4. Staff can list ambiguity events through a narrow endpoint.
+5. Staff can mark an event reviewed.
+6. No merge/link/reconciliation behavior was introduced.
+7. Docs clearly state this is an observational ops path only.
+
+---
+
+## PR guidance
+### PR title
+`feat(slice-14): add ops ambiguity path for PeopleCore identity conflicts`
+
+### PR summary bullets
+- adds ConnectShyft-local ambiguity-event persistence
+- records final identity ambiguity outcomes as best-effort side effects
+- adds narrow read/review ops endpoints
+- preserves existing ambiguity route behavior
+- explicitly avoids reconciliation actions
+


### PR DESCRIPTION
- makes PeopleCore first read authority for identity invalidation
- forces ambiguity on cross-system disagreement and multi-link PeopleCore cases
- preserves legacy fallback when PeopleCore has no current links or is unavailable
- blocks create-new under ambiguity in inbound SMS flows
- keeps current route envelopes stable
- documents Slice 13 as a safety slice, not a reconciliation slice