### PR TITLE
Slice 14: add ops ambiguity visibility and review flow

### DIFF
--- a/apps/admin-api/src/migrations/20260321110000_create_connectshyft_identity_ambiguity_events.ts
+++ b/apps/admin-api/src/migrations/20260321110000_create_connectshyft_identity_ambiguity_events.ts
@@ -1,0 +1,4 @@
+export {
+  down,
+  up,
+} from '../../../../shared/database/migrations/20260321110000_create_connectshyft_identity_ambiguity_events';

--- a/apps/connectshyft-api/src/migrations/20260321110000_create_connectshyft_identity_ambiguity_events.ts
+++ b/apps/connectshyft-api/src/migrations/20260321110000_create_connectshyft_identity_ambiguity_events.ts
@@ -1,0 +1,4 @@
+export {
+  down,
+  up,
+} from '../../../../shared/database/migrations/20260321110000_create_connectshyft_identity_ambiguity_events';

--- a/apps/connectshyft-api/src/migrations/__tests__/connectshyftIdentityAmbiguityEventsMigration.test.ts
+++ b/apps/connectshyft-api/src/migrations/__tests__/connectshyftIdentityAmbiguityEventsMigration.test.ts
@@ -1,0 +1,51 @@
+import { down, up } from '../20260321110000_create_connectshyft_identity_ambiguity_events';
+
+function buildKnexMock() {
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+  };
+
+  return { knex };
+}
+
+describe('20260321110000_create_connectshyft_identity_ambiguity_events migration', () => {
+  it('creates the connectshyft ambiguity-events table, constraints, and indexes idempotently', async () => {
+    const { knex } = buildKnexMock();
+
+    await up(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+
+    expect(rawSql).toContain('CREATE SCHEMA IF NOT EXISTS connectshyft');
+    expect(rawSql).toContain('CREATE TABLE IF NOT EXISTS connectshyft.cs_identity_ambiguity_events');
+    expect(rawSql).toContain('tenant_id UUID NOT NULL');
+    expect(rawSql).toContain('org_unit_id UUID NULL');
+    expect(rawSql).toContain(`candidate_neighbor_ids JSONB NOT NULL`);
+    expect(rawSql).toContain(`candidate_count INTEGER NOT NULL`);
+    expect(rawSql).toContain('cs_identity_ambiguity_events_contact_point_type_ck');
+    expect(rawSql).toContain(`CHECK (contact_point_type IN ('phone'))`);
+    expect(rawSql).toContain('cs_identity_ambiguity_events_status_ck');
+    expect(rawSql).toContain(`CHECK (status IN ('pending', 'reviewed'))`);
+    expect(rawSql).toContain('cs_identity_ambiguity_events_reason_code_ck');
+    expect(rawSql).toContain(`'IDENTITY_MATCH_AMBIGUOUS'`);
+    expect(rawSql).toContain(`'PEOPLECORE_LEGACY_DISAGREEMENT'`);
+    expect(rawSql).toContain(`'PEOPLECORE_MULTI_CURRENT_LINKS'`);
+    expect(rawSql).toContain('connectshyft_cs_identity_ambiguity_events_tenant_created_idx');
+    expect(rawSql).toContain('(tenant_id, created_at_utc DESC)');
+    expect(rawSql).toContain('connectshyft_cs_identity_ambiguity_events_tenant_status_created_idx');
+    expect(rawSql).toContain('(tenant_id, status, created_at_utc DESC)');
+    expect(rawSql).toContain('connectshyft_cs_identity_ambiguity_events_tenant_contact_point_idx');
+    expect(rawSql).toContain('(tenant_id, normalized_contact_point)');
+    expect(rawSql).toContain('connectshyft_cs_identity_ambiguity_events_tenant_source_context_created_idx');
+    expect(rawSql).toContain('(tenant_id, source_context, created_at_utc DESC)');
+  });
+
+  it('drops the ambiguity-events table on down migration', async () => {
+    const { knex } = buildKnexMock();
+
+    await down(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+    expect(rawSql).toContain('DROP TABLE IF EXISTS connectshyft.cs_identity_ambiguity_events');
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts
@@ -1,0 +1,185 @@
+import {
+  AsyncConnectShyftIdentityAmbiguityEventService,
+  createIdentityAmbiguityEvent,
+  InMemoryConnectShyftIdentityAmbiguityEventStore,
+  listIdentityAmbiguityEvents,
+  markIdentityAmbiguityEventReviewed,
+  resetIdentityAmbiguityEventsForTests,
+} from '../ambiguityEvents';
+
+describe('connectshyft ambiguity events', () => {
+  let store: InMemoryConnectShyftIdentityAmbiguityEventStore;
+  let service: AsyncConnectShyftIdentityAmbiguityEventService;
+
+  beforeEach(() => {
+    resetIdentityAmbiguityEventsForTests();
+    store = new InMemoryConnectShyftIdentityAmbiguityEventStore();
+    service = new AsyncConnectShyftIdentityAmbiguityEventService(store);
+  });
+
+  it('creates ambiguity events with pending status and preserves candidate ordering', async () => {
+    const created = await service.createIdentityAmbiguityEvent({
+      tenantId: 'tenant-connectshyft-ambiguity',
+      orgUnitId: 'org-connectshyft-ambiguity',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:disagreement',
+      normalizedContactPoint: '+12605551218',
+      candidateNeighborIds: ['neighbor-b', 'neighbor-a'],
+      ambiguityReasonCode: 'PEOPLECORE_LEGACY_DISAGREEMENT',
+      requestedByUserId: 'user-1',
+      correlationId: 'corr-ambiguity-1',
+      idempotencyKey: 'identity-match:disagreement',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+
+    expect(created).toMatchObject({
+      tenantId: 'tenant-connectshyft-ambiguity',
+      orgUnitId: 'org-connectshyft-ambiguity',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:disagreement',
+      normalizedContactPoint: '+12605551218',
+      contactPointType: 'phone',
+      candidateNeighborIds: ['neighbor-b', 'neighbor-a'],
+      candidateCount: 2,
+      ambiguityReasonCode: 'PEOPLECORE_LEGACY_DISAGREEMENT',
+      status: 'pending',
+      requestedByUserId: 'user-1',
+      correlationId: 'corr-ambiguity-1',
+      idempotencyKey: 'identity-match:disagreement',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+      updatedAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+  });
+
+  it('lists ambiguity events newest first with tenant filters and keyset pagination', async () => {
+    await service.createIdentityAmbiguityEvent({
+      id: '00000000-0000-4000-8000-000000000001',
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      sourceContext: 'connectshyft_identity_match',
+      normalizedContactPoint: '+12605550001',
+      candidateNeighborIds: ['neighbor-a'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+      createdAtUtc: '2026-03-21T10:00:00.000Z',
+    });
+    await service.createIdentityAmbiguityEvent({
+      id: '00000000-0000-4000-8000-000000000002',
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      sourceContext: 'connectshyft_inbound_subject_resolution',
+      normalizedContactPoint: '+12605550002',
+      candidateNeighborIds: ['neighbor-b'],
+      ambiguityReasonCode: 'PEOPLECORE_MULTI_CURRENT_LINKS',
+      createdAtUtc: '2026-03-21T11:00:00.000Z',
+    });
+    await service.createIdentityAmbiguityEvent({
+      id: '00000000-0000-4000-8000-000000000003',
+      tenantId: 'tenant-b',
+      orgUnitId: 'org-west',
+      sourceContext: 'connectshyft_identity_match',
+      normalizedContactPoint: '+12605550003',
+      candidateNeighborIds: ['neighbor-c'],
+      ambiguityReasonCode: 'PEOPLECORE_LEGACY_DISAGREEMENT',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+
+    const firstPage = await service.listIdentityAmbiguityEvents({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      limit: 1,
+    });
+
+    expect(firstPage.events).toHaveLength(1);
+    expect(firstPage.events[0]).toMatchObject({
+      tenantId: 'tenant-a',
+      sourceContext: 'connectshyft_inbound_subject_resolution',
+      normalizedContactPoint: '+12605550002',
+    });
+    expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+    const secondPage = await service.listIdentityAmbiguityEvents({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      limit: 1,
+      cursor: firstPage.nextCursor,
+    });
+
+    expect(secondPage.events).toHaveLength(1);
+    expect(secondPage.events[0]).toMatchObject({
+      tenantId: 'tenant-a',
+      sourceContext: 'connectshyft_identity_match',
+      normalizedContactPoint: '+12605550001',
+    });
+    expect(secondPage.nextCursor).toBeNull();
+  });
+
+  it('marks pending ambiguity events reviewed and keeps repeated reviewed updates idempotent', async () => {
+    const created = await service.createIdentityAmbiguityEvent({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      sourceContext: 'connectshyft_identity_match',
+      normalizedContactPoint: '+12605550004',
+      candidateNeighborIds: ['neighbor-d'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+
+    const reviewed = await service.markIdentityAmbiguityEventReviewed({
+      tenantId: 'tenant-a',
+      ambiguityEventId: created.id,
+      reviewedAtUtc: '2026-03-21T12:15:00.000Z',
+    });
+
+    expect(reviewed).toMatchObject({
+      id: created.id,
+      status: 'reviewed',
+      updatedAtUtc: '2026-03-21T12:15:00.000Z',
+    });
+
+    const reviewedAgain = await service.markIdentityAmbiguityEventReviewed({
+      tenantId: 'tenant-a',
+      ambiguityEventId: created.id,
+      reviewedAtUtc: '2026-03-21T12:30:00.000Z',
+    });
+
+    expect(reviewedAgain).toMatchObject({
+      id: created.id,
+      status: 'reviewed',
+      updatedAtUtc: '2026-03-21T12:15:00.000Z',
+    });
+  });
+
+  it('uses the exported module surface with in-memory persistence for non-uuid test scope ids', async () => {
+    const created = await createIdentityAmbiguityEvent({
+      tenantId: 'tenant-test-scope',
+      orgUnitId: 'org-test-scope',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:test-scope',
+      normalizedContactPoint: '+12605550005',
+      candidateNeighborIds: ['neighbor-e', 'neighbor-f'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+    });
+
+    const listed = await listIdentityAmbiguityEvents({
+      tenantId: 'tenant-test-scope',
+      normalizedContactPoint: '+12605550005',
+    });
+
+    expect(listed.events).toHaveLength(1);
+    expect(listed.events[0]).toMatchObject({
+      id: created.id,
+      candidateNeighborIds: ['neighbor-e', 'neighbor-f'],
+      status: 'pending',
+    });
+
+    const reviewed = await markIdentityAmbiguityEventReviewed({
+      tenantId: 'tenant-test-scope',
+      ambiguityEventId: created.id,
+    });
+
+    expect(reviewed).toMatchObject({
+      id: created.id,
+      status: 'reviewed',
+    });
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts
@@ -2,6 +2,14 @@ import { PeopleCorePersistenceUnavailableError } from '../../peoplecore/service'
 import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from '../peoplecoreIdentityAdapter';
 import type { ConnectShyftIdentityBoundaryNeighbor } from '../identityBoundary';
 
+jest.mock('../ambiguityEvents', () => ({
+  createIdentityAmbiguityEvent: jest.fn(),
+}), { virtual: true });
+
+const ambiguityEventsModule = jest.requireMock('../ambiguityEvents') as {
+  createIdentityAmbiguityEvent: jest.Mock;
+};
+
 const TIMESTAMP = '2026-03-21T12:00:00.000Z';
 
 const buildNeighbor = (
@@ -53,6 +61,10 @@ const buildContactPointLink = (contactPointId: string, subjectId: string) => ({
 });
 
 describe('connectshyft peoplecore identity adapter', () => {
+  beforeEach(() => {
+    ambiguityEventsModule.createIdentityAmbiguityEvent.mockReset();
+  });
+
   it('creates provisional PeopleCore foundation on no-match without changing the ConnectShyft result', async () => {
     const peopleCoreService = {
       listContactPointsByNormalizedValue: jest.fn(async () => []),
@@ -124,6 +136,7 @@ describe('connectshyft peoplecore identity adapter', () => {
       status: 'active_provisional',
     }));
     expect(peopleCoreService.createContactPointLink).toHaveBeenCalled();
+    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).not.toHaveBeenCalled();
   });
 
   it('evaluates normalized contact-point candidates through the PeopleCore lookup path before preserving current ConnectShyft candidates', async () => {
@@ -194,6 +207,7 @@ describe('connectshyft peoplecore identity adapter', () => {
     await expect(adapter.evaluateMatch({
       actorRoles: ['ORGUNIT_MEMBER'],
       tenantId: 'tenant-a',
+      idempotencyKey: 'identity-match:auto-merge-allowed',
       contactPoint: {
         label: 'mobile',
         value: '260-555-1212',
@@ -211,6 +225,7 @@ describe('connectshyft peoplecore identity adapter', () => {
         },
       },
     });
+    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).not.toHaveBeenCalled();
   });
 
   it('preserves current ambiguous/manual-resolution behavior when fallback candidates remain ambiguous', async () => {
@@ -318,6 +333,7 @@ describe('connectshyft peoplecore identity adapter', () => {
       actorRoles: ['ORGUNIT_MEMBER'],
       tenantId: 'tenant-a',
       orgUnitId: 'org-a',
+      idempotencyKey: 'identity-match:peoplecore-disagreement',
       contactPoint: {
         label: 'mobile',
         value: '(260) 555-1218',
@@ -343,6 +359,20 @@ describe('connectshyft peoplecore identity adapter', () => {
         },
       },
     });
+    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledTimes(1);
+    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:peoplecore-disagreement',
+      normalizedContactPoint: '+12605551218',
+      contactPointType: 'phone',
+      candidateNeighborIds: ['neighbor-legacy-b'],
+      candidateCount: 1,
+      ambiguityReasonCode: 'PEOPLECORE_LEGACY_DISAGREEMENT',
+      requestedByUserId: 'user-1',
+      idempotencyKey: 'identity-match:peoplecore-disagreement',
+    }));
   });
 
   it('characterizes multiple PeopleCore current links as ambiguous even when legacy has a single candidate', async () => {
@@ -364,10 +394,16 @@ describe('connectshyft peoplecore identity adapter', () => {
       actorRoles: ['ORGUNIT_MEMBER'],
       tenantId: 'tenant-a',
       orgUnitId: 'org-a',
+      idempotencyKey: 'identity-match:peoplecore-multi-current-links',
       contactPoint: {
         label: 'mobile',
         value: '2605551219',
         verificationStatus: 'verified',
+      },
+      hookContext: {
+        triggerSourceType: 'connectshyft_identity_match',
+        triggerSourceId: 'identity-match:peoplecore-multi-current-links',
+        requestedByUserId: 'user-1',
       },
     })).resolves.toMatchObject({
       ok: false,
@@ -383,6 +419,20 @@ describe('connectshyft peoplecore identity adapter', () => {
         },
       },
     });
+    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledTimes(1);
+    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:peoplecore-multi-current-links',
+      normalizedContactPoint: '+12605551219',
+      contactPointType: 'phone',
+      candidateNeighborIds: ['neighbor-legacy-19'],
+      candidateCount: 1,
+      ambiguityReasonCode: 'PEOPLECORE_MULTI_CURRENT_LINKS',
+      requestedByUserId: 'user-1',
+      idempotencyKey: 'identity-match:peoplecore-multi-current-links',
+    }));
   });
 
   it('preserves legacy single-match fallback when PeopleCore has no current person links', async () => {
@@ -501,6 +551,7 @@ describe('connectshyft peoplecore identity adapter', () => {
       actorRoles: ['ORGUNIT_MEMBER'],
       tenantId: 'tenant-a',
       orgUnitId: 'org-a',
+      idempotencyKey: 'identity-match:no-auto-merge-shared',
       contactPoint: {
         label: 'mobile',
         value: '2605551222',
@@ -522,5 +573,6 @@ describe('connectshyft peoplecore identity adapter', () => {
         },
       },
     });
+    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts
@@ -2,12 +2,28 @@ import { PeopleCorePersistenceUnavailableError } from '../../peoplecore/service'
 import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from '../peoplecoreIdentityAdapter';
 import type { ConnectShyftIdentityBoundaryNeighbor } from '../identityBoundary';
 
+jest.mock('../../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
 jest.mock('../ambiguityEvents', () => ({
   createIdentityAmbiguityEvent: jest.fn(),
 }), { virtual: true });
 
 const ambiguityEventsModule = jest.requireMock('../ambiguityEvents') as {
   createIdentityAmbiguityEvent: jest.Mock;
+};
+const loggerModule = jest.requireMock('../../../utils/logger') as {
+  default: {
+    info: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+  };
 };
 
 const TIMESTAMP = '2026-03-21T12:00:00.000Z';
@@ -63,6 +79,7 @@ const buildContactPointLink = (contactPointId: string, subjectId: string) => ({
 describe('connectshyft peoplecore identity adapter', () => {
   beforeEach(() => {
     ambiguityEventsModule.createIdentityAmbiguityEvent.mockReset();
+    loggerModule.default.warn.mockReset();
   });
 
   it('creates provisional PeopleCore foundation on no-match without changing the ConnectShyft result', async () => {
@@ -308,6 +325,20 @@ describe('connectshyft peoplecore identity adapter', () => {
       triggerSourceId: 'identity-match:ambiguous',
       requestedByUserId: 'user-1',
     }));
+    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledTimes(1);
+    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:ambiguous',
+      normalizedContactPoint: '+12605551213',
+      contactPointType: 'phone',
+      candidateNeighborIds: ['neighbor-1', 'neighbor-2'],
+      candidateCount: 2,
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+      requestedByUserId: 'user-1',
+      idempotencyKey: expect.stringMatching(/^identity-match:/),
+    }));
   });
 
   it('characterizes a PeopleCore single-current-link disagreement with a different legacy neighbor as ambiguous', async () => {
@@ -433,6 +464,71 @@ describe('connectshyft peoplecore identity adapter', () => {
       requestedByUserId: 'user-1',
       idempotencyKey: 'identity-match:peoplecore-multi-current-links',
     }));
+  });
+
+  it('logs and continues when ambiguity-event persistence fails', async () => {
+    ambiguityEventsModule.createIdentityAmbiguityEvent.mockRejectedValueOnce(
+      new Error('ambiguity event persistence unavailable'),
+    );
+
+    const adapter = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+      async () => [buildNeighbor('neighbor-legacy-a', '+12605551228')],
+      async () => [buildNeighbor('neighbor-legacy-b', '+12605551228')],
+      {
+        listContactPointsByNormalizedValue: async () => [
+          buildContactPoint('contact-point-28', '+12605551228'),
+        ],
+        listCurrentContactPointLinks: async () => [
+          buildContactPointLink('contact-point-28', 'person-28'),
+        ],
+        listResolverReviews: async () => [],
+        createResolverReview: jest.fn(),
+        createContactPoint: jest.fn(),
+        createPerson: jest.fn(),
+        createContactPointLink: jest.fn(),
+      } as any,
+    );
+
+    await expect(adapter.evaluateMatch({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-a',
+      idempotencyKey: 'identity-match:ambiguity-write-failure',
+      contactPoint: {
+        label: 'mobile',
+        value: '(260) 555-1228',
+        verificationStatus: 'verified',
+      },
+      hookContext: {
+        triggerSourceType: 'connectshyft_identity_match',
+        triggerSourceId: 'identity-match:ambiguity-write-failure',
+        requestedByUserId: 'user-1',
+      },
+    })).resolves.toMatchObject({
+      ok: false,
+      code: 'IDENTITY_MATCH_AMBIGUOUS',
+      data: {
+        identityMatch: {
+          decision: 'AMBIGUOUS',
+          matchedNeighborId: null,
+          candidateNeighborIds: ['neighbor-legacy-b'],
+        },
+      },
+    });
+
+    expect(loggerModule.default.warn).toHaveBeenCalledWith(
+      'ConnectShyft identity ambiguity event persistence failed',
+      expect.objectContaining({
+        tenantId: 'tenant-a',
+        orgUnitId: 'org-a',
+        normalizedContactPoint: '+12605551228',
+        ambiguityReasonCode: 'PEOPLECORE_LEGACY_DISAGREEMENT',
+        sourceContext: 'connectshyft_identity_match',
+        correlationId: null,
+        idempotencyKey: 'identity-match:ambiguity-write-failure',
+        error: 'ambiguity event persistence unavailable',
+      }),
+    );
   });
 
   it('preserves legacy single-match fallback when PeopleCore has no current person links', async () => {

--- a/apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
@@ -1,0 +1,593 @@
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const AMBIGUITY_EVENTS_TABLE = 'cs_identity_ambiguity_events';
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_LIST_LIMIT = 200;
+
+export type ConnectShyftIdentityAmbiguityReasonCode =
+  | 'IDENTITY_MATCH_AMBIGUOUS'
+  | 'PEOPLECORE_LEGACY_DISAGREEMENT'
+  | 'PEOPLECORE_MULTI_CURRENT_LINKS';
+
+export type ConnectShyftIdentityAmbiguityStatus = 'pending' | 'reviewed';
+
+export type ConnectShyftIdentityAmbiguityEvent = {
+  id: string;
+  tenantId: string;
+  orgUnitId: string | null;
+  sourceContext: string;
+  sourceContextId: string | null;
+  normalizedContactPoint: string;
+  contactPointType: 'phone';
+  candidateNeighborIds: string[];
+  candidateCount: number;
+  ambiguityReasonCode: ConnectShyftIdentityAmbiguityReasonCode;
+  status: ConnectShyftIdentityAmbiguityStatus;
+  requestedByUserId: string | null;
+  correlationId: string | null;
+  idempotencyKey: string | null;
+  createdAtUtc: string;
+  updatedAtUtc: string;
+};
+
+export type CreateIdentityAmbiguityEventInput = {
+  id?: string;
+  tenantId: string;
+  orgUnitId?: string | null;
+  sourceContext: string;
+  sourceContextId?: string | null;
+  normalizedContactPoint: string;
+  contactPointType?: 'phone';
+  candidateNeighborIds: string[];
+  candidateCount?: number;
+  ambiguityReasonCode: ConnectShyftIdentityAmbiguityReasonCode;
+  status?: ConnectShyftIdentityAmbiguityStatus;
+  requestedByUserId?: string | null;
+  correlationId?: string | null;
+  idempotencyKey?: string | null;
+  createdAtUtc?: string;
+  updatedAtUtc?: string;
+};
+
+export type ListIdentityAmbiguityEventsInput = {
+  tenantId: string;
+  orgUnitId?: string | null;
+  status?: ConnectShyftIdentityAmbiguityStatus | null;
+  normalizedContactPoint?: string | null;
+  sourceContext?: string | null;
+  limit?: number;
+  cursor?: string | null;
+};
+
+export type ListIdentityAmbiguityEventsResult = {
+  events: ConnectShyftIdentityAmbiguityEvent[];
+  nextCursor: string | null;
+};
+
+export type MarkIdentityAmbiguityEventReviewedInput = {
+  tenantId: string;
+  ambiguityEventId: string;
+  reviewedAtUtc?: string;
+};
+
+type DbIdentityAmbiguityEventRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string | null;
+  source_context: string;
+  source_context_id: string | null;
+  normalized_contact_point: string;
+  contact_point_type: 'phone';
+  candidate_neighbor_ids: unknown;
+  candidate_count: number;
+  ambiguity_reason_code: ConnectShyftIdentityAmbiguityReasonCode;
+  status: ConnectShyftIdentityAmbiguityStatus;
+  requested_by_user_id: string | null;
+  correlation_id: string | null;
+  idempotency_key: string | null;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+type IdentityAmbiguityEventCursor = {
+  createdAtUtc: string;
+  id: string;
+};
+
+export interface ConnectShyftIdentityAmbiguityEventStore {
+  createEvent(
+    input: CreateIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent>;
+  listEvents(
+    input: ListIdentityAmbiguityEventsInput,
+  ): Promise<ListIdentityAmbiguityEventsResult>;
+  markReviewed(
+    input: MarkIdentityAmbiguityEventReviewedInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null>;
+}
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const normalizeOptionalString = (value: unknown): string | null => {
+  const normalized = normalizeString(value);
+  return normalized.length > 0 ? normalized : null;
+};
+
+const normalizeContactPointType = (value: unknown): 'phone' => {
+  return value === 'phone' ? 'phone' : 'phone';
+};
+
+const normalizeStatus = (value: unknown): ConnectShyftIdentityAmbiguityStatus => {
+  return value === 'reviewed' ? 'reviewed' : 'pending';
+};
+
+const normalizeLimit = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_LIST_LIMIT;
+  }
+
+  const normalized = Math.trunc(value);
+  if (normalized <= 0) {
+    return DEFAULT_LIST_LIMIT;
+  }
+
+  return Math.min(normalized, MAX_LIST_LIMIT);
+};
+
+const toIsoUtc = (value?: string | Date): string => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return new Date().toISOString();
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+};
+
+const cloneEvent = (
+  event: ConnectShyftIdentityAmbiguityEvent,
+): ConnectShyftIdentityAmbiguityEvent => ({
+  ...event,
+  candidateNeighborIds: [...event.candidateNeighborIds],
+});
+
+const compareEventsNewestFirst = (
+  left: ConnectShyftIdentityAmbiguityEvent,
+  right: ConnectShyftIdentityAmbiguityEvent,
+): number => {
+  const createdAtDelta = new Date(right.createdAtUtc).getTime() - new Date(left.createdAtUtc).getTime();
+  if (createdAtDelta !== 0) {
+    return createdAtDelta;
+  }
+
+  return right.id.localeCompare(left.id);
+};
+
+const encodeCursor = (cursor: IdentityAmbiguityEventCursor): string =>
+  Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64');
+
+const decodeCursor = (value: string | null | undefined): IdentityAmbiguityEventCursor | null => {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  try {
+    const decoded = JSON.parse(Buffer.from(normalized, 'base64').toString('utf8')) as {
+      createdAtUtc?: unknown;
+      id?: unknown;
+    };
+    const createdAtUtc = normalizeOptionalString(decoded.createdAtUtc);
+    const id = normalizeOptionalString(decoded.id);
+    if (!createdAtUtc || !id) {
+      return null;
+    }
+
+    return {
+      createdAtUtc,
+      id,
+    };
+  } catch (_error) {
+    return null;
+  }
+};
+
+const isAfterCursor = (
+  event: ConnectShyftIdentityAmbiguityEvent,
+  cursor: IdentityAmbiguityEventCursor | null,
+): boolean => {
+  if (!cursor) {
+    return true;
+  }
+
+  if (event.createdAtUtc < cursor.createdAtUtc) {
+    return true;
+  }
+
+  if (event.createdAtUtc > cursor.createdAtUtc) {
+    return false;
+  }
+
+  return event.id.localeCompare(cursor.id) < 0;
+};
+
+const isUuid = (value: string | null | undefined): value is string =>
+  typeof value === 'string' && UUID_PATTERN.test(value);
+
+const shouldUseInMemoryStore = (input: {
+  tenantId: string;
+  orgUnitId?: string | null;
+  ambiguityEventId?: string | null;
+}): boolean => {
+  const orgUnitId = normalizeOptionalString(input.orgUnitId);
+  const ambiguityEventId = normalizeOptionalString(input.ambiguityEventId);
+
+  return !isUuid(input.tenantId)
+    || Boolean(orgUnitId && !isUuid(orgUnitId))
+    || Boolean(ambiguityEventId && !isUuid(ambiguityEventId));
+};
+
+const parseCandidateNeighborIds = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => normalizeOptionalString(entry))
+      .filter((entry): entry is string => !!entry);
+  }
+
+  if (typeof value === 'string') {
+    try {
+      return parseCandidateNeighborIds(JSON.parse(value));
+    } catch (_error) {
+      return [];
+    }
+  }
+
+  return [];
+};
+
+const mapDbRowToEvent = (
+  row: DbIdentityAmbiguityEventRow,
+): ConnectShyftIdentityAmbiguityEvent => ({
+  id: row.id,
+  tenantId: row.tenant_id,
+  orgUnitId: row.org_unit_id,
+  sourceContext: row.source_context,
+  sourceContextId: row.source_context_id,
+  normalizedContactPoint: row.normalized_contact_point,
+  contactPointType: row.contact_point_type,
+  candidateNeighborIds: parseCandidateNeighborIds(row.candidate_neighbor_ids),
+  candidateCount: row.candidate_count,
+  ambiguityReasonCode: row.ambiguity_reason_code,
+  status: row.status,
+  requestedByUserId: row.requested_by_user_id,
+  correlationId: row.correlation_id,
+  idempotencyKey: row.idempotency_key,
+  createdAtUtc: row.created_at_utc instanceof Date
+    ? row.created_at_utc.toISOString()
+    : String(row.created_at_utc),
+  updatedAtUtc: row.updated_at_utc instanceof Date
+    ? row.updated_at_utc.toISOString()
+    : String(row.updated_at_utc),
+});
+
+const buildStoredEvent = (
+  input: CreateIdentityAmbiguityEventInput,
+): ConnectShyftIdentityAmbiguityEvent => {
+  const createdAtUtc = input.createdAtUtc ? toIsoUtc(input.createdAtUtc) : new Date().toISOString();
+  const updatedAtUtc = input.updatedAtUtc ? toIsoUtc(input.updatedAtUtc) : createdAtUtc;
+  const candidateNeighborIds = [...input.candidateNeighborIds];
+
+  return {
+    id: normalizeOptionalString(input.id) || randomUUID(),
+    tenantId: input.tenantId,
+    orgUnitId: normalizeOptionalString(input.orgUnitId),
+    sourceContext: normalizeString(input.sourceContext),
+    sourceContextId: normalizeOptionalString(input.sourceContextId),
+    normalizedContactPoint: normalizeString(input.normalizedContactPoint),
+    contactPointType: normalizeContactPointType(input.contactPointType),
+    candidateNeighborIds,
+    candidateCount: candidateNeighborIds.length,
+    ambiguityReasonCode: input.ambiguityReasonCode,
+    status: normalizeStatus(input.status),
+    requestedByUserId: normalizeOptionalString(input.requestedByUserId),
+    correlationId: normalizeOptionalString(input.correlationId),
+    idempotencyKey: normalizeOptionalString(input.idempotencyKey),
+    createdAtUtc,
+    updatedAtUtc,
+  };
+};
+
+export class InMemoryConnectShyftIdentityAmbiguityEventStore
+implements ConnectShyftIdentityAmbiguityEventStore {
+  private eventsById = new Map<string, ConnectShyftIdentityAmbiguityEvent>();
+
+  async createEvent(
+    input: CreateIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent> {
+    const event = buildStoredEvent(input);
+    this.eventsById.set(event.id, event);
+    return cloneEvent(event);
+  }
+
+  async listEvents(
+    input: ListIdentityAmbiguityEventsInput,
+  ): Promise<ListIdentityAmbiguityEventsResult> {
+    const orgUnitId = normalizeOptionalString(input.orgUnitId);
+    const status = normalizeOptionalString(input.status);
+    const normalizedContactPoint = normalizeOptionalString(input.normalizedContactPoint);
+    const sourceContext = normalizeOptionalString(input.sourceContext);
+    const cursor = decodeCursor(input.cursor);
+    const limit = normalizeLimit(input.limit);
+
+    const filtered = Array.from(this.eventsById.values())
+      .filter((event) => event.tenantId === input.tenantId)
+      .filter((event) => !orgUnitId || event.orgUnitId === orgUnitId)
+      .filter((event) => !status || event.status === status)
+      .filter((event) => !normalizedContactPoint || event.normalizedContactPoint === normalizedContactPoint)
+      .filter((event) => !sourceContext || event.sourceContext === sourceContext)
+      .filter((event) => isAfterCursor(event, cursor))
+      .sort(compareEventsNewestFirst);
+
+    const page = filtered.slice(0, limit + 1);
+    const hasMore = page.length > limit;
+    const events = page.slice(0, limit).map((event) => cloneEvent(event));
+    const lastEvent = events[events.length - 1];
+
+    return {
+      events,
+      nextCursor: hasMore && lastEvent
+        ? encodeCursor({
+          createdAtUtc: lastEvent.createdAtUtc,
+          id: lastEvent.id,
+        })
+        : null,
+    };
+  }
+
+  async markReviewed(
+    input: MarkIdentityAmbiguityEventReviewedInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
+    const existing = this.eventsById.get(input.ambiguityEventId);
+    if (!existing || existing.tenantId !== input.tenantId) {
+      return null;
+    }
+
+    if (existing.status === 'reviewed') {
+      return cloneEvent(existing);
+    }
+
+    const updated: ConnectShyftIdentityAmbiguityEvent = {
+      ...existing,
+      status: 'reviewed',
+      updatedAtUtc: input.reviewedAtUtc ? toIsoUtc(input.reviewedAtUtc) : new Date().toISOString(),
+    };
+    this.eventsById.set(updated.id, updated);
+    return cloneEvent(updated);
+  }
+
+  reset(): void {
+    this.eventsById.clear();
+  }
+}
+
+export class KnexConnectShyftIdentityAmbiguityEventStore
+implements ConnectShyftIdentityAmbiguityEventStore {
+  constructor(private readonly resolveDb: () => Knex) {}
+
+  private table() {
+    return this.resolveDb()
+      .withSchema(CONNECTSHYFT_SCHEMA)
+      .table<DbIdentityAmbiguityEventRow>(AMBIGUITY_EVENTS_TABLE);
+  }
+
+  async createEvent(
+    input: CreateIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent> {
+    const event = buildStoredEvent(input);
+
+    const insertedRows = await this.table()
+      .insert({
+        id: event.id,
+        tenant_id: event.tenantId,
+        org_unit_id: event.orgUnitId,
+        source_context: event.sourceContext,
+        source_context_id: event.sourceContextId,
+        normalized_contact_point: event.normalizedContactPoint,
+        contact_point_type: event.contactPointType,
+        candidate_neighbor_ids: event.candidateNeighborIds,
+        candidate_count: event.candidateCount,
+        ambiguity_reason_code: event.ambiguityReasonCode,
+        status: event.status,
+        requested_by_user_id: event.requestedByUserId,
+        correlation_id: event.correlationId,
+        idempotency_key: event.idempotencyKey,
+        created_at_utc: event.createdAtUtc,
+        updated_at_utc: event.updatedAtUtc,
+      })
+      .returning('*');
+
+    const inserted = insertedRows[0];
+    return inserted ? mapDbRowToEvent(inserted) : event;
+  }
+
+  async listEvents(
+    input: ListIdentityAmbiguityEventsInput,
+  ): Promise<ListIdentityAmbiguityEventsResult> {
+    const orgUnitId = normalizeOptionalString(input.orgUnitId);
+    const status = normalizeOptionalString(input.status);
+    const normalizedContactPoint = normalizeOptionalString(input.normalizedContactPoint);
+    const sourceContext = normalizeOptionalString(input.sourceContext);
+    const cursor = decodeCursor(input.cursor);
+    const limit = normalizeLimit(input.limit);
+
+    const query = this.table()
+      .where({
+        tenant_id: input.tenantId,
+      })
+      .orderBy('created_at_utc', 'desc')
+      .orderBy('id', 'desc')
+      .limit(limit + 1);
+
+    if (orgUnitId) {
+      query.andWhere('org_unit_id', orgUnitId);
+    }
+    if (status) {
+      query.andWhere('status', status);
+    }
+    if (normalizedContactPoint) {
+      query.andWhere('normalized_contact_point', normalizedContactPoint);
+    }
+    if (sourceContext) {
+      query.andWhere('source_context', sourceContext);
+    }
+    if (cursor) {
+      query.andWhere((builder) => {
+        builder
+          .where('created_at_utc', '<', cursor.createdAtUtc)
+          .orWhere((nestedBuilder) => {
+            nestedBuilder
+              .where('created_at_utc', '=', cursor.createdAtUtc)
+              .andWhere('id', '<', cursor.id);
+          });
+      });
+    }
+
+    const rows = await query.select('*');
+    const mapped = rows.map((row) => mapDbRowToEvent(row));
+    const hasMore = mapped.length > limit;
+    const events = mapped.slice(0, limit);
+    const lastEvent = events[events.length - 1];
+
+    return {
+      events,
+      nextCursor: hasMore && lastEvent
+        ? encodeCursor({
+          createdAtUtc: lastEvent.createdAtUtc,
+          id: lastEvent.id,
+        })
+        : null,
+    };
+  }
+
+  async markReviewed(
+    input: MarkIdentityAmbiguityEventReviewedInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
+    const existing = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        id: input.ambiguityEventId,
+      })
+      .first();
+
+    if (!existing) {
+      return null;
+    }
+
+    if (existing.status === 'reviewed') {
+      return mapDbRowToEvent(existing);
+    }
+
+    const updatedRows = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        id: input.ambiguityEventId,
+      })
+      .update({
+        status: 'reviewed',
+        updated_at_utc: input.reviewedAtUtc ? toIsoUtc(input.reviewedAtUtc) : new Date().toISOString(),
+      })
+      .returning('*');
+
+    const updated = updatedRows[0];
+    return updated ? mapDbRowToEvent(updated) : mapDbRowToEvent(existing);
+  }
+}
+
+export class AsyncConnectShyftIdentityAmbiguityEventService {
+  constructor(
+    private readonly primaryStore: ConnectShyftIdentityAmbiguityEventStore,
+    private readonly fallbackStore: ConnectShyftIdentityAmbiguityEventStore | null = null,
+  ) {}
+
+  private resolveStore(input: {
+    tenantId: string;
+    orgUnitId?: string | null;
+    ambiguityEventId?: string | null;
+  }): ConnectShyftIdentityAmbiguityEventStore {
+    if (this.fallbackStore && shouldUseInMemoryStore(input)) {
+      return this.fallbackStore;
+    }
+
+    return this.primaryStore;
+  }
+
+  async createIdentityAmbiguityEvent(
+    input: CreateIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent> {
+    return this.resolveStore({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+    }).createEvent(input);
+  }
+
+  async listIdentityAmbiguityEvents(
+    input: ListIdentityAmbiguityEventsInput,
+  ): Promise<ListIdentityAmbiguityEventsResult> {
+    return this.resolveStore({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+    }).listEvents(input);
+  }
+
+  async markIdentityAmbiguityEventReviewed(
+    input: MarkIdentityAmbiguityEventReviewedInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
+    return this.resolveStore({
+      tenantId: input.tenantId,
+      ambiguityEventId: input.ambiguityEventId,
+    }).markReviewed(input);
+  }
+}
+
+const inMemoryConnectShyftIdentityAmbiguityEventStore =
+  new InMemoryConnectShyftIdentityAmbiguityEventStore();
+const knexConnectShyftIdentityAmbiguityEventStore =
+  new KnexConnectShyftIdentityAmbiguityEventStore(() => db);
+const defaultConnectShyftIdentityAmbiguityEventService =
+  new AsyncConnectShyftIdentityAmbiguityEventService(
+    knexConnectShyftIdentityAmbiguityEventStore,
+    inMemoryConnectShyftIdentityAmbiguityEventStore,
+  );
+
+export const createIdentityAmbiguityEvent = (
+  input: CreateIdentityAmbiguityEventInput,
+): Promise<ConnectShyftIdentityAmbiguityEvent> =>
+  defaultConnectShyftIdentityAmbiguityEventService.createIdentityAmbiguityEvent(input);
+
+export const listIdentityAmbiguityEvents = (
+  input: ListIdentityAmbiguityEventsInput,
+): Promise<ListIdentityAmbiguityEventsResult> =>
+  defaultConnectShyftIdentityAmbiguityEventService.listIdentityAmbiguityEvents(input);
+
+export const markIdentityAmbiguityEventReviewed = (
+  input: MarkIdentityAmbiguityEventReviewedInput,
+): Promise<ConnectShyftIdentityAmbiguityEvent | null> =>
+  defaultConnectShyftIdentityAmbiguityEventService.markIdentityAmbiguityEventReviewed(input);
+
+export const resetIdentityAmbiguityEventsForTests = (): void => {
+  inMemoryConnectShyftIdentityAmbiguityEventStore.reset();
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts
@@ -1,8 +1,13 @@
 import { normalizePhone } from '../../../../../domains/communication';
+import logger from '../../utils/logger';
 import {
   AsyncPeopleCoreService,
   peopleCoreServiceAsync,
 } from '../peoplecore/service';
+import {
+  createIdentityAmbiguityEvent,
+  type ConnectShyftIdentityAmbiguityReasonCode,
+} from './ambiguityEvents';
 import {
   evaluateConnectShyftIdentityBoundary,
   type ConnectShyftIdentityBoundaryDecision,
@@ -138,6 +143,22 @@ const hasLegacySameSubjectProof = (
     && tenantExactMatchNeighborIds[0] === legacyCandidateNeighborIds[0];
 };
 
+const resolveAmbiguityReasonCode = (
+  lookup: ConnectShyftPeopleCoreIdentityCandidateLookup | null,
+  legacyResult: ConnectShyftIdentityBoundaryResult,
+): ConnectShyftIdentityAmbiguityReasonCode => {
+  if (!legacyResult.ok && legacyResult.code === 'IDENTITY_MATCH_AMBIGUOUS') {
+    return 'IDENTITY_MATCH_AMBIGUOUS';
+  }
+
+  const currentPersonIds = lookup ? collectDistinctCurrentPersonIds(lookup) : [];
+  if (currentPersonIds.length > 1) {
+    return 'PEOPLECORE_MULTI_CURRENT_LINKS';
+  }
+
+  return 'PEOPLECORE_LEGACY_DISAGREEMENT';
+};
+
 export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
 {
   private readonly hooks: ConnectShyftPeopleCoreIdentityHooks;
@@ -257,6 +278,24 @@ export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
     );
     const result = this.applyPeopleCoreAuthorityPolicy(lookup, legacyResult);
 
+    try {
+      await this.persistAmbiguityEventIfNeeded(input, lookup, legacyResult, result);
+    } catch (error) {
+      const ambiguityReasonCode = resolveAmbiguityReasonCode(lookup, legacyResult);
+      const sourceContext = input.hookContext?.triggerSourceType || 'connectshyft_identity_seam';
+      const idempotencyKey = result.data?.idempotency.key || input.idempotencyKey || null;
+      logger.warn('ConnectShyft identity ambiguity event persistence failed', {
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId || null,
+        normalizedContactPoint: result.data?.identityMatch?.contactPoint.value || normalizedContactPointValue,
+        ambiguityReasonCode,
+        sourceContext,
+        correlationId: null,
+        idempotencyKey,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     if (lookup) {
       try {
         await this.hooks.applyIdentityHooks(input, result, lookup);
@@ -266,6 +305,33 @@ export class AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter
     }
 
     return result;
+  }
+
+  private async persistAmbiguityEventIfNeeded(
+    input: ConnectShyftIdentityBoundaryRequest,
+    lookup: ConnectShyftPeopleCoreIdentityCandidateLookup | null,
+    legacyResult: ConnectShyftIdentityBoundaryResult,
+    result: ConnectShyftIdentityBoundaryResult,
+  ): Promise<void> {
+    if (result.ok || result.code !== 'IDENTITY_MATCH_AMBIGUOUS' || !result.data?.identityMatch) {
+      return;
+    }
+
+    const identityMatch = result.data.identityMatch;
+    await createIdentityAmbiguityEvent({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId || null,
+      sourceContext: input.hookContext?.triggerSourceType || 'connectshyft_identity_seam',
+      sourceContextId: input.hookContext?.triggerSourceId || result.data.idempotency.key,
+      normalizedContactPoint: identityMatch.contactPoint.value,
+      contactPointType: 'phone',
+      candidateNeighborIds: [...identityMatch.candidateNeighborIds],
+      candidateCount: identityMatch.candidateCount,
+      ambiguityReasonCode: resolveAmbiguityReasonCode(lookup, legacyResult),
+      requestedByUserId: input.hookContext?.requestedByUserId || null,
+      correlationId: null,
+      idempotencyKey: result.data.idempotency.key,
+    });
   }
 
   private applyPeopleCoreAuthorityPolicy(

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
@@ -1,0 +1,447 @@
+// @ts-nocheck
+import express from 'express';
+import request from 'supertest';
+import {
+  createIdentityAmbiguityEvent,
+  resetIdentityAmbiguityEventsForTests,
+} from '../../../../modules/connectshyft/ambiguityEvents';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import connectShyftRouter from '../connectshyft';
+
+const TEST_TENANT_ID = 'tenant-connectshyft-ambiguity-ops';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-ambiguity-ops-east';
+const OTHER_ORG_UNIT_ID = 'org-connectshyft-ambiguity-ops-west';
+const OTHER_TENANT_ID = 'tenant-connectshyft-ambiguity-ops-other';
+const TEST_USER_ID = 'user-connectshyft-ambiguity-ops';
+const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+  connectshyft_enabled: true,
+  connectshyft_inbox_enabled: true,
+  connectshyft_escalation_enabled: true,
+  connectshyft_webhooks_enabled: true,
+});
+
+type HarnessOptions = {
+  defaultTenantId?: string;
+  defaultOrgUnitId?: string | null;
+  defaultRole?: string;
+  defaultUserId?: string;
+};
+
+type HeaderOptions = {
+  tenantId?: string;
+  orgUnitId?: string | undefined;
+  role?: string;
+  userId?: string;
+  memberships?: string[] | undefined;
+  correlationId?: string;
+  flags?: string;
+};
+
+const buildApp = (options: HarnessOptions = {}) => {
+  const {
+    defaultTenantId = TEST_TENANT_ID,
+    defaultOrgUnitId = TEST_ORG_UNIT_ID,
+    defaultRole = 'TENANT_ADMIN',
+    defaultUserId = TEST_USER_ID,
+  } = options;
+
+  const app = express();
+  app.use(express.json());
+  app.use(responseEnvelope);
+
+  app.use((req, _res, next) => {
+    const tenantId = req.header('x-test-connectshyft-tenant-id') || defaultTenantId;
+    const orgUnitId = req.header('x-test-connectshyft-orgunit-id') || defaultOrgUnitId;
+    const role = req.header('x-test-connectshyft-role') || defaultRole;
+    const userId = req.header('x-test-connectshyft-user-id') || defaultUserId;
+
+    req.user = {
+      userId,
+      email: `${String(userId).trim() || 'anonymous'}@connectshyft.test`,
+      householdId: tenantId,
+      activeTenantId: tenantId,
+      activeOrgUnitId: orgUnitId ?? undefined,
+      role,
+    };
+    req.tenantId = tenantId;
+    req.orgUnitId = orgUnitId ?? undefined;
+    req.tenantContext = tenantId
+      ? {
+        tenantId,
+        orgUnitId: orgUnitId ?? undefined,
+        scopeMode: orgUnitId ? 'ORG_UNIT' : 'TENANT',
+        source: 'auth',
+      }
+      : undefined;
+
+    next();
+  });
+
+  app.use('/api/v1/connectshyft', connectShyftRouter);
+  return app;
+};
+
+const buildHeaders = (
+  options: HeaderOptions = {},
+): Record<string, string> => {
+  const tenantId = Object.prototype.hasOwnProperty.call(options, 'tenantId')
+    ? options.tenantId
+    : TEST_TENANT_ID;
+  const orgUnitId = Object.prototype.hasOwnProperty.call(options, 'orgUnitId')
+    ? options.orgUnitId
+    : TEST_ORG_UNIT_ID;
+  const role = Object.prototype.hasOwnProperty.call(options, 'role')
+    ? options.role
+    : 'TENANT_ADMIN';
+  const userId = Object.prototype.hasOwnProperty.call(options, 'userId')
+    ? options.userId
+    : TEST_USER_ID;
+  const memberships = Object.prototype.hasOwnProperty.call(options, 'memberships')
+    ? options.memberships
+    : (orgUnitId ? [orgUnitId] : undefined);
+  const correlationId = Object.prototype.hasOwnProperty.call(options, 'correlationId')
+    ? options.correlationId
+    : 'corr-connectshyft-identity-ambiguity-ops';
+  const flags = Object.prototype.hasOwnProperty.call(options, 'flags')
+    ? options.flags
+    : CONNECTSHYFT_TEST_FLAGS;
+
+  const headers: Record<string, string> = {
+    'x-correlation-id': correlationId,
+    'x-test-connectshyft-flags': flags,
+    'x-test-connectshyft-tenant-id': tenantId,
+    'x-test-connectshyft-role': role,
+    'x-test-connectshyft-user-id': userId,
+  };
+
+  if (orgUnitId) {
+    headers['x-test-connectshyft-orgunit-id'] = orgUnitId;
+  }
+
+  if (memberships) {
+    headers['x-test-connectshyft-orgunit-memberships'] = JSON.stringify(memberships);
+  }
+
+  return headers;
+};
+
+const createEvent = async (overrides: Record<string, unknown> = {}) => createIdentityAmbiguityEvent({
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  sourceContext: 'connectshyft_identity_match',
+  sourceContextId: 'identity-match:ops-default',
+  normalizedContactPoint: '+12605550181',
+  candidateNeighborIds: ['neighbor-a', 'neighbor-b'],
+  ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+  status: 'pending',
+  requestedByUserId: TEST_USER_ID,
+  correlationId: 'corr-connectshyft-identity-ambiguity-ops',
+  idempotencyKey: 'identity-match:ops-default',
+  createdAtUtc: '2026-03-21T12:00:00.000Z',
+  updatedAtUtc: '2026-03-21T12:00:00.000Z',
+  ...overrides,
+});
+
+describe('connectshyft identity ambiguity ops route', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+    process.env.CONNECTSHYFT_ENABLED = 'true';
+    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+  });
+
+  beforeEach(() => {
+    resetIdentityAmbiguityEventsForTests();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    resetIdentityAmbiguityEventsForTests();
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+  });
+
+  it('returns tenant-scoped ambiguity events newest first for tenant-privileged reads and supports orgUnit filters', async () => {
+    await createEvent({
+      id: 'ambiguity-event-east',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+      updatedAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+    await createEvent({
+      id: 'ambiguity-event-west',
+      orgUnitId: OTHER_ORG_UNIT_ID,
+      sourceContextId: 'identity-match:ops-west',
+      normalizedContactPoint: '+12605550182',
+      ambiguityReasonCode: 'PEOPLECORE_LEGACY_DISAGREEMENT',
+      createdAtUtc: '2026-03-21T12:05:00.000Z',
+      updatedAtUtc: '2026-03-21T12:05:00.000Z',
+    });
+    await createEvent({
+      id: 'ambiguity-event-other-tenant',
+      tenantId: OTHER_TENANT_ID,
+      orgUnitId: OTHER_ORG_UNIT_ID,
+      sourceContextId: 'identity-match:ops-other-tenant',
+      normalizedContactPoint: '+12605550183',
+      createdAtUtc: '2026-03-21T12:10:00.000Z',
+      updatedAtUtc: '2026-03-21T12:10:00.000Z',
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITIES_RESOLVED',
+      data: {
+        events: [
+          expect.objectContaining({
+            id: 'ambiguity-event-west',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: OTHER_ORG_UNIT_ID,
+            ambiguityReasonCode: 'PEOPLECORE_LEGACY_DISAGREEMENT',
+          }),
+          expect.objectContaining({
+            id: 'ambiguity-event-east',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+          }),
+        ],
+        nextCursor: null,
+      },
+    });
+    expect(response.body.data.events).toHaveLength(2);
+    expect(Object.keys(response.body.data.events[0]).sort()).toEqual([
+      'ambiguityReasonCode',
+      'candidateCount',
+      'candidateNeighborIds',
+      'contactPointType',
+      'correlationId',
+      'createdAtUtc',
+      'id',
+      'idempotencyKey',
+      'normalizedContactPoint',
+      'orgUnitId',
+      'requestedByUserId',
+      'sourceContext',
+      'sourceContextId',
+      'status',
+      'tenantId',
+      'updatedAtUtc',
+    ].sort());
+
+    const filteredResponse = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .query({
+        orgUnitId: OTHER_ORG_UNIT_ID,
+      })
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(filteredResponse.status).toBe(200);
+    expect(filteredResponse.body.data.events).toHaveLength(1);
+    expect(filteredResponse.body.data.events[0]).toMatchObject({
+      id: 'ambiguity-event-west',
+      orgUnitId: OTHER_ORG_UNIT_ID,
+    });
+  });
+
+  it('keeps org-unit identity reads scoped to the active orgUnit and refuses cross-orgUnit overrides', async () => {
+    await createEvent({
+      id: 'ambiguity-event-east',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+      updatedAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+    await createEvent({
+      id: 'ambiguity-event-west',
+      orgUnitId: OTHER_ORG_UNIT_ID,
+      sourceContextId: 'identity-match:ops-west',
+      normalizedContactPoint: '+12605550184',
+      createdAtUtc: '2026-03-21T12:05:00.000Z',
+      updatedAtUtc: '2026-03-21T12:05:00.000Z',
+    });
+
+    const app = buildApp({
+      defaultRole: 'ORGUNIT_IDENTITY_LEAD',
+    });
+    const response = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .set(buildHeaders({
+        role: 'ORGUNIT_IDENTITY_LEAD',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.events).toHaveLength(1);
+    expect(response.body.data.events[0]).toMatchObject({
+      id: 'ambiguity-event-east',
+      orgUnitId: TEST_ORG_UNIT_ID,
+    });
+
+    const crossOrgUnitResponse = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .query({
+        orgUnitId: OTHER_ORG_UNIT_ID,
+      })
+      .set(buildHeaders({
+        role: 'ORGUNIT_IDENTITY_LEAD',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(crossOrgUnitResponse.status).toBe(200);
+    expect(crossOrgUnitResponse.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+      message: 'Cross-orgUnit context overrides are not allowed for this route',
+    });
+  });
+
+  it('applies optional status, contact-point, and source-context filters', async () => {
+    await createEvent({
+      id: 'ambiguity-event-match',
+      normalizedContactPoint: '+12605550191',
+      sourceContext: 'connectshyft_identity_match',
+      status: 'pending',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+      updatedAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+    await createEvent({
+      id: 'ambiguity-event-reviewed',
+      normalizedContactPoint: '+12605550191',
+      sourceContext: 'connectshyft_identity_match',
+      status: 'reviewed',
+      createdAtUtc: '2026-03-21T12:01:00.000Z',
+      updatedAtUtc: '2026-03-21T12:01:00.000Z',
+    });
+    await createEvent({
+      id: 'ambiguity-event-other-source',
+      normalizedContactPoint: '+12605550191',
+      sourceContext: 'connectshyft_inbound_subject_resolution',
+      status: 'pending',
+      createdAtUtc: '2026-03-21T12:02:00.000Z',
+      updatedAtUtc: '2026-03-21T12:02:00.000Z',
+    });
+
+    const app = buildApp({
+      defaultRole: 'ORGUNIT_IDENTITY_LEAD',
+    });
+    const response = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .query({
+        status: 'pending',
+        normalizedContactPoint: '+12605550191',
+        sourceContext: 'connectshyft_identity_match',
+      })
+      .set(buildHeaders({
+        role: 'ORGUNIT_IDENTITY_LEAD',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.events).toHaveLength(1);
+    expect(response.body.data.events[0]).toMatchObject({
+      id: 'ambiguity-event-match',
+      normalizedContactPoint: '+12605550191',
+      sourceContext: 'connectshyft_identity_match',
+      status: 'pending',
+    });
+  });
+
+  it('caps the read limit and preserves keyset pagination', async () => {
+    const baseCreatedAt = Date.parse('2026-03-21T12:00:00.000Z');
+    const events = Array.from({ length: 201 }, (_value, index) =>
+      createEvent({
+        id: `ambiguity-event-${String(index).padStart(3, '0')}`,
+        normalizedContactPoint: `+1260555${String(1000 + index).padStart(4, '0')}`,
+        sourceContextId: `identity-match:ops-${index}`,
+        createdAtUtc: new Date(baseCreatedAt + (index * 1000)).toISOString(),
+        updatedAtUtc: new Date(baseCreatedAt + (index * 1000)).toISOString(),
+      }));
+    await Promise.all(events);
+
+    const app = buildApp();
+    const firstPage = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .query({
+        limit: '999',
+      })
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(firstPage.status).toBe(200);
+    expect(firstPage.body.data.events).toHaveLength(200);
+    expect(firstPage.body.data.events[0]).toMatchObject({
+      id: 'ambiguity-event-200',
+      createdAtUtc: new Date(baseCreatedAt + (200 * 1000)).toISOString(),
+    });
+    expect(firstPage.body.data.events[199]).toMatchObject({
+      id: 'ambiguity-event-001',
+      createdAtUtc: new Date(baseCreatedAt + 1000).toISOString(),
+    });
+    expect(firstPage.body.data.nextCursor).toEqual(expect.any(String));
+
+    const secondPage = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .query({
+        limit: '999',
+        cursor: firstPage.body.data.nextCursor,
+      })
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(secondPage.status).toBe(200);
+    expect(secondPage.body.data.events).toHaveLength(1);
+    expect(secondPage.body.data.events[0]).toMatchObject({
+      id: 'ambiguity-event-000',
+      createdAtUtc: new Date(baseCreatedAt).toISOString(),
+    });
+    expect(secondPage.body.data.nextCursor).toBeNull();
+  });
+
+  it('refuses reads for roles without identity-resolution or tenant-privileged access', async () => {
+    const app = buildApp({
+      defaultRole: 'ORGUNIT_MEMBER',
+    });
+    const response = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .set(buildHeaders({
+        role: 'ORGUNIT_MEMBER',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_READ_FORBIDDEN',
+      message: 'Identity ambiguity access requires an authorized ConnectShyft role.',
+    });
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
@@ -444,4 +444,173 @@ describe('connectshyft identity ambiguity ops route', () => {
       message: 'Identity ambiguity access requires an authorized ConnectShyft role.',
     });
   });
+
+  it('marks pending ambiguity events reviewed for tenant-privileged roles', async () => {
+    await createEvent({
+      id: 'ambiguity-event-review-pending',
+      status: 'pending',
+      createdAtUtc: '2026-03-21T13:00:00.000Z',
+      updatedAtUtc: '2026-03-21T13:00:00.000Z',
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-review-pending')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        status: 'reviewed',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_REVIEWED',
+      data: {
+        event: expect.objectContaining({
+          id: 'ambiguity-event-review-pending',
+          tenantId: TEST_TENANT_ID,
+          status: 'reviewed',
+        }),
+      },
+    });
+    expect(response.body.data.event.updatedAtUtc).not.toBe('2026-03-21T13:00:00.000Z');
+  });
+
+  it('treats repeated reviewed updates as idempotent success', async () => {
+    await createEvent({
+      id: 'ambiguity-event-review-idempotent',
+      status: 'reviewed',
+      createdAtUtc: '2026-03-21T13:10:00.000Z',
+      updatedAtUtc: '2026-03-21T13:15:00.000Z',
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-review-idempotent')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        status: 'reviewed',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_REVIEWED',
+      data: {
+        event: expect.objectContaining({
+          id: 'ambiguity-event-review-idempotent',
+          status: 'reviewed',
+          updatedAtUtc: '2026-03-21T13:15:00.000Z',
+        }),
+      },
+    });
+  });
+
+  it('keeps review updates tenant-scoped and returns not found outside the active tenant', async () => {
+    await createIdentityAmbiguityEvent({
+      id: 'ambiguity-event-other-tenant-review',
+      tenantId: OTHER_TENANT_ID,
+      orgUnitId: OTHER_ORG_UNIT_ID,
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:ops-other-tenant-review',
+      normalizedContactPoint: '+12605550201',
+      candidateNeighborIds: ['neighbor-z'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+      status: 'pending',
+      requestedByUserId: TEST_USER_ID,
+      correlationId: 'corr-connectshyft-identity-ambiguity-ops',
+      idempotencyKey: 'identity-match:ops-other-tenant-review',
+      createdAtUtc: '2026-03-21T13:20:00.000Z',
+      updatedAtUtc: '2026-03-21T13:20:00.000Z',
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-other-tenant-review')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        status: 'reviewed',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_NOT_FOUND',
+      message: 'Identity ambiguity event is unavailable for the active tenant context.',
+    });
+  });
+
+  it('rejects non-reviewed status payloads', async () => {
+    await createEvent({
+      id: 'ambiguity-event-invalid-status',
+      status: 'pending',
+      createdAtUtc: '2026-03-21T13:30:00.000Z',
+      updatedAtUtc: '2026-03-21T13:30:00.000Z',
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-invalid-status')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        status: 'pending',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_STATUS_INVALID',
+      message: 'status must be reviewed.',
+      data: {
+        fieldErrors: [
+          {
+            field: 'status',
+            reason: 'INVALID',
+            message: 'status must be reviewed.',
+          },
+        ],
+      },
+    });
+  });
+
+  it('refuses review updates for roles without tenant-privileged access', async () => {
+    await createEvent({
+      id: 'ambiguity-event-review-forbidden',
+      status: 'pending',
+      createdAtUtc: '2026-03-21T13:40:00.000Z',
+      updatedAtUtc: '2026-03-21T13:40:00.000Z',
+    });
+
+    const app = buildApp({
+      defaultRole: 'ORGUNIT_IDENTITY_LEAD',
+    });
+    const response = await request(app)
+      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-review-forbidden')
+      .set(buildHeaders({
+        role: 'ORGUNIT_IDENTITY_LEAD',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        status: 'reviewed',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_UPDATE_FORBIDDEN',
+      message: 'Identity ambiguity review requires a tenant-privileged ConnectShyft admin role.',
+    });
+  });
 });

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts
@@ -521,4 +521,16 @@ describe('connectshyft identity-match route', () => {
     }));
   });
 
+  it('does not expose the identity ambiguity reviewed-status route before the checkpoint 5 implementation lands', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-1')
+      .set(buildHeaders())
+      .send({
+        status: 'reviewed',
+      });
+
+    expect(response.status).toBe(404);
+  });
+
 });

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -176,6 +176,7 @@ import {
 } from '../../../modules/connectshyft/communicationAuditLog';
 import {
   listIdentityAmbiguityEvents,
+  markIdentityAmbiguityEventReviewed,
 } from '../../../modules/connectshyft/ambiguityEvents';
 import { isStrictUtcIsoTimestamp } from '../../../platform/time/timezoneService';
 
@@ -2228,6 +2229,29 @@ const resolveIdentityAmbiguityReadScope = (
   };
 };
 
+const resolveIdentityAmbiguityTenantPrivilegedScope = (
+  req: Request,
+  res: Response,
+  context: Pick<ResolvedConnectShyftContext, 'effectiveRoles'>,
+): {
+  actorRoles: string[];
+} | null => {
+  const actorRoles = resolveConnectShyftActorRoles(req, context);
+  if (hasCapability(actorRoles, CAPABILITIES.NEIGHBOR_EDIT_ALL)) {
+    return {
+      actorRoles,
+    };
+  }
+
+  refusal(res, {
+    code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_UPDATE_FORBIDDEN',
+    message: 'Identity ambiguity review requires a tenant-privileged ConnectShyft admin role.',
+    refusalType: 'business',
+    httpStatus: 200,
+  });
+  return null;
+};
+
 const parseOrgUnitIdFromBody = (req: Request): string | null => {
   if (typeof req.body?.orgUnitId !== 'string') {
     return null;
@@ -2302,6 +2326,25 @@ const parseIdentityAmbiguityFilters = (req: Request): {
   limit: parseIdentityAmbiguityLimit(req),
   cursor: parseIdentityAmbiguityOptionalFilter(req.query?.cursor),
 });
+
+const parseIdentityAmbiguityEventIdParam = (req: Request): string => {
+  if (typeof req.params.ambiguityEventId !== 'string') {
+    return '';
+  }
+
+  return req.params.ambiguityEventId.trim();
+};
+
+const parseIdentityAmbiguityStatusUpdate = (
+  req: Request,
+): 'reviewed' | null => {
+  if (typeof req.body?.status !== 'string') {
+    return null;
+  }
+
+  const normalized = req.body.status.trim().toLowerCase();
+  return normalized === 'reviewed' ? 'reviewed' : null;
+};
 
 const parseThreadDueLimit = (req: Request): number => {
   const rawLimit = typeof req.query?.limit === 'string'
@@ -4177,6 +4220,71 @@ router.get('/identity-ambiguities', async (req: Request, res: Response) => {
     data: {
       events: listed.events,
       nextCursor: listed.nextCursor,
+    },
+  });
+});
+
+router.patch('/identity-ambiguities/:ambiguityEventId', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  if (!resolveIdentityAmbiguityTenantPrivilegedScope(req, res, context)) {
+    return;
+  }
+
+  const ambiguityEventId = parseIdentityAmbiguityEventIdParam(req);
+  if (!ambiguityEventId) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_ID_REQUIRED',
+      message: 'ambiguityEventId is required',
+    });
+    return;
+  }
+
+  if (!parseIdentityAmbiguityStatusUpdate(req)) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_STATUS_INVALID',
+      message: 'status must be reviewed.',
+      data: {
+        fieldErrors: [
+          {
+            field: 'status',
+            reason: 'INVALID',
+            message: 'status must be reviewed.',
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  const event = await markIdentityAmbiguityEventReviewed({
+    tenantId: context.tenantId,
+    ambiguityEventId,
+  });
+
+  if (!event) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_NOT_FOUND',
+      message: 'Identity ambiguity event is unavailable for the active tenant context.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  return success(res, {
+    code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_REVIEWED',
+    message: 'ConnectShyft identity ambiguity reviewed',
+    httpStatus: 200,
+    data: {
+      event,
     },
   });
 });

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -174,6 +174,9 @@ import {
   appendConnectShyftCommunicationAuditEntry,
   resetConnectShyftCommunicationAuditLogForTests,
 } from '../../../modules/connectshyft/communicationAuditLog';
+import {
+  listIdentityAmbiguityEvents,
+} from '../../../modules/connectshyft/ambiguityEvents';
 import { isStrictUtcIsoTimestamp } from '../../../platform/time/timezoneService';
 
 const router = Router();
@@ -214,6 +217,8 @@ const CONNECTSHYFT_CANONICAL_EVENT_TYPES = {
 } as const;
 const CONNECTSHYFT_CANONICAL_EVENTS_DEFAULT_LIMIT = 50;
 const CONNECTSHYFT_CANONICAL_EVENTS_MAX_LIMIT = 200;
+const CONNECTSHYFT_IDENTITY_AMBIGUITIES_DEFAULT_LIMIT = 50;
+const CONNECTSHYFT_IDENTITY_AMBIGUITIES_MAX_LIMIT = 200;
 const CONNECTSHYFT_OUTBOUND_CALL_POLICY = {
   transport: 'bridge',
   autoRetry: false,
@@ -2182,6 +2187,47 @@ const enforceThreadMessageCapability = (
   return false;
 };
 
+const resolveIdentityAmbiguityReadScope = (
+  req: Request,
+  res: Response,
+  context: Pick<ResolvedConnectShyftContext, 'orgUnitId' | 'effectiveRoles'>,
+  requestedOrgUnitId: string | null,
+): {
+  actorRoles: string[];
+  orgUnitId: string | null;
+} | null => {
+  const actorRoles = resolveConnectShyftActorRoles(req, context);
+  const tenantPrivileged =
+    hasCapability(actorRoles, CAPABILITIES.NEIGHBOR_EDIT_ALL);
+  const identityResolutionCapable =
+    hasCapability(actorRoles, CAPABILITIES.ORG_UNIT_IDENTITY_RESOLVE);
+
+  if (!tenantPrivileged && !identityResolutionCapable) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_READ_FORBIDDEN',
+      message: 'Identity ambiguity access requires an authorized ConnectShyft role.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return null;
+  }
+
+  if (requestedOrgUnitId && !tenantPrivileged && requestedOrgUnitId !== context.orgUnitId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+      message: 'Cross-orgUnit context overrides are not allowed for this route',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return null;
+  }
+
+  return {
+    actorRoles,
+    orgUnitId: requestedOrgUnitId ?? (tenantPrivileged ? null : context.orgUnitId),
+  };
+};
+
 const parseOrgUnitIdFromBody = (req: Request): string | null => {
   if (typeof req.body?.orgUnitId !== 'string') {
     return null;
@@ -2198,6 +2244,64 @@ const parseOrgUnitIdFromQuery = (req: Request): string | null => {
   const normalized = req.query.orgUnitId.trim();
   return normalized.length > 0 ? normalized : null;
 };
+
+const parseIdentityAmbiguityStatusFromQuery = (
+  req: Request,
+): 'pending' | 'reviewed' | null => {
+  if (typeof req.query?.status !== 'string') {
+    return null;
+  }
+
+  const normalized = req.query.status.trim().toLowerCase();
+  if (normalized === 'pending' || normalized === 'reviewed') {
+    return normalized;
+  }
+
+  return null;
+};
+
+const parseIdentityAmbiguityOptionalFilter = (
+  value: unknown,
+): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+const parseIdentityAmbiguityLimit = (req: Request): number => {
+  const rawLimit = typeof req.query?.limit === 'string'
+    ? Number.parseInt(req.query.limit, 10)
+    : Number.NaN;
+  if (!Number.isFinite(rawLimit) || rawLimit <= 0) {
+    return CONNECTSHYFT_IDENTITY_AMBIGUITIES_DEFAULT_LIMIT;
+  }
+
+  return Math.min(
+    Math.trunc(rawLimit),
+    CONNECTSHYFT_IDENTITY_AMBIGUITIES_MAX_LIMIT,
+  );
+};
+
+const parseIdentityAmbiguityFilters = (req: Request): {
+  orgUnitId: string | null;
+  status: 'pending' | 'reviewed' | null;
+  normalizedContactPoint: string | null;
+  sourceContext: string | null;
+  limit: number;
+  cursor: string | null;
+} => ({
+  orgUnitId: parseOrgUnitIdFromQuery(req),
+  status: parseIdentityAmbiguityStatusFromQuery(req),
+  normalizedContactPoint: parseIdentityAmbiguityOptionalFilter(
+    req.query?.normalizedContactPoint,
+  ),
+  sourceContext: parseIdentityAmbiguityOptionalFilter(req.query?.sourceContext),
+  limit: parseIdentityAmbiguityLimit(req),
+  cursor: parseIdentityAmbiguityOptionalFilter(req.query?.cursor),
+});
 
 const parseThreadDueLimit = (req: Request): number => {
   const rawLimit = typeof req.query?.limit === 'string'
@@ -4031,6 +4135,48 @@ router.get('/events', async (req: Request, res: Response) => {
       deterministic: true,
       providerNeutral: true,
       events,
+    },
+  });
+});
+
+router.get('/identity-ambiguities', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const filters = parseIdentityAmbiguityFilters(req);
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  const readScope = resolveIdentityAmbiguityReadScope(
+    req,
+    res,
+    context,
+    filters.orgUnitId,
+  );
+  if (!readScope) {
+    return;
+  }
+
+  const listed = await listIdentityAmbiguityEvents({
+    tenantId: context.tenantId,
+    orgUnitId: readScope.orgUnitId,
+    status: filters.status,
+    normalizedContactPoint: filters.normalizedContactPoint,
+    sourceContext: filters.sourceContext,
+    limit: filters.limit,
+    cursor: filters.cursor,
+  });
+
+  return success(res, {
+    code: 'CONNECTSHYFT_IDENTITY_AMBIGUITIES_RESOLVED',
+    message: 'ConnectShyft identity ambiguities resolved',
+    httpStatus: 200,
+    data: {
+      events: listed.events,
+      nextCursor: listed.nextCursor,
     },
   });
 });

--- a/apps/moneyshyft-api/src/migrations/20260321110000_create_connectshyft_identity_ambiguity_events.ts
+++ b/apps/moneyshyft-api/src/migrations/20260321110000_create_connectshyft_identity_ambiguity_events.ts
@@ -1,0 +1,4 @@
+export {
+  down,
+  up,
+} from '../../../../shared/database/migrations/20260321110000_create_connectshyft_identity_ambiguity_events';

--- a/docs/architecture/connectshyft-router-refactor-plan.md
+++ b/docs/architecture/connectshyft-router-refactor-plan.md
@@ -7,6 +7,7 @@
 - Frontend build/test surface separation completed in Slice 11.
 - Slice 12 PeopleCore persistence foundation and identity seam complete.
 - Slice 13 PeopleCore ambiguity precedence documentation and handler-preservation rules complete.
+- Slice 14 operational ambiguity visibility and review-status documentation complete.
 
 ## Purpose
 
@@ -244,6 +245,22 @@ Did not add:
 - merge engine behavior
 - scoring engine behavior
 
+### Slice 14
+
+Locked the narrow operational ambiguity layer without broadening router or identity scope:
+
+- `GET /api/v1/connectshyft/identity-ambiguities` for ops visibility
+- `PATCH /api/v1/connectshyft/identity-ambiguities/:ambiguityEventId` for reviewed-status updates
+- ambiguity persistence remains observational only
+- reviewed status remains operational only
+
+Did not add:
+
+- reconciliation
+- crosswalk infrastructure
+- PeopleCore record mutation from ops review status
+- ConnectShyft neighbor mutation from ops review status
+
 ## Route-family extraction result
 
 The ConnectShyft route-family extraction sequence is complete:
@@ -272,11 +289,13 @@ Slice 12 adds the identity convergence foundation behind that extracted surface,
 
 Slice 13 adds ambiguity precedence behind that extracted surface, not a router redesign.
 
+Slice 14 adds a narrow operational ambiguity surface, not reconciliation or a router redesign.
+
 ## Next intentional work
 
-Next work after Slice 13 should be:
+Next work after Slice 14 should be:
 
-- operationalization of ambiguity and resolver handling behind the PeopleCore seam
+- true resolver operations no earlier than Slice 15
 - continued model-alignment work without changing current route envelopes lightly
 - not reconciliation or crosswalk implementation by default
 - not Application Shell by default

--- a/docs/architecture/identity-resolution-model.md
+++ b/docs/architecture/identity-resolution-model.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Authoritative for the Slice 13 identity-resolution architecture and seam behavior.
+Authoritative for the Slice 14 identity-resolution architecture and seam behavior.
 
 ---
 
@@ -107,6 +107,15 @@ PeopleCore available?
       single disagreement -> ambiguous
       none -> no-match (unchanged in Slice 13)
 ```
+
+### 5.3 Slice 14 operational ambiguity layer
+
+Slice 14 adds a narrow operational layer on top of ambiguous outcomes:
+
+- ambiguity events are persisted for ops visibility only
+- ambiguity-event persistence is observational only and does not alter the returned identity decision
+- reviewed status is operational only and does not change PeopleCore or ConnectShyft identity records
+- no reconciliation or automatic winner selection exists in this slice
 
 ---
 
@@ -247,8 +256,8 @@ Still deferred beyond Slice 13:
 
 ---
 
-## 15. Slice 14 Handoff
+## 15. Next Slice
 
-The next logical slice after Slice 13 is operationalization of ambiguity and resolver handling while preserving current route contracts.
+Slice 15 or later is where true resolver operations may begin while preserving current route contracts.
 
 It is not reconciliation, cross-system equivalence solving, or automatic PeopleCore-to-neighbor linking.

--- a/docs/architecture/peoplecore-identity-seam.md
+++ b/docs/architecture/peoplecore-identity-seam.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Authoritative for the Slice 13 ConnectShyft-to-PeopleCore identity seam.
+Authoritative for the Slice 14 ConnectShyft-to-PeopleCore identity seam.
 
 ## Purpose
 
@@ -34,6 +34,7 @@ The seam currently supports:
   - deleted-only exclusion where already characterized
 - exposing the normalized contact-point value back to ConnectShyft callers
 - running best-effort internal hook writes for provisional identity and resolver review creation where enabled
+- recording best-effort operational ambiguity events when the final PeopleCore-aware identity result is ambiguous
 
 Slice 13 explicitly recognizes these ambiguity categories:
 
@@ -91,15 +92,25 @@ The seam does not:
 
 ## Deferred Work
 
-Still deferred beyond Slice 13:
+Still deferred beyond Slice 14:
 
-- explicit operational handling for ambiguity and resolver workflows
+- broader operational handling for ambiguity and resolver workflows
 - explicit neighbor-to-person convergence strategy
 - conversation rebinding mechanics
 - resolver UI and broader PeopleCore operational workflows
 
-## Slice 14 Handoff
+## Slice 14 Lock
 
-The next logical slice after Slice 13 is operationalization of ambiguity and resolver handling behind this seam.
+Slice 14 adds an operational ambiguity layer behind this seam:
+
+- ambiguity-event persistence is observational only
+- write failure does not change request-path ambiguity outcomes
+- reviewed status is operational only
+- reviewed status does not reconcile PeopleCore and ConnectShyft identity state
+- no reconciliation or winner-selection behavior exists yet
+
+## Next Slice
+
+Slice 15 or later is where true resolver operations may begin.
 
 It should not default to reconciliation, crosswalk implementation, or Application Shell work.

--- a/shared/database/migrations/20260321110000_create_connectshyft_identity_ambiguity_events.ts
+++ b/shared/database/migrations/20260321110000_create_connectshyft_identity_ambiguity_events.ts
@@ -1,0 +1,115 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const AMBIGUITY_EVENTS_TABLE = 'cs_identity_ambiguity_events';
+const CONTACT_POINT_TYPE_CHECK = 'cs_identity_ambiguity_events_contact_point_type_ck';
+const STATUS_CHECK = 'cs_identity_ambiguity_events_status_ck';
+const REASON_CODE_CHECK = 'cs_identity_ambiguity_events_reason_code_ck';
+const TENANT_CREATED_INDEX = 'connectshyft_cs_identity_ambiguity_events_tenant_created_idx';
+const TENANT_STATUS_CREATED_INDEX = 'connectshyft_cs_identity_ambiguity_events_tenant_status_created_idx';
+const TENANT_CONTACT_POINT_INDEX = 'connectshyft_cs_identity_ambiguity_events_tenant_contact_point_idx';
+const TENANT_SOURCE_CONTEXT_CREATED_INDEX =
+  'connectshyft_cs_identity_ambiguity_events_tenant_source_context_created_idx';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}`);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE} (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      tenant_id UUID NOT NULL,
+      org_unit_id UUID NULL,
+      source_context TEXT NOT NULL,
+      source_context_id TEXT NULL,
+      normalized_contact_point TEXT NOT NULL,
+      contact_point_type TEXT NOT NULL DEFAULT 'phone',
+      candidate_neighbor_ids JSONB NOT NULL,
+      candidate_count INTEGER NOT NULL,
+      ambiguity_reason_code TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      requested_by_user_id TEXT NULL,
+      correlation_id TEXT NULL,
+      idempotency_key TEXT NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${CONTACT_POINT_TYPE_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+          ADD CONSTRAINT ${CONTACT_POINT_TYPE_CHECK}
+          CHECK (contact_point_type IN ('phone'));
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${STATUS_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+          ADD CONSTRAINT ${STATUS_CHECK}
+          CHECK (status IN ('pending', 'reviewed'));
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '${REASON_CODE_CHECK}'
+          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}'::regclass
+      ) THEN
+        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+          ADD CONSTRAINT ${REASON_CODE_CHECK}
+          CHECK (ambiguity_reason_code IN (
+            'IDENTITY_MATCH_AMBIGUOUS',
+            'PEOPLECORE_LEGACY_DISAGREEMENT',
+            'PEOPLECORE_MULTI_CURRENT_LINKS'
+          ));
+      END IF;
+    END $$;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${TENANT_CREATED_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE} (tenant_id, created_at_utc DESC)
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${TENANT_STATUS_CREATED_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE} (tenant_id, status, created_at_utc DESC)
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${TENANT_CONTACT_POINT_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE} (tenant_id, normalized_contact_point)
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${TENANT_SOURCE_CONTEXT_CREATED_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE} (tenant_id, source_context, created_at_utc DESC)
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+  `);
+}


### PR DESCRIPTION
## Summary
- add ConnectShyft identity ambiguity event persistence for ambiguous PeopleCore-aware identity outcomes
- add ops read and reviewed-status endpoints for identity ambiguity events
- lock Slice 14 architecture and behavior with focused tests and docs

## Validation
- pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
- pnpm nx run connectshyft-api:test
- pnpm nx run contracts:test