### PR TITLE
Fix: implement ConnectShyft ops visibility

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts
@@ -1,0 +1,320 @@
+import { Request, Response } from 'express';
+import logger from '../../../utils/logger';
+import { refusal, success } from '../../../platform/envelopes/response';
+import { CAPABILITIES } from '../../../platform/rbac/capabilities';
+import {
+  enforceConnectShyftCapability,
+  requestHasAnyCapability,
+  resolveConnectShyftRouteContextDecision,
+  respondWithConnectShyftContextRefusal,
+  sendConnectShyftRouteRefusal,
+} from './accessContext';
+import { readConnectShyftIdentityVisibility } from '../ops/identityVisibility.service';
+import { readConnectShyftBridgeVisibility } from '../ops/bridgeVisibility.service';
+import { readConnectShyftThreadVisibility } from '../ops/threadVisibility.service';
+
+const parseParam = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const logOpsVisibilityRequested = (input: {
+  surface: 'identity' | 'thread' | 'bridge';
+  tenantId: string;
+  orgUnitId: string;
+  resourceId: string;
+}) => {
+  logger.info('ops.visibility.requested', {
+    eventName: 'ops.visibility.requested',
+    surface: input.surface,
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    resourceId: input.resourceId,
+  });
+};
+
+const logOpsVisibilityReturned = (input: {
+  surface: 'identity' | 'thread' | 'bridge';
+  tenantId: string;
+  orgUnitId: string;
+  resourceId: string;
+  outcome: 'success' | 'refusal';
+  code: string;
+}) => {
+  logger.info('ops.visibility.response_returned', {
+    eventName: 'ops.visibility.response_returned',
+    surface: input.surface,
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    resourceId: input.resourceId,
+    outcome: input.outcome,
+    code: input.code,
+  });
+};
+
+const resolveOpsIdentityReadContext = async (
+  req: Request,
+  res: Response,
+) => {
+  if (!await enforceConnectShyftCapability(req, res, 'module')) {
+    return null;
+  }
+
+  const contextDecision = await resolveConnectShyftRouteContextDecision(req);
+  if (!contextDecision.ok) {
+    respondWithConnectShyftContextRefusal(res, contextDecision);
+    return null;
+  }
+
+  const allowed = requestHasAnyCapability(req, [
+    CAPABILITIES.NEIGHBOR_EDIT_ALL,
+    CAPABILITIES.ORG_UNIT_IDENTITY_RESOLVE,
+  ], contextDecision.context);
+  if (!allowed) {
+    sendConnectShyftRouteRefusal(res, {
+      code: 'CONNECTSHYFT_OPS_IDENTITY_VIEW_FORBIDDEN',
+      message: 'Ops identity visibility requires an authorized ConnectShyft role.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return null;
+  }
+
+  return {
+    context: contextDecision.context,
+  };
+};
+
+const resolveOpsThreadReadContext = async (
+  req: Request,
+  res: Response,
+) => {
+  if (!await enforceConnectShyftCapability(req, res, 'module')) {
+    return null;
+  }
+
+  const contextDecision = await resolveConnectShyftRouteContextDecision(req);
+  if (!contextDecision.ok) {
+    respondWithConnectShyftContextRefusal(res, contextDecision);
+    return null;
+  }
+
+  const allowed = requestHasAnyCapability(req, [
+    CAPABILITIES.ORG_UNIT_THREAD_VIEW,
+    CAPABILITIES.THREAD_VIEW_ALL,
+  ], contextDecision.context);
+  if (!allowed) {
+    sendConnectShyftRouteRefusal(res, {
+      code: 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN',
+      message: 'Thread access requires an authorized ConnectShyft role.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return null;
+  }
+
+  return {
+    context: contextDecision.context,
+    allowCrossOrgUnit: requestHasAnyCapability(req, [CAPABILITIES.THREAD_VIEW_ALL], contextDecision.context),
+  };
+};
+
+export const getConnectOpsIdentityVisibility = async (req: Request, res: Response) => {
+  const phone = parseParam(req.params.phone);
+  if (!phone) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_OPS_PHONE_REQUIRED',
+      message: 'phone is required',
+      refusalType: 'client',
+      httpStatus: 400,
+    });
+    return;
+  }
+
+  const accessContext = await resolveOpsIdentityReadContext(req, res);
+  if (!accessContext) {
+    return;
+  }
+
+  logOpsVisibilityRequested({
+    surface: 'identity',
+    tenantId: accessContext.context.tenantId,
+    orgUnitId: accessContext.context.orgUnitId,
+    resourceId: phone,
+  });
+
+  const visibility = await readConnectShyftIdentityVisibility({
+    tenantId: accessContext.context.tenantId,
+    orgUnitId: accessContext.context.orgUnitId,
+    phone,
+  });
+
+  if (!visibility.ok) {
+    logOpsVisibilityReturned({
+      surface: 'identity',
+      tenantId: accessContext.context.tenantId,
+      orgUnitId: accessContext.context.orgUnitId,
+      resourceId: phone,
+      outcome: 'refusal',
+      code: visibility.code,
+    });
+    refusal(res, visibility);
+    return;
+  }
+
+  logOpsVisibilityReturned({
+    surface: 'identity',
+    tenantId: accessContext.context.tenantId,
+    orgUnitId: accessContext.context.orgUnitId,
+    resourceId: phone,
+    outcome: 'success',
+    code: 'CONNECTSHYFT_OPS_IDENTITY_VISIBILITY_LOADED',
+  });
+
+  success(res, {
+    code: 'CONNECTSHYFT_OPS_IDENTITY_VISIBILITY_LOADED',
+    message: 'ConnectShyft ops identity visibility loaded',
+    data: visibility.data,
+  });
+};
+
+export const getConnectOpsThreadVisibility = async (req: Request, res: Response) => {
+  const threadId = parseParam(req.params.threadId);
+  if (!threadId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+      message: 'threadId is required',
+      refusalType: 'client',
+      httpStatus: 400,
+    });
+    return;
+  }
+
+  const accessContext = await resolveOpsThreadReadContext(req, res);
+  if (!accessContext) {
+    return;
+  }
+
+  logOpsVisibilityRequested({
+    surface: 'thread',
+    tenantId: accessContext.context.tenantId,
+    orgUnitId: accessContext.context.orgUnitId,
+    resourceId: threadId,
+  });
+
+  const visibility = await readConnectShyftThreadVisibility({
+    tenantId: accessContext.context.tenantId,
+    orgUnitId: accessContext.context.orgUnitId,
+    threadId,
+    allowCrossOrgUnit: accessContext.allowCrossOrgUnit,
+  });
+
+  if (!visibility) {
+    logOpsVisibilityReturned({
+      surface: 'thread',
+      tenantId: accessContext.context.tenantId,
+      orgUnitId: accessContext.context.orgUnitId,
+      resourceId: threadId,
+      outcome: 'refusal',
+      code: 'CONNECTSHYFT_OPS_THREAD_NOT_FOUND',
+    });
+    sendConnectShyftRouteRefusal(res, {
+      code: 'CONNECTSHYFT_OPS_THREAD_NOT_FOUND',
+      message: 'Thread visibility is unavailable for the requested orgUnit context.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        threadId,
+        orgUnitId: accessContext.context.orgUnitId,
+      },
+    });
+    return;
+  }
+
+  logOpsVisibilityReturned({
+    surface: 'thread',
+    tenantId: accessContext.context.tenantId,
+    orgUnitId: accessContext.context.orgUnitId,
+    resourceId: threadId,
+    outcome: 'success',
+    code: 'CONNECTSHYFT_OPS_THREAD_VISIBILITY_LOADED',
+  });
+
+  success(res, {
+    code: 'CONNECTSHYFT_OPS_THREAD_VISIBILITY_LOADED',
+    message: 'ConnectShyft ops thread visibility loaded',
+    data: visibility,
+  });
+};
+
+export const getConnectOpsBridgeVisibility = async (req: Request, res: Response) => {
+  const bridgeId = parseParam(req.params.bridgeId);
+  if (!bridgeId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_OPS_BRIDGE_ID_REQUIRED',
+      message: 'bridgeId is required',
+      refusalType: 'client',
+      httpStatus: 400,
+    });
+    return;
+  }
+
+  const accessContext = await resolveOpsThreadReadContext(req, res);
+  if (!accessContext) {
+    return;
+  }
+
+  logOpsVisibilityRequested({
+    surface: 'bridge',
+    tenantId: accessContext.context.tenantId,
+    orgUnitId: accessContext.context.orgUnitId,
+    resourceId: bridgeId,
+  });
+
+  const visibility = await readConnectShyftBridgeVisibility({
+    tenantId: accessContext.context.tenantId,
+    orgUnitId: accessContext.context.orgUnitId,
+    bridgeId,
+    allowCrossOrgUnit: accessContext.allowCrossOrgUnit,
+  });
+
+  if (!visibility) {
+    logOpsVisibilityReturned({
+      surface: 'bridge',
+      tenantId: accessContext.context.tenantId,
+      orgUnitId: accessContext.context.orgUnitId,
+      resourceId: bridgeId,
+      outcome: 'refusal',
+      code: 'CONNECTSHYFT_OPS_BRIDGE_NOT_FOUND',
+    });
+    sendConnectShyftRouteRefusal(res, {
+      code: 'CONNECTSHYFT_OPS_BRIDGE_NOT_FOUND',
+      message: 'Bridge visibility is unavailable for the requested orgUnit context.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        bridgeId,
+        orgUnitId: accessContext.context.orgUnitId,
+      },
+    });
+    return;
+  }
+
+  logOpsVisibilityReturned({
+    surface: 'bridge',
+    tenantId: accessContext.context.tenantId,
+    orgUnitId: accessContext.context.orgUnitId,
+    resourceId: bridgeId,
+    outcome: 'success',
+    code: 'CONNECTSHYFT_OPS_BRIDGE_VISIBILITY_LOADED',
+  });
+
+  success(res, {
+    code: 'CONNECTSHYFT_OPS_BRIDGE_VISIBILITY_LOADED',
+    message: 'ConnectShyft ops bridge visibility loaded',
+    data: visibility,
+  });
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts
@@ -102,4 +102,51 @@ describe('connectshyft ops bridge visibility route', () => {
       },
     });
   });
+
+  it('maps operator dialing bridge state to ringing from the runtime seam', async () => {
+    jest.spyOn(
+      BridgeSessionsModule,
+      'loadConnectShyftBridgeAggregateBySessionId',
+    ).mockResolvedValue({
+      ...buildBridgeAggregate(),
+      session: {
+        ...buildBridgeAggregate().session,
+        status: 'operator_dialing',
+      },
+      operatorLeg: {
+        ...buildBridgeAggregate().operatorLeg,
+        status: 'ringing',
+      },
+      neighborLeg: {
+        ...buildBridgeAggregate().neighborLeg,
+        status: 'created',
+        startedAt: null,
+        answeredAt: null,
+        updatedAt: new Date('2026-03-21T12:00:30.000Z'),
+      },
+    });
+
+    const response = await request(buildApp())
+      .get('/api/v1/connectshyft/ops/bridge/bridge-session-ops-1001')
+      .set(buildHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_OPS_BRIDGE_VISIBILITY_LOADED',
+      data: {
+        bridgeId: 'bridge-session-ops-1001',
+        status: 'ringing',
+        operatorLeg: {
+          phone: '+12605550155',
+          status: 'ringing',
+        },
+        neighborLeg: {
+          phone: '+12605550111',
+          status: 'created',
+        },
+        provider: 'telnyx',
+      },
+    });
+  });
 });

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts
@@ -1,0 +1,105 @@
+// @ts-nocheck
+import request from 'supertest';
+import type { BridgeSessionAggregate } from '../../../../../../domains/communication';
+import * as BridgeSessionsModule from '../../bridgeSessions';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from '../../../../routes/api/v1/__tests__/connectshyft.provider-registry.test.shared';
+
+registerProviderRegistryRouteIntegrationHooks();
+
+const buildBridgeAggregate = (): BridgeSessionAggregate => ({
+  session: {
+    id: 'bridge-session-ops-1001',
+    tenantId: 'tenant-connectshyft-f1',
+    orgUnitId: 'org-connectshyft-f1-east',
+    threadId: 'thread-ops-1001',
+    operatorParticipantId: 'user-connectshyft-f1-operator',
+    neighborParticipantId: 'neighbor-connectshyft-f1-1001',
+    operatorContactPointId: '+12605550155',
+    neighborContactPointId: '+12605550111',
+    selectedOutboundContactPointId: '+12605550191',
+    status: 'bridged',
+    failureCode: null,
+    failureMessage: null,
+    endedBy: null,
+    idempotencyKey: null,
+    auditCorrelationId: null,
+    createdAt: new Date('2026-03-21T12:00:00.000Z'),
+    updatedAt: new Date('2026-03-21T12:03:00.000Z'),
+    completedAt: null,
+  },
+  operatorLeg: {
+    id: 'bridge-leg-operator-1001',
+    tenantId: 'tenant-connectshyft-f1',
+    orgUnitId: 'org-connectshyft-f1-east',
+    bridgeSessionId: 'bridge-session-ops-1001',
+    legRole: 'operator',
+    contactPointId: '+12605550155',
+    providerCallId: 'provider-leg-operator-1001',
+    status: 'answered',
+    startedAt: new Date('2026-03-21T12:00:00.000Z'),
+    answeredAt: new Date('2026-03-21T12:01:00.000Z'),
+    endedAt: null,
+    failureCode: null,
+    failureMessage: null,
+    createdAt: new Date('2026-03-21T12:00:00.000Z'),
+    updatedAt: new Date('2026-03-21T12:02:00.000Z'),
+  },
+  neighborLeg: {
+    id: 'bridge-leg-neighbor-1001',
+    tenantId: 'tenant-connectshyft-f1',
+    orgUnitId: 'org-connectshyft-f1-east',
+    bridgeSessionId: 'bridge-session-ops-1001',
+    legRole: 'neighbor',
+    contactPointId: '+12605550111',
+    providerCallId: 'provider-leg-neighbor-1001',
+    status: 'answered',
+    startedAt: new Date('2026-03-21T12:01:00.000Z'),
+    answeredAt: new Date('2026-03-21T12:02:30.000Z'),
+    endedAt: null,
+    failureCode: null,
+    failureMessage: null,
+    createdAt: new Date('2026-03-21T12:01:00.000Z'),
+    updatedAt: new Date('2026-03-21T12:03:00.000Z'),
+  },
+});
+
+describe('connectshyft ops bridge visibility route', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('surfaces bridge runtime state from the existing bridge-session seam', async () => {
+    jest.spyOn(
+      BridgeSessionsModule,
+      'loadConnectShyftBridgeAggregateBySessionId',
+    ).mockResolvedValue(buildBridgeAggregate());
+
+    const response = await request(buildApp())
+      .get('/api/v1/connectshyft/ops/bridge/bridge-session-ops-1001')
+      .set(buildHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_OPS_BRIDGE_VISIBILITY_LOADED',
+      data: {
+        bridgeId: 'bridge-session-ops-1001',
+        status: 'connected',
+        operatorLeg: {
+          phone: '+12605550155',
+          status: 'answered',
+        },
+        neighborLeg: {
+          phone: '+12605550111',
+          status: 'answered',
+        },
+        provider: 'telnyx',
+        lastEventAt: '2026-03-21T12:03:00.000Z',
+      },
+    });
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.identity.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.identity.test.ts
@@ -1,0 +1,153 @@
+// @ts-nocheck
+import request from 'supertest';
+import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from '../../peoplecoreIdentityAdapter';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from '../../../../routes/api/v1/__tests__/connectshyft.provider-registry.test.shared';
+
+registerProviderRegistryRouteIntegrationHooks();
+
+describe('connectshyft ops identity visibility route', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('surfaces identity ambiguity when PeopleCore current links disagree with the legacy winner', async () => {
+    jest.spyOn(
+      AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter.prototype,
+      'evaluateIdentityCandidatesForContactPoint',
+    ).mockResolvedValue({
+      normalizedContactPointValue: '+12605551219',
+      peopleCoreAvailable: true,
+      peopleCoreContactPoints: [
+        {
+          id: 'contact-point-19',
+          tenantId: 'tenant-connectshyft-f1',
+          type: 'phone',
+          value: '+12605551219',
+          normalizedValue: '+12605551219',
+          label: 'mobile',
+          verificationStatus: 'verified',
+          isShared: false,
+          status: 'active',
+          createdAt: '2026-03-21T12:00:00.000Z',
+          updatedAt: '2026-03-21T12:00:00.000Z',
+        },
+      ],
+      peopleCoreCurrentLinks: [
+        {
+          id: 'link-19-a',
+          tenantId: 'tenant-connectshyft-f1',
+          contactPointId: 'contact-point-19',
+          subjectType: 'person',
+          subjectId: 'person-19-a',
+          relationshipType: 'self',
+          isCurrent: true,
+          sourceSystem: 'peoplecore',
+          sourceRecordId: null,
+          effectiveFrom: '2026-03-21T12:00:00.000Z',
+          effectiveTo: null,
+          createdAt: '2026-03-21T12:00:00.000Z',
+          updatedAt: '2026-03-21T12:00:00.000Z',
+        },
+        {
+          id: 'link-19-b',
+          tenantId: 'tenant-connectshyft-f1',
+          contactPointId: 'contact-point-19',
+          subjectType: 'person',
+          subjectId: 'person-19-b',
+          relationshipType: 'self',
+          isCurrent: true,
+          sourceSystem: 'peoplecore',
+          sourceRecordId: null,
+          effectiveFrom: '2026-03-21T12:00:00.000Z',
+          effectiveTo: null,
+          createdAt: '2026-03-21T12:00:00.000Z',
+          updatedAt: '2026-03-21T12:00:00.000Z',
+        },
+      ],
+      tenantNeighbors: [
+        {
+          neighborId: 'neighbor-legacy-19',
+          phones: [
+            {
+              phoneId: 'phone-19',
+              value: '+12605551219',
+              isShared: false,
+              verificationStatus: 'verified',
+            },
+          ],
+        },
+      ],
+      candidateNeighbors: [
+        {
+          neighborId: 'neighbor-legacy-19',
+          phones: [
+            {
+              phoneId: 'phone-19',
+              value: '+12605551219',
+              isShared: false,
+              verificationStatus: 'verified',
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    const response = await request(buildApp())
+      .get('/api/v1/connectshyft/ops/identity/%2B12605551219')
+      .set(buildHeaders({
+        'x-test-connectshyft-role': 'TENANT_ADMIN',
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_OPS_IDENTITY_VISIBILITY_LOADED',
+      data: {
+        phone: '+12605551219',
+        resolution: 'ambiguous',
+        source: 'peoplecore',
+        candidates: [
+          {
+            id: 'neighbor-legacy-19',
+            confidence: 1,
+          },
+        ],
+      },
+    });
+  });
+
+  it('surfaces the no-match path without creating any write-side identity behavior', async () => {
+    jest.spyOn(
+      AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter.prototype,
+      'evaluateIdentityCandidatesForContactPoint',
+    ).mockResolvedValue({
+      normalizedContactPointValue: '+12605559999',
+      peopleCoreAvailable: false,
+      peopleCoreContactPoints: [],
+      peopleCoreCurrentLinks: [],
+      tenantNeighbors: [],
+      candidateNeighbors: [],
+    } as any);
+
+    const response = await request(buildApp())
+      .get('/api/v1/connectshyft/ops/identity/%2B12605559999')
+      .set(buildHeaders({
+        'x-test-connectshyft-role': 'TENANT_ADMIN',
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_OPS_IDENTITY_VISIBILITY_LOADED',
+      data: {
+        phone: '+12605559999',
+        resolution: 'no_match',
+        source: 'legacy',
+      },
+    });
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.identity.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.identity.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import request from 'supertest';
-import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from '../../peoplecoreIdentityAdapter';
+import { AsyncPeopleCoreService } from '../../../peoplecore/service';
+import { KnexConnectShyftNeighborStore } from '../../neighbors';
 import {
   buildApp,
   buildHeaders,
@@ -16,12 +17,9 @@ describe('connectshyft ops identity visibility route', () => {
 
   it('surfaces identity ambiguity when PeopleCore current links disagree with the legacy winner', async () => {
     jest.spyOn(
-      AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter.prototype,
-      'evaluateIdentityCandidatesForContactPoint',
-    ).mockResolvedValue({
-      normalizedContactPointValue: '+12605551219',
-      peopleCoreAvailable: true,
-      peopleCoreContactPoints: [
+      AsyncPeopleCoreService.prototype,
+      'listContactPointsByNormalizedValue',
+    ).mockResolvedValue([
         {
           id: 'contact-point-19',
           tenantId: 'tenant-connectshyft-f1',
@@ -35,40 +33,58 @@ describe('connectshyft ops identity visibility route', () => {
           createdAt: '2026-03-21T12:00:00.000Z',
           updatedAt: '2026-03-21T12:00:00.000Z',
         },
-      ],
-      peopleCoreCurrentLinks: [
+      ]);
+    jest.spyOn(
+      AsyncPeopleCoreService.prototype,
+      'listCurrentContactPointLinks',
+    ).mockResolvedValue([
         {
           id: 'link-19-a',
-          tenantId: 'tenant-connectshyft-f1',
           contactPointId: 'contact-point-19',
           subjectType: 'person',
           subjectId: 'person-19-a',
-          relationshipType: 'self',
+          linkType: 'self',
+          confidenceBand: 'high',
           isCurrent: true,
-          sourceSystem: 'peoplecore',
-          sourceRecordId: null,
-          effectiveFrom: '2026-03-21T12:00:00.000Z',
-          effectiveTo: null,
+          isPrimary: true,
+          manuallyConfirmed: false,
+          confirmationSource: undefined,
+          firstLinkedAt: '2026-03-21T12:00:00.000Z',
+          lastConfirmedAt: undefined,
+          lastUsedAt: undefined,
+          linkedBy: 'system',
+          linkedByUserId: undefined,
+          unlinkReason: undefined,
+          unlinkedAt: undefined,
           createdAt: '2026-03-21T12:00:00.000Z',
           updatedAt: '2026-03-21T12:00:00.000Z',
         },
         {
           id: 'link-19-b',
-          tenantId: 'tenant-connectshyft-f1',
           contactPointId: 'contact-point-19',
           subjectType: 'person',
           subjectId: 'person-19-b',
-          relationshipType: 'self',
+          linkType: 'self',
+          confidenceBand: 'high',
           isCurrent: true,
-          sourceSystem: 'peoplecore',
-          sourceRecordId: null,
-          effectiveFrom: '2026-03-21T12:00:00.000Z',
-          effectiveTo: null,
+          isPrimary: false,
+          manuallyConfirmed: false,
+          confirmationSource: undefined,
+          firstLinkedAt: '2026-03-21T12:00:00.000Z',
+          lastConfirmedAt: undefined,
+          lastUsedAt: undefined,
+          linkedBy: 'system',
+          linkedByUserId: undefined,
+          unlinkReason: undefined,
+          unlinkedAt: undefined,
           createdAt: '2026-03-21T12:00:00.000Z',
           updatedAt: '2026-03-21T12:00:00.000Z',
         },
-      ],
-      tenantNeighbors: [
+      ]);
+    jest.spyOn(
+      KnexConnectShyftNeighborStore.prototype,
+      'listActiveIdentityBoundaryNeighborsByTenant',
+    ).mockResolvedValue([
         {
           neighborId: 'neighbor-legacy-19',
           phones: [
@@ -80,8 +96,11 @@ describe('connectshyft ops identity visibility route', () => {
             },
           ],
         },
-      ],
-      candidateNeighbors: [
+      ]);
+    jest.spyOn(
+      KnexConnectShyftNeighborStore.prototype,
+      'listActiveIdentityBoundaryNeighborsByPhoneValue',
+    ).mockResolvedValue([
         {
           neighborId: 'neighbor-legacy-19',
           phones: [
@@ -93,8 +112,7 @@ describe('connectshyft ops identity visibility route', () => {
             },
           ],
         },
-      ],
-    } as any);
+      ]);
 
     const response = await request(buildApp())
       .get('/api/v1/connectshyft/ops/identity/%2B12605551219')
@@ -122,16 +140,17 @@ describe('connectshyft ops identity visibility route', () => {
 
   it('surfaces the no-match path without creating any write-side identity behavior', async () => {
     jest.spyOn(
-      AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter.prototype,
-      'evaluateIdentityCandidatesForContactPoint',
-    ).mockResolvedValue({
-      normalizedContactPointValue: '+12605559999',
-      peopleCoreAvailable: false,
-      peopleCoreContactPoints: [],
-      peopleCoreCurrentLinks: [],
-      tenantNeighbors: [],
-      candidateNeighbors: [],
-    } as any);
+      AsyncPeopleCoreService.prototype,
+      'listContactPointsByNormalizedValue',
+    ).mockResolvedValue([]);
+    jest.spyOn(
+      KnexConnectShyftNeighborStore.prototype,
+      'listActiveIdentityBoundaryNeighborsByTenant',
+    ).mockResolvedValue([]);
+    jest.spyOn(
+      KnexConnectShyftNeighborStore.prototype,
+      'listActiveIdentityBoundaryNeighborsByPhoneValue',
+    ).mockResolvedValue([]);
 
     const response = await request(buildApp())
       .get('/api/v1/connectshyft/ops/identity/%2B12605559999')

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.thread.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.thread.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import request from 'supertest';
-import { AsyncConnectShyftThreadService } from '../../threads';
+import { KnexConnectShyftThreadStore } from '../../threads';
 import {
   buildApp,
   buildHeaders,
@@ -16,7 +16,7 @@ describe('connectshyft ops thread visibility route', () => {
 
   it('surfaces a found thread through the read-only thread store seam', async () => {
     jest.spyOn(
-      AsyncConnectShyftThreadService.prototype,
+      KnexConnectShyftThreadStore.prototype,
       'findThreadById',
     ).mockResolvedValue({
       threadId: 'thread-ops-1001',
@@ -61,7 +61,7 @@ describe('connectshyft ops thread visibility route', () => {
 
   it('surfaces not-found without introducing any thread mutation path', async () => {
     jest.spyOn(
-      AsyncConnectShyftThreadService.prototype,
+      KnexConnectShyftThreadStore.prototype,
       'findThreadById',
     ).mockResolvedValue(null);
 

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.thread.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.thread.test.ts
@@ -1,0 +1,84 @@
+// @ts-nocheck
+import request from 'supertest';
+import { AsyncConnectShyftThreadService } from '../../threads';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from '../../../../routes/api/v1/__tests__/connectshyft.provider-registry.test.shared';
+
+registerProviderRegistryRouteIntegrationHooks();
+
+describe('connectshyft ops thread visibility route', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('surfaces a found thread through the read-only thread store seam', async () => {
+    jest.spyOn(
+      AsyncConnectShyftThreadService.prototype,
+      'findThreadById',
+    ).mockResolvedValue({
+      threadId: 'thread-ops-1001',
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      neighborId: 'neighbor-connectshyft-f1-1001',
+      source: 'VOICE',
+      state: 'CLAIMED',
+      lastInboundCsNumberId: 'cs-number-1001',
+      preferredOutboundCsNumberId: 'cs-number-2001',
+      claimedByUserId: 'user-connectshyft-f1-operator',
+      claimedAtUtc: '2026-03-21T12:00:00.000Z',
+      closedByUserId: null,
+      closedAtUtc: null,
+      createdAtUtc: '2026-03-21T11:55:00.000Z',
+      updatedAtUtc: '2026-03-21T12:05:00.000Z',
+      escalation: {
+        stage: 1,
+        nextEvaluationAtUtc: '2026-03-22T12:05:00.000Z',
+      },
+    });
+
+    const response = await request(buildApp())
+      .get('/api/v1/connectshyft/ops/threads/thread-ops-1001')
+      .set(buildHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_OPS_THREAD_VISIBILITY_LOADED',
+      data: {
+        threadId: 'thread-ops-1001',
+        found: true,
+        thread: {
+          threadId: 'thread-ops-1001',
+          state: 'CLAIMED',
+          neighborId: 'neighbor-connectshyft-f1-1001',
+        },
+      },
+    });
+  });
+
+  it('surfaces not-found without introducing any thread mutation path', async () => {
+    jest.spyOn(
+      AsyncConnectShyftThreadService.prototype,
+      'findThreadById',
+    ).mockResolvedValue(null);
+
+    const response = await request(buildApp())
+      .get('/api/v1/connectshyft/ops/threads/thread-ops-missing')
+      .set(buildHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_OPS_THREAD_NOT_FOUND',
+      message: 'Thread visibility is unavailable for the requested orgUnit context.',
+      refusalType: 'business',
+      data: {
+        threadId: 'thread-ops-missing',
+        orgUnitId: 'org-connectshyft-f1-east',
+      },
+    });
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts
@@ -1,0 +1,92 @@
+import type { BridgeSessionAggregate, BridgeSessionStatus } from '../../../../../../domains/communication';
+import { loadConnectShyftBridgeAggregateBySessionId } from '../bridgeSessions';
+
+export type ConnectShyftBridgeVisibility = {
+  bridgeId: string;
+  status: 'initiated' | 'ringing' | 'connected' | 'failed' | 'ended';
+  operatorLeg: {
+    phone: string;
+    status: string;
+  };
+  neighborLeg: {
+    phone: string;
+    status: string;
+  };
+  provider: 'telnyx';
+  lastEventAt: string;
+};
+
+const mapBridgeStatus = (
+  status: BridgeSessionStatus,
+): ConnectShyftBridgeVisibility['status'] => {
+  if (status === 'bridged') {
+    return 'connected';
+  }
+
+  if (status === 'failed') {
+    return 'failed';
+  }
+
+  if (status === 'completed' || status === 'canceled' || status === 'expired') {
+    return 'ended';
+  }
+
+  if (status === 'neighbor_dialing' || status === 'operator_answered' || status === 'neighbor_answered') {
+    return 'ringing';
+  }
+
+  return 'initiated';
+};
+
+const resolveLastEventAt = (aggregate: BridgeSessionAggregate): string => {
+  const timestamps = [
+    aggregate.session.completedAt,
+    aggregate.session.updatedAt,
+    aggregate.session.createdAt,
+    aggregate.operatorLeg.endedAt,
+    aggregate.operatorLeg.answeredAt,
+    aggregate.operatorLeg.startedAt,
+    aggregate.operatorLeg.updatedAt,
+    aggregate.operatorLeg.createdAt,
+    aggregate.neighborLeg.endedAt,
+    aggregate.neighborLeg.answeredAt,
+    aggregate.neighborLeg.startedAt,
+    aggregate.neighborLeg.updatedAt,
+    aggregate.neighborLeg.createdAt,
+  ]
+    .filter((value): value is Date => value instanceof Date)
+    .sort((left, right) => right.getTime() - left.getTime());
+
+  return (timestamps[0] || aggregate.session.updatedAt).toISOString();
+};
+
+export const readConnectShyftBridgeVisibility = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  bridgeId: string;
+  allowCrossOrgUnit?: boolean;
+}): Promise<ConnectShyftBridgeVisibility | null> => {
+  const aggregate = await loadConnectShyftBridgeAggregateBySessionId(input.bridgeId);
+  if (!aggregate || aggregate.session.tenantId !== input.tenantId) {
+    return null;
+  }
+
+  if (input.allowCrossOrgUnit !== true && aggregate.session.orgUnitId !== input.orgUnitId) {
+    return null;
+  }
+
+  return {
+    bridgeId: aggregate.session.id,
+    status: mapBridgeStatus(aggregate.session.status),
+    operatorLeg: {
+      phone: aggregate.session.operatorContactPointId,
+      status: aggregate.operatorLeg.status,
+    },
+    neighborLeg: {
+      phone: aggregate.session.neighborContactPointId,
+      status: aggregate.neighborLeg.status,
+    },
+    provider: 'telnyx',
+    lastEventAt: resolveLastEventAt(aggregate),
+  };
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts
@@ -1,5 +1,11 @@
-import type { BridgeSessionAggregate, BridgeSessionStatus } from '../../../../../../domains/communication';
 import { loadConnectShyftBridgeAggregateBySessionId } from '../bridgeSessions';
+
+type ConnectShyftBridgeRuntimeAggregate = NonNullable<
+  Awaited<ReturnType<typeof loadConnectShyftBridgeAggregateBySessionId>>
+>;
+
+type ConnectShyftBridgeRuntimeStatus =
+  ConnectShyftBridgeRuntimeAggregate['session']['status'];
 
 export type ConnectShyftBridgeVisibility = {
   bridgeId: string;
@@ -17,7 +23,7 @@ export type ConnectShyftBridgeVisibility = {
 };
 
 const mapBridgeStatus = (
-  status: BridgeSessionStatus,
+  status: ConnectShyftBridgeRuntimeStatus,
 ): ConnectShyftBridgeVisibility['status'] => {
   if (status === 'bridged') {
     return 'connected';
@@ -31,14 +37,21 @@ const mapBridgeStatus = (
     return 'ended';
   }
 
-  if (status === 'neighbor_dialing' || status === 'operator_answered' || status === 'neighbor_answered') {
+  if (
+    status === 'operator_dialing'
+    || status === 'operator_answered'
+    || status === 'neighbor_dialing'
+    || status === 'neighbor_answered'
+  ) {
     return 'ringing';
   }
 
   return 'initiated';
 };
 
-const resolveLastEventAt = (aggregate: BridgeSessionAggregate): string => {
+const resolveLastEventAt = (
+  aggregate: ConnectShyftBridgeRuntimeAggregate,
+): string => {
   const timestamps = [
     aggregate.session.completedAt,
     aggregate.session.updatedAt,

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/identityVisibility.service.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/identityVisibility.service.ts
@@ -1,16 +1,18 @@
 import { normalizePhone } from '../../../../../../domains/communication';
-import {
-  AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter,
-  type ConnectShyftPeopleCoreIdentityCandidateLookup,
-} from '../peoplecoreIdentityAdapter';
+import { AsyncPeopleCoreService } from '../../peoplecore/service';
 import {
   evaluateConnectShyftIdentityBoundary,
-  type ConnectShyftIdentityBoundaryResult,
+  type ConnectShyftIdentityBoundaryNeighbor,
 } from '../identityBoundary';
 import { KnexConnectShyftNeighborStore } from '../neighbors';
-import { resolveConnectShyftPhoneNormalizationContext } from '../phoneIdentityContext';
 
+const DEFAULT_PHONE_COUNTRY = 'US';
 const INTERNAL_ACTOR_ROLES = ['SYSTEM_ADMIN'] as const;
+
+type ConnectShyftPeopleCoreLookup = {
+  peopleCoreAvailable: boolean;
+  currentPersonIds: string[];
+};
 
 export type ConnectShyftIdentityVisibility = {
   phone: string;
@@ -40,6 +42,11 @@ export type ConnectShyftIdentityVisibilityReadResult =
     };
   };
 
+const normalizeOptionalEnvValue = (value: string | undefined): string | undefined => {
+  const normalized = value?.trim();
+  return normalized && normalized.length > 0 ? normalized : undefined;
+};
+
 const uniqueSortedStrings = (values: string[]): string[] =>
   Array.from(
     new Set(
@@ -49,44 +56,6 @@ const uniqueSortedStrings = (values: string[]): string[] =>
         .filter((value) => value.length > 0),
     ),
   ).sort((left, right) => left.localeCompare(right));
-
-const collectDistinctCurrentPersonIds = (
-  lookup: ConnectShyftPeopleCoreIdentityCandidateLookup,
-): string[] =>
-  uniqueSortedStrings(
-    lookup.peopleCoreCurrentLinks
-      .filter((link) => link.subjectType === 'person' && link.isCurrent !== false)
-      .map((link) => link.subjectId),
-  );
-
-const collectExactMatchNeighborIds = (
-  lookup: ConnectShyftPeopleCoreIdentityCandidateLookup,
-): string[] => {
-  if (!lookup.normalizedContactPointValue) {
-    return [];
-  }
-
-  return uniqueSortedStrings(
-    lookup.tenantNeighbors
-      .filter((neighbor) =>
-        neighbor.phones.some((phone) => phone.value === lookup.normalizedContactPointValue))
-      .map((neighbor) => neighbor.neighborId),
-  );
-};
-
-const hasLegacySameSubjectProof = (
-  lookup: ConnectShyftPeopleCoreIdentityCandidateLookup,
-  legacyResult: Extract<ConnectShyftIdentityBoundaryResult, { ok: true }>,
-): boolean => {
-  const legacyCandidateNeighborIds = uniqueSortedStrings(
-    legacyResult.data.identityMatch.candidateNeighborIds,
-  );
-  const tenantExactMatchNeighborIds = collectExactMatchNeighborIds(lookup);
-
-  return legacyCandidateNeighborIds.length === 1
-    && tenantExactMatchNeighborIds.length === 1
-    && tenantExactMatchNeighborIds[0] === legacyCandidateNeighborIds[0];
-};
 
 const buildCandidateConfidenceList = (
   candidateIds: string[],
@@ -103,57 +72,86 @@ const buildCandidateConfidenceList = (
   }));
 };
 
-const buildForcedPeopleCoreAmbiguousVisibility = (
-  phone: string,
-  legacyResult: ConnectShyftIdentityBoundaryResult,
-): ConnectShyftIdentityVisibility => {
-  const legacyCandidates = legacyResult.ok
-    ? legacyResult.data.identityMatch.candidateNeighborIds
-    : (legacyResult.data?.identityMatch?.candidateNeighborIds || []);
+const buildPhoneNormalizationContext = () => ({
+  defaultCountry:
+    normalizeOptionalEnvValue(process.env.CONNECTSHYFT_PHONE_DEFAULT_COUNTRY)
+    || DEFAULT_PHONE_COUNTRY,
+  defaultAreaCode: normalizeOptionalEnvValue(process.env.CONNECTSHYFT_PHONE_DEFAULT_AREA_CODE),
+  source: 'user_entered' as const,
+});
 
-  return {
-    phone,
-    resolution: 'ambiguous',
-    source: 'peoplecore',
-    candidates: buildCandidateConfidenceList(legacyCandidates),
-  };
+const collectExactMatchNeighborIds = (
+  neighbors: ConnectShyftIdentityBoundaryNeighbor[],
+  normalizedPhone: string,
+): string[] =>
+  uniqueSortedStrings(
+    neighbors
+      .filter((neighbor) => neighbor.phones.some((phone) => phone.value === normalizedPhone))
+      .map((neighbor) => neighbor.neighborId),
+  );
+
+const loadPeopleCoreLookup = async (input: {
+  tenantId: string;
+  normalizedPhone: string;
+}): Promise<ConnectShyftPeopleCoreLookup> => {
+  const peopleCoreService = new AsyncPeopleCoreService();
+
+  try {
+    const contactPoints = await peopleCoreService.listContactPointsByNormalizedValue({
+      tenantId: input.tenantId,
+      type: 'phone',
+      normalizedValue: input.normalizedPhone,
+    });
+
+    const currentLinks = (
+      await Promise.all(
+        contactPoints.map((contactPoint) =>
+          peopleCoreService.listCurrentContactPointLinks({
+            tenantId: input.tenantId,
+            contactPointId: contactPoint.id,
+            subjectType: 'person',
+          })),
+      )
+    ).flat();
+
+    return {
+      peopleCoreAvailable: true,
+      currentPersonIds: uniqueSortedStrings(
+        currentLinks
+          .filter((link) => link.isCurrent !== false && link.subjectType === 'person')
+          .map((link) => link.subjectId),
+      ),
+    };
+  } catch (_error) {
+    return {
+      peopleCoreAvailable: false,
+      currentPersonIds: [],
+    };
+  }
 };
 
-const mapLegacyResultToVisibility = (
-  phone: string,
-  legacyResult: ConnectShyftIdentityBoundaryResult,
-): ConnectShyftIdentityVisibility => {
-  if (!legacyResult.ok) {
+const mapLegacyResultToVisibility = (input: {
+  phone: string;
+  legacyResult: ReturnType<typeof evaluateConnectShyftIdentityBoundary>;
+}): ConnectShyftIdentityVisibility => {
+  if (!input.legacyResult.ok) {
     return {
-      phone,
+      phone: input.phone,
       resolution: 'ambiguous',
       source: 'legacy',
       candidates: buildCandidateConfidenceList(
-        legacyResult.data?.identityMatch?.candidateNeighborIds || [],
+        input.legacyResult.data?.identityMatch?.candidateNeighborIds || [],
       ),
     };
   }
 
-  const selectedId = legacyResult.data.identityMatch.matchedNeighborId || undefined;
+  const selectedId = input.legacyResult.data.identityMatch.matchedNeighborId || undefined;
   return {
-    phone,
+    phone: input.phone,
     resolution: selectedId ? 'single_match' : 'no_match',
     source: 'legacy',
     ...(selectedId ? { selectedId } : {}),
   };
-};
-
-const createIdentityLookupAdapter = () => {
-  const neighborStore = new KnexConnectShyftNeighborStore();
-
-  return new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
-    async (tenantId) => neighborStore.listActiveIdentityBoundaryNeighborsByTenant(tenantId),
-    async (tenantId, normalizedContactPointValue) =>
-      neighborStore.listActiveIdentityBoundaryNeighborsByPhoneValue(
-        tenantId,
-        normalizedContactPointValue,
-      ),
-  );
 };
 
 export const readConnectShyftIdentityVisibility = async (input: {
@@ -163,7 +161,7 @@ export const readConnectShyftIdentityVisibility = async (input: {
 }): Promise<ConnectShyftIdentityVisibilityReadResult> => {
   const normalizedPhone = normalizePhone(
     input.phone.trim(),
-    resolveConnectShyftPhoneNormalizationContext('user_entered'),
+    buildPhoneNormalizationContext(),
   );
 
   if (!normalizedPhone.ok) {
@@ -185,11 +183,19 @@ export const readConnectShyftIdentityVisibility = async (input: {
     };
   }
 
-  const lookupAdapter = createIdentityLookupAdapter();
-  const lookup = await lookupAdapter.evaluateIdentityCandidatesForContactPoint({
-    tenantId: input.tenantId,
-    contactPointValue: normalizedPhone.phone.normalizedE164,
-  });
+  const neighborStore = new KnexConnectShyftNeighborStore();
+  const normalizedValue = normalizedPhone.phone.normalizedE164;
+  const [peopleCoreLookup, candidateNeighbors, tenantNeighbors] = await Promise.all([
+    loadPeopleCoreLookup({
+      tenantId: input.tenantId,
+      normalizedPhone: normalizedValue,
+    }),
+    neighborStore.listActiveIdentityBoundaryNeighborsByPhoneValue(
+      input.tenantId,
+      normalizedValue,
+    ),
+    neighborStore.listActiveIdentityBoundaryNeighborsByTenant(input.tenantId),
+  ]);
 
   const legacyResult = evaluateConnectShyftIdentityBoundary({
     actorRoles: [...INTERNAL_ACTOR_ROLES],
@@ -197,30 +203,48 @@ export const readConnectShyftIdentityVisibility = async (input: {
     orgUnitId: input.orgUnitId,
     contactPoint: {
       label: 'mobile',
-      value: normalizedPhone.phone.normalizedE164,
+      value: normalizedValue,
       isShared: false,
       verificationStatus: 'verified',
     },
-  }, lookup.candidateNeighbors);
+  }, candidateNeighbors);
 
-  const currentPersonIds = lookup.peopleCoreAvailable
-    ? collectDistinctCurrentPersonIds(lookup)
-    : [];
-  const peopleCoreForcesAmbiguous = currentPersonIds.length > 1
-    || (
-      currentPersonIds.length === 1
-      && legacyResult.ok
-      && legacyResult.code === 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED'
-      && !hasLegacySameSubjectProof(lookup, legacyResult)
+  const legacyCandidateIds = legacyResult.ok
+    ? uniqueSortedStrings(legacyResult.data.identityMatch.candidateNeighborIds)
+    : uniqueSortedStrings(legacyResult.data?.identityMatch?.candidateNeighborIds || []);
+  const tenantExactMatchNeighborIds = collectExactMatchNeighborIds(tenantNeighbors, normalizedValue);
+  const peopleCoreForcesAmbiguous = peopleCoreLookup.peopleCoreAvailable
+    && (
+      peopleCoreLookup.currentPersonIds.length > 1
+      || (
+        peopleCoreLookup.currentPersonIds.length === 1
+        && legacyResult.ok
+        && legacyResult.code === 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED'
+        && !(
+          legacyCandidateIds.length === 1
+          && tenantExactMatchNeighborIds.length === 1
+          && tenantExactMatchNeighborIds[0] === legacyCandidateIds[0]
+        )
+      )
     );
+
+  if (peopleCoreForcesAmbiguous) {
+    return {
+      ok: true,
+      data: {
+        phone: normalizedValue,
+        resolution: 'ambiguous',
+        source: 'peoplecore',
+        candidates: buildCandidateConfidenceList(legacyCandidateIds),
+      },
+    };
+  }
 
   return {
     ok: true,
-    data: peopleCoreForcesAmbiguous
-      ? buildForcedPeopleCoreAmbiguousVisibility(
-        normalizedPhone.phone.normalizedE164,
-        legacyResult,
-      )
-      : mapLegacyResultToVisibility(normalizedPhone.phone.normalizedE164, legacyResult),
+    data: mapLegacyResultToVisibility({
+      phone: normalizedValue,
+      legacyResult,
+    }),
   };
 };

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/identityVisibility.service.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/identityVisibility.service.ts
@@ -1,0 +1,226 @@
+import { normalizePhone } from '../../../../../../domains/communication';
+import {
+  AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter,
+  type ConnectShyftPeopleCoreIdentityCandidateLookup,
+} from '../peoplecoreIdentityAdapter';
+import {
+  evaluateConnectShyftIdentityBoundary,
+  type ConnectShyftIdentityBoundaryResult,
+} from '../identityBoundary';
+import { KnexConnectShyftNeighborStore } from '../neighbors';
+import { resolveConnectShyftPhoneNormalizationContext } from '../phoneIdentityContext';
+
+const INTERNAL_ACTOR_ROLES = ['SYSTEM_ADMIN'] as const;
+
+export type ConnectShyftIdentityVisibility = {
+  phone: string;
+  resolution: 'single_match' | 'ambiguous' | 'no_match';
+  source: 'peoplecore' | 'legacy';
+  candidates?: Array<{ id: string; confidence: number }>;
+  selectedId?: string;
+};
+
+export type ConnectShyftIdentityVisibilityReadResult =
+  | {
+    ok: true;
+    data: ConnectShyftIdentityVisibility;
+  }
+  | {
+    ok: false;
+    code: 'CONNECTSHYFT_OPS_PHONE_INVALID';
+    message: string;
+    refusalType: 'client';
+    httpStatus: 400;
+    data: {
+      fieldErrors: Array<{
+        field: 'phone';
+        reason: 'INVALID_FORMAT';
+        message: string;
+      }>;
+    };
+  };
+
+const uniqueSortedStrings = (values: string[]): string[] =>
+  Array.from(
+    new Set(
+      values
+        .filter((value) => typeof value === 'string')
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0),
+    ),
+  ).sort((left, right) => left.localeCompare(right));
+
+const collectDistinctCurrentPersonIds = (
+  lookup: ConnectShyftPeopleCoreIdentityCandidateLookup,
+): string[] =>
+  uniqueSortedStrings(
+    lookup.peopleCoreCurrentLinks
+      .filter((link) => link.subjectType === 'person' && link.isCurrent !== false)
+      .map((link) => link.subjectId),
+  );
+
+const collectExactMatchNeighborIds = (
+  lookup: ConnectShyftPeopleCoreIdentityCandidateLookup,
+): string[] => {
+  if (!lookup.normalizedContactPointValue) {
+    return [];
+  }
+
+  return uniqueSortedStrings(
+    lookup.tenantNeighbors
+      .filter((neighbor) =>
+        neighbor.phones.some((phone) => phone.value === lookup.normalizedContactPointValue))
+      .map((neighbor) => neighbor.neighborId),
+  );
+};
+
+const hasLegacySameSubjectProof = (
+  lookup: ConnectShyftPeopleCoreIdentityCandidateLookup,
+  legacyResult: Extract<ConnectShyftIdentityBoundaryResult, { ok: true }>,
+): boolean => {
+  const legacyCandidateNeighborIds = uniqueSortedStrings(
+    legacyResult.data.identityMatch.candidateNeighborIds,
+  );
+  const tenantExactMatchNeighborIds = collectExactMatchNeighborIds(lookup);
+
+  return legacyCandidateNeighborIds.length === 1
+    && tenantExactMatchNeighborIds.length === 1
+    && tenantExactMatchNeighborIds[0] === legacyCandidateNeighborIds[0];
+};
+
+const buildCandidateConfidenceList = (
+  candidateIds: string[],
+): Array<{ id: string; confidence: number }> | undefined => {
+  const normalized = uniqueSortedStrings(candidateIds);
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  const confidence = 1 / normalized.length;
+  return normalized.map((id) => ({
+    id,
+    confidence,
+  }));
+};
+
+const buildForcedPeopleCoreAmbiguousVisibility = (
+  phone: string,
+  legacyResult: ConnectShyftIdentityBoundaryResult,
+): ConnectShyftIdentityVisibility => {
+  const legacyCandidates = legacyResult.ok
+    ? legacyResult.data.identityMatch.candidateNeighborIds
+    : (legacyResult.data?.identityMatch?.candidateNeighborIds || []);
+
+  return {
+    phone,
+    resolution: 'ambiguous',
+    source: 'peoplecore',
+    candidates: buildCandidateConfidenceList(legacyCandidates),
+  };
+};
+
+const mapLegacyResultToVisibility = (
+  phone: string,
+  legacyResult: ConnectShyftIdentityBoundaryResult,
+): ConnectShyftIdentityVisibility => {
+  if (!legacyResult.ok) {
+    return {
+      phone,
+      resolution: 'ambiguous',
+      source: 'legacy',
+      candidates: buildCandidateConfidenceList(
+        legacyResult.data?.identityMatch?.candidateNeighborIds || [],
+      ),
+    };
+  }
+
+  const selectedId = legacyResult.data.identityMatch.matchedNeighborId || undefined;
+  return {
+    phone,
+    resolution: selectedId ? 'single_match' : 'no_match',
+    source: 'legacy',
+    ...(selectedId ? { selectedId } : {}),
+  };
+};
+
+const createIdentityLookupAdapter = () => {
+  const neighborStore = new KnexConnectShyftNeighborStore();
+
+  return new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+    async (tenantId) => neighborStore.listActiveIdentityBoundaryNeighborsByTenant(tenantId),
+    async (tenantId, normalizedContactPointValue) =>
+      neighborStore.listActiveIdentityBoundaryNeighborsByPhoneValue(
+        tenantId,
+        normalizedContactPointValue,
+      ),
+  );
+};
+
+export const readConnectShyftIdentityVisibility = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  phone: string;
+}): Promise<ConnectShyftIdentityVisibilityReadResult> => {
+  const normalizedPhone = normalizePhone(
+    input.phone.trim(),
+    resolveConnectShyftPhoneNormalizationContext('user_entered'),
+  );
+
+  if (!normalizedPhone.ok) {
+    return {
+      ok: false,
+      code: 'CONNECTSHYFT_OPS_PHONE_INVALID',
+      message: 'Provide a valid phone number (for example, 2605550199).',
+      refusalType: 'client',
+      httpStatus: 400,
+      data: {
+        fieldErrors: [
+          {
+            field: 'phone',
+            reason: 'INVALID_FORMAT',
+            message: 'Provide a valid phone number (for example, 2605550199).',
+          },
+        ],
+      },
+    };
+  }
+
+  const lookupAdapter = createIdentityLookupAdapter();
+  const lookup = await lookupAdapter.evaluateIdentityCandidatesForContactPoint({
+    tenantId: input.tenantId,
+    contactPointValue: normalizedPhone.phone.normalizedE164,
+  });
+
+  const legacyResult = evaluateConnectShyftIdentityBoundary({
+    actorRoles: [...INTERNAL_ACTOR_ROLES],
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    contactPoint: {
+      label: 'mobile',
+      value: normalizedPhone.phone.normalizedE164,
+      isShared: false,
+      verificationStatus: 'verified',
+    },
+  }, lookup.candidateNeighbors);
+
+  const currentPersonIds = lookup.peopleCoreAvailable
+    ? collectDistinctCurrentPersonIds(lookup)
+    : [];
+  const peopleCoreForcesAmbiguous = currentPersonIds.length > 1
+    || (
+      currentPersonIds.length === 1
+      && legacyResult.ok
+      && legacyResult.code === 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED'
+      && !hasLegacySameSubjectProof(lookup, legacyResult)
+    );
+
+  return {
+    ok: true,
+    data: peopleCoreForcesAmbiguous
+      ? buildForcedPeopleCoreAmbiguousVisibility(
+        normalizedPhone.phone.normalizedE164,
+        legacyResult,
+      )
+      : mapLegacyResultToVisibility(normalizedPhone.phone.normalizedE164, legacyResult),
+  };
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/threadVisibility.service.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/threadVisibility.service.ts
@@ -1,4 +1,4 @@
-import { AsyncConnectShyftThreadService, type ConnectShyftThread } from '../threads';
+import { KnexConnectShyftThreadStore, type ConnectShyftThread } from '../threads';
 
 export type ConnectShyftThreadVisibility = {
   threadId: string;
@@ -6,7 +6,7 @@ export type ConnectShyftThreadVisibility = {
   thread: ConnectShyftThread;
 };
 
-const defaultThreadService = new AsyncConnectShyftThreadService();
+const defaultThreadStore = new KnexConnectShyftThreadStore();
 
 export const readConnectShyftThreadVisibility = async (input: {
   tenantId: string;
@@ -14,7 +14,7 @@ export const readConnectShyftThreadVisibility = async (input: {
   threadId: string;
   allowCrossOrgUnit?: boolean;
 }): Promise<ConnectShyftThreadVisibility | null> => {
-  const thread = await defaultThreadService.findThreadById({
+  const thread = await defaultThreadStore.findThreadById({
     tenantId: input.tenantId,
     threadId: input.threadId,
   });

--- a/apps/connectshyft-api/src/modules/connectshyft/ops/threadVisibility.service.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ops/threadVisibility.service.ts
@@ -1,0 +1,34 @@
+import { AsyncConnectShyftThreadService, type ConnectShyftThread } from '../threads';
+
+export type ConnectShyftThreadVisibility = {
+  threadId: string;
+  found: true;
+  thread: ConnectShyftThread;
+};
+
+const defaultThreadService = new AsyncConnectShyftThreadService();
+
+export const readConnectShyftThreadVisibility = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  allowCrossOrgUnit?: boolean;
+}): Promise<ConnectShyftThreadVisibility | null> => {
+  const thread = await defaultThreadService.findThreadById({
+    tenantId: input.tenantId,
+    threadId: input.threadId,
+  });
+  if (!thread) {
+    return null;
+  }
+
+  if (input.allowCrossOrgUnit !== true && thread.orgUnitId !== input.orgUnitId) {
+    return null;
+  }
+
+  return {
+    threadId: thread.threadId,
+    found: true,
+    thread,
+  };
+};

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -179,6 +179,7 @@ import {
   markIdentityAmbiguityEventReviewed,
 } from '../../../modules/connectshyft/ambiguityEvents';
 import { isStrictUtcIsoTimestamp } from '../../../platform/time/timezoneService';
+import connectShyftOpsRouter from './connectshyft/ops.routes';
 
 const router = Router();
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -3964,6 +3965,8 @@ router.get('/availability', getConnectAvailability);
 router.get('/context', getConnectContext);
 
 router.get('/inbox', getConnectInbox);
+
+router.use('/ops', connectShyftOpsRouter);
 
 router.post('/neighbors', postConnectNeighborCreate);
 

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft/ops.routes.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft/ops.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import {
+  getConnectOpsBridgeVisibility,
+  getConnectOpsIdentityVisibility,
+  getConnectOpsThreadVisibility,
+} from '../../../../modules/connectshyft/http/ops.handlers';
+
+const router = Router();
+
+router.get('/identity/:phone', getConnectOpsIdentityVisibility);
+router.get('/threads/:threadId', getConnectOpsThreadVisibility);
+router.get('/bridge/:bridgeId', getConnectOpsBridgeVisibility);
+
+export default router;

--- a/slice15-ambiguity-surface-audit.txt
+++ b/slice15-ambiguity-surface-audit.txt
@@ -1,0 +1,86 @@
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:527:      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-1')
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts:8:  createIdentityAmbiguityEvent,
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts:10:} from './ambiguityEvents';
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts:321:    await createIdentityAmbiguityEvent({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:5:  createIdentityAmbiguityEvent,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:7:} from '../../../../modules/connectshyft/ambiguityEvents';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:128:const createEvent = async (overrides: Record<string, unknown> = {}) => createIdentityAmbiguityEvent({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:207:      .get('/api/v1/connectshyft/identity-ambiguities')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:256:      .get('/api/v1/connectshyft/identity-ambiguities')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:292:      .get('/api/v1/connectshyft/identity-ambiguities')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:306:      .get('/api/v1/connectshyft/identity-ambiguities')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:353:      .get('/api/v1/connectshyft/identity-ambiguities')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:388:      .get('/api/v1/connectshyft/identity-ambiguities')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:410:      .get('/api/v1/connectshyft/identity-ambiguities')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:434:      .get('/api/v1/connectshyft/identity-ambiguities')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:458:      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-review-pending')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:492:      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-review-idempotent')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:516:    await createIdentityAmbiguityEvent({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:535:      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-other-tenant-review')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:562:      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-invalid-status')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:600:      .patch('/api/v1/connectshyft/identity-ambiguities/ambiguity-event-review-forbidden')
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:178:  listIdentityAmbiguityEvents,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:179:  markIdentityAmbiguityEventReviewed,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:180:} from '../../../modules/connectshyft/ambiguityEvents';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2331:  if (typeof req.params.ambiguityEventId !== 'string') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2335:  return req.params.ambiguityEventId.trim();
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4185:router.get('/identity-ambiguities', async (req: Request, res: Response) => {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4206:  const listed = await listIdentityAmbiguityEvents({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4227:router.patch('/identity-ambiguities/:ambiguityEventId', async (req: Request, res: Response) => {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4241:  const ambiguityEventId = parseIdentityAmbiguityEventIdParam(req);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4242:  if (!ambiguityEventId) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4245:      message: 'ambiguityEventId is required',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4267:  const event = await markIdentityAmbiguityEventReviewed({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4269:    ambiguityEventId,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:3:  createIdentityAmbiguityEvent,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:5:  listIdentityAmbiguityEvents,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:6:  markIdentityAmbiguityEventReviewed,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:8:} from '../ambiguityEvents';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:21:    const created = await service.createIdentityAmbiguityEvent({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:55:    await service.createIdentityAmbiguityEvent({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:65:    await service.createIdentityAmbiguityEvent({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:75:    await service.createIdentityAmbiguityEvent({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:86:    const firstPage = await service.listIdentityAmbiguityEvents({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:100:    const secondPage = await service.listIdentityAmbiguityEvents({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:117:    const created = await service.createIdentityAmbiguityEvent({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:127:    const reviewed = await service.markIdentityAmbiguityEventReviewed({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:129:      ambiguityEventId: created.id,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:139:    const reviewedAgain = await service.markIdentityAmbiguityEventReviewed({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:141:      ambiguityEventId: created.id,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:153:    const created = await createIdentityAmbiguityEvent({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:163:    const listed = await listIdentityAmbiguityEvents({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:175:    const reviewed = await markIdentityAmbiguityEventReviewed({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:177:      ambiguityEventId: created.id,
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:73:  ambiguityEventId: string;
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:234:  ambiguityEventId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:237:  const ambiguityEventId = normalizeOptionalString(input.ambiguityEventId);
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:241:    || Boolean(ambiguityEventId && !isUuid(ambiguityEventId));
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:364:    const existing = this.eventsById.get(input.ambiguityEventId);
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:492:        id: input.ambiguityEventId,
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:507:        id: input.ambiguityEventId,
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:529:    ambiguityEventId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:538:  async createIdentityAmbiguityEvent(
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:547:  async listIdentityAmbiguityEvents(
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:556:  async markIdentityAmbiguityEventReviewed(
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:561:      ambiguityEventId: input.ambiguityEventId,
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:576:export const createIdentityAmbiguityEvent = (
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:579:  defaultConnectShyftIdentityAmbiguityEventService.createIdentityAmbiguityEvent(input);
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:581:export const listIdentityAmbiguityEvents = (
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:584:  defaultConnectShyftIdentityAmbiguityEventService.listIdentityAmbiguityEvents(input);
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:586:export const markIdentityAmbiguityEventReviewed = (
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:589:  defaultConnectShyftIdentityAmbiguityEventService.markIdentityAmbiguityEventReviewed(input);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:14:jest.mock('../ambiguityEvents', () => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:15:  createIdentityAmbiguityEvent: jest.fn(),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:18:const ambiguityEventsModule = jest.requireMock('../ambiguityEvents') as {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:19:  createIdentityAmbiguityEvent: jest.Mock;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:81:    ambiguityEventsModule.createIdentityAmbiguityEvent.mockReset();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:156:    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).not.toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:245:    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).not.toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:328:    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledTimes(1);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:329:    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledWith(expect.objectContaining({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:393:    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledTimes(1);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:394:    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledWith(expect.objectContaining({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:453:    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledTimes(1);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:454:    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).toHaveBeenCalledWith(expect.objectContaining({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:470:    ambiguityEventsModule.createIdentityAmbiguityEvent.mockRejectedValueOnce(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:672:    expect(ambiguityEventsModule.createIdentityAmbiguityEvent).not.toHaveBeenCalled();

--- a/slice15-env-audit.txt
+++ b/slice15-env-audit.txt
@@ -1,0 +1,2104 @@
+apps/connectshyft-api/.env.example:20:TELNYX_API_KEY=REPLACE_TELNYX_API_KEY
+apps/connectshyft-api/.env.example:21:TELNYX_FROM_NUMBER=+12605550199
+apps/connectshyft-api/.env.example:22:TELNYX_CONNECTION_ID=REPLACE_TELNYX_CONNECTION_ID
+apps/connectshyft-api/.env.example:23:TELNYX_MESSAGING_PROFILE_ID=
+apps/connectshyft-api/.env.example:24:TELNYX_PUBLIC_KEY=REPLACE_TELNYX_PUBLIC_KEY
+apps/connectshyft-api/.env.example:25:TELNYX_API_BASE_URL=https://api.telnyx.com/v2
+apps/connectshyft-api/.env.example:27:CONNECTSHYFT_ENABLED_PROVIDERS=telnyx
+apps/connectshyft-api/.env.example:28:CONNECTSHYFT_PROVIDER_ROLLOUT_ALLOWLIST=
+apps/connectshyft-api/.env.example:29:CONNECTSHYFT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS=300
+apps/connectshyft-api/src/knexfile.ts:5:  const value = process.env[primary] ?? process.env[fallback];
+apps/connectshyft-api/src/knexfile.ts:20:  if (process.env.NODE_ENV === 'test') {
+apps/connectshyft-api/src/knexfile.ts:28:  if (process.env.NODE_ENV === 'test') {
+apps/connectshyft-api/src/knexfile.ts:32:  const databaseUrl = process.env.DATABASE_URL?.trim();
+apps/connectshyft-api/src/knexfile.ts:43:  if (process.env.NODE_ENV === 'production') {
+apps/connectshyft-api/src/knexfile.ts:54:  if (process.env.NODE_ENV === 'test') {
+apps/connectshyft-api/src/knexfile.ts:64:  if (process.env.DATABASE_URL) {
+apps/connectshyft-api/src/knexfile.ts:65:    return process.env.DATABASE_URL;
+apps/connectshyft-api/src/knexfile.ts:68:  if (process.env.NODE_ENV === 'test') {
+apps/connectshyft-api/src/knexfile.ts:132:    connection: process.env.DATABASE_URL || buildNonProductionConnection(),
+apps/connectshyft-api/src/server.ts:5:const PORT = parseInt(process.env.PORT || `${CANONICAL_PORT}`, 10);
+apps/connectshyft-api/src/server.ts:6:const DEFAULT_HOST = process.env.NODE_ENV === 'production' ? '0.0.0.0' : '0.0.0.0';
+apps/connectshyft-api/src/server.ts:7:const HOST = process.env.HOST || DEFAULT_HOST;
+apps/connectshyft-api/src/server.ts:9:if (process.env.NODE_ENV === 'production' && PORT !== CANONICAL_PORT) {
+apps/connectshyft-api/src/server.ts:13:if (process.env.NODE_ENV === 'production' && !['0.0.0.0', '127.0.0.1', 'localhost'].includes(HOST)) {
+apps/connectshyft-api/src/server.ts:19:  logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:139:    ? 'CONNECTSHYFT_SENDER_MAPPING_AMBIGUOUS'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:140:    : 'CONNECTSHYFT_SENDER_MAPPING_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:199:      code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:214:          source: 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:438:      code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:599:      code: 'CONNECTSHYFT_OPERATOR_CALLBACK_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:639:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:686:      code: 'CONNECTSHYFT_CALL_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:731:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:756:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:123:  CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:131:  CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:132:  CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:133:  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:134:  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:135:  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:151:  CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:185:const CONNECTSHYFT_NEIGHBOR_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:187:const CONNECTSHYFT_SYSTEM_ACTOR_USER_ID = '00000000-0000-4000-8000-000000000001';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:189:const CONNECTSHYFT_INBOX_P95_BUDGET_MS = 750;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:190:const CONNECTSHYFT_INBOX_P99_BUDGET_MS = 1500;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:198:const CONNECTSHYFT_LIFECYCLE_EVENT_NAMES = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:203:  inboundSmsAppended: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:204:  inboundVoiceVoicemail: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:205:  inboundVoiceFallback: CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:206:  voicemailTranscriptionRequested: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:207:  voicemailTranscriptionAttached: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:209:const CONNECTSHYFT_OUTBOUND_EVENT_NAMES = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:213:const CONNECTSHYFT_CANONICAL_EVENT_TYPES = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:219:const CONNECTSHYFT_CANONICAL_EVENTS_DEFAULT_LIMIT = 50;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:220:const CONNECTSHYFT_CANONICAL_EVENTS_MAX_LIMIT = 200;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:221:const CONNECTSHYFT_IDENTITY_AMBIGUITIES_DEFAULT_LIMIT = 50;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:222:const CONNECTSHYFT_IDENTITY_AMBIGUITIES_MAX_LIMIT = 200;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:223:const CONNECTSHYFT_OUTBOUND_CALL_POLICY = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:229:const CONNECTSHYFT_OUTBOUND_CALL_AUTO_CLAIM_POLICY = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:234:const CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT = CONNECTSHYFT_OUTBOUND_CALL_POLICY.transport;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:235:const CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY = CONNECTSHYFT_OUTBOUND_CALL_POLICY.redialPolicy;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:236:const CONNECTSHYFT_CONNECTED_CALL_EVENT_TYPES = new Set(['voice.connected', 'call.connected', 'callconnected']);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:237:const CONNECTSHYFT_ESCALATION_NOTIFICATION_EVENT_PREFIXES = [
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:241:const CONNECTSHYFT_LEGACY_ROLE_ALIASES: Record<string, string> = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:261:const CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS: Record<string, ConnectShyftSyntheticThreadDescriptor> = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:527:const CONNECTSHYFT_DYNAMIC_C5_THREAD_PREFIX = 'thread-c5-unclaimed-';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:528:const CONNECTSHYFT_DYNAMIC_C5_THREAD_TEMPLATE_ID = 'thread-c5-unclaimed-1001';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:529:const CONNECTSHYFT_COMMUNICATION_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:530:const CONNECTSHYFT_WEBHOOK_RETRY_MAX_ATTEMPTS = 3;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:531:const CONNECTSHYFT_WEBHOOK_RETRY_BASE_DELAY_MS = 60 * 1000;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:532:const CONNECTSHYFT_WEBHOOK_RETRY_MAX_DELAY_MS = 15 * 60 * 1000;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:781:    evaluation.code === 'CONNECTSHYFT_MODULE_DISABLED'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:851:    const legacyAlias = CONNECTSHYFT_LEGACY_ROLE_ALIASES[normalizedBaseRole.toLowerCase()];
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:941:    code: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1022:    code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED' | 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1049:        code: 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1050:        message: 'Inbound SMS sender number is ambiguous across scoped provider mappings.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1057:      code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1059:        ? 'Inbound SMS sender number resolved outside the active orgUnit scope.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1060:        : 'Inbound SMS sender number does not map to an active scoped provider number.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1071:      code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1072:      message: 'Inbound SMS alignment requires a mapped provider number.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1092:        ? 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1093:        : 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1144:    return CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.claimed;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1147:    return CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.takenOver;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1149:  return CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.closed;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1159:  const existing = CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[input.threadId];
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1193:      CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[input.threadId] = seededDescriptor;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1198:  if (!input.threadId.startsWith(CONNECTSHYFT_DYNAMIC_C5_THREAD_PREFIX)) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1202:  const template = CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[CONNECTSHYFT_DYNAMIC_C5_THREAD_TEMPLATE_ID];
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1218:  CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[input.threadId] = dynamicDescriptor;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1232:  const descriptor = CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[thread.threadId];
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1288:    source: 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1330:    source: 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1504:    ? CONNECTSHYFT_OUTBOUND_EVENT_NAMES.callDispatched
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1505:    : CONNECTSHYFT_OUTBOUND_EVENT_NAMES.messageDispatched;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1577:            'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1610:      code: 'CONNECTSHYFT_OUTBOUND_SIDE_EFFECTS_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1672:        CONNECTSHYFT_ESCALATION_NOTIFICATION_EVENT_PREFIXES.forEach((prefix, index) => {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1788:    code: 'CONNECTSHYFT_THREAD_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1847:      code: 'CONNECTSHYFT_THREAD_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1939:        code: 'CONNECTSHYFT_LIFECYCLE_SIDE_EFFECTS_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1985:  if (transitioned.code !== 'CONNECTSHYFT_THREAD_NOT_FOUND' || !input.syntheticThread) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2050:    code: 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2073:    code: 'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2095:    code: 'CONNECTSHYFT_THREAD_CLAIM_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2117:    code: 'CONNECTSHYFT_THREAD_TAKEOVER_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2139:    code: 'CONNECTSHYFT_THREAD_CLOSE_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2161:    code: 'CONNECTSHYFT_THREAD_CALL_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2176:    hasCapability(actorRoles, CAPABILITIES.ORG_UNIT_SMS_SEND)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2183:    code: 'CONNECTSHYFT_THREAD_MESSAGE_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2208:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_READ_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2218:      code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2247:    code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_UPDATE_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2303:    return CONNECTSHYFT_IDENTITY_AMBIGUITIES_DEFAULT_LIMIT;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2308:    CONNECTSHYFT_IDENTITY_AMBIGUITIES_MAX_LIMIT,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2365:    return CONNECTSHYFT_CANONICAL_EVENTS_DEFAULT_LIMIT;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2368:  return Math.min(Math.trunc(rawLimit), CONNECTSHYFT_CANONICAL_EVENTS_MAX_LIMIT);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2457:    ? CONNECTSHYFT_CANONICAL_EVENT_TYPES.callAttemptStarted
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2458:    : CONNECTSHYFT_CANONICAL_EVENT_TYPES.messageQueued;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2478:      ? CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2595:        source: 'SMS',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2661:    code: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2697:        code: callLegMappingResult.errorCode || 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2702:          code: messageMappingResult.errorCode || 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2821:    if (event.eventName !== CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.voicemailTranscriptionAttached) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2927:    limit: CONNECTSHYFT_CANONICAL_EVENTS_MAX_LIMIT,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3039:  const dueSyntheticThreads = Object.entries(CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3471:      ? 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3472:      : 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3474:      ? 'Resolve the mapped ConnectShyft sender number so exactly one active scoped mapping remains before sending SMS.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3475:      : 'Persist one valid mapped ConnectShyft sender number on the thread before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3516:    code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3517:    message: 'Add or select a valid phone number before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3550:        code: 'CONNECTSHYFT_SMS_TARGET_INVALID',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3551:        message: 'Select a valid phone number before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3598:          code: 'CONNECTSHYFT_SMS_TARGET_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3599:          message: 'Select a specific phone number before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3611:        code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3612:        message: 'Add or select a valid phone number before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3622:    if (resolvedNeighbor.code !== 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3652:    code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3653:    message: 'Add or select a valid phone number before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3772:    maxAttempts: CONNECTSHYFT_WEBHOOK_RETRY_MAX_ATTEMPTS,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3774:    baseDelayMs: CONNECTSHYFT_WEBHOOK_RETRY_BASE_DELAY_MS,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3775:    maxDelayMs: CONNECTSHYFT_WEBHOOK_RETRY_MAX_DELAY_MS,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3788:    && callPolicy.transport !== CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3791:      code: 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3796:        allowedTransport: CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3808:      && callPolicy.redialPolicy !== CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3813:      code: 'CONNECTSHYFT_OUTBOUND_CALL_RETRY_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3821:        allowedRedialPolicy: CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3838:  return CONNECTSHYFT_SYSTEM_ACTOR_USER_ID;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3861:  if (CONNECTSHYFT_NEIGHBOR_SLUG_PATTERN.test(normalizedSlugCandidate)) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3873:  source: typeof req.body?.source === 'string' ? req.body.source : 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3887:  return UUID_PATTERN.test(neighborId) || CONNECTSHYFT_NEIGHBOR_SLUG_PATTERN.test(neighborId);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4016:      code: 'CONNECTSHYFT_ESCALATION_AS_OF_INVALID',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4033:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4170:    code: 'CONNECTSHYFT_CANONICAL_EVENTS_LISTED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4217:    code: 'CONNECTSHYFT_IDENTITY_AMBIGUITIES_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4244:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_ID_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4252:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_STATUS_INVALID',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4274:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4283:    code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_REVIEWED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4313:      code: 'CONNECTSHYFT_NEIGHBOR_ID_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4323:      code: 'CONNECTSHYFT_NEIGHBOR_ID_INVALID',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4341:      code: 'CONNECTSHYFT_THREAD_ID_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4463:      transport: outboundCallPolicyRequest?.transport || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4465:      redialPolicy: outboundCallPolicyRequest?.redialPolicy || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4526:      threadReopenedByUser: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4530:        thread_reopened_by_user: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4544:        eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4550:      eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4575:    lifecycleEvent = CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4583:    lifecycleEvent === CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4631:          ? 'CONNECTSHYFT_SMS_OVERRIDE_REASON_REQUIRED'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4632:          : 'CONNECTSHYFT_SMS_OVERRIDE_REASON_INVALID',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4709:        code: 'CONNECTSHYFT_OPERATOR_CALLBACK_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4754:        code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4947:        ? 'CONNECTSHYFT_CALL_SENDER_AMBIGUOUS'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4948:        : 'CONNECTSHYFT_CALL_SENDER_REQUIRED';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5041:      expiresAt: new Date(Date.now() + CONNECTSHYFT_COMMUNICATION_IDEMPOTENCY_TTL_MS),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5047:      code: 'CONNECTSHYFT_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5063:      code: 'CONNECTSHYFT_IDEMPOTENT_OPERATION_IN_PROGRESS',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5108:        resultCode: 'CONNECTSHYFT_DUPLICATE_REQUEST_REPLAYED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5138:      code: 'CONNECTSHYFT_IDEMPOTENT_REPLAY_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5172:        : 'Outbound SMS override persistence is unavailable.';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5175:        : 'CONNECTSHYFT_SMS_OVERRIDE_AUDIT_UNAVAILABLE';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5179:        message: 'Outbound SMS cannot be sent because override persistence is unavailable.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5336:      code: 'CONNECTSHYFT_PROVIDER_DISPATCH_FAILED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5427:      thread_reopened_by_user: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5439:      ? CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5488:        reopenedFromClosed: lifecycleEvent === CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5503:      code: 'CONNECTSHYFT_CANONICAL_EVENT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5550:      code: 'CONNECTSHYFT_PROVIDER_CORRELATION_SKIPPED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5556:  const reopenedFromClosed = lifecycleEvent === CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5601:    ? 'CONNECTSHYFT_THREAD_CALL_DISPATCHED'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5602:    : 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5656:          call: CONNECTSHYFT_OUTBOUND_CALL_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5657:          autoClaimPolicy: CONNECTSHYFT_OUTBOUND_CALL_AUTO_CLAIM_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5765:  const isConnectedCallEvent = CONNECTSHYFT_CONNECTED_CALL_EVENT_TYPES.has(normalizedEventType);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5775:        code: 'CONNECTSHYFT_TRANSCRIPTION_PROVIDER_EVENT_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5882:        code: 'CONNECTSHYFT_TRANSCRIPTION_CALLBACK_DUPLICATE_SUPPRESSED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5971:        code: 'CONNECTSHYFT_TRANSCRIPTION_CORRELATION_INVALID',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6053:        code: 'CONNECTSHYFT_TRANSCRIPTION_ATTACHMENT_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6096:      code: 'CONNECTSHYFT_TRANSCRIPTION_CALLBACK_ATTACHED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6124:          eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.voicemailTranscriptionAttached,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6298:      resultCode: 'CONNECTSHYFT_WEBHOOK_DUPLICATE_SUPPRESSED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6310:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6363:    callPolicy: CONNECTSHYFT_OUTBOUND_CALL_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6368:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6445:        code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6484:        await markWebhookReceipt('FAILED_TERMINAL', senderPhone.code === 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6522:            reason: senderPhone.code === 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6614:            message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6657:          code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6698:        code: 'CONNECTSHYFT_WEBHOOK_NEIGHBOR_UNRESOLVED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6699:        message: 'Inbound SMS processing requires a resolvable neighbor context.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6790:        inboundAlignedProviderNumber.code === 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6855:        eventType: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.inboundSmsAppended,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6911:          code: 'CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6912:          message: 'Inbound SMS thread ensure is temporarily unavailable.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6950:        code: 'CONNECTSHYFT_INBOUND_SMS_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6951:        message: 'Inbound SMS processing could not persist timeline side effects.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7000:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7140:  const canApplyAutoClaimForTransport = callTransport === CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7207:          eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.claimed,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7235:        lifecycleEvent: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.claimed,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7266:      ? CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.claimed
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7267:      : CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.inboundVoiceVoicemail;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7345:      code: 'CONNECTSHYFT_CANONICAL_EVENT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7396:    code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7462:        redialPolicy: CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7514:              eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.voicemailTranscriptionRequested,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7515:              queueName: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts:118:      code: 'CONNECTSHYFT_THREAD_CLOSED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts:135:          source: 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts:242:      code: 'CONNECTSHYFT_THREAD_OWNERSHIP_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts:268:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts:299:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts:315:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:8:const CONNECTSHYFT_PROVIDER_REGISTRY_TEST_TENANT_IDS = [
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:100:    const testTenantIds = [...CONNECTSHYFT_PROVIDER_REGISTRY_TEST_TENANT_IDS];
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:117:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:118:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:119:  const previousTelnyxPublicKey = process.env.TELNYX_PUBLIC_KEY;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:120:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:121:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:122:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:123:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:132:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:133:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:134:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:135:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:136:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:137:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:143:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:150:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:151:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:152:    process.env.TELNYX_PUBLIC_KEY = previousTelnyxPublicKey;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:153:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:154:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:155:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:156:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:166:    previousValues.set(key, process.env[key]);
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:168:      delete process.env[key];
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:171:    process.env[key] = value;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:179:        delete process.env[key];
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:182:      process.env[key] = value;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:12:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:104:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:149:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:150:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:151:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:152:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:153:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:154:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:157:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:158:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:159:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:160:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:161:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:162:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:170:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:171:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:172:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:173:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:174:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:175:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:189:      code: 'CONNECTSHYFT_ESCALATION_RECIPIENTS_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:248:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:281:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_SAVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:314:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_SAVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:360:      code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_INTEGER',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:392:      code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_INTEGER',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:430:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.escalation-config.characterization.test.ts:462:      code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:11:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:102:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:124:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:125:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:126:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:127:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:128:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:129:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:132:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:133:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:134:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:135:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:136:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:137:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:145:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:146:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:147:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:148:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:149:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:150:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:180:      code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_METRICS_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:223:        code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:239:      code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:279:      code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_APPLIED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:332:        code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:350:      code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/app.ts:67:const useMinimalAppShell = process.env.CONNECTSHYFT_MINIMAL_APP === '1';
+apps/connectshyft-api/src/app.ts:90:  origin: process.env.FRONTEND_URL || 'http://localhost:5173',
+apps/connectshyft-api/src/app.ts:216:    code: 'CONNECTSHYFT_UNHANDLED_ERROR',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:15:const TEST_PROVIDER_NUMBER_F1 = '+12605550191';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:16:const TEST_PROVIDER_NUMBER_F2 = '+12605550192';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:17:const CONNECTSHYFT_SYSTEM_ACTOR_USER_ID = '00000000-0000-4000-8000-000000000001';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:103:  to: TEST_PROVIDER_NUMBER_F1,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:152:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:157:        to: TEST_PROVIDER_NUMBER_F1,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:175:          providerNumberE164: TEST_PROVIDER_NUMBER_F1,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:203:          source: 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:205:          lastInboundCsNumberId: TEST_PROVIDER_NUMBER_F1,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:206:          preferredOutboundCsNumberId: TEST_PROVIDER_NUMBER_F1,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:234:          to: TEST_PROVIDER_NUMBER_F1,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:364:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:375:          providerNumberE164: TEST_PROVIDER_NUMBER_F1,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:461:          to: TEST_PROVIDER_NUMBER_F2,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:470:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:475:          to: TEST_PROVIDER_NUMBER_F2,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:486:            providerNumberE164: TEST_PROVIDER_NUMBER_F2,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:500:            source: 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:502:            lastInboundCsNumberId: TEST_PROVIDER_NUMBER_F2,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:503:            preferredOutboundCsNumberId: TEST_PROVIDER_NUMBER_F2,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:504:            claimedByUserId: CONNECTSHYFT_SYSTEM_ACTOR_USER_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:582:      code: 'CONNECTSHYFT_CANONICAL_EVENT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:601:          providerNumberE164: TEST_PROVIDER_NUMBER_F1,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:12:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:103:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:137:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:138:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:139:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:140:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:141:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:142:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:145:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:146:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:147:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:148:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:149:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:150:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:158:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:159:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:160:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:161:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:162:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:163:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:187:      code: 'CONNECTSHYFT_NUMBER_MAPPINGS_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:234:      code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:267:      code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:311:      code: 'CONNECTSHYFT_NUMBER_MAPPING_INVALID_E164',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:337:      code: 'CONNECTSHYFT_NUMBER_MAPPING_INVALID_E164',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:386:      code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:412:      code: 'CONNECTSHYFT_NUMBER_MAPPING_ID_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:425:      code: 'CONNECTSHYFT_NUMBER_MAPPING_UPDATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:457:      code: 'CONNECTSHYFT_NUMBER_MAPPING_UPDATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:34:    code: 'CONNECTSHYFT_THREAD_ENSURED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:163:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:202:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:261:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:304:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:328:  it('refuses inbound SMS when the mapped sender number is ambiguous in scoped routing', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:374:      code: 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:385:  it('refuses inbound SMS when multiple active neighbors share the same sender phone', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:428:  it('refuses inbound SMS when the sender phone is malformed', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:446:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:470:      code: 'CONNECTSHYFT_PROVIDER_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:562:        code: 'CONNECTSHYFT_PROVIDER_DISPATCH_FAILED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:9:  CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:12:  CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:13:  CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:101:        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:107:          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:121:          eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:136:        code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:173:        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:179:          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:193:          eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:207:          eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:235:        code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:258:      code: 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:288:        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:294:          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:319:        code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:325:        code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:360:        code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:384:        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:390:          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:398:        eventType: CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:404:          eventName: CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:415:          eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:147:  code: 'CONNECTSHYFT_SENDER_MAPPING_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:210:      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:225:          source: 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:441:      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:593:  it('returns the current SMS-target-required refusal shape before outbound message dispatch', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:606:      code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:607:      message: 'Add or select a valid phone number before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:638:          message: 'Add or select a valid phone number before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:654:  it('returns the current SMS-sender-required refusal shape before outbound message dispatch', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:674:      code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:675:      message: 'Persist one valid mapped ConnectShyft sender number on the thread before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:710:          message: 'Persist one valid mapped ConnectShyft sender number on the thread before sending SMS.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:744:      code: 'CONNECTSHYFT_SMS_OVERRIDE_REASON_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:745:      message: 'Outbound SMS requires an override reason when prefers_texting=NO.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:774:          message: 'Outbound SMS requires an override reason when prefers_texting=NO.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:820:      code: 'CONNECTSHYFT_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:854:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/platform/mutations/__tests__/executePlatformMutation.contract.test.ts:4:const DATABASE_URL = process.env.MONEYSHYFT_TEST_DATABASE_URL;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:18:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:110:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:176:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:177:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:178:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:179:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:180:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:181:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:185:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:186:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:187:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:188:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:189:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:190:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:196:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:208:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:215:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:216:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:217:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:218:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:219:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:220:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:226:      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:279:      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:311:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:357:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:473:      code: 'CONNECTSHYFT_NEIGHBOR_MERGED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:508:      code: 'CONNECTSHYFT_NEIGHBOR_MERGED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:557:      code: 'CONNECTSHYFT_NEIGHBOR_MERGE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:584:      code: 'CONNECTSHYFT_NEIGHBOR_MERGE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-identity-merge.characterization.test.ts:618:      code: 'CONNECTSHYFT_NEIGHBOR_MERGE_INVALID',
+apps/connectshyft-api/src/config/database.ts:6:  const value = process.env[primary] ?? process.env[fallback];
+apps/connectshyft-api/src/config/database.ts:21:  if (process.env.NODE_ENV === 'test') {
+apps/connectshyft-api/src/config/database.ts:29:  if (process.env.NODE_ENV === 'test') {
+apps/connectshyft-api/src/config/database.ts:33:  const databaseUrl = process.env.DATABASE_URL?.trim();
+apps/connectshyft-api/src/config/database.ts:44:  if (process.env.NODE_ENV === 'production') {
+apps/connectshyft-api/src/config/database.ts:55:  if (process.env.NODE_ENV === 'test') {
+apps/connectshyft-api/src/config/database.ts:66:  if (process.env.DATABASE_URL) {
+apps/connectshyft-api/src/config/database.ts:67:    const url = new URL(process.env.DATABASE_URL);
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:16:const TEST_PROVIDER_NUMBER = '+12605550191';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:17:const TEST_CALLBACK_PROVIDER_EVENT_ID = 'provider-event-voice-seed-1001';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:18:const TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID = 'vm-thread-f1-claimed-1002-provider-event-voice-seed-1001';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:97:  to: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:102:    providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:104:    voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:123:        providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:124:        voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:181:      code: 'CONNECTSHYFT_TRANSCRIPTION_CALLBACK_ATTACHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:197:          providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:198:          voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:208:          voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:227:              artifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:274:      code: 'CONNECTSHYFT_TRANSCRIPTION_CALLBACK_DUPLICATE_SUPPRESSED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:293:          providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:330:      code: 'CONNECTSHYFT_TRANSCRIPTION_CORRELATION_INVALID',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:346:          providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:347:          voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:364:            provider_event_id: TEST_CALLBACK_PROVIDER_EVENT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:365:            voicemail_artifact_id: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:394:      code: 'CONNECTSHYFT_TRANSCRIPTION_ATTACHMENT_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:404:          providerEventId: TEST_CALLBACK_PROVIDER_EVENT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:405:          voicemailArtifactId: TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:67:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:68:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:69:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:70:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:71:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:72:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:76:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:77:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:78:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:79:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:80:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:81:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:87:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:99:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:106:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:107:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:108:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:109:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:110:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:111:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:117:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:152:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:173:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:210:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:231:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:289:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:310:      code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:367:      code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:405:      code: 'CONNECTSHYFT_NEIGHBOR_DELETE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:424:      code: 'CONNECTSHYFT_NEIGHBOR_DELETE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:453:      code: 'CONNECTSHYFT_NEIGHBOR_DELETE_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:462:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:481:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:500:      code: 'CONNECTSHYFT_NEIGHBORS_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:532:      code: 'CONNECTSHYFT_NEIGHBORS_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:551:      code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:584:      code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:603:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:617:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:682:      code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:709:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:7:import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../../../../modules/connectshyft/inboundSms';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:8:import { CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME } from '../../../../modules/connectshyft/inboundVoice';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:10:import { CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME } from '../../../../modules/connectshyft/threadTimeline';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:99:      eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:105:        eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:113:      eventType: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:118:        eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:136:        eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:151:      code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:242:      eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:248:        eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:262:        eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:276:        eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:294:      code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:332:      eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:338:        eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:363:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:369:      code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:18:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:110:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:176:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:177:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:178:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:179:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:180:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:181:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:185:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:186:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:187:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:188:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:189:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:190:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:196:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:208:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:215:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:216:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:217:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:218:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:219:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:220:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:226:      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:261:      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:340:      code: 'CONNECTSHYFT_NEIGHBOR_EDIT_RELATIONSHIP_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:356:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:396:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:446:      code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:471:      code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:539:      code: 'CONNECTSHYFT_NEIGHBOR_DELETE_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:549:      code: 'CONNECTSHYFT_NEIGHBOR_DELETE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-update-delete.characterization.test.ts:570:      code: 'CONNECTSHYFT_NEIGHBOR_DELETE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:66:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:67:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:68:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:69:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:70:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:71:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:75:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:76:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:77:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:78:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:79:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:80:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:86:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:98:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:105:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:106:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:107:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:108:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:109:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:110:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:380:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:432:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:463:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-match.test.ts:506:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+apps/connectshyft-api/src/config/loadEnv.ts:6:  const explicitEnvFile = process.env.CONNECT_API_ENV_FILE || process.env.CONNECTSHYFT_API_ENV_FILE;
+apps/connectshyft-api/src/config/loadEnv.ts:39:    process.env.CONNECTSHYFT_ENV_LOADED_PATHS = loadedPaths.join(path.delimiter);
+apps/connectshyft-api/src/config/knex.ts:5:const db: Knex = createKnexClient(knexConfig, process.env.NODE_ENV || 'development');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:23:const TEST_PROVIDER_NUMBER = '+12605550191';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:121:  source: 'SMS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:123:  lastInboundCsNumberId: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:124:  preferredOutboundCsNumberId: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:147:  to: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:178:      code: 'CONNECTSHYFT_THREAD_ENSURED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:260:        input.twilioNumberE164 === TEST_PROVIDER_NUMBER
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:269:            twilioNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:285:  it('returns the current inbound SMS success envelope and response payload shape on /webhooks/sms', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:304:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:309:          to: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:327:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:365:            to: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:443:  it('preserves the current duplicate-safe replay surface for inbound SMS webhooks', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:469:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:474:          to: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:490:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:529:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:530:      message: 'Inbound SMS processing requires a sender phone number.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:541:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:542:      message: 'Inbound SMS processing requires a valid sender phone number.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:545:  ])('returns the current sender-phone-%s refusal shape before inbound SMS processing continues', async ({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:581:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:641:        message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:658:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:724:        message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:735:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:782:        message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:793:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:813:  it('returns the current inbound SMS success shape when subject resolution finds a single reusable neighbor', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:841:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:845:          to: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:856:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:876:            to: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:911:        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:934:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:938:          to: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:949:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:969:            to: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1008:        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1031:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1067:        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1090:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1122:        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1145:        code: 'CONNECTSHYFT_WEBHOOK_NEIGHBOR_UNRESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1146:        message: 'Inbound SMS processing requires a resolvable neighbor context.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1163:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1198:  it('returns the current inbound SMS thread-ensure persistence refusal mapping', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1216:        code: 'CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1217:        message: 'Inbound SMS thread ensure is temporarily unavailable.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1235:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1264:  it('returns the current inbound SMS canonical persistence refusal mapping', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1282:        code: 'CONNECTSHYFT_INBOUND_SMS_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1283:        message: 'Inbound SMS processing could not persist timeline side effects.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1301:            providerNumberE164: TEST_PROVIDER_NUMBER,
+apps/connectshyft-api/src/utils/__tests__/jwt.cookiePolicy.test.ts:7:  const originalEnv = process.env;
+apps/connectshyft-api/src/utils/__tests__/jwt.cookiePolicy.test.ts:11:    process.env = { ...originalEnv };
+apps/connectshyft-api/src/utils/__tests__/jwt.cookiePolicy.test.ts:15:    process.env = originalEnv;
+apps/connectshyft-api/src/utils/__tests__/jwt.cookiePolicy.test.ts:26:    process.env.NODE_ENV = 'development';
+apps/connectshyft-api/src/utils/__tests__/jwt.cookiePolicy.test.ts:27:    process.env.COOKIE_DOMAIN = 'example.com';
+apps/connectshyft-api/src/utils/__tests__/jwt.cookiePolicy.test.ts:63:    process.env.NODE_ENV = 'production';
+apps/connectshyft-api/src/utils/__tests__/jwt.cookiePolicy.test.ts:64:    process.env.COOKIE_DOMAIN = 'example.com';
+apps/connectshyft-api/src/utils/__tests__/jwt.cookiePolicy.test.ts:96:    process.env.NODE_ENV = 'production';
+apps/connectshyft-api/src/utils/__tests__/jwt.cookiePolicy.test.ts:97:    process.env.COOKIE_DOMAIN = 'example.com';
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts:312:      && result.code === 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:12:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:104:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:172:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:173:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:174:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:175:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:176:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:177:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:181:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:182:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:183:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:184:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:185:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:186:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:192:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:204:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:211:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:212:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:213:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:214:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:215:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:216:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:222:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:250:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:288:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:320:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:342:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:377:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:420:      code: 'CONNECTSHYFT_NEIGHBOR_CREATE_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-create.characterization.test.ts:457:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/middleware/errorHandler.ts:96:      message: process.env.NODE_ENV === 'development' ? err.message : 'An error occurred'
+apps/connectshyft-api/src/middleware/errorHandler.ts:116:    message: process.env.NODE_ENV === 'development' ? err.message : undefined
+apps/connectshyft-api/src/utils/logger.ts:23:  level: process.env.LOG_LEVEL || 'info',
+apps/connectshyft-api/src/utils/logger.ts:36:if (process.env.NODE_ENV === 'production') {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:100:    code: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:571:        code: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:42:    code: 'CONNECTSHYFT_THREAD_ENSURED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:238:          code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED' as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:260:            code: 'CONNECTSHYFT_NUMBER_MAPPING_NOT_FOUND' as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:281:          code: 'CONNECTSHYFT_NUMBER_MAPPING_UPDATED' as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:317:      code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:353:      code: 'CONNECTSHYFT_ACTOR_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:361:  it('prefers canonical neighborId metadata over thread correlation for inbound SMS', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:389:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:405:  it('uses thread correlation before phone matching for inbound SMS', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:429:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:473:        code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:534:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:570:        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:624:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:658:        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:692:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:742:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:785:        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:829:      code: 'CONNECTSHYFT_NUMBER_MAPPINGS_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:846:        code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:878:        code: 'CONNECTSHYFT_NUMBER_MAPPING_UPDATED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:915:      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:937:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:963:      code: 'CONNECTSHYFT_CANONICAL_EVENTS_LISTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:1116:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft'
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:8:  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}`)
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:11:    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE} (
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:48:    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_LEGS_TABLE} (
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:52:      bridge_session_id TEXT NOT NULL REFERENCES ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}(id) ON DELETE CASCADE,
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:74:    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE} (tenant_id, org_unit_id, thread_id, created_at_utc DESC, id)
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:79:    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_LEGS_TABLE} (bridge_session_id, leg_role, id)
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:84:    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_LEGS_TABLE} (provider_call_id)
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:90:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(BRIDGE_LEGS_TABLE)
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:91:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(BRIDGE_SESSIONS_TABLE)
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:8:import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../../../../modules/connectshyft/inboundSms';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:102:      eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:108:        eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:126:      code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:160:              eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:161:              eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:170:                eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:257:      code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:289:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:12:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:23:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:25:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:33:    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:38:         FROM ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:46:    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:52:      FROM ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:53:      JOIN ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:62:    , ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:72:    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} AS phones
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:74:    FROM ${CONNECTSHYFT_SCHEMA}.${NEIGHBORS_TABLE} AS neighbors
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:85:    ON ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} (tenant_id, normalized_e164)
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:92:    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${CURRENT_UNIQUE_E164_INDEX}
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:96:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260318143000_add_connectshyft_neighbor_phone_uniqueness.ts:101:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/modules/connectshyft/phoneIdentityContext.ts:13:  defaultCountry: normalizeOptionalEnvValue(process.env.CONNECTSHYFT_PHONE_DEFAULT_COUNTRY) || DEFAULT_COUNTRY,
+apps/connectshyft-api/src/modules/connectshyft/phoneIdentityContext.ts:14:  defaultAreaCode: normalizeOptionalEnvValue(process.env.CONNECTSHYFT_PHONE_DEFAULT_AREA_CODE),
+apps/connectshyft-api/src/platform/rbac/__tests__/capabilities.test.ts:31:    expect(hasCapability(['ORGUNIT_MEMBER'], CAPABILITIES.ORG_UNIT_SMS_SEND)).toBe(true);
+apps/connectshyft-api/src/platform/rbac/__tests__/capabilities.test.ts:39:    expect(capabilities.has(CAPABILITIES.ORG_UNIT_SMS_SEND)).toBe(true);
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:9:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:101:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:132:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:133:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:134:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:135:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:136:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:137:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:140:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:141:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:142:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:143:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:144:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:145:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:153:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:154:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:155:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:156:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:157:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:158:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:170:      code: 'CONNECTSHYFT_SETTINGS_NAVIGATION_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:216:      code: 'CONNECTSHYFT_SETTINGS_NAVIGATION_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:263:      code: 'CONNECTSHYFT_SETTINGS_NAVIGATION_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:300:      code: 'CONNECTSHYFT_AVAILABILITY_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts:334:      code: 'CONNECTSHYFT_AVAILABILITY_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:256:  code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:298:const DEFAULT_SMS_SENDER_MAPPINGS: Record<string, ConnectShyftNumberMapping[]> = {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:324:  const scopedMappings = Object.values(DEFAULT_SMS_SENDER_MAPPINGS)
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:353:  source: overrides.source ?? 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:370:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:371:  const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:374:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:375:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:398:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:399:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:402:  it('returns providerMessageId values and replays idempotent outbound SMS without a second adapter call', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:421:      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:447:      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:470:  it('prefers an explicit outbound request target over neighbor-record phones for SMS dispatch', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:489:      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:498:  it('dispatches composer-origin SMS without request targetPhone by resolving the target server-side', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:512:      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:529:  it('dispatches outbound SMS from different orgUnit-specific sender numbers', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:569:  it('selects the primary active valid neighbor phone when no explicit SMS target is provided', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:604:  it('selects the only active valid neighbor phone when the primary phone is not SMS eligible', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:642:  it('refuses ambiguous SMS target resolution before provider dispatch', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:674:      code: 'CONNECTSHYFT_SMS_TARGET_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:686:  it('refuses outbound SMS when no active valid neighbor phone exists', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:720:      code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:731:  it('resolves outbound SMS sender from the single active orgUnit mapping', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:746:  it('reuses the same mapped sender metadata across repeated outbound SMS dispatches on one thread', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:770:      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:784:      code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:831:  it('refuses outbound SMS sender resolution when no active orgUnit mapping exists', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:846:      code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:876:      code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:915:      code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:926:  it('refuses outbound SMS sender resolution when multiple active orgUnit mappings exist', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:959:      code: 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:971:  it('refuses non-dispatchable SMS targets at the exported dispatch-ready helper boundary', () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:978:      code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:989:  it('refuses outbound SMS before provider dispatch when the route does not hold a dispatch-ready target', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1001:      code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1011:  it('refuses outbound SMS before provider dispatch when no active sender mapping exists', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1030:      code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1042:  it('refuses outbound SMS before provider dispatch when sender mappings are ambiguous', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1079:      code: 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1091:  it('keeps canonical texting preference gating ahead of SMS target dispatch behavior', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1111:      code: 'CONNECTSHYFT_SMS_OVERRIDE_REASON_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1137:      code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1212:      code: 'CONNECTSHYFT_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1230:      code: 'CONNECTSHYFT_OPERATOR_CALLBACK_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1260:      code: 'CONNECTSHYFT_PROVIDER_DISPATCH_FAILED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:12:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:103:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:162:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:163:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:164:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:165:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:166:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:167:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:171:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:172:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:173:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:174:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:175:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:176:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:182:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:194:      refusalCode: 'CONNECTSHYFT_ENTITLEMENT_ENABLED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:201:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:202:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:203:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:204:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:205:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:206:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:212:      code: 'CONNECTSHYFT_NEIGHBORS_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:234:      code: 'CONNECTSHYFT_NEIGHBORS_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:266:      code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:291:      code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:327:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:341:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbor-list-detail.characterization.test.ts:369:      code: 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN',
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:4:const SMS_OVERRIDE_TABLE = 'cs_sms_preference_overrides';
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:5:const SMS_OVERRIDE_REASON_CHECK = 'cs_sms_pref_override_reason_ck';
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:14:        WHERE table_schema = '${CONNECTSHYFT_SCHEMA}'
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:15:          AND table_name = '${SMS_OVERRIDE_TABLE}'
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:19:        WHERE conname = '${SMS_OVERRIDE_REASON_CHECK}'
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:20:          AND conrelid = 'connectshyft.${SMS_OVERRIDE_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:22:        ALTER TABLE connectshyft.${SMS_OVERRIDE_TABLE}
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:23:          ADD CONSTRAINT ${SMS_OVERRIDE_REASON_CHECK}
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:39:    ALTER TABLE IF EXISTS connectshyft.${SMS_OVERRIDE_TABLE}
+apps/connectshyft-api/src/migrations/20260227150000_add_connectshyft_sms_override_reason_constraint.ts:40:      DROP CONSTRAINT IF EXISTS ${SMS_OVERRIDE_REASON_CHECK}
+apps/connectshyft-api/src/migrations/20260224143000_add_shared_phone_metadata_to_connectshyft_neighbor_phones.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260224143000_add_shared_phone_metadata_to_connectshyft_neighbor_phones.ts:9:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260224143000_add_shared_phone_metadata_to_connectshyft_neighbor_phones.ts:14:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260224143000_add_shared_phone_metadata_to_connectshyft_neighbor_phones.ts:24:        WHERE table_schema = '${CONNECTSHYFT_SCHEMA}'
+apps/connectshyft-api/src/migrations/20260224143000_add_shared_phone_metadata_to_connectshyft_neighbor_phones.ts:32:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260224143000_add_shared_phone_metadata_to_connectshyft_neighbor_phones.ts:34:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260224143000_add_shared_phone_metadata_to_connectshyft_neighbor_phones.ts:44:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260224143000_add_shared_phone_metadata_to_connectshyft_neighbor_phones.ts:49:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260224143000_add_shared_phone_metadata_to_connectshyft_neighbor_phones.ts:54:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts:121:      code: 'CONNECTSHYFT_THREAD_TAKEOVER_READY',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts:138:          source: 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts:240:      code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts:269:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts:305:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts:324:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:16:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:107:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:146:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:147:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:148:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:149:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:150:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:151:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:154:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:155:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:156:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:157:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:158:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:159:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:172:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:173:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:174:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:175:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:176:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:177:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:216:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITIES_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:318:      code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:443:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_READ_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:470:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_REVIEWED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:504:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_REVIEWED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:547:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:574:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_STATUS_INVALID',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts:612:      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_UPDATE_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:12:const CONNECTSHYFT_TEST_FLAGS = JSON.stringify({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:104:    : CONNECTSHYFT_TEST_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:135:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:136:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:137:  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:138:  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:139:  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:140:  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:143:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:144:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:145:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:146:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:147:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:148:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:156:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:157:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:158:    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:159:    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:160:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:161:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:173:      code: 'CONNECTSHYFT_CONTEXT_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:199:      code: 'CONNECTSHYFT_CONTEXT_RESOLVED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:231:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:250:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_INVALID',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:273:      code: 'CONNECTSHYFT_INBOX_READY',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:324:      code: 'CONNECTSHYFT_MINE_LISTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:363:      code: 'CONNECTSHYFT_ACTOR_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts:391:      code: 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN',
+apps/connectshyft-api/src/migrations/20260222100000_create_connectshyft_escalation_config.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260222100000_create_connectshyft_escalation_config.ts:9:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).createTable(ESCALATION_CONFIG_TABLE, (table) => {
+apps/connectshyft-api/src/migrations/20260222100000_create_connectshyft_escalation_config.ts:27:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(ESCALATION_CONFIG_TABLE);
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:7:const CONNECTSHYFT_CANONICAL_THREAD_STATES = ['UNCLAIMED', 'CLAIMED', 'CLOSED'] as const;
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:8:const CONNECTSHYFT_CANONICAL_THREAD_STATE_SET = new Set<string>(CONNECTSHYFT_CANONICAL_THREAD_STATES);
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:9:const DEFAULT_THREAD_SOURCE = 'VOICE';
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:19:export type ConnectShyftThreadState = (typeof CONNECTSHYFT_CANONICAL_THREAD_STATES)[number];
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:29:    code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID' | 'CONNECTSHYFT_THREAD_OWNERSHIP_REQUIRED';
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:134:    | 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:135:    | 'CONNECTSHYFT_THREAD_TRANSITION_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:136:    | 'CONNECTSHYFT_THREAD_STATE_INVALID'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:137:    | 'CONNECTSHYFT_THREAD_NEXT_EVALUATION_INVALID'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:138:    | 'CONNECTSHYFT_ESCALATION_AS_OF_INVALID'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:139:    | 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_INTEGER'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:140:    | 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_RANGE'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:141:    | 'CONNECTSHYFT_THREAD_TRANSITION_INVALID'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:142:    | 'CONNECTSHYFT_THREAD_NOT_FOUND'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:143:    | 'CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE'
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:144:    | 'CONNECTSHYFT_THREAD_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:190:    code: 'CONNECTSHYFT_THREAD_ENSURED';
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:206:    code: 'CONNECTSHYFT_DUE_THREADS_LISTED';
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:217:    code: 'CONNECTSHYFT_THREAD_TRANSITIONED';
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:228:    code: 'CONNECTSHYFT_ESCALATION_EVALUATED';
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:305:  return CONNECTSHYFT_CANONICAL_THREAD_STATE_SET.has(value);
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:567:  code: 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:573:  code: 'CONNECTSHYFT_THREAD_TRANSITION_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:579:  code: 'CONNECTSHYFT_THREAD_TRANSITION_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:585:  code: 'CONNECTSHYFT_THREAD_STATE_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:591:  code: 'CONNECTSHYFT_THREAD_NEXT_EVALUATION_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:597:  code: 'CONNECTSHYFT_ESCALATION_AS_OF_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:603:  code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_INTEGER',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:609:  code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_RANGE',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:615:  code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:621:  code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:627:  code: 'CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:633:  code: 'CONNECTSHYFT_THREAD_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:676:      code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:684:      code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:699:      code: 'CONNECTSHYFT_THREAD_OWNERSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1308:      code: 'CONNECTSHYFT_THREAD_ENSURED',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1334:      code: 'CONNECTSHYFT_DUE_THREADS_LISTED',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1370:      code: 'CONNECTSHYFT_ESCALATION_EVALUATED',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1408:      code: 'CONNECTSHYFT_THREAD_TRANSITIONED',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1475:        code: 'CONNECTSHYFT_THREAD_ENSURED',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1511:        code: 'CONNECTSHYFT_DUE_THREADS_LISTED',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1555:        code: 'CONNECTSHYFT_ESCALATION_EVALUATED',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1601:        code: 'CONNECTSHYFT_THREAD_TRANSITIONED',
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:4:const PROVIDER_IDENTIFIER_MAPPINGS_TABLE = 'cs_provider_identifier_mappings';
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:5:const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:7:const PROVIDER_IDENTIFIER_UNIQUE = 'cs_provider_identifier_mappings_provider_identifier_uq';
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:8:const WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE = 'cs_webhook_receipts_provider_dedupe_uq';
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:14:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:15:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:16:          DROP CONSTRAINT IF EXISTS ${PROVIDER_IDENTIFIER_UNIQUE};
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:17:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:18:          ADD CONSTRAINT ${PROVIDER_IDENTIFIER_UNIQUE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:27:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:28:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:29:          DROP CONSTRAINT IF EXISTS ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE};
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:30:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:31:          ADD CONSTRAINT ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:42:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:43:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:44:          DROP CONSTRAINT IF EXISTS ${PROVIDER_IDENTIFIER_UNIQUE};
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:45:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:46:          ADD CONSTRAINT ${PROVIDER_IDENTIFIER_UNIQUE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:55:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:56:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:57:          DROP CONSTRAINT IF EXISTS ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE};
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:58:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260301113000_scope_provider_correlation_uniqueness_to_tenant.ts:59:          ADD CONSTRAINT ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE}
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:59:      code: 'WEBHOOK_SIGNATURE_NOT_CONFIGURED' | 'WEBHOOK_SIGNATURE_MISSING' | 'WEBHOOK_SIGNATURE_INVALID'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:207:  const previousNodeEnv = process.env.NODE_ENV
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:208:  const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:211:    process.env.NODE_ENV = 'test'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:212:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:255:    process.env.NODE_ENV = previousNodeEnv
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:256:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:273:      code: 'CONNECTSHYFT_THREAD_CALL_DISPATCHED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:325:      code: 'CONNECTSHYFT_CALL_SENDER_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:343:        code: 'WEBHOOK_SIGNATURE_INVALID' as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:363:      code: 'CONNECTSHYFT_WEBHOOK_SIGNATURE_INVALID',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:427:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:468:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:535:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:551:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:632:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:656:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:706:      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:784:      code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:6:const CONNECTSHYFT_CANONICAL_EVENT_NAME = 'connectshyft.canonical.event_recorded';
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:49:const CONNECTSHYFT_PROVIDER_SPECIFIC_KEYS = new Set([
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:123:      CONNECTSHYFT_PROVIDER_SPECIFIC_KEYS.has(key)
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:227:      event_name: CONNECTSHYFT_CANONICAL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:315:      eventName: CONNECTSHYFT_CANONICAL_EVENT_NAME,
+apps/connectshyft-api/src/migrations/20260224170000_create_connectshyft_threads.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260224170000_create_connectshyft_threads.ts:20:      source TEXT NOT NULL DEFAULT 'VOICE',
+apps/connectshyft-api/src/migrations/20260224170000_create_connectshyft_threads.ts:51:      ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'VOICE'
+apps/connectshyft-api/src/migrations/20260224170000_create_connectshyft_threads.ts:205:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(THREADS_TABLE);
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:51:const CONNECTSHYFT_LEGACY_ROLE_ALIASES: Record<string, string> = {
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:88:  return CONNECTSHYFT_LEGACY_ROLE_ALIASES[normalized.toLowerCase()] || normalized;
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:239:      'CONNECTSHYFT_ORGUNIT_TENANT_MISMATCH',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:246:      'CONNECTSHYFT_ORGUNIT_CONTEXT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:252:    'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:284:      'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:313:      'CONNECTSHYFT_AUTH_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:336:      'CONNECTSHYFT_TENANT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:345:      'CONNECTSHYFT_TENANT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:362:      'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:369:      'CONNECTSHYFT_ORGUNIT_CONTEXT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:376:      'CONNECTSHYFT_ORGUNIT_TENANT_MISMATCH',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:384:      'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:395:        'CONNECTSHYFT_ORGUNIT_CONTEXT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:402:        'CONNECTSHYFT_ORGUNIT_TENANT_MISMATCH',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:409:        'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:439:      'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:446:      'CONNECTSHYFT_ORGUNIT_ACCESS_VALIDATION_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/contextAccess.ts:476:      'CONNECTSHYFT_ORGUNIT_ACCESS_VALIDATION_FAILED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts:102:      code: 'CONNECTSHYFT_THREAD_CLAIMED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts:119:          source: 'VOICE',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts:237:      code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts:263:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts:290:      code: 'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts:309:      code: 'CONNECTSHYFT_THREAD_CLAIM_FORBIDDEN',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts:332:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts:348:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:5:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts:393:      .withSchema(CONNECTSHYFT_SCHEMA)
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:7:const CONNECTSHYFT_CANONICAL_TEXTING_PREFERENCES = new Set<ConnectShyftCanonicalTextingPreference>([
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:13:const CONNECTSHYFT_ALLOWED_SMS_OVERRIDE_REASONS = [
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:20:export const CONNECTSHYFT_SMS_OVERRIDE_REASON_OPTIONS: readonly string[] = [
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:21:  ...CONNECTSHYFT_ALLOWED_SMS_OVERRIDE_REASONS,
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:25:  (typeof CONNECTSHYFT_ALLOWED_SMS_OVERRIDE_REASONS)[number];
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:104:const CONNECTSHYFT_SYNTHETIC_THREAD_TEXTING_PREFERENCES: Record<string, ConnectShyftCanonicalTextingPreference> = {
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:140:  if (CONNECTSHYFT_CANONICAL_TEXTING_PREFERENCES.has(normalized as ConnectShyftCanonicalTextingPreference)) {
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:153:  return CONNECTSHYFT_ALLOWED_SMS_OVERRIDE_REASONS.includes(
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:172:  readonly code = 'CONNECTSHYFT_SMS_OVERRIDE_AUDIT_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:175:    super('Outbound SMS override persistence is unavailable.');
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:207:      message: 'Outbound SMS requires an override reason when prefers_texting=NO.',
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:208:      allowedReasons: CONNECTSHYFT_SMS_OVERRIDE_REASON_OPTIONS,
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:217:      allowedReasons: CONNECTSHYFT_SMS_OVERRIDE_REASON_OPTIONS,
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:233:    Object.entries(CONNECTSHYFT_SYNTHETIC_THREAD_TEXTING_PREFERENCES),
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:122:const CONNECTSHYFT_URGENCY_LABELS = {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:128:const CONNECTSHYFT_THREAD_ACTIONS: Record<
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:138:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:139:const CONNECTSHYFT_THREADS_TABLE = 'cs_threads';
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:142:const CONNECTSHYFT_DEFAULT_SCOPE = {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:146:const CONNECTSHYFT_C4_SCOPE = {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:150:const CONNECTSHYFT_D4_SCOPE = {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:154:const CONNECTSHYFT_G1_SCOPE = {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:158:const CONNECTSHYFT_UX_R1_SCOPE = {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:162:const CONNECTSHYFT_UX_R3_SCOPE = {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:166:const CONNECTSHYFT_UX_R4_SCOPE = {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:171:const CONNECTSHYFT_THREAD_SEED_DATA: readonly ConnectShyftThreadSeed[] = [
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:173:    tenantId: CONNECTSHYFT_DEFAULT_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:174:    orgUnitId: CONNECTSHYFT_DEFAULT_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:189:    tenantId: CONNECTSHYFT_DEFAULT_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:190:    orgUnitId: CONNECTSHYFT_DEFAULT_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:205:    tenantId: CONNECTSHYFT_DEFAULT_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:206:    orgUnitId: CONNECTSHYFT_DEFAULT_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:221:    tenantId: CONNECTSHYFT_DEFAULT_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:222:    orgUnitId: CONNECTSHYFT_DEFAULT_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:237:    tenantId: CONNECTSHYFT_DEFAULT_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:238:    orgUnitId: CONNECTSHYFT_DEFAULT_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:253:    tenantId: CONNECTSHYFT_DEFAULT_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:254:    orgUnitId: CONNECTSHYFT_DEFAULT_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:269:    tenantId: CONNECTSHYFT_C4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:270:    orgUnitId: CONNECTSHYFT_C4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:285:    tenantId: CONNECTSHYFT_C4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:286:    orgUnitId: CONNECTSHYFT_C4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:301:    tenantId: CONNECTSHYFT_C4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:302:    orgUnitId: CONNECTSHYFT_C4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:317:    tenantId: CONNECTSHYFT_D4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:318:    orgUnitId: CONNECTSHYFT_D4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:333:    tenantId: CONNECTSHYFT_D4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:334:    orgUnitId: CONNECTSHYFT_D4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:349:    tenantId: CONNECTSHYFT_D4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:350:    orgUnitId: CONNECTSHYFT_D4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:365:    tenantId: CONNECTSHYFT_D4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:366:    orgUnitId: CONNECTSHYFT_D4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:381:    tenantId: CONNECTSHYFT_D4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:382:    orgUnitId: CONNECTSHYFT_D4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:397:    tenantId: CONNECTSHYFT_UX_R1_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:398:    orgUnitId: CONNECTSHYFT_UX_R1_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:413:    tenantId: CONNECTSHYFT_UX_R1_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:414:    orgUnitId: CONNECTSHYFT_UX_R1_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:429:    tenantId: CONNECTSHYFT_UX_R1_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:430:    orgUnitId: CONNECTSHYFT_UX_R1_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:445:    tenantId: CONNECTSHYFT_UX_R1_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:446:    orgUnitId: CONNECTSHYFT_UX_R1_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:461:    tenantId: CONNECTSHYFT_UX_R3_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:462:    orgUnitId: CONNECTSHYFT_UX_R3_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:477:    tenantId: CONNECTSHYFT_UX_R3_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:478:    orgUnitId: CONNECTSHYFT_UX_R3_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:493:    tenantId: CONNECTSHYFT_UX_R3_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:494:    orgUnitId: CONNECTSHYFT_UX_R3_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:509:    tenantId: CONNECTSHYFT_G1_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:510:    orgUnitId: CONNECTSHYFT_G1_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:525:    tenantId: CONNECTSHYFT_G1_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:526:    orgUnitId: CONNECTSHYFT_G1_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:541:    tenantId: CONNECTSHYFT_G1_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:542:    orgUnitId: CONNECTSHYFT_G1_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:557:    tenantId: CONNECTSHYFT_G1_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:558:    orgUnitId: CONNECTSHYFT_G1_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:573:    tenantId: CONNECTSHYFT_UX_R4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:574:    orgUnitId: CONNECTSHYFT_UX_R4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:589:    tenantId: CONNECTSHYFT_UX_R4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:590:    orgUnitId: CONNECTSHYFT_UX_R4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:605:    tenantId: CONNECTSHYFT_UX_R4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:606:    orgUnitId: CONNECTSHYFT_UX_R4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:621:    tenantId: CONNECTSHYFT_UX_R4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:622:    orgUnitId: CONNECTSHYFT_UX_R4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:637:    tenantId: CONNECTSHYFT_UX_R4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:638:    orgUnitId: CONNECTSHYFT_UX_R4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:653:    tenantId: CONNECTSHYFT_UX_R4_SCOPE.tenantId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:654:    orgUnitId: CONNECTSHYFT_UX_R4_SCOPE.orgUnitId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:716:    return CONNECTSHYFT_URGENCY_LABELS.stage0;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:720:    return CONNECTSHYFT_URGENCY_LABELS.stage1;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:723:  return CONNECTSHYFT_URGENCY_LABELS.stage2Plus;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:732:  return CONNECTSHYFT_THREAD_ACTIONS[state];
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:914:  return CONNECTSHYFT_THREAD_SEED_DATA.some((seed) => (
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1014:  return CONNECTSHYFT_THREAD_SEED_DATA
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1044:  const matchedSeed = CONNECTSHYFT_THREAD_SEED_DATA.find((seed) => (
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1075:      .withSchema(CONNECTSHYFT_SCHEMA)
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1076:      .table(CONNECTSHYFT_THREADS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1205:      .withSchema(CONNECTSHYFT_SCHEMA)
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1206:      .table(CONNECTSHYFT_THREADS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1236:      .withSchema(CONNECTSHYFT_SCHEMA)
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:49:    | 'CONNECTSHYFT_THREAD_NOT_FOUND'
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:50:    | 'CONNECTSHYFT_SENDER_ALIGNMENT_REQUIRED'
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:51:    | 'CONNECTSHYFT_SENDER_ALIGNMENT_INVALID'
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:52:    | 'CONNECTSHYFT_SENDER_MAPPING_REQUIRED'
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:53:    | 'CONNECTSHYFT_SENDER_MAPPING_AMBIGUOUS'
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:54:    | 'CONNECTSHYFT_SENDER_SCOPE_MISMATCH';
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:204:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:217:      code: 'CONNECTSHYFT_SENDER_ALIGNMENT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:232:      code: 'CONNECTSHYFT_SENDER_ALIGNMENT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:249:      code: 'CONNECTSHYFT_SENDER_MAPPING_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:261:      code: 'CONNECTSHYFT_SENDER_MAPPING_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:274:      code: 'CONNECTSHYFT_SENDER_SCOPE_MISMATCH',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:27:const CONNECTSHYFT_TEST_FLAGS_HEADER = 'x-test-connectshyft-flags';
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:28:const ENABLE_TEST_CONNECTSHYFT_FLAGS_ENV = 'ENABLE_TEST_CONNECTSHYFT_FLAGS';
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:29:const CONNECTSHYFT_FLAG_ENV_MAP: Record<keyof ConnectShyftFeatureFlags, string> = {
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:30:  connectshyft_enabled: 'CONNECTSHYFT_ENABLED',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:31:  connectshyft_inbox_enabled: 'CONNECTSHYFT_INBOX_ENABLED',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:32:  connectshyft_escalation_enabled: 'CONNECTSHYFT_ESCALATION_ENABLED',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:33:  connectshyft_webhooks_enabled: 'CONNECTSHYFT_WEBHOOKS_ENABLED',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:36:const DEFAULT_CONNECTSHYFT_FLAGS: ConnectShyftFeatureFlags = {
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:44:  code: 'CONNECTSHYFT_MODULE_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:54:    code: 'CONNECTSHYFT_INBOX_CAPABILITY_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:59:    code: 'CONNECTSHYFT_ESCALATION_CAPABILITY_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:64:    code: 'CONNECTSHYFT_WEBHOOKS_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:84:const isNodeTestEnv = (): boolean => process.env.NODE_ENV?.trim().toLowerCase() === 'test';
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:88:    return { ...DEFAULT_CONNECTSHYFT_FLAGS };
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:101:  connectshyft_enabled: parseBooleanEnv(process.env[CONNECTSHYFT_FLAG_ENV_MAP.connectshyft_enabled]),
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:102:  connectshyft_inbox_enabled: parseBooleanEnv(process.env[CONNECTSHYFT_FLAG_ENV_MAP.connectshyft_inbox_enabled]),
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:104:    process.env[CONNECTSHYFT_FLAG_ENV_MAP.connectshyft_escalation_enabled],
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:107:    process.env[CONNECTSHYFT_FLAG_ENV_MAP.connectshyft_webhooks_enabled],
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:112:  parseBooleanEnv(process.env[ENABLE_TEST_CONNECTSHYFT_FLAGS_ENV]) && isNodeTestEnv();
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:119:  const rawHeader = req.header(CONNECTSHYFT_TEST_FLAGS_HEADER);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:4:const PROVIDER_IDENTIFIER_MAPPINGS_TABLE = 'cs_provider_identifier_mappings';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:5:const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:6:const WEBHOOK_RECEIPT_RETENTION_DEFAULT_DAYS = 180;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:25:export const CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS = WEBHOOK_RECEIPT_RETENTION_DEFAULT_DAYS;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:335:    .table(PROVIDER_IDENTIFIER_MAPPINGS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:369:    .table(PROVIDER_IDENTIFIER_MAPPINGS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:412:    .table(PROVIDER_IDENTIFIER_MAPPINGS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:520:    return WEBHOOK_RECEIPT_RETENTION_DEFAULT_DAYS;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:539:  errorCode?: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:597:      errorCode: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:617:  errorCode?: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:849:    code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:942:    code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1074:      .table(WEBHOOK_RECEIPTS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1118:      .table(WEBHOOK_RECEIPTS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1137:      .table(WEBHOOK_RECEIPTS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1182:        code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1209:    code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1324:      .table(WEBHOOK_RECEIPTS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1368:        code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1392:    code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1426:        .table(WEBHOOK_RECEIPTS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1459:          code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1502:    code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1544:        .table(WEBHOOK_RECEIPTS_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1594:          code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts:356:      && legacyResult.code === 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED'
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:6:import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from './inboundSms';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:8:  CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:9:  CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:10:  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:11:  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:14:export const CONNECTSHYFT_THREAD_TIMELINE_DEFAULT_LIMIT = 200;
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:15:export const CONNECTSHYFT_THREAD_TIMELINE_MAX_LIMIT = 200;
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:16:export const CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME = 'connectshyft.outbound.sms_appended' as const;
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:17:export const CONNECTSHYFT_OUTBOUND_SMS_EVENT_NAME_ALIAS = 'connectshyft.thread.outbound_message_dispatched' as const;
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:18:export const CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES = {
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:271:const CONNECTSHYFT_TIMELINE_MAPPERS = new Map<string, TimelineEventMapper>([
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:272:  [CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME, mapInboundSmsTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:273:  [CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME, mapOutboundSmsTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:274:  [CONNECTSHYFT_OUTBOUND_SMS_EVENT_NAME_ALIAS, mapOutboundSmsTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:275:  [CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started, mapVoiceEventTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:276:  [CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.connected, mapVoiceEventTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:277:  [CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.ended, mapVoiceEventTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:278:  [CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.outboundDispatched, mapVoiceEventTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:281:  [CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME, mapVoiceEventTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:282:  [CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME, mapVoicemailTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:283:  [CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME, mapVoicemailTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:284:  [CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME, mapVoicemailTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:310:    return CONNECTSHYFT_THREAD_TIMELINE_DEFAULT_LIMIT;
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:315:    return CONNECTSHYFT_THREAD_TIMELINE_DEFAULT_LIMIT;
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:318:  return Math.min(normalized, CONNECTSHYFT_THREAD_TIMELINE_MAX_LIMIT);
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:330:    const mapper = CONNECTSHYFT_TIMELINE_MAPPERS.get(key);
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:370:    limit: CONNECTSHYFT_THREAD_TIMELINE_MAX_LIMIT,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:16:const DEFAULT_ENABLED_PROVIDERS = ['telnyx'];
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:17:const ENABLED_PROVIDERS_ENV = 'CONNECTSHYFT_ENABLED_PROVIDERS';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:18:const DISABLED_PROVIDERS_ENV = 'CONNECTSHYFT_DISABLED_PROVIDERS';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:19:const PROVIDER_ROLLOUT_ALLOWLIST_ENV = 'CONNECTSHYFT_PROVIDER_ROLLOUT_ALLOWLIST';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:20:const TEST_ENABLED_PROVIDERS_HEADER = 'x-test-connectshyft-enabled-providers';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:21:const TEST_DISABLED_PROVIDERS_HEADER = 'x-test-connectshyft-disabled-providers';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:22:const TEST_REQUESTED_PROVIDER_HEADER = 'x-test-connectshyft-provider-requested';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:23:const TEST_PROVIDER_ROLLOUT_ALLOWLIST_HEADER = 'x-test-connectshyft-provider-rollout-allowlist';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:24:const TEST_ENFORCE_WEBHOOK_SIGNATURE_HEADER = 'x-test-connectshyft-enforce-webhook-signature';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:25:const CONNECTSHYFT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS_ENV = 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:26:const TEST_PROVIDER_PUBLIC_KEY_HEADER = 'x-test-connectshyft-provider-public-key';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:27:const TEST_PROVIDER_PUBLIC_KEY_LEGACY_HEADER = 'x-test-connectshyft-telnyx-public-key';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:28:const CONNECTSHYFT_REQUIRED_CALL_TRANSPORT = 'bridge';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:29:const CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY = 'manual_only';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:51:    | 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:52:    | 'CONNECTSHYFT_OUTBOUND_CALL_RETRY_FORBIDDEN';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:57:      | 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:58:      | 'CONNECTSHYFT_OUTBOUND_CALL_RETRY_FORBIDDEN';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:85:  code: 'CONNECTSHYFT_PROVIDER_DISABLED' | 'CONNECTSHYFT_PROVIDER_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:98:    | 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:99:    | 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MISSING'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:100:    | 'CONNECTSHYFT_WEBHOOK_SIGNATURE_INVALID';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:362:  const parsed = parseProviderList(process.env[envVar]);
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:380:      req.header(TEST_PROVIDER_ROLLOUT_ALLOWLIST_HEADER),
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:382:    const enabledProviders = parseProviderList(req.header(TEST_ENABLED_PROVIDERS_HEADER));
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:383:    const disabledProviders = parseProviderList(req.header(TEST_DISABLED_PROVIDERS_HEADER));
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:385:      enabledProviders: enabledProviders.length > 0 ? enabledProviders : [...DEFAULT_ENABLED_PROVIDERS],
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:393:  const rolloutAllowlist = resolveProviderRolloutAllowlist(process.env[PROVIDER_ROLLOUT_ALLOWLIST_ENV]);
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:395:    enabledProviders: resolveProvidersFromEnv(ENABLED_PROVIDERS_ENV, DEFAULT_ENABLED_PROVIDERS),
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:396:    disabledProviders: resolveProvidersFromEnv(DISABLED_PROVIDERS_ENV),
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:409:  const isDisabled = input.code === 'CONNECTSHYFT_PROVIDER_DISABLED';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:527:    readHeader(req, TEST_ENFORCE_WEBHOOK_SIGNATURE_HEADER),
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:586:    TEST_ENFORCE_WEBHOOK_SIGNATURE_HEADER,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:587:    TEST_PROVIDER_PUBLIC_KEY_HEADER,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:588:    TEST_PROVIDER_PUBLIC_KEY_LEGACY_HEADER,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:613:      TEST_PROVIDER_PUBLIC_KEY_HEADER,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:614:      TEST_PROVIDER_PUBLIC_KEY_LEGACY_HEADER,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:617:      process.env[CONNECTSHYFT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS_ENV],
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:629:  const refusalCode = result.refusal.code === 'WEBHOOK_SIGNATURE_NOT_CONFIGURED'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:630:    ? 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:631:    : result.refusal.code === 'WEBHOOK_SIGNATURE_MISSING'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:632:      ? 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MISSING'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:633:      : 'CONNECTSHYFT_WEBHOOK_SIGNATURE_INVALID';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:734:      && requestedTransport !== CONNECTSHYFT_REQUIRED_CALL_TRANSPORT
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:737:        code: 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:741:          allowedTransport: CONNECTSHYFT_REQUIRED_CALL_TRANSPORT,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:752:        && requestedRedialPolicy !== CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:756:        code: 'CONNECTSHYFT_OUTBOUND_CALL_RETRY_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:761:          allowedRedialPolicy: CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:778:          transport: CONNECTSHYFT_REQUIRED_CALL_TRANSPORT,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:780:          redialPolicy: CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:830:    return normalizeProviderKey(req.header(TEST_REQUESTED_PROVIDER_HEADER));
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:855:      code: 'CONNECTSHYFT_PROVIDER_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:864:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:873:      code: 'CONNECTSHYFT_PROVIDER_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:883:      code: 'CONNECTSHYFT_PROVIDER_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:892:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:906:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:925:  parseBooleanEnv(process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS) && process.env.NODE_ENV === 'test';
+apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts:9:const CONNECTSHYFT_SCHEMA = 'connectshyft'
+apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts:39:        .withSchema(CONNECTSHYFT_SCHEMA)
+apps/connectshyft-api/src/modules/connectshyft/http/threadReadContext.ts:90:    code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/http/threadReadContext.ts:102:    code: 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/threadReadContext.ts:146:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/threadReadContext.ts:170:    code: 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/threadReadContext.ts:194:    code: 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:34:const CONNECTSHYFT_LIFECYCLE_EVENT_NAMES = {
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:39:const CONNECTSHYFT_ESCALATION_NOTIFICATION_EVENT_PREFIXES = [
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:57:const CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS: Record<string, ConnectShyftSyntheticThreadDescriptor> = {
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:324:const CONNECTSHYFT_DYNAMIC_C5_THREAD_PREFIX = 'thread-c5-unclaimed-';
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:325:const CONNECTSHYFT_DYNAMIC_C5_THREAD_TEMPLATE_ID = 'thread-c5-unclaimed-1001';
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:397:    return CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.claimed;
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:401:    return CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.takenOver;
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:404:  return CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.closed;
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:469:  const existing = CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[input.threadId];
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:501:      CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[input.threadId] = seededDescriptor;
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:506:  if (!input.threadId.startsWith(CONNECTSHYFT_DYNAMIC_C5_THREAD_PREFIX)) {
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:510:  const template = CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[CONNECTSHYFT_DYNAMIC_C5_THREAD_TEMPLATE_ID];
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:526:  CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[input.threadId] = dynamicDescriptor;
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:535:  const descriptor = CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS[thread.threadId];
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:586:    source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:740:        code: 'CONNECTSHYFT_LIFECYCLE_SIDE_EFFECTS_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:785:  if (transitioned.code !== 'CONNECTSHYFT_THREAD_NOT_FOUND' || !input.syntheticThread) {
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:835:        CONNECTSHYFT_ESCALATION_NOTIFICATION_EVENT_PREFIXES.forEach((prefix, index) => {
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:866:      code: 'CONNECTSHYFT_THREAD_CLAIM_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:876:      code: 'CONNECTSHYFT_THREAD_TAKEOVER_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:885:    code: 'CONNECTSHYFT_THREAD_CLOSE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:920:      code: 'CONNECTSHYFT_THREAD_CLAIMED',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:927:      code: 'CONNECTSHYFT_THREAD_TAKEOVER_READY',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:933:    code: 'CONNECTSHYFT_THREAD_CLOSED',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:963:      code: 'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:974:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:993:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:52:    code: 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:65:      ? 'CONNECTSHYFT_THREAD_CALL_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:66:      : 'CONNECTSHYFT_THREAD_MESSAGE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:77:    code: 'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:112:        : [CAPABILITIES.ORG_UNIT_SMS_SEND, CAPABILITIES.THREAD_TAKEOVER_ALL],
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:131:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:150:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectWebhookReceiptMetrics.ts:37:    code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_METRICS_LOADED',
+apps/connectshyft-api/src/modules/connectshyft/http/numberMappingContext.ts:75:    code: 'CONNECTSHYFT_NUMBER_MAPPING_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/numberMappingContext.ts:102:  if (!requestHasAnyCapability(req, [CAPABILITIES.NUMBER_MAPPING_MANAGE], contextDecision.context)) {
+apps/connectshyft-api/src/modules/connectshyft/http/numberMappingContext.ts:154:      code: 'CONNECTSHYFT_NUMBER_MAPPING_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:3:const CONNECTSHYFT_INBOUND_VOICE_FROM_KEYS = [
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:12:const CONNECTSHYFT_INBOUND_VOICE_TO_KEYS = [
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:21:const CONNECTSHYFT_INBOUND_VOICE_NEIGHBOR_KEYS = [
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:26:const CONNECTSHYFT_INBOUND_VOICE_RECORDING_URL_KEYS = [
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:31:const CONNECTSHYFT_INBOUND_VOICE_DURATION_KEYS = [
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:38:export const CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME = 'connectshyft.inbound.voice_voicemail_recorded' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:39:export const CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME = 'connectshyft.inbound.voice_fallback_recorded' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:40:export const CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME = 'connectshyft.voicemail.transcription_requested' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:41:export const CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME = 'connectshyft.voicemail.transcription_attached' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:42:export const CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME = 'connectshyft.voicemail.transcription' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:144:    | typeof CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:145:    | typeof CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:155:  queueName: typeof CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:206:    CONNECTSHYFT_INBOUND_VOICE_NEIGHBOR_KEYS,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:276:    | typeof CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:277:    | typeof CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:287:      eventName: CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:296:      eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:306:    eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:317:    | typeof CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:318:    | typeof CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:326:  const from = readFromSources(sources, CONNECTSHYFT_INBOUND_VOICE_FROM_KEYS);
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:327:  const to = readFromSources(sources, CONNECTSHYFT_INBOUND_VOICE_TO_KEYS);
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:328:  const recordingUrl = readFromSources(sources, CONNECTSHYFT_INBOUND_VOICE_RECORDING_URL_KEYS);
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:329:  const durationSeconds = readDurationFromSources(sources, CONNECTSHYFT_INBOUND_VOICE_DURATION_KEYS);
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:384:  queueName: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:410:  eventName: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/http/webhookReceiptAdminContext.ts:4:import { CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS } from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/http/webhookReceiptAdminContext.ts:13:const CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_DAYS_MAX = 3650;
+apps/connectshyft-api/src/modules/connectshyft/http/webhookReceiptAdminContext.ts:91:  fallback = CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS,
+apps/connectshyft-api/src/modules/connectshyft/http/webhookReceiptAdminContext.ts:98:  return Math.min(parsed, CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_DAYS_MAX);
+apps/connectshyft-api/src/modules/connectshyft/http/webhookReceiptAdminContext.ts:124:      CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS,
+apps/connectshyft-api/src/modules/connectshyft/http/webhookReceiptAdminContext.ts:133:    code: 'CONNECTSHYFT_NUMBER_MAPPING_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/webhookReceiptAdminContext.ts:159:  if (!requestHasAnyCapability(req, [CAPABILITIES.NUMBER_MAPPING_MANAGE], contextDecision.context)) {
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:92:- inbound SMS extraction
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:72:  code: 'CONNECTSHYFT_ESCALATION_CONFIG_SAVED';
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:85:    | 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_INTEGER'
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:86:    | 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_RANGE'
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:87:    | 'CONNECTSHYFT_ESCALATION_RECIPIENT_REQUIRED'
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:88:    | 'CONNECTSHYFT_ESCALATION_RECIPIENT_INVALID_ASSIGNMENT';
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:97:  code: 'CONNECTSHYFT_ESCALATION_CONFIG_FORBIDDEN';
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:174:  code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_INTEGER',
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:189:  code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_RANGE',
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:204:  code: 'CONNECTSHYFT_ESCALATION_RECIPIENT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:221:  code: 'CONNECTSHYFT_ESCALATION_RECIPIENT_INVALID_ASSIGNMENT',
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:230:  code: 'CONNECTSHYFT_ESCALATION_CONFIG_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/escalationConfig.ts:515:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_SAVED',
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:126:      | 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED'
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:127:      | 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE'
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:128:      | 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH';
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:138:      | 'CONNECTSHYFT_IDENTITY_MATCH_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:139:      | 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT'
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:141:      | 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:355:  code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:373:  code: 'CONNECTSHYFT_IDENTITY_MATCH_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:400:    ? 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED'
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:402:      ? 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH'
+apps/connectshyft-api/src/modules/connectshyft/identityBoundary.ts:403:      : 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:5:const SMS_OVERRIDE_TABLE = 'cs_sms_preference_overrides';
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:8:const SMS_OVERRIDE_PREFERENCE_CHECK = 'cs_sms_pref_override_pref_value_ck';
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:9:const SMS_OVERRIDE_REASON_CHECK = 'cs_sms_pref_override_reason_ck';
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:10:const SMS_OVERRIDE_SCOPE_INDEX = 'cs_sms_pref_override_scope_idx';
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:11:const SMS_OVERRIDE_REASON_INDEX = 'cs_sms_pref_override_reason_idx';
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:38:    CREATE TABLE IF NOT EXISTS connectshyft.${SMS_OVERRIDE_TABLE} (
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:61:        WHERE conname = '${SMS_OVERRIDE_PREFERENCE_CHECK}'
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:62:          AND conrelid = 'connectshyft.${SMS_OVERRIDE_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:64:        ALTER TABLE connectshyft.${SMS_OVERRIDE_TABLE}
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:65:          ADD CONSTRAINT ${SMS_OVERRIDE_PREFERENCE_CHECK}
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:77:        WHERE conname = '${SMS_OVERRIDE_REASON_CHECK}'
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:78:          AND conrelid = 'connectshyft.${SMS_OVERRIDE_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:80:        ALTER TABLE connectshyft.${SMS_OVERRIDE_TABLE}
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:81:          ADD CONSTRAINT ${SMS_OVERRIDE_REASON_CHECK}
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:95:    CREATE INDEX IF NOT EXISTS ${SMS_OVERRIDE_SCOPE_INDEX}
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:96:      ON connectshyft.${SMS_OVERRIDE_TABLE} (tenant_id, org_unit_id, thread_id, created_at_utc)
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:100:    CREATE INDEX IF NOT EXISTS ${SMS_OVERRIDE_REASON_INDEX}
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:101:      ON connectshyft.${SMS_OVERRIDE_TABLE} (tenant_id, override_reason, created_at_utc)
+apps/connectshyft-api/src/migrations/20260227123000_create_connectshyft_sms_preference_overrides.ts:106:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(SMS_OVERRIDE_TABLE);
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:11:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:16:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:21:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:26:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:31:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:36:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:41:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:46:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:51:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:56:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:61:    UPDATE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:88:    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:99:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:101:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:115:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:117:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:131:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:133:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:143:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:148:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:153:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:158:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:163:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:168:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:173:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:178:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:183:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:188:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:193:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:198:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/migrations/20260311100000_shape_connectshyft_neighbor_phones_for_canonical_identity.ts:203:    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE}
+apps/connectshyft-api/src/modules/connectshyft/http/escalationConfigContext.ts:46:    code: 'CONNECTSHYFT_ESCALATION_CONFIG_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/accessContext.ts:30:const CONNECTSHYFT_LEGACY_ROLE_ALIASES: Record<string, string> = {
+apps/connectshyft-api/src/modules/connectshyft/http/accessContext.ts:97:    const legacyAlias = CONNECTSHYFT_LEGACY_ROLE_ALIASES[normalizedBaseRole.toLowerCase()];
+apps/connectshyft-api/src/modules/connectshyft/http/accessContext.ts:387:    evaluation.code === 'CONNECTSHYFT_MODULE_DISABLED'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:2:  CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:25:      eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:81:      eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:18:const CONNECTSHYFT_SETTINGS_PRIMARY_OPTIONS: readonly ConnectShyftSettingsNavigationOption[] = [
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:46:const CONNECTSHYFT_SETTINGS_ADMIN_OPTIONS: readonly ConnectShyftSettingsNavigationOption[] = [
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:66:    ...CONNECTSHYFT_SETTINGS_PRIMARY_OPTIONS.map((option) => ({
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:70:    ...CONNECTSHYFT_SETTINGS_ADMIN_OPTIONS.map((option) => ({
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:81:  CAPABILITIES.NUMBER_MAPPING_MANAGE,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:100:  code: 'CONNECTSHYFT_SETTINGS_NAVIGATION_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:105:    primaryOptions: CONNECTSHYFT_SETTINGS_PRIMARY_OPTIONS,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:130:    code: 'CONNECTSHYFT_SETTINGS_NAVIGATION_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:133:      primaryOptions: CONNECTSHYFT_SETTINGS_PRIMARY_OPTIONS,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts:134:      adminOptions: adminAccess ? CONNECTSHYFT_SETTINGS_ADMIN_OPTIONS : [],
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:4:const PROVIDER_IDENTIFIER_MAPPINGS_TABLE = 'cs_provider_identifier_mappings';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:5:const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:7:const PROVIDER_IDENTIFIER_KIND_CHECK = 'cs_provider_identifier_mappings_kind_ck';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:8:const PROVIDER_IDENTIFIER_UNIQUE = 'cs_provider_identifier_mappings_provider_identifier_uq';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:9:const PROVIDER_IDENTIFIER_SCOPE_INDEX = 'connectshyft_cs_provider_identifier_mappings_scope_idx';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:11:const WEBHOOK_RECEIPT_IDENTIFIER_KIND_CHECK = 'cs_webhook_receipts_identifier_kind_ck';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:12:const WEBHOOK_RECEIPT_IDENTIFIER_PRESENCE_CHECK = 'cs_webhook_receipts_identifier_presence_ck';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:13:const WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE = 'cs_webhook_receipts_provider_dedupe_uq';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:14:const WEBHOOK_RECEIPT_SCOPE_INDEX = 'connectshyft_cs_webhook_receipts_scope_idx';
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:17:  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}`);
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:20:    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE} (
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:39:        WHERE conname = '${PROVIDER_IDENTIFIER_KIND_CHECK}'
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:40:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:42:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:43:          ADD CONSTRAINT ${PROVIDER_IDENTIFIER_KIND_CHECK}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:55:        WHERE conname = '${PROVIDER_IDENTIFIER_UNIQUE}'
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:56:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:58:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:59:          ADD CONSTRAINT ${PROVIDER_IDENTIFIER_UNIQUE}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:66:    CREATE INDEX IF NOT EXISTS ${PROVIDER_IDENTIFIER_SCOPE_INDEX}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:67:      ON ${CONNECTSHYFT_SCHEMA}.${PROVIDER_IDENTIFIER_MAPPINGS_TABLE} (
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:77:    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE} (
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:98:        WHERE conname = '${WEBHOOK_RECEIPT_IDENTIFIER_KIND_CHECK}'
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:99:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:101:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:102:          ADD CONSTRAINT ${WEBHOOK_RECEIPT_IDENTIFIER_KIND_CHECK}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:117:        WHERE conname = '${WEBHOOK_RECEIPT_IDENTIFIER_PRESENCE_CHECK}'
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:118:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:120:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:121:          ADD CONSTRAINT ${WEBHOOK_RECEIPT_IDENTIFIER_PRESENCE_CHECK}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:136:        WHERE conname = '${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE}'
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:137:          AND conrelid = '${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:139:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:140:          ADD CONSTRAINT ${WEBHOOK_RECEIPT_PROVIDER_DEDUPE_UNIQUE}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:147:    CREATE INDEX IF NOT EXISTS ${WEBHOOK_RECEIPT_SCOPE_INDEX}
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:148:      ON ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE} (
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:159:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(WEBHOOK_RECEIPTS_TABLE);
+apps/connectshyft-api/src/migrations/20260228103000_create_connectshyft_provider_correlation_mappings.ts:160:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(PROVIDER_IDENTIFIER_MAPPINGS_TABLE);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:3:import { CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS } from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:135:      [CAPABILITIES.NUMBER_MAPPING_MANAGE],
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:159:        policyWindowDays: CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:196:      code: 'CONNECTSHYFT_NUMBER_MAPPING_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:30:const NEIGHBOR_RELATIONSHIP_REQUIRED_CODE = 'CONNECTSHYFT_NEIGHBOR_EDIT_RELATIONSHIP_REQUIRED';
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:32:const NEIGHBOR_MERGE_FORBIDDEN_CODE = 'CONNECTSHYFT_NEIGHBOR_MERGE_FORBIDDEN';
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:34:const NEIGHBOR_MERGE_TRANSACTION_ABORTED_CODE = 'CONNECTSHYFT_NEIGHBOR_MERGE_TRANSACTION_ABORTED';
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:605:    process.env.CONNECTSHYFT_CONTACT_HASH_SECRET,
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:606:    process.env.CONNECTSHYFT_AUDIT_HASH_SECRET,
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:607:    process.env.JWT_SECRET,
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:608:    process.env.DB_PASSWORD,
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:618:const CONNECTSHYFT_CONTACT_HASH_SECRET = resolveIdentityContactHashSecret();
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:621:  `hmac-sha256:${createHmac('sha256', CONNECTSHYFT_CONTACT_HASH_SECRET).update(value).digest('hex')}`;
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:771:    code: 'CONNECTSHYFT_NEIGHBOR_UPDATED';
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:848:      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:865:      code: 'CONNECTSHYFT_NEIGHBOR_UPDATE_SIDE_EFFECTS_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:881:    code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED';
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:987:      code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:998:        code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1016:      code: 'CONNECTSHYFT_NEIGHBOR_DELETE_SIDE_EFFECTS_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1039:    code: 'CONNECTSHYFT_NEIGHBOR_MERGED';
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1113:      code: 'CONNECTSHYFT_NEIGHBOR_MERGED',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1149:    code: 'CONNECTSHYFT_NEIGHBOR_CREATE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1173:    code: 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1195:    code: 'CONNECTSHYFT_NEIGHBOR_UPDATE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1211:    code: 'CONNECTSHYFT_NEIGHBOR_DELETE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1321:      code: 'CONNECTSHYFT_NEIGHBOR_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1342:      code: 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1392:      code: 'CONNECTSHYFT_NEIGHBOR_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1459:      code: 'CONNECTSHYFT_NEIGHBOR_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1480:      code: 'CONNECTSHYFT_ACTOR_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1551:  if (code === 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED') {
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1554:  if (code === 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH') {
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectEscalationRecipients.ts:19:    code: 'CONNECTSHYFT_ESCALATION_RECIPIENTS_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:36:      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:37:      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:38:      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:39:      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:40:      | 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:109:    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:110:    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:111:    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:112:    | 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:117:      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_IDENTIFIERS_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:123:      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:129:      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:135:    code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:188:        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:241:          code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:253:        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_LOOKUP_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:266:        code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:298:      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_CONFLICT',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:355:    const signatureMessageKey = signatureDecision.refusal.code === 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MISSING'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:357:      : signatureDecision.refusal.code === 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:6:const DATABASE_URL = process.env.MONEYSHYFT_TEST_DATABASE_URL;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:62:        source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:74:      source: 'SMS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:91:    expect(result.thread.source).toBe('SMS');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:122:        source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:145:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:190:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:230:      source: 'SMS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:266:      source: 'SMS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:317:      source: 'SMS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:348:      code: 'CONNECTSHYFT_SENDER_ALIGNMENT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:365:        source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:377:        source: 'SMS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/escalationConfig.test.ts:62:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_SAVED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/escalationConfig.test.ts:85:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_SAVED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/escalationConfig.test.ts:108:      code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_INTEGER',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/escalationConfig.test.ts:136:      code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_RANGE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/escalationConfig.test.ts:164:      code: 'CONNECTSHYFT_ESCALATION_RECIPIENT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/escalationConfig.test.ts:192:      code: 'CONNECTSHYFT_ESCALATION_RECIPIENT_INVALID_ASSIGNMENT',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/escalationConfig.test.ts:235:      code: 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_RANGE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/escalationConfig.test.ts:263:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectAvailability.ts:17:  CAPABILITIES.NUMBER_MAPPING_MANAGE,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectAvailability.ts:46:    code: 'CONNECTSHYFT_AVAILABILITY_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectAvailability.ts:72:    code: 'CONNECTSHYFT_AVAILABILITY_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:33:- SMS preference override validation and persistence
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:66:- inbound SMS extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:73:- idempotency, audit, sender-resolution, or SMS-override redesign
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:83:5. Do not fold provider, bridge, reliability, audit, or SMS-override internals into the thin handlers or helper boundary.
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:8:const ORIGINAL_ENV = { ...process.env };
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:10:  'CONNECTSHYFT_ENABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:11:  'CONNECTSHYFT_INBOX_ENABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:12:  'CONNECTSHYFT_ESCALATION_ENABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:13:  'CONNECTSHYFT_WEBHOOKS_ENABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:14:  'ENABLE_TEST_CONNECTSHYFT_FLAGS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:19:    delete process.env[key];
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:39:    process.env = ORIGINAL_ENV;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:53:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:54:    process.env.CONNECTSHYFT_INBOX_ENABLED = '1';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:55:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'off';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:56:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'enabled';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:68:    process.env.CONNECTSHYFT_ENABLED = 'false';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:69:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'false';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:70:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'false';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:71:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'false';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:89:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:90:    process.env.CONNECTSHYFT_ENABLED = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:91:    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:92:    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'false';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:93:    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:105:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:123:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:152:      code: 'CONNECTSHYFT_MODULE_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:169:      code: 'CONNECTSHYFT_ESCALATION_CAPABILITY_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:2:  CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:3:  CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:4:  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:5:  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:28:      eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:36:      eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:61:      eventName: CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:70:      eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:79:      eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:91:      eventName: CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:108:      eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:134:      queueName: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:150:      eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:231:      eventName: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadTimeline.ts:36:    code: 'CONNECTSHYFT_THREAD_TIMELINE_LOADED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:183:      code: 'CONNECTSHYFT_NUMBER_MAPPING_INVALID_E164',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:217:      code: 'CONNECTSHYFT_NUMBER_MAPPING_DUPLICATE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:266:    expect(updated.code).toBe('CONNECTSHYFT_NUMBER_MAPPING_UPDATED');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:330:      code: 'CONNECTSHYFT_NUMBER_MAPPING_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:346:      code: 'CONNECTSHYFT_NUMBER_MAPPING_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:361:      code: 'CONNECTSHYFT_NUMBER_MAPPING_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:19:const CONNECTSHYFT_INBOX_P95_BUDGET_MS = 750;
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:20:const CONNECTSHYFT_INBOX_P99_BUDGET_MS = 1500;
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:33:      code: 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:52:      code: 'CONNECTSHYFT_ACTOR_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:73:      ? 'CONNECTSHYFT_MINE_LISTED'
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:74:      : 'CONNECTSHYFT_INBOX_LISTED')
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:75:    : 'CONNECTSHYFT_INBOX_READY';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:99:        p95: CONNECTSHYFT_INBOX_P95_BUDGET_MS,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectInbox.ts:100:        p99: CONNECTSHYFT_INBOX_P99_BUDGET_MS,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectContext.ts:21:    code: 'CONNECTSHYFT_CONTEXT_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNeighborMerge.ts:19:      code: 'CONNECTSHYFT_NEIGHBOR_MERGE_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.escalationConfigContext.test.ts:163:      code: 'CONNECTSHYFT_ESCALATION_CONFIG_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.escalationConfigContext.test.ts:174:      code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.escalationConfigContext.test.ts:190:        code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookReceiptCleanup.ts:39:    code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_APPLIED',
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:4:const CONNECTSHYFT_INBOUND_SMS_MESSAGE_BODY_KEYS = [
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:11:const CONNECTSHYFT_INBOUND_SMS_FROM_KEYS = [
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:20:const CONNECTSHYFT_INBOUND_SMS_TO_KEYS = [
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:29:const CONNECTSHYFT_INBOUND_SMS_NEIGHBOR_KEYS = [
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:33:export const CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME = 'connectshyft.inbound.sms_appended' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:43:    code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED' | 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT';
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:106:  eventName: typeof CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:119:    CONNECTSHYFT_INBOUND_SMS_NEIGHBOR_KEYS,
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:128:    CONNECTSHYFT_INBOUND_SMS_FROM_KEYS,
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:134:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:135:      message: 'Inbound SMS processing requires a sender phone number.',
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:146:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:147:      message: 'Inbound SMS processing requires a valid sender phone number.',
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:166:  const body = readFromSources(sources, CONNECTSHYFT_INBOUND_SMS_MESSAGE_BODY_KEYS) || '';
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:167:  const from = readFromSources(sources, CONNECTSHYFT_INBOUND_SMS_FROM_KEYS);
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:168:  const to = readFromSources(sources, CONNECTSHYFT_INBOUND_SMS_TO_KEYS);
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:171:    eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:45:    previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:46:    previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:47:    previousTelnyxPublicKey = process.env.TELNYX_PUBLIC_KEY;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:48:    previousProviderRolloutAllowlist = process.env.CONNECTSHYFT_PROVIDER_ROLLOUT_ALLOWLIST;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:49:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:50:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:51:    delete process.env.CONNECTSHYFT_PROVIDER_ROLLOUT_ALLOWLIST;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:55:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:56:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:57:    process.env.TELNYX_PUBLIC_KEY = previousTelnyxPublicKey;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:58:    process.env.CONNECTSHYFT_PROVIDER_ROLLOUT_ALLOWLIST = previousProviderRolloutAllowlist;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:104:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:147:      code: 'CONNECTSHYFT_PROVIDER_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:199:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:274:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:333:      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:540:      code: 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:612:        code: 'WEBHOOK_SIGNATURE_MISSING',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:691:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'false';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:707:    process.env.TELNYX_PUBLIC_KEY = generateKeyPairSync('ed25519').publicKey.export({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:726:        code: 'WEBHOOK_SIGNATURE_MISSING',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:733:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'false';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:736:    process.env.TELNYX_PUBLIC_KEY = publicKey.export({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:788:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'false';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:791:    process.env.TELNYX_PUBLIC_KEY = publicKey.export({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:842:        code: 'WEBHOOK_SIGNATURE_INVALID',
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:4:const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:13:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:14:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:16:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:25:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:26:        UPDATE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:31:        UPDATE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:35:        UPDATE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:39:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:41:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:50:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:51:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:58:            AND conrelid = '${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:60:          ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:70:      ON ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE} (
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:81:    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${RETENTION_LOOKUP_INDEX}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:87:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:88:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:95:            AND conrelid = '${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:97:          ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:102:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303170000_add_connectshyft_webhook_receipt_replay_identity.ts:104:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectNumberMappings.ts:14:    code: 'CONNECTSHYFT_NUMBER_MAPPINGS_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectEscalationConfig.ts:26:    code: 'CONNECTSHYFT_ESCALATION_CONFIG_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:11:  - owns the currently registered inbound webhook core execution path that preserves the existing inbound SMS, inbound voice, voicemail, transcription callback, and auto-claim behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:15:  - owns SMS-webhook route handoff and delegates execution through the shared helper boundary with deterministic `sms` route preparation
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:38:- inbound SMS domain mapping and neighbor-resolution behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:63:- current inbound SMS handling and neighbor-resolution semantics
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:194:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:254:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:289:        CAPABILITIES.ORG_UNIT_SMS_SEND,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:273:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH' as const,
+apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts:12:const CONNECTSHYFT_SCHEMA = 'connectshyft'
+apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts:187:        .withSchema(CONNECTSHYFT_SCHEMA)
+apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts:199:      await knex.withSchema(CONNECTSHYFT_SCHEMA).table(IDEMPOTENCY_TABLE).insert(toRow(record))
+apps/connectshyft-api/src/modules/connectshyft/communicationReliability.ts:203:        .withSchema(CONNECTSHYFT_SCHEMA)
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:9:  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:25:const CONNECTSHYFT_CANONICAL_EVENTS_MAX_LIMIT = 200;
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:26:const CONNECTSHYFT_INBOX_P95_BUDGET_MS = 750;
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:27:const CONNECTSHYFT_INBOX_P99_BUDGET_MS = 1500;
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:201:    if (event.eventName !== CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME) {
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:287:    limit: CONNECTSHYFT_CANONICAL_EVENTS_MAX_LIMIT,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:332:    code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:350:        p95: CONNECTSHYFT_INBOX_P95_BUDGET_MS,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:351:        p99: CONNECTSHYFT_INBOX_P99_BUDGET_MS,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts:39:      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts:68:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts:126:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityBoundary.test.ts:158:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:63:    | 'CONNECTSHYFT_NUMBER_MAPPING_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:64:    | 'CONNECTSHYFT_NUMBER_MAPPING_INVALID_E164'
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:65:    | 'CONNECTSHYFT_NUMBER_MAPPING_DUPLICATE'
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:66:    | 'CONNECTSHYFT_NUMBER_MAPPING_ID_CONFLICT'
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:67:    | 'CONNECTSHYFT_NUMBER_MAPPING_NOT_FOUND'
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:68:    | 'CONNECTSHYFT_NUMBER_MAPPING_SCOPE_VIOLATION';
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:78:    code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED' | 'CONNECTSHYFT_NUMBER_MAPPING_UPDATED';
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:121:  code: 'CONNECTSHYFT_NUMBER_MAPPING_INVALID_E164',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:136:  code: 'CONNECTSHYFT_NUMBER_MAPPING_DUPLICATE',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:151:  code: 'CONNECTSHYFT_NUMBER_MAPPING_ID_CONFLICT',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:157:  code: 'CONNECTSHYFT_NUMBER_MAPPING_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:163:  code: 'CONNECTSHYFT_NUMBER_MAPPING_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:612:    if (!hasCapability(input.actorRoles, CAPABILITIES.NUMBER_MAPPING_MANAGE)) {
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:644:      code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:658:    if (!hasCapability(input.actorRoles, CAPABILITIES.NUMBER_MAPPING_MANAGE)) {
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:675:        code: 'CONNECTSHYFT_NUMBER_MAPPING_SCOPE_VIOLATION',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:708:      code: 'CONNECTSHYFT_NUMBER_MAPPING_UPDATED',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:826:    if (!hasCapability(input.actorRoles, CAPABILITIES.NUMBER_MAPPING_MANAGE)) {
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:859:        code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:879:    if (!hasCapability(input.actorRoles, CAPABILITIES.NUMBER_MAPPING_MANAGE)) {
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:897:          code: 'CONNECTSHYFT_NUMBER_MAPPING_SCOPE_VIOLATION',
+apps/connectshyft-api/src/modules/connectshyft/numberMappings.ts:930:        code: 'CONNECTSHYFT_NUMBER_MAPPING_UPDATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:9:  const originalEnv = process.env;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:14:    process.env = { ...originalEnv };
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:20:    process.env = originalEnv;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:40:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:77:    process.env.CONNECTSHYFT_PHONE_DEFAULT_AREA_CODE = '260';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:95:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:168:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:215:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:265:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:355:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:442:      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:499:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:528:      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:582:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:627:      code: 'CONNECTSHYFT_NEIGHBOR_DELETE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:639:      code: 'CONNECTSHYFT_NEIGHBOR_DELETE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:652:      code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:693:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:723:      code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:774:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:829:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:839:  it('promotes UNKNOWN texting preference to YES on inbound SMS only', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:906:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:935:      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:964:      code: 'CONNECTSHYFT_NEIGHBOR_CREATE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1002:      code: 'CONNECTSHYFT_NEIGHBOR_CREATE_CONFLICT',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1039:      code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1063:      code: 'CONNECTSHYFT_NEIGHBORS_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1133:      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1265:      code: 'CONNECTSHYFT_NEIGHBOR_EDIT_RELATIONSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1296:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1316:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1369:      code: 'CONNECTSHYFT_NEIGHBOR_MERGED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1386:      code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1396:      code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1424:      code: 'CONNECTSHYFT_NEIGHBOR_MERGE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1444:      code: 'CONNECTSHYFT_NEIGHBOR_MERGE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1464:      code: 'CONNECTSHYFT_NEIGHBOR_MERGE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1502:      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1550:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1593:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1671:        code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH' as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1742:      code: 'CONNECTSHYFT_NEIGHBOR_CREATE_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1825:      code: 'CONNECTSHYFT_NEIGHBOR_CREATE_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1835:      code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1844:      code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1863:      code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1875:      code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1890:      code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1929:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:1951:      code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:139:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_MATCH',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:235:      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:557:      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:620:      code: 'CONNECTSHYFT_IDENTITY_MATCH_AUTO_MERGE_ALLOWED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:659:      code: 'CONNECTSHYFT_IDENTITY_MATCH_NO_AUTO_MERGE',
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft'
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:6:const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts'
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:9:  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}`)
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:12:    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${IDEMPOTENCY_TABLE} (
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:46:    ON ${CONNECTSHYFT_SCHEMA}.${IDEMPOTENCY_TABLE} (
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:56:    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${AUDIT_TABLE} (
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:89:    ON ${CONNECTSHYFT_SCHEMA}.${AUDIT_TABLE} (
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:98:    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:103:    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:110:    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:115:    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:119:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(AUDIT_TABLE)
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:120:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(IDEMPOTENCY_TABLE)
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:69:- inbound SMS or voice rewrites
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:24:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:31:      code: 'CONNECTSHYFT_THREAD_ENSURED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:69:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:78:      code: 'CONNECTSHYFT_THREAD_TRANSITION_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:89:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:100:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:135:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:147:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:171:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:179:      code: 'CONNECTSHYFT_THREAD_STATE_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:190:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:201:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:212:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:244:      source: 'SMS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:273:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:364:      code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:379:      code: 'CONNECTSHYFT_THREAD_OWNERSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:413:        code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:429:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:454:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:486:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:493:      code: 'CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:514:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:532:      code: 'CONNECTSHYFT_ESCALATION_EVALUATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:608:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:636:      code: 'CONNECTSHYFT_ESCALATION_EVALUATED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:653:      source: 'VOICE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:719:      source: 'SMS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:775:      source: 'SMS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:804:      code: 'CONNECTSHYFT_SENDER_ALIGNMENT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:55:export const CONNECTSHYFT_NEIGHBOR_MERGE_CONFIRMATION_PHRASE = 'IRREVERSIBLE MERGE';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:56:const CONNECTSHYFT_INBOUND_NEIGHBOR_AUDIT_OPERATION_NAME = 'connectshyft.inbound.neighbor_created';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:57:const CONNECTSHYFT_PHONE_DUPLICATE_INDEX = 'connectshyft_cs_neighbor_phones_current_unique_e164_uq';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:58:const CONNECTSHYFT_PHONE_DUPLICATE_MESSAGE = 'That phone number is already assigned to another current neighbor.';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:258:    | 'CONNECTSHYFT_NEIGHBOR_CREATE_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:259:    | 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:260:    | 'CONNECTSHYFT_NEIGHBOR_UPDATE_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:261:    | 'CONNECTSHYFT_NEIGHBOR_DELETE_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:262:    | 'CONNECTSHYFT_NEIGHBOR_DELETE_CONFIRMATION_REQUIRED'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:263:    | 'CONNECTSHYFT_NEIGHBOR_EDIT_RELATIONSHIP_REQUIRED'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:264:    | 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:265:    | 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:266:    | 'CONNECTSHYFT_PHONE_DUPLICATE'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:267:    | 'CONNECTSHYFT_NEIGHBOR_CREATE_CONFLICT'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:268:    | 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:269:    | 'CONNECTSHYFT_NEIGHBOR_MERGE_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:270:    | 'CONNECTSHYFT_NEIGHBOR_MERGE_CONFIRMATION_REQUIRED'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:271:    | 'CONNECTSHYFT_NEIGHBOR_MERGE_INVALID'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:272:    | 'CONNECTSHYFT_IDENTITY_MATCH_FORBIDDEN'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:274:    | 'CONNECTSHYFT_ORGUNIT_TENANT_MISMATCH'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:275:    | 'CONNECTSHYFT_NEIGHBOR_CREATE_PERSISTENCE_UNAVAILABLE'
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:276:    | 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:284:    code: 'CONNECTSHYFT_NEIGHBOR_CREATED';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:295:    code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:306:    code: 'CONNECTSHYFT_NEIGHBORS_RESOLVED';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:317:    code: 'CONNECTSHYFT_NEIGHBOR_UPDATED';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:328:    code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:340:    code: 'CONNECTSHYFT_NEIGHBOR_MERGED';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:387:  code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:402:  code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:417:  code: 'CONNECTSHYFT_PHONE_DUPLICATE',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:418:  message: CONNECTSHYFT_PHONE_DUPLICATE_MESSAGE,
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:425:        message: CONNECTSHYFT_PHONE_DUPLICATE_MESSAGE,
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:433:  code: 'CONNECTSHYFT_NEIGHBOR_CREATE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:439:  code: 'CONNECTSHYFT_NEIGHBOR_READ_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:445:  code: 'CONNECTSHYFT_NEIGHBOR_UPDATE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:451:  code: 'CONNECTSHYFT_NEIGHBOR_DELETE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:457:  code: 'CONNECTSHYFT_NEIGHBOR_DELETE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:463:  code: 'CONNECTSHYFT_NEIGHBOR_MERGE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:469:  code: 'CONNECTSHYFT_NEIGHBOR_MERGE_CONFIRMATION_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:475:  code: 'CONNECTSHYFT_NEIGHBOR_MERGE_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:481:  code: 'CONNECTSHYFT_NEIGHBOR_EDIT_RELATIONSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:487:  code: 'CONNECTSHYFT_NEIGHBOR_CREATE_CONFLICT',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:493:  code: 'CONNECTSHYFT_NEIGHBOR_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:499:  code: 'CONNECTSHYFT_NEIGHBOR_CREATE_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:505:  code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:511:  code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:585:  return candidate.code === '23505' && candidate.constraint === CONNECTSHYFT_PHONE_DUPLICATE_INDEX;
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:613:    && confirmation.phrase === CONNECTSHYFT_NEIGHBOR_MERGE_CONFIRMATION_PHRASE;
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2398:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2428:      code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2480:      code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2514:      code: 'CONNECTSHYFT_NEIGHBORS_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2544:      code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2594:      code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2641:      code: 'CONNECTSHYFT_NEIGHBOR_MERGED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2772:        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2814:        code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2878:        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2937:        code: 'CONNECTSHYFT_NEIGHBORS_RESOLVED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:2979:        code: 'CONNECTSHYFT_NEIGHBOR_SOFT_DELETED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3037:        code: 'CONNECTSHYFT_NEIGHBOR_UPDATED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3099:        code: 'CONNECTSHYFT_NEIGHBOR_MERGED',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3142:    operationName: CONNECTSHYFT_INBOUND_NEIGHBOR_AUDIT_OPERATION_NAME,
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3148:    resultMessage: 'Created inbound SMS neighbor from unmatched sender phone.',
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:49:- inbound SMS and inbound voice extraction
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:104:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:105:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:114:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:115:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:141:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:142:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:230:      code: 'CONNECTSHYFT_NEIGHBOR_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:251:      code: 'CONNECTSHYFT_NEIGHBOR_UPDATE_FORBIDDEN',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:271:      code: 'CONNECTSHYFT_NEIGHBOR_MERGE_FORBIDDEN',
+apps/connectshyft-api/src/migrations/20260304100000_add_connectshyft_neighbor_phone_lookup_index.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260304100000_add_connectshyft_neighbor_phone_lookup_index.ts:10:    ON ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} (tenant_id, value_e164, neighbor_id, sort_order, id)
+apps/connectshyft-api/src/migrations/20260304100000_add_connectshyft_neighbor_phone_lookup_index.ts:16:    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_LOOKUP_INDEX}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:4:const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:5:const WEBHOOK_RECEIPT_PROCESSING_STATUS_CHECK = 'cs_webhook_receipts_processing_status_ck';
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:6:const WEBHOOK_RECEIPT_PROCESSING_STATUS_INDEX = 'connectshyft_cs_webhook_receipts_processing_status_idx';
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:12:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:13:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:15:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:17:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:19:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:21:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:23:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:32:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:33:        UPDATE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:50:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:54:          WHERE conname = '${WEBHOOK_RECEIPT_PROCESSING_STATUS_CHECK}'
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:55:            AND conrelid = '${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}'::regclass
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:57:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:58:          ADD CONSTRAINT ${WEBHOOK_RECEIPT_PROCESSING_STATUS_CHECK}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:65:    CREATE INDEX IF NOT EXISTS ${WEBHOOK_RECEIPT_PROCESSING_STATUS_INDEX}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:66:      ON ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE} (
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:80:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:81:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:82:          DROP CONSTRAINT IF EXISTS ${WEBHOOK_RECEIPT_PROCESSING_STATUS_CHECK};
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:88:    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPT_PROCESSING_STATUS_INDEX}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:94:      IF to_regclass('${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}') IS NOT NULL THEN
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:95:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:97:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:99:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:101:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:103:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/migrations/20260303153000_add_connectshyft_webhook_receipt_processing_state.ts:105:        ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${WEBHOOK_RECEIPTS_TABLE}
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:56:- inbound SMS extraction
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:578:    expect(mappingResult.errorCode).toBe('CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:596:        code: 'CONNECTSHYFT_WEBHOOK_RECEIPT_PERSISTENCE_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:66:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:67:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:76:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:77:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:108:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:109:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:176:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:212:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:237:      code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID',
+apps/connectshyft-api/src/migrations/20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.ts:10:    ON ${CONNECTSHYFT_SCHEMA}.${NEIGHBOR_PHONES_TABLE} (tenant_id, normalized_e164, neighbor_id, sort_order, id)
+apps/connectshyft-api/src/migrations/20260311103000_add_connectshyft_neighbor_canonical_phone_lookup_index.ts:16:    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${CANONICAL_LOOKUP_INDEX}
+apps/connectshyft-api/src/migrations/20260224113000_create_connectshyft_neighbors.ts:3:const CONNECTSHYFT_SCHEMA = 'connectshyft';
+apps/connectshyft-api/src/migrations/20260224113000_create_connectshyft_neighbors.ts:104:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(NEIGHBOR_PHONES_TABLE);
+apps/connectshyft-api/src/migrations/20260224113000_create_connectshyft_neighbors.ts:105:  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(NEIGHBORS_TABLE);
+apps/connectshyft-api/src/migrations/20260223153000_admin_console_integrity_foundation.ts:5:const NUMBER_MAPPINGS_UNIQUE_NUMBER = 'cs_number_mappings_tenant_number_uq';
+apps/connectshyft-api/src/migrations/20260223153000_admin_console_integrity_foundation.ts:6:const NUMBER_MAPPINGS_UNIQUE_ID = 'cs_number_mappings_tenant_mapping_uq';
+apps/connectshyft-api/src/migrations/20260223153000_admin_console_integrity_foundation.ts:136:    ADD CONSTRAINT ${NUMBER_MAPPINGS_UNIQUE_NUMBER}
+apps/connectshyft-api/src/migrations/20260223153000_admin_console_integrity_foundation.ts:142:    ADD CONSTRAINT ${NUMBER_MAPPINGS_UNIQUE_ID}
+apps/connectshyft-api/src/migrations/20260223153000_admin_console_integrity_foundation.ts:198:  await knex.raw(`ALTER TABLE connectshyft.cs_number_mappings DROP CONSTRAINT IF EXISTS ${NUMBER_MAPPINGS_UNIQUE_NUMBER}`);
+apps/connectshyft-api/src/migrations/20260223153000_admin_console_integrity_foundation.ts:199:  await knex.raw(`ALTER TABLE connectshyft.cs_number_mappings DROP CONSTRAINT IF EXISTS ${NUMBER_MAPPINGS_UNIQUE_ID}`);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadReadContext.test.ts:142:      code: 'CONNECTSHYFT_THREAD_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadReadContext.test.ts:161:      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.accessContext.test.ts:91:  const previousNodeEnv = process.env.NODE_ENV;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.accessContext.test.ts:92:  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.accessContext.test.ts:95:    process.env.NODE_ENV = 'test';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.accessContext.test.ts:96:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.accessContext.test.ts:104:    process.env.NODE_ENV = previousNodeEnv;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.accessContext.test.ts:105:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.accessContext.test.ts:140:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.accessContext.test.ts:154:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.accessContext.test.ts:165:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:9:  source: overrides.source ?? 'SMS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:88:      code: 'CONNECTSHYFT_SENDER_ALIGNMENT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:117:      code: 'CONNECTSHYFT_SENDER_ALIGNMENT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:167:      code: 'CONNECTSHYFT_SENDER_MAPPING_AMBIGUOUS',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:145:  it('returns the scoped webhook prerequisites for a valid SMS webhook request', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:241:          code: 'WEBHOOK_SIGNATURE_MISSING',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:264:      code: 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MISSING',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:326:      throw new Error('Inbound SMS domain mapping should not run during inbound helper preparation.');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:84:  const previousNodeEnv = process.env.NODE_ENV
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:85:  const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:88:    process.env.NODE_ENV = 'test'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:89:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:105:    process.env.NODE_ENV = previousNodeEnv
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:106:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:62:    delete process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:66:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:71:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:78:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:83:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_INVALID',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:90:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:97:      code: 'CONNECTSHYFT_ORGUNIT_TENANT_MISMATCH',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:104:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:115:      code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:122:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:135:      code: 'CONNECTSHYFT_ORGUNIT_MEMBERSHIP_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:142:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:166:    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:196:      code: 'CONNECTSHYFT_ORGUNIT_ACCESS_VALIDATION_UNAVAILABLE',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/contextAccess.test.ts:218:      code: 'CONNECTSHYFT_ORGUNIT_TENANT_MISMATCH',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.numberMappingContext.test.ts:142:      [CAPABILITIES.NUMBER_MAPPING_MANAGE],
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.numberMappingContext.test.ts:163:      code: 'CONNECTSHYFT_NUMBER_MAPPING_ID_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.numberMappingContext.test.ts:176:      code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.numberMappingContext.test.ts:192:        code: 'CONNECTSHYFT_ORGUNIT_CONTEXT_REQUIRED',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:2:import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../inboundSms';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:4:  CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:5:  CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:8:  CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:9:  CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:25:      eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:31:        eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:65:        eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:142:          eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:148:            eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:158:          eventType: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:164:            eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:174:          eventType: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:180:            eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:236:        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:242:          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:252:        eventType: CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:258:          eventName: CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.started,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:265:        eventType: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:270:          eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:282:        eventType: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:287:          eventName: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,

--- a/slice15-full-connectshyft-api-test.txt
+++ b/slice15-full-connectshyft-api-test.txt
@@ -1,0 +1,74 @@
+
+> moneyshyft-monorepo@0.3.6 nx /Users/jeremiahotis/projects/connectshyft
+> node scripts/nx-shim.mjs "run" "connectshyft-api:test"
+
+
+> connectshyft-api@0.3.6 test:integration
+> NODE_ENV=test CONNECTSHYFT_MINIMAL_APP=1 jest --runInBand --config jest.config.js --runTestsByPath ../../tests/integration/connectshyft-api/health.test.ts ../../tests/integration/connectshyft-api/work-intents.test.ts ../../tests/integration/peoplecore/contact-points.test.ts ../../tests/integration/peoplecore/identity-decision.test.ts ../../tests/integration/peoplecore/resolver-reviews.test.ts
+
+PASS ../../tests/integration/peoplecore/contact-points.test.ts
+  ● Console
+
+    console.log
+      [32minfo[39m: POST /people/contact-points {"service":"connectshyft-api","timestamp":"2026-03-21T21:23:03.521Z"}
+
+      at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+
+    console.log
+      [32minfo[39m: GET /people/contact-points {"service":"connectshyft-api","timestamp":"2026-03-21T21:23:03.534Z"}
+
+      at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+
+    console.log
+      [32minfo[39m: POST /people/contact-point-links {"service":"connectshyft-api","timestamp":"2026-03-21T21:23:03.539Z"}
+
+      at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+
+PASS ../../tests/integration/peoplecore/resolver-reviews.test.ts
+  ● Console
+
+    console.log
+      [32minfo[39m: POST /people/resolver-reviews {"service":"connectshyft-api","timestamp":"2026-03-21T21:23:03.627Z"}
+
+      at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+
+    console.log
+      [32minfo[39m: GET /people/resolver-reviews {"service":"connectshyft-api","timestamp":"2026-03-21T21:23:03.630Z"}
+
+      at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+
+PASS ../../tests/integration/connectshyft-api/health.test.ts
+  ● Console
+
+    console.log
+      [32minfo[39m: GET /health {"service":"connectshyft-api","timestamp":"2026-03-21T21:23:03.699Z"}
+
+      at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+
+PASS ../../tests/integration/peoplecore/identity-decision.test.ts
+  ● Console
+
+    console.log
+      [32minfo[39m: POST /people/identity/decision {"service":"connectshyft-api","timestamp":"2026-03-21T21:23:03.766Z"}
+
+      at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+
+    console.log
+      [32minfo[39m: POST /people/identity/decision {"service":"connectshyft-api","timestamp":"2026-03-21T21:23:03.771Z"}
+
+      at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+
+PASS ../../tests/integration/connectshyft-api/work-intents.test.ts
+  ● Console
+
+    console.log
+      [32minfo[39m: POST /work-intents {"service":"connectshyft-api","timestamp":"2026-03-21T21:23:03.835Z"}
+
+      at Console.log (../../node_modules/.pnpm/winston@3.19.0/node_modules/winston/lib/winston/transports/console.js:87:23)
+
+
+Test Suites: 5 passed, 5 total
+Tests:       6 passed, 6 total
+Snapshots:   0 total
+Time:        1.673 s, estimated 2 s
+Ran all test suites within paths "../../tests/integration/connectshyft-api/health.test.ts", "../../tests/integration/connectshyft-api/work-intents.test.ts", "../../tests/integration/peoplecore/contact-points.test.ts", "../../tests/integration/peoplecore/identity-decision.test.ts", "../../tests/integration/peoplecore/resolver-reviews.test.ts".

--- a/slice15-router-endpoints.txt
+++ b/slice15-router-endpoints.txt
@@ -1,0 +1,34 @@
+3960:router.get('/settings/navigation', getConnectSettingsNavigation);
+3962:router.get('/availability', getConnectAvailability);
+3964:router.get('/context', getConnectContext);
+3966:router.get('/inbox', getConnectInbox);
+3968:router.post('/neighbors', postConnectNeighborCreate);
+3970:router.get('/neighbors', getConnectNeighbors);
+3972:router.get('/neighbors/:neighborId', getConnectNeighborDetail);
+3974:router.delete('/neighbors/:neighborId', deleteConnectNeighbor);
+3976:router.put('/neighbors/:neighborId', putConnectNeighbor);
+3978:router.post('/neighbors/identity-match', postConnectNeighborIdentityMatch);
+3980:router.post('/neighbors/merge', postConnectNeighborMerge);
+3982:router.get('/numbers', getConnectNumberMappings);
+3984:router.post('/numbers', postConnectNumberMapping);
+3986:router.put('/numbers/:mappingId', putConnectNumberMapping);
+3988:router.get('/admin/webhook-receipts/metrics', getConnectWebhookReceiptMetrics);
+3990:router.post('/admin/webhook-receipts/cleanup', postConnectWebhookReceiptCleanup);
+3992:router.get('/escalation/recipients', getConnectEscalationRecipients);
+3994:router.get('/escalation/config', getConnectEscalationConfig);
+3996:router.put('/escalation/config', putConnectEscalationConfig);
+3998:router.post('/internal/escalation/evaluate', async (req: Request, res: Response) => {
+4099:router.get('/internal/threads/due', async (req: Request, res: Response) => {
+4144:router.get('/events', async (req: Request, res: Response) => {
+4185:router.get('/identity-ambiguities', async (req: Request, res: Response) => {
+4227:router.patch('/identity-ambiguities/:ambiguityEventId', async (req: Request, res: Response) => {
+4292:router.get('/threads/:threadId/timeline', getConnectThreadTimeline);
+4294:router.get('/threads/:threadId', getConnectThreadDetail);
+4296:router.post('/threads', async (req: Request, res: Response) => {
+7534:router.post('/threads/:threadId/claim', postConnectThreadClaim);
+7536:router.post('/threads/:threadId/takeover', postConnectThreadTakeover);
+7538:router.post('/threads/:threadId/close', postConnectThreadClose);
+7540:router.post('/threads/:threadId/call', postConnectThreadCall);
+7542:router.post('/threads/:threadId/messages', postConnectThreadMessage);
+7544:router.post('/webhooks/inbound', postConnectWebhookInbound);
+7546:router.post('/webhooks/sms', postConnectWebhookSms);

--- a/slice15-runtime-seams.txt
+++ b/slice15-runtime-seams.txt
@@ -1,0 +1,335 @@
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:4:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:44:const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:46:  bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:47:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:48:  providerRequestId: 'req-bridge-3001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:162:  let resolveSenderNumberSpy: jest.SpyInstance;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:177:    resolveSenderNumberSpy = jest.spyOn(SenderNumberResolverModule, 'resolveSenderNumber')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:182:    resolveSenderNumberSpy.mockRestore();
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:185:  it('returns the current outbound call success envelope and bridge-session response shape', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:315:          transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:325:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:326:          bridgeSessionId: expect.any(String),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:380:      'bridgeSession',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:493:          transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:503:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:504:          bridgeSessionId: expect.any(String),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:560:      'bridgeSession',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:586:  it('returns the current operator-callback-required refusal shape for outbound bridge calls', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:600:      message: 'Outbound bridge calls require an operator callback number.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:626:  it('returns the current neighbor-phone-required refusal shape for outbound bridge calls', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:640:      message: 'Outbound bridge calls require a dialable neighbor phone.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:667:    resolveSenderNumberSpy.mockResolvedValueOnce(
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:4:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:435:      'resolveConnectShyftProviderCorrelationByIdentifiers',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:462:          transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:531:            transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:550:              call_transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:3:import * as BridgeSessionsModule from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:133:        bridgeSession: null,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:183:      'bridgeSession',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:259:        bridgeSession: null,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:4:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:47:const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:49:  bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:50:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:51:  providerRequestId: 'req-bridge-3001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:168:  let resolveSenderNumberSpy: jest.SpyInstance;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:187:    resolveSenderNumberSpy = jest.spyOn(SenderNumberResolverModule, 'resolveSenderNumber')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:193:    resolveSenderNumberSpy.mockRestore();
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:655:    resolveSenderNumberSpy.mockResolvedValueOnce(
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:12:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:81:const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:83:  bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:84:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:85:  providerRequestId: 'req-bridge-3001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1123:  it('starts a persisted bridge session for outbound calls and returns bridge-session state', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1145:          transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1149:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1168:    expect((response.body as any).data.bridgeSession.bridgeSessionId).toBeTruthy();
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1174:        transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1217:  it('refuses outbound bridge calls when no operator callback number is provided', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:513:    const dispatchFailureSpy = jest.spyOn(ProviderRegistry, 'resolveConnectShyftProviderAdapter').mockReturnValue({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:39:  postConnectThreadCall,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:41:  postConnectThreadMessage,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:44:  postConnectWebhookInbound,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:45:  postConnectWebhookSms,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:89:  resolveSenderNumber,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:101:  resolveConnectShyftProviderAdapter,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:160:  resolveConnectShyftProviderCorrelationByIdentifiers,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:166:} from '../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:224:  transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:915:  bridgeSessionId: aggregate.session.id,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:947:  bridgeSessionId: string;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1077:  const resolution = await resolveSenderNumber({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1121:  const lookup = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3673:  const resolution = await resolveSenderNumber(
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3714:): 'send_sms' | 'start_bridge_session' => (
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3715:  outboundAction === 'call' ? 'start_bridge_session' : 'send_sms'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3734:  channel: 'sms' | 'voice' | 'bridge' | 'webhook';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3792:      message: 'Outbound calls require bridge transport only.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4435:  const providerSelection = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4493:  let bridgeSessionState: ConnectShyftBridgeSessionStateContract | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4494:  let bridgeCorrelationMapping: ConnectShyftBridgeCorrelationMapping | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4710:        message: 'Outbound bridge calls require an operator callback number.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4755:        message: 'Outbound bridge calls require a dialable neighbor phone.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4934:    const voiceSenderResolution = await resolveSenderNumber(
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5104:        targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5106:        channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5225:        const bridgeStart = await startConnectShyftBridgeSession({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5241:        bridgeSessionState = buildProviderNeutralBridgeSessionState(bridgeStart.aggregate);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5242:        bridgeCorrelationMapping = bridgeStart.correlationMapping;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5247:          providerLegId: bridgeStart.aggregate.operatorLeg.providerCallId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5251:          requestedAt: bridgeStart.aggregate.operatorLeg.updatedAt.toISOString(),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5313:        targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5315:        channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5380:      targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5382:      channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5518:    bridgeCorrelationMapping as ConnectShyftBridgeCorrelationMapping | null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5658:          bridgeSession: bridgeSessionState,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5694:  const bridgeSessionId = (
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5695:    bridgeSessionState as ConnectShyftBridgeSessionStateContract | null
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5696:  )?.bridgeSessionId || null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5710:      resourceType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5712:        ? normalizeLifecycleString(bridgeSessionId)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5723:    targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5725:    channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5736:      bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6347:  const bridgeWebhookProgression = await handleConnectShyftBridgeWebhookEvent({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6365:  if (bridgeWebhookProgression.handled && !isConnectedCallEvent) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6392:        bridgeSession: bridgeWebhookProgression.aggregate
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6393:          ? buildProviderNeutralBridgeSessionState(bridgeWebhookProgression.aggregate)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6395:        bridgeEvent: bridgeWebhookProgression.domainEvent,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6396:        correlationMapping: bridgeWebhookProgression.correlationMapping,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7429:      ...(bridgeWebhookProgression.handled
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7431:            bridgeSession: bridgeWebhookProgression.aggregate
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7432:              ? buildProviderNeutralBridgeSessionState(bridgeWebhookProgression.aggregate)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7434:            bridgeEvent: bridgeWebhookProgression.domainEvent,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7435:            correlationMapping: bridgeWebhookProgression.correlationMapping,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7540:router.post('/threads/:threadId/call', postConnectThreadCall);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7542:router.post('/threads/:threadId/messages', postConnectThreadMessage);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7544:router.post('/webhooks/inbound', postConnectWebhookInbound);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7546:router.post('/webhooks/sms', postConnectWebhookSms);
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:5:import * as BridgeSessionsModule from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:22:const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:23:const BRIDGE_LEGS_TABLE = 'cs_bridge_legs'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:35:  bridge_status: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:50:  bridge_session_id: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:156:  status: row.bridge_status as BridgeSessionRecord['status'],
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:171:  bridgeSessionId: row.bridge_session_id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:195:  bridge_status: session.status,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:210:  bridge_session_id: leg.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:235:    const current = this.legsBySessionId.get(leg.bridgeSessionId) || new Map()
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:237:    this.legsBySessionId.set(leg.bridgeSessionId, current)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:239:      this.sessionIdByProviderCallId.set(leg.providerCallId, leg.bridgeSessionId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:364:      .where({ bridge_session_id: sessionId })
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:369:        'bridge_session_id',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:403:      .join(`${BRIDGE_SESSIONS_TABLE} as bs`, 'bs.id', 'bl.bridge_session_id')
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:412:      .first<{ bridgeSessionId?: string }>('bl.bridge_session_id as bridgeSessionId')
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:414:    const sessionId = normalizeString(legRow?.bridgeSessionId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:452:  transport: normalizeString(callPolicy?.transport) || 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:474:        bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:502:      throw new Error(`Provider ${input.providerKey} does not support bridge control.`)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:507:      bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:532:    bridgeLegId: input.leg.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:598:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:607:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:615:    normalizedEventType === 'callbridged'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:619:      type: 'bridge_connected',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:620:      bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:630:    if (input.aggregate.session.status === 'bridged' || input.aggregate.session.status === 'completed') {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:633:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:642:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:652:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:668:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:678:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:2:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:43:  bridgeSessionId: string
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:48:  bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:49:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:50:  providerRequestId: 'req-bridge-3001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:206:describe('connectshyft bridge webhook flow', () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:259:  it('creates a persisted bridge session on call start with operator-first dialing', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:279:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:280:          bridgeSessionId: expect.any(String),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:339:  it('rejects unverified webhooks before receipt processing or bridge side effects', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:398:  it('advances operator answered to neighbor dialing and bridges on neighbor answered', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:429:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:443:        bridgeEvent: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:470:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:471:          status: 'bridged',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:472:          sessionState: 'bridged',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:484:        bridgeEvent: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:496:  it('suppresses duplicate webhook receipts before bridge side effects are re-applied', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:541:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:634:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:648:        bridgeEvent: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:667:  it('persists terminal bridge failure when the neighbor leg fails before bridge completion', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:708:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:721:        bridgeEvent: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:729:  it('loads persisted bridge state from a fresh thread detail read after completion', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:786:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:787:          bridgeSessionId: expect.any(String),
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:28:const CONNECTSHYFT_REQUIRED_CALL_TRANSPORT = 'bridge';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:675:      providerLegId: `${providerKey}-bridge-leg-${command.legRole}-${command.bridgeSessionId}`,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:684:      bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:685:      bridgeEstablished: true,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:738:        message: 'Outbound calls require bridge transport only.',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:795:      throw new Error(`Provider ${baseAdapter.providerKey} does not support bridge control.`);
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:836:export const resolveConnectShyftProviderAdapter = (input: {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:611:  bridgeLegId: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:627:    internalReferenceId: input.bridgeLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:633:export const resolveConnectShyftProviderCorrelationByIdentifiers = async (input: {
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadMessage.ts:4:export const postConnectThreadMessage = async (req: Request, res: Response) =>
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:4:const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions'
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:5:const BRIDGE_LEGS_TABLE = 'cs_bridge_legs'
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:21:      bridge_status TEXT NOT NULL,
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:30:      CONSTRAINT cs_bridge_sessions_status_ck CHECK (
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:31:        bridge_status IN (
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:37:          'bridged',
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:52:      bridge_session_id TEXT NOT NULL REFERENCES ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}(id) ON DELETE CASCADE,
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:64:      CONSTRAINT cs_bridge_legs_role_ck CHECK (leg_role IN ('operator', 'neighbor')),
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:65:      CONSTRAINT cs_bridge_legs_status_ck CHECK (
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:68:      CONSTRAINT cs_bridge_legs_session_role_uq UNIQUE (bridge_session_id, leg_role)
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:73:    CREATE INDEX IF NOT EXISTS connectshyft_cs_bridge_sessions_scope_idx
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:78:    CREATE INDEX IF NOT EXISTS connectshyft_cs_bridge_legs_session_idx
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:79:    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_LEGS_TABLE} (bridge_session_id, leg_role, id)
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:83:    CREATE UNIQUE INDEX IF NOT EXISTS connectshyft_cs_bridge_legs_provider_call_id_uq
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:5:The ConnectShyft neighbor / identity bridge surface is currently split across these files:
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:27:  - owns identity-match request handoff, identity bridge refusal mapping, and preserved identity-match response assembly
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:35:Slice 7 intentionally preserves the exact current response shapes for the full neighbor / identity bridge family.
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:47:This was deliberate. The goal of this slice was thin-router extraction and a cleaner bridge boundary, not payload redesign.
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:82:- the bridge boundary is documented as the seam where future PeopleCore convergence can swap internals without re-thickening the router
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:88:The following work remains deferred beyond the neighbor / identity bridge family:
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadCall.ts:4:export const postConnectThreadCall = async (req: Request, res: Response) =>
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:1:import { down, up } from '../20260311110000_create_connectshyft_bridge_sessions'
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:23:describe('20260311110000_create_connectshyft_bridge_sessions migration', () => {
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:24:  it('creates bridge session and bridge leg persistence with scope and provider-call indexes', async () => {
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:34:    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_bridge_sessions'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:35:    expect(rawCalls.some((sql: string) => sql.includes('bridge_status TEXT NOT NULL'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:36:    expect(rawCalls.some((sql: string) => sql.includes('CONSTRAINT cs_bridge_sessions_status_ck CHECK'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:38:    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_bridge_legs'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:39:    expect(rawCalls.some((sql: string) => sql.includes("CONSTRAINT cs_bridge_legs_role_ck CHECK (leg_role IN ('operator', 'neighbor'))"))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:41:    expect(rawCalls.some((sql: string) => sql.includes('CONSTRAINT cs_bridge_legs_session_role_uq UNIQUE'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:42:    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_bridge_sessions_scope_idx'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:43:    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_bridge_legs_session_idx'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:44:    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_bridge_legs_provider_call_id_uq'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:47:  it('drops bridge leg and bridge session tables in down migration', async () => {
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:53:      'connectshyft.cs_bridge_legs',
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:54:      'connectshyft.cs_bridge_sessions',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:184:export const resolveSenderNumber = async (
+apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts:19:export { postConnectThreadCall } from './postConnectThreadCall';
+apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts:21:export { postConnectThreadMessage } from './postConnectThreadMessage';
+apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts:24:export { postConnectWebhookInbound } from './postConnectWebhookInbound';
+apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts:25:export { postConnectWebhookSms } from './postConnectWebhookSms';
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:12:- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadCall.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:14:- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadMessage.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:27:- bridge session startup and bridge-session state orchestration
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:28:  - still owned by the existing outbound core in `connectshyft.ts` and `bridgeSessions.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:36:Slice 8 was an extraction slice, not a provider, bridge, reliability, or audit redesign.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:46:- existing nested provider, bridge-session, idempotency, audit, override, and side-effect payload structure remains unchanged
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:72:- provider or bridge architecture redesign
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:83:5. Do not fold provider, bridge, reliability, audit, or SMS-override internals into the thin handlers or helper boundary.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:90:That separation should stay explicit. Follow-up cleanup should not use the outbound handlers or `threadOutboundContext.ts` as a place to absorb inbound message intake, webhook correlation, provider signature handling, bridge webhook progression, voicemail processing, or transcription callbacks. Those surfaces remain intentionally deferred to the next slice after Slice 8.
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:79:        channel IN ('sms', 'voice', 'bridge', 'webhook')
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:6:  resolveConnectShyftProviderAdapter,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:12:import { resolveConnectShyftProviderCorrelationByIdentifiers } from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:170:    const fallbackProbe = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:211:  const fallback = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:330:  const providerSelection = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:456:  const rolloutContextValidation = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:12:- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookInbound.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:14:- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookSms.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:36:- bridge-session webhook progression and bridge alignment behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:37:  - still owned by the existing inbound core in `connectshyft.ts` and `bridgeSessions.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:43:Provider, correlation, canonical, bridge, and transcription internals remain intentionally deferred from the route-family extraction sequence.
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:53:- existing nested provider, correlation, canonical, bridge, voicemail, transcription, auto-claim, and side-effect payload structure remains unchanged
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:80:- redesign bridge handling
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:87:That work should build on the current thin handlers and `inboundWebhookContext.ts` boundary rather than pulling deferred provider, correlation, canonical, bridge, or transcription internals into the route-family extraction seam.
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookSms.ts:4:export const postConnectWebhookSms = async (req: Request, res: Response) =>
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:7:import { loadConnectShyftBridgeAggregateByThreadId } from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:83:  bridgeSessionId: aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:337:      bridgeSession: activeBridgeSession
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:2:import { postConnectWebhookInbound } from '../handlers/postConnectWebhookInbound';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:3:import { postConnectWebhookSms } from '../handlers/postConnectWebhookSms';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:13:import * as bridgeSessionsModule from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:148:      .spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:151:      .spyOn(providerCorrelationMappingsModule, 'resolveConnectShyftProviderCorrelationByIdentifiers')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:250:      'resolveConnectShyftProviderCorrelationByIdentifiers',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:252:    jest.spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter').mockReturnValue(selection as any);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:300:  it('stays limited to prerequisite resolution and execution delegation without bridge or canonical side effects', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:302:    jest.spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter').mockReturnValue(selection as any);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:305:      'resolveConnectShyftProviderCorrelationByIdentifiers',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:310:    const bridgeWebhookSpy = jest.spyOn(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:311:      bridgeSessionsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:390:    expect(bridgeWebhookSpy).not.toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:405:    await postConnectWebhookInbound(req, res);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:406:    await postConnectWebhookSms(req, res);
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1560:// This helper intentionally keeps the neighbor/identity bridge ConnectShyft-local for now.
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:71:- bridge-session orchestration moves
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:7:} from '../bridgeSessions'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:25:const startBridgeSessionMock = jest.fn(async (input: { bridgeSessionId: string }) => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:27:  bridgeSessionId: input.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:28:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:29:  providerRequestId: 'req-bridge-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:83:describe('connectshyft bridgeSessions', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:109:  it('persists a created bridge session with operator and neighbor legs on startup', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:206:  it('persists completed bridge sessions after both legs answer and the bridge ends', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:240:    expect(afterNeighborAnswer.aggregate?.session.status).toBe('bridged')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:264:  it('persists failed bridge sessions when the neighbor leg fails before bridge completion', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:1:import { resolveSenderNumber } from '../senderNumberResolver';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:27:    const result = await resolveSenderNumber(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:68:    const result = await resolveSenderNumber(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:97:    const result = await resolveSenderNumber(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:126:    const result = await resolveSenderNumber(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:4:import { resolveSenderNumber } from '../senderNumberResolver';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:278:    const resolved = await resolveSenderNumber(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:329:    const refused = await resolveSenderNumber(
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookInbound.ts:4:export const postConnectWebhookInbound = async (req: Request, res: Response) =>
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:278:  it('stays limited to neighbor identity prerequisites and does not execute bridge side effects', async () => {
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:12:  - owns thread detail request handoff, response assembly, canonical timeline inclusion, voicemail artifact projection, and bridge-session payload shaping
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:24:- the current detail envelope with `thread`, `bridgeSession`, `voicemailArtifacts`, `actions`, and policy metadata
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:6:  resolveConnectShyftProviderAdapter,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:62:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:85:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:129:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:172:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:219:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:253:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:300:    const preCorrelation = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:315:    const postCorrelation = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:348:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:476:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:512:  it('enforces bridge-only/manual retry policy at the adapter dispatch boundary', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:513:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:550:          transport: 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:580:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:637:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:693:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:753:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:808:    const result = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:11:import * as bridgeSessionsModule from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:265:  it('stays limited to prerequisite resolution and execution delegation without provider or bridge side effects', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:268:      'resolveConnectShyftProviderAdapter',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:271:      bridgeSessionsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:7:import { resolveSenderNumber } from '../senderNumberResolver';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:728:    const resolved = await resolveSenderNumber(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:784:    const resolved = await resolveSenderNumber(
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:59:- PeopleCore neighbor or identity bridge convergence work
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:77:That separation should remain explicit. Follow-up cleanup should not use the lifecycle helper boundary as a place to absorb outbound reopen rules, provider dispatch concerns, inbound correlation work, or webhook processing. The next extraction target after Slice 6 is neighbors / identity bridge, while outbound and webhook surfaces remain intentionally deferred.
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:10:  resolveConnectShyftProviderCorrelationByIdentifiers,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:71:  it('records provider call-leg mappings against persisted bridge-leg ids', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:77:      providerIdentifier: 'provider-leg-bridge-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:78:      bridgeLegId: 'bridge-leg-neighbor-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:86:        providerIdentifier: 'provider-leg-bridge-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:87:        internalReferenceId: 'bridge-leg-neighbor-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:91:    const resolved = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:93:      providerLegId: 'provider-leg-bridge-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:100:        internalCallReferenceId: 'bridge-leg-neighbor-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:116:    const resolvedByCallLeg = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:141:    const resolvedByMessage = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:178:    const resolution = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:191:    const missingIdentifiers = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:199:    const notFound = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:489:    const ambiguousLookup = await resolveConnectShyftProviderCorrelationByIdentifiers({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:499:    const tenantScopedLookup = await resolveConnectShyftProviderCorrelationByIdentifiers({

--- a/slice15-telephony-module-audit.txt
+++ b/slice15-telephony-module-audit.txt
@@ -1,0 +1,19 @@
+FAIL src/modules/connectshyft/__tests__/communicationReliability.test.ts
+  ● Test suite failed to run
+
+    ENOENT: no such file or directory, open '/Users/jeremiahotis/projects/connectshyft/apps/connectshyft-api/src/modules/connectshyft/__tests__/communicationReliability.test.ts'
+
+      at runTestInternal (../../node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:170:27)
+
+PASS src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts
+PASS src/modules/connectshyft/__tests__/identityResolver.test.ts
+PASS src/modules/connectshyft/__tests__/ambiguityEvents.test.ts
+PASS src/modules/connectshyft/__tests__/bridgeSessions.test.ts
+PASS src/modules/connectshyft/__tests__/senderNumberResolver.test.ts
+PASS src/modules/connectshyft/__tests__/providerRegistry.test.ts
+
+Test Suites: 1 failed, 1 skipped, 6 passed, 7 of 8 total
+Tests:       7 skipped, 53 passed, 60 total
+Snapshots:   0 total
+Time:        2.821 s, estimated 3 s
+Ran all test suites within paths "src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts", "src/modules/connectshyft/__tests__/identityResolver.test.ts", "src/modules/connectshyft/__tests__/providerRegistry.test.ts", "src/modules/connectshyft/__tests__/senderNumberResolver.test.ts", "src/modules/connectshyft/__tests__/threads.contract.test.ts", "src/modules/connectshyft/__tests__/bridgeSessions.test.ts", "src/modules/connectshyft/__tests__/communicationReliability.test.ts", "src/modules/connectshyft/__tests__/ambiguityEvents.test.ts".

--- a/slice15-telephony-test-audit.txt
+++ b/slice15-telephony-test-audit.txt
@@ -1,0 +1,12 @@
+PASS src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+PASS src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts
+PASS src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
+PASS src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts
+PASS src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts
+PASS src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts
+
+Test Suites: 6 passed, 6 total
+Tests:       71 passed, 71 total
+Snapshots:   0 total
+Time:        4.649 s, estimated 5 s
+Ran all test suites within paths "src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts", "src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts", "src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts", "src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts", "src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts", "src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts".

--- a/specs/slice-15-codex-ready-implementation-brief.md
+++ b/specs/slice-15-codex-ready-implementation-brief.md
@@ -1,0 +1,252 @@
+# SLICE 15 — OPS VISIBILITY (READ-ONLY SURFACES)
+
+## STATUS: READY FOR IMPLEMENTATION
+
+## TYPE: EXECUTION BRIEF (AUTHORITATIVE)
+
+---
+
+## OBJECTIVE
+
+Expose operational visibility for identity + telephony state WITHOUT introducing any write paths or behavioral mutations.
+
+This slice is strictly read-only.
+
+---
+
+## SCOPE
+
+### INCLUDED
+
+1. Identity Resolution Visibility
+   - ambiguity state
+   - resolution path taken
+   - PeopleCore vs legacy decision
+
+2. Telephony Runtime Visibility
+   - bridge session state
+   - call leg status (operator / neighbor)
+   - provider state (Telnyx)
+
+3. Ops-Facing Endpoints
+   - read-only endpoints under `/api/v1/connectshyft/ops/*`
+
+4. Structured Logging + Telemetry
+
+---
+
+### EXCLUDED (HARD BLOCK)
+
+- NO mutation endpoints
+- NO retry logic
+- NO resolution overrides
+- NO lifecycle actions (close/reopen/escalate)
+- NO telephony control (no call manipulation)
+
+---
+
+## POLICY: OPS VISIBILITY (LOCKED)
+
+Decision:
+
+- Ops visibility is read-only and non-interventionist
+
+Rules:
+
+- No endpoint may trigger state mutation
+- No endpoint may call write services
+- No endpoint may invoke provider actions
+- All responses must reflect current system state only
+
+Enforcement:
+
+- All handlers must be pure read adapters
+- Service layer calls must be read-only functions
+- Type system must prevent mutation imports
+
+Telemetry:
+
+- Emit `ops.visibility.requested`
+- Emit `ops.visibility.response_returned`
+
+---
+
+## MODULES
+
+### 1. Ops Visibility Router
+
+Path:
+`apps/connectshyft-api/src/routes/api/v1/connectshyft/ops.routes.ts`
+
+Responsibilities:
+
+- Define all ops endpoints
+- Enforce read-only contract
+- Map to service layer
+
+Endpoints:
+
+GET `/ops/identity/:phone`
+GET `/ops/threads/:threadId`
+GET `/ops/bridge/:bridgeId`
+
+---
+
+### 2. Identity Visibility Service
+
+Path:
+`apps/connectshyft-api/src/modules/connectshyft/ops/identityVisibility.service.ts`
+
+Responsibilities:
+
+- Surface identity resolution outcome
+- Include ambiguity state
+- Include PeopleCore decision path
+
+Output shape:
+
+```ts
+{
+  phone: string,
+  resolution: 'single_match' | 'ambiguous' | 'no_match',
+  source: 'peoplecore' | 'legacy',
+  candidates?: Array<{ id: string, confidence: number }>,
+  selectedId?: string
+}
+```
+
+---
+
+### 3. Bridge Session Visibility Service
+
+Path:
+`apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts`
+
+Dependencies:
+
+- bridgeSessions runtime seam
+
+Responsibilities:
+
+- Surface bridge state
+- Show both call legs
+- Reflect provider status
+
+Output shape:
+
+```ts
+{
+  bridgeId: string,
+  status: 'initiated' | 'ringing' | 'connected' | 'failed' | 'ended',
+  operatorLeg: {
+    phone: string,
+    status: string
+  },
+  neighborLeg: {
+    phone: string,
+    status: string
+  },
+  provider: 'telnyx',
+  lastEventAt: string
+}
+```
+
+---
+
+### 4. Thread Visibility Adapter
+
+Path:
+`apps/connectshyft-api/src/modules/connectshyft/ops/threadVisibility.service.ts`
+
+Responsibilities:
+
+- Read-only thread lookup
+- Surface existence vs not-found
+- No mutation
+
+---
+
+## ROUTE HANDLERS
+
+Path:
+`apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts`
+
+Rules:
+
+- No business logic
+- No mutation
+- Only call visibility services
+
+---
+
+## CONTRACT ENFORCEMENT
+
+- No import of:
+  - create\*
+  - update\*
+  - resolve\*
+  - provider outbound calls
+
+- Allowed:
+  - store.get\*
+  - service.read\*
+  - adapters
+
+---
+
+## TESTS
+
+Create:
+
+```
+__tests__/ops.identity.test.ts
+__tests__/ops.bridge.test.ts
+__tests__/ops.thread.test.ts
+```
+
+Coverage:
+
+- identity ambiguity surfaced correctly
+- no-match path surfaced correctly
+- bridge state reflects runtime seam
+- thread not-found vs found behavior
+
+---
+
+## VALIDATION COMMANDS
+
+pnpm nx run connectshyft-api:test
+
+pnpm --dir apps/connectshyft-api exec jest --runInBand \
+ src/modules/connectshyft/ops/**tests**/\*.test.ts
+
+---
+
+## ACCEPTANCE CRITERIA
+
+- All endpoints return without mutation
+- No provider calls triggered
+- Identity ambiguity visible
+- Bridge session visible
+- Tests pass clean
+
+---
+
+## STOP CONDITIONS
+
+STOP if:
+
+- Any write path is introduced
+- Any provider call is triggered
+- Any ambiguity is auto-resolved
+
+---
+
+## COMPLETION SIGNAL
+
+Slice 15 is complete when:
+
+- Ops endpoints exist
+- Tests pass
+- No mutation paths exist
+- PR merged to `codex/dev`


### PR DESCRIPTION
## Summary
- add the read-only ConnectShyft ops visibility router and handlers
- surface identity, thread, and bridge visibility through read-only services only
- add and tighten the Slice 15 ops visibility tests and validation coverage

## Validation
- pnpm nx run connectshyft-api:test
- pnpm --dir apps/connectshyft-api exec jest --runInBand 'src/modules/connectshyft/ops/__tests__/ops.identity.test.ts' 'src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts' 'src/modules/connectshyft/ops/__tests__/ops.thread.test.ts'
- pnpm --dir apps/connectshyft-api run build