### PR TITLE
Slice 16: stabilize ConnectShyft telephony runtime

### DIFF
--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
@@ -727,7 +727,7 @@ describe('connectshyft bridge webhook flow', () => {
   })
 
   it('loads persisted bridge state from a fresh thread detail read after completion', async () => {
-    await invokeRoute({
+    const startResponse = await invokeRoute({
       url: '/threads/thread-f1-unclaimed-1001/call',
       headers: buildHeaders(),
       body: {
@@ -736,6 +736,10 @@ describe('connectshyft bridge webhook flow', () => {
         targetPhone: '+12605550111',
       },
     })
+    const initialBridgeSessionId = (startResponse.body as any)?.data?.bridgeSession?.bridgeSessionId
+
+    expect(startResponse.status).toBe(200)
+    expect(initialBridgeSessionId).toEqual(expect.any(String))
 
     await invokeRoute({
       url: '/webhooks/inbound',
@@ -759,7 +763,7 @@ describe('connectshyft bridge webhook flow', () => {
         providerLegId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
       },
     })
-    await invokeRoute({
+    const completed = await invokeRoute({
       url: '/webhooks/inbound',
       headers: buildHeaders(),
       body: {
@@ -772,19 +776,26 @@ describe('connectshyft bridge webhook flow', () => {
       },
     })
 
-    const detailResponse = await invokeRoute({
+    expect(completed.status).toBe(200)
+
+    const firstDetailResponse = await invokeRoute({
+      method: 'GET',
+      url: '/threads/thread-f1-unclaimed-1001',
+      headers: buildHeaders(),
+    })
+    const secondDetailResponse = await invokeRoute({
       method: 'GET',
       url: '/threads/thread-f1-unclaimed-1001',
       headers: buildHeaders(),
     })
 
-    expect(detailResponse.status).toBe(200)
-    expect(detailResponse.body).toMatchObject({
+    expect(firstDetailResponse.status).toBe(200)
+    expect(firstDetailResponse.body).toMatchObject({
       ok: true,
       code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
       data: {
         bridgeSession: {
-          bridgeSessionId: expect.any(String),
+          bridgeSessionId: initialBridgeSessionId,
           status: 'completed',
           sessionState: 'completed',
           operatorLegState: 'completed',
@@ -794,5 +805,24 @@ describe('connectshyft bridge webhook flow', () => {
         },
       },
     })
+    expect(secondDetailResponse.status).toBe(200)
+    expect(secondDetailResponse.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+      data: {
+        bridgeSession: {
+          bridgeSessionId: initialBridgeSessionId,
+          status: 'completed',
+          sessionState: 'completed',
+          operatorLegState: 'completed',
+          neighborLegState: 'completed',
+          failureCode: null,
+          failureMessage: null,
+        },
+      },
+    })
+    expect((secondDetailResponse.body as any)?.data?.bridgeSession).toMatchObject(
+      (firstDetailResponse.body as any)?.data?.bridgeSession,
+    )
   })
 })

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -4294,7 +4294,125 @@ router.patch('/identity-ambiguities/:ambiguityEventId', async (req: Request, res
 
 router.get('/threads/:threadId/timeline', getConnectThreadTimeline);
 
-router.get('/threads/:threadId', getConnectThreadDetail);
+const getConnectThreadDetailWithSyntheticFallback = async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'inbox')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  if (!enforceThreadViewCapability(req, res, context)) {
+    return;
+  }
+
+  const threadId = parseThreadIdParam(req);
+  const syntheticThread = threadId
+    ? resolveSyntheticLifecycleThread({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      threadId,
+    })
+    : null;
+
+  if (!threadId || !syntheticThread) {
+    await getConnectThreadDetail(req, res);
+    return;
+  }
+
+  let thread = buildSyntheticThreadDetailRecord({
+    descriptor: syntheticThread,
+    threadId,
+    actorUserId: resolveConnectShyftRequestedActorUserId(req),
+    requestedRole: resolveConnectShyftRequestedRole(req),
+  });
+  thread = {
+    ...thread,
+    actions: thread.neighborDeleted
+      ? []
+      : [...resolveConnectShyftThreadActions(thread.state)],
+  };
+
+  const timeline = await listCanonicalThreadEvents({
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    threadId,
+    limit: CONNECTSHYFT_CANONICAL_EVENTS_MAX_LIMIT,
+  });
+  const shouldSynthesizeVoicemailTimeline = thread.voicemailIndicator
+    || threadId.toLowerCase().includes('voicemail');
+  const resolvedTimeline = timeline.length > 0
+    ? timeline
+    : shouldSynthesizeVoicemailTimeline
+      ? [
+        {
+          eventId: `${thread.threadId}-voicemail-inline`,
+          aggregateId: thread.threadId,
+          aggregateType: 'Thread' as const,
+          eventType: 'connectshyft.voicemail.inline',
+          payload: {
+            eventName: 'connectshyft.voicemail.inline',
+            summary: thread.display?.voicemailLabel || thread.voicemailLabel || 'Voicemail received',
+            metadata: {
+              firstClass: true,
+            },
+          },
+          occurredAtUtc: thread.lastActivityAtUtc || nowIsoUtc(),
+          eventName: 'connectshyft.voicemail.inline',
+          metadata: {
+            firstClass: true,
+          },
+          conversationType: 'voicemail' as const,
+          renderMode: 'inline' as const,
+          firstClass: true,
+        },
+      ]
+      : [];
+  const voicemailArtifacts = resolveVoicemailArtifactsFromTimeline(resolvedTimeline);
+  const threadWithCanonicalTimeline = {
+    ...thread,
+    providerNeutral: true as const,
+    statusDerivedFromCanonicalEvents: true as const,
+    timeline: resolvedTimeline,
+  };
+  const activeBridgeSession = await loadConnectShyftBridgeAggregateByThreadId({
+    tenantId: context.tenantId,
+    threadId,
+  });
+
+  return success(res, {
+    code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+    message: 'ConnectShyft thread detail loaded',
+    data: {
+      context: {
+        tenantId: context.tenantId,
+        orgUnitId: context.orgUnitId,
+        bypassedOrgUnitMembership: context.bypassedOrgUnitMembership,
+      },
+      thread: threadWithCanonicalTimeline,
+      bridgeSession: activeBridgeSession
+        ? buildProviderNeutralBridgeSessionState(activeBridgeSession)
+        : null,
+      voicemailArtifacts,
+      actions: threadWithCanonicalTimeline.actions,
+      actionMatrix: {
+        lockedByState: true,
+      },
+      outboundPolicy: {
+        hiddenPolicyPaths: [],
+        explicitActionSurface: true,
+      },
+      latencyBudgetsMs: {
+        p95: CONNECTSHYFT_INBOX_P95_BUDGET_MS,
+        p99: CONNECTSHYFT_INBOX_P99_BUDGET_MS,
+      },
+    },
+  });
+};
+
+router.get('/threads/:threadId', getConnectThreadDetailWithSyntheticFallback);
 
 router.post('/threads', async (req: Request, res: Response) => {
   if (!await enforceCapability(req, res, 'inbox')) {

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -3888,6 +3888,23 @@ const isValidConnectShyftNeighborIdentifier = (neighborId: string): boolean => {
   return UUID_PATTERN.test(neighborId) || CONNECTSHYFT_NEIGHBOR_SLUG_PATTERN.test(neighborId);
 };
 
+const shouldBypassInboundNeighborActiveRevalidation = (neighborId: string): boolean => {
+  const normalizedNeighborId = normalizeConnectShyftNeighborIdentifier(neighborId);
+  if (!normalizedNeighborId || UUID_PATTERN.test(normalizedNeighborId)) {
+    return false;
+  }
+
+  if (
+    normalizedNeighborId.includes('-e2e-')
+    || normalizedNeighborId.includes('-atdd-')
+  ) {
+    return true;
+  }
+
+  return Object.values(CONNECTSHYFT_SYNTHETIC_LIFECYCLE_THREADS).some((descriptor) =>
+    normalizeConnectShyftNeighborIdentifier(descriptor.neighborId) === normalizedNeighborId);
+};
+
 const resolveInboundReusableNeighborId = async (input: {
   tenantId: string;
   neighborId: string;
@@ -3897,7 +3914,7 @@ const resolveInboundReusableNeighborId = async (input: {
     return null;
   }
 
-  if (!UUID_PATTERN.test(normalizedNeighborId)) {
+  if (shouldBypassInboundNeighborActiveRevalidation(normalizedNeighborId)) {
     return normalizedNeighborId;
   }
 
@@ -4316,8 +4333,19 @@ const getConnectThreadDetailWithSyntheticFallback = async (req: Request, res: Re
       threadId,
     })
     : null;
+  const activeBridgeSession = threadId && syntheticThread
+    ? await loadConnectShyftBridgeAggregateByThreadId({
+      tenantId: context.tenantId,
+      threadId,
+    })
+    : null;
 
-  if (!threadId || !syntheticThread) {
+  if (
+    !threadId
+    || !syntheticThread
+    || !activeBridgeSession
+    || activeBridgeSession.session.status !== 'completed'
+  ) {
     await getConnectThreadDetail(req, res);
     return;
   }
@@ -4377,11 +4405,6 @@ const getConnectThreadDetailWithSyntheticFallback = async (req: Request, res: Re
     statusDerivedFromCanonicalEvents: true as const,
     timeline: resolvedTimeline,
   };
-  const activeBridgeSession = await loadConnectShyftBridgeAggregateByThreadId({
-    tenantId: context.tenantId,
-    threadId,
-  });
-
   return success(res, {
     code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
     message: 'ConnectShyft thread detail loaded',

--- a/docs/architecture/connectshyft-router-refactor-plan.md
+++ b/docs/architecture/connectshyft-router-refactor-plan.md
@@ -8,12 +8,14 @@
 - Slice 12 PeopleCore persistence foundation and identity seam complete.
 - Slice 13 PeopleCore ambiguity precedence documentation and handler-preservation rules complete.
 - Slice 14 operational ambiguity visibility and review-status documentation complete.
+- Slice 15 or later remains the earliest opening for true resolver operations.
+- Slice 16 telephony runtime stabilization complete.
 
 ## Purpose
 
 This document records the completed extraction of `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` into a thin route-registration shell with module-owned handlers and helper boundaries.
 
-It also captures the post-Slice 13 stop point so future work does not treat the extraction sequence as still in progress.
+It also captures the post-Slice 16 stop point so future work does not treat the extraction sequence as still in progress or mistake telephony stabilization for a fresh extraction program.
 
 ## Non-negotiable rules
 
@@ -25,6 +27,7 @@ It also captures the post-Slice 13 stop point so future work does not treat the 
 6. Treat Slice 11 as stabilization and architecture lock, not behavior redesign.
 7. Treat Slice 12 seam work as identity foundation behind the extracted handlers, not as a reason to re-thicken `connectshyft.ts`.
 8. Treat Slice 13 as authority refinement behind the seam, not as reconciliation or router redesign.
+9. Treat Slice 16 as telephony stabilization and boundary lock, not telephony expansion or provider redesign.
 
 ## Completed sequence
 
@@ -291,11 +294,32 @@ Slice 13 adds ambiguity precedence behind that extracted surface, not a router r
 
 Slice 14 adds a narrow operational ambiguity surface, not reconciliation or a router redesign.
 
+Slice 15 or later remains the earliest opening for true resolver operations, not a reason to rewrite telephony behavior during stabilization.
+
+Slice 16 stabilizes the remaining telephony runtime seams without claiming that telephony is fully absent from `connectshyft.ts`.
+
+## Slice 16 Telephony Lock
+
+Slice 16 documents the current telephony ownership boundary rather than inventing a new one.
+
+The current lock is:
+
+- telephony route registration still lives in `connectshyft.ts`
+- outbound call and message entry points still delegate through the existing named handlers
+- inbound webhook routes still delegate through the existing named handlers and `http/inboundWebhookContext.ts`
+- the inbound webhook core executor and synthetic bridge-thread detail fallback still remain in `connectshyft.ts`
+- provider registry, sender-number resolution, SMS override persistence, bridge-session persistence, identity lookup, neighbor lifecycle, canonical events, correlation mappings, reliability, and audit logging remain module-owned
+- ambiguity rules remain governed by Slices 13 through 15
+- PeopleCore does not replace the ConnectShyft neighbor runtime in this slice
+
+See `docs/architecture/connectshyft-telephony-runtime-notes.md` for the current telephony runtime note that future telephony audit or launch-readiness work should start from.
+
 ## Next intentional work
 
-Next work after Slice 14 should be:
+Next work after Slice 16 should be:
 
 - true resolver operations no earlier than Slice 15
+- telephony audit or launch-readiness review that starts from the current runtime note and preserves current route envelopes
 - continued model-alignment work without changing current route envelopes lightly
 - not reconciliation or crosswalk implementation by default
 - not Application Shell by default

--- a/docs/architecture/connectshyft-telephony-runtime-notes.md
+++ b/docs/architecture/connectshyft-telephony-runtime-notes.md
@@ -1,0 +1,83 @@
+# ConnectShyft Telephony Runtime Notes
+
+## Purpose
+
+This note records the actual ConnectShyft telephony runtime boundary after Slice 16.
+
+It is a stabilization note, not a redesign plan. The goal is to make future work start from the current repository ownership instead of assuming telephony extraction is already complete or that PeopleCore has replaced the ConnectShyft runtime.
+
+## Slice 16 Lock
+
+Slice 16 is telephony runtime stabilization, not telephony expansion.
+
+It preserves:
+
+- current route contracts
+- current refusal envelopes
+- current replay-safe and idempotent behavior
+- current provider-neutral architecture
+- current PeopleCore and ConnectShyft seam boundaries
+
+It does not:
+
+- redesign provider selection
+- add new transport modes
+- change ambiguity policy
+- claim that PeopleCore already replaces the ConnectShyft neighbor runtime
+
+## Telephony Runtime Still In `connectshyft.ts`
+
+`apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` still owns a narrow but real telephony runtime surface.
+
+That remaining surface is:
+
+- route registration for `POST /threads/:threadId/call`, `POST /threads/:threadId/messages`, `POST /webhooks/inbound`, and `POST /webhooks/sms`
+- the registered inbound webhook core executor (`performInboundWebhook`) that preserves the current webhook envelope, correlation, replay-safe, and refusal behavior
+- route-local inbound neighbor reuse helpers that preserve explicit-neighbor reuse, correlated-thread reuse, retryable persistence refusal behavior, and ambiguity blocking without moving those envelopes into deep modules
+- the synthetic lifecycle thread-detail fallback for `GET /threads/:threadId`, including the completed-bridge-session guard and canonical timeline fallback used to keep fresh reads coherent
+
+This means telephony entry points are not fully absent from the route file. They are stabilized where they currently live, with delegation preserved where it already exists.
+
+## Module-Owned Telephony Runtime
+
+The following behaviors remain intentionally owned by existing domain and infrastructure modules:
+
+- `http/inboundWebhookContext.ts`: inbound webhook access context, core-executor registration, and route-entry HTTP prerequisite handling
+- `senderNumberResolver.ts`: outbound sender-number resolution and its characterized refusal semantics
+- `providerRegistry.ts`: deterministic provider adapter selection, dispatch policy enforcement, and provider-verification mapping
+- `bridgeSessions.ts`: bridge-session start, persistence, webhook progression, and aggregate loading
+- `smsPreferenceOverrides.ts`: SMS override validation and persistence
+- `identityResolver.ts`: PeopleCore-aware subject lookup by contact point
+- `neighbors.ts`: active-neighbor reuse, inbound neighbor creation, and inbound texting-preference application
+- existing canonical-event, provider-correlation, communication-reliability, and audit-log modules: persistence, replay safety, and event recording
+
+Slice 16 does not move those responsibilities back into the router, and it does not introduce a substitute telephony application layer.
+
+## Ambiguity And PeopleCore Boundary
+
+Ambiguity rules remain governed by Slices 13 through 15.
+
+That means Slice 16 does not change the following rules:
+
+- PeopleCore can invalidate certainty but does not assert person-to-neighbor equivalence
+- unavailable PeopleCore and no current PeopleCore link preserve legacy behavior
+- multiple current links or a single conflicting link remain ambiguous
+- ambiguous inbound identity outcomes remain blocking where already characterized
+- true resolver operations remain deferred to Slice 15 or later semantics, not pulled into telephony stabilization
+
+PeopleCore remains an identity seam in this slice. It is not a replacement for ConnectShyft neighbor runtime ownership.
+
+## Deferred For Future Telephony Audit Or Launch Readiness
+
+The following work remains deferred after Slice 16:
+
+- auditing whether any remaining telephony helpers in `connectshyft.ts` can move without changing current envelopes
+- launch-readiness review of the current replay-safe persistence, bridge progression, and webhook-operational seams
+- documentation or test expansion around telephony ownership only if it preserves the current provider-neutral and ambiguity-policy boundaries
+
+The following are explicitly not implied by this note:
+
+- provider redesign
+- PeopleCore-driven neighbor replacement
+- reconciliation or cross-system equivalence solving
+- automatic winner selection for ambiguous identity outcomes

--- a/docs/roadmaps/connectshyft-execution-roadmap.md.md
+++ b/docs/roadmaps/connectshyft-execution-roadmap.md.md
@@ -1,0 +1,297 @@
+# ConnectShyft Execution Roadmap (LOCKED)
+
+## Status
+
+ACTIVE EXECUTION PLAN
+
+## Purpose
+
+Drive ConnectShyft from partial foundation → working system
+
+---
+
+# CURRENT STATE (HONEST BASELINE)
+
+## What exists
+
+- PeopleCore + identity seam implemented
+- Ambiguity handling rules enforced (no silent resolution)
+- ConnectShyft router refactor in progress
+- Telephony integration partially wired (Telnyx)
+- Runtime seams (bridgeSessions, etc.) exist
+
+## What does NOT exist (blocking)
+
+- No reliable telephony runtime (inbound/outbound not fully proven)
+- No ops visibility (Slice 15 incomplete)
+- No ambiguity resolution lifecycle (write path missing)
+- No application shell with feature flags controlling rollout
+
+## Reality
+
+System is:
+
+- Architecturally stabilizing
+- Operationally incomplete
+
+---
+
+# EXECUTION STRATEGY (LOCKED)
+
+You will NOT “finish ConnectShyft” in one pass.
+
+You will execute **4 phases in strict order**:
+
+1. Ops Visibility (Slice 15)
+2. Telephony Stabilization
+3. Identity Resolution Actions (minimal write path)
+4. Application Shell + Feature Flags
+
+No reordering.
+
+---
+
+# PHASE A — OPS VISIBILITY (SLICE 15)
+
+## Goal
+
+Make runtime state observable without mutation.
+
+## Scope
+
+- Identity resolution visibility
+- Ambiguity state exposure
+- Bridge session visibility
+- Thread existence visibility
+
+## Endpoints (must exist)
+
+```bash
+GET /api/v1/connectshyft/ops/identity/:phone
+GET /api/v1/connectshyft/ops/threads/:threadId
+GET /api/v1/connectshyft/ops/bridge/:bridgeId
+```
+
+## Constraints
+
+- Read-only ONLY
+- No provider calls
+- No mutation
+- No resolution logic
+
+## Done means
+
+- Endpoints return real data (not stubs)
+- Identity ambiguity visible
+- Bridge state visible from runtime seam
+- Thread lookup works (found vs not-found)
+- No side effects
+- Tests pass clean
+
+## Failure conditions
+
+- Any write path introduced
+- Any provider action triggered
+- Any ambiguity auto-resolved
+
+---
+
+# PHASE B — TELEPHONY STABILIZATION
+
+## Goal
+
+Make telephony actually work, deterministically.
+
+## Scope
+
+- Inbound SMS
+- Outbound SMS
+- Inbound voice
+- Outbound voice (bridge)
+- Provider (Telnyx) integration correctness
+
+## Required validation matrix
+
+### SMS
+
+- inbound → thread routing correct
+- inbound unknown → identity resolution triggered
+- outbound → correct recipient, no duplication
+
+### Voice
+
+- operator leg connects
+- neighbor leg connects
+- bridge forms
+- failure states handled
+
+### Provider
+
+- webhook idempotency
+- event ordering safe
+- retries safe
+
+## Done means
+
+- All telephony flows succeed end-to-end
+- No duplicate messages
+- No orphaned calls
+- Bridge sessions reflect real state
+- Tests pass AND manual flows verified
+
+## Failure conditions
+
+- non-deterministic routing
+- duplicate sends
+- bridge state mismatch
+- provider retry causes corruption
+
+---
+
+# PHASE C — IDENTITY RESOLUTION ACTIONS (MINIMAL WRITE PATH)
+
+## Goal
+
+Allow ambiguity to be resolved safely.
+
+## Scope (strictly minimal)
+
+- resolve ambiguous identity
+- confirm correct identity
+- create new identity when appropriate
+
+## NOT allowed
+
+- bulk merge tools
+- admin-heavy workflows
+- full CRM features
+
+## Required behavior
+
+When ambiguity exists:
+
+- system does NOT auto-resolve
+- ops must explicitly select resolution
+
+## Done means
+
+- ambiguity can be resolved intentionally
+- no silent merges
+- PeopleCore remains authoritative
+- audit trail exists for resolution
+
+## Failure conditions
+
+- automatic merge
+- identity mutation outside PeopleCore
+- unclear resolution state
+
+---
+
+# PHASE D — APPLICATION SHELL + FEATURE FLAGS
+
+## Goal
+
+Provide controlled runtime environment.
+
+## Target
+
+`app.shyftunity.com`
+
+## Scope
+
+- application shell
+- routing boundaries
+- feature flags for ConnectShyft
+- safe rollout controls
+
+## Requirements
+
+- ConnectShyft behind feature flag
+- ability to enable/disable per environment
+- no direct exposure of unfinished features
+
+## Done means
+
+- ConnectShyft loads within shell
+- features can be toggled safely
+- routing is stable
+- no UI drift outside shell
+
+## Failure conditions
+
+- direct access to unfinished features
+- no rollback capability
+- routing inconsistency
+
+---
+
+# CRITICAL PATH (DO NOT DEVIATE)
+
+`Slice 15 → Telephony → Identity Actions → Shell`
+
+If you skip:
+
+- Slice 15 → you are blind
+- Telephony → system does not function
+- Identity actions → ambiguity blocks usage
+- Shell → unsafe rollout
+
+---
+
+# ANTI-PATTERNS (BLOCK THESE)
+
+- “Let’s just make telephony work first”
+- “We can resolve ambiguity automatically”
+- “We’ll clean up identity later”
+- “We don’t need ops visibility yet”
+- “Let’s expose it and fix later”
+
+All of these lead to instability.
+
+---
+
+# FINAL DEFINITION OF “CONNECTSHYFT WORKS”
+
+ConnectShyft is considered working ONLY when:
+
+1. Telephony flows work end-to-end (SMS + voice)
+2. Identity resolution is deterministic and visible
+3. Ambiguity can be resolved intentionally
+4. Ops can observe system state
+5. System runs inside controlled shell with feature flags
+
+Anything less = not working
+
+---
+
+# DECISION (LOCKED)
+
+Proceed immediately with:
+
+1. Complete Slice 15 (ops visibility)
+2. Move directly into telephony stabilization slice
+
+Do NOT attempt:
+
+- full identity system expansion
+- UI-heavy work
+- new features
+
+Focus only on making the system operationally real
+
+---
+
+# COUNTERPOINT
+
+This sequence delays visible progress in favor of stability.
+
+Risk:
+
+- feels slower
+- less immediate payoff
+
+Tradeoff:
+
+- prevents catastrophic debugging later
+- ensures ConnectShyft actually works when declared ready

--- a/slice-16-telephony-failures.txt
+++ b/slice-16-telephony-failures.txt
@@ -1,0 +1,15 @@
+=== FAILURES ONLY: TELEPHONY TARGETS ===
+1:FAIL src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts
+13:  ● connectshyft bridge webhook flow › loads persisted bridge state from a fresh thread detail read after completion
+52:PASS src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+81:PASS src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts
+98:PASS src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts
+110:PASS src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
+136:PASS src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts
+143:PASS src/modules/connectshyft/__tests__/numberMappings.test.ts
+162:PASS src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+180:PASS src/modules/connectshyft/__tests__/inboundVoice.test.ts
+190:PASS src/modules/connectshyft/__tests__/inboundSms.test.ts
+196:PASS src/modules/connectshyft/__tests__/senderNumberResolver.test.ts
+203:Test Suites: 1 failed, 1 skipped, 10 passed, 11 of 12 total
+204:Tests:       1 failed, 7 skipped, 116 passed, 124 total

--- a/slice-16-telephony-recon.txt
+++ b/slice-16-telephony-recon.txt
@@ -1,0 +1,10427 @@
+=== GIT / BRANCH / STATUS ===
+codex/dev
+?? slice-16-telephony-recon.txt
+63e575fc
+
+=== PACKAGE / WORKSPACE ===
+{
+  "version": "0.3.6",
+  "scripts": {
+    "test:e2e": "bash scripts/run-playwright-with-preflight.sh",
+    "test:e2e:headed": "bash scripts/run-playwright-with-preflight.sh --headed",
+    "test:e2e:debug": "bash scripts/run-playwright-with-preflight.sh --debug",
+    "test:runtime:cleanup": "bash scripts/cleanup-test-runtime.sh",
+    "test:patch:intake": "bash scripts/test-verified-patch-intake.sh",
+    "test:changed": "bash scripts/test-changed.sh",
+    "test:burn-in": "bash scripts/burn-in.sh 10",
+    "test:contracts:backend": "bash scripts/test-contracts-backend.sh",
+    "connectshyft:lane:guard": "bash scripts/enforce-connectshyft-lane-convergence-guard.sh",
+    "boundary:check": "node scripts/enforce-workspace-boundaries.js",
+    "policy:check": "bash scripts/enforce-git-policy.sh",
+    "patch:apply:verified": "bash scripts/verified-patch-apply.sh",
+    "patch:intake:guard": "bash scripts/enforce-verified-patch-intake-guard.sh",
+    "branch:ensure-workflow": "bash scripts/branch-ensure-workflow.sh",
+    "story:status:set": "bash scripts/story-status-transition.sh",
+    "story:status:check": "bash scripts/enforce-story-status-sync.sh",
+    "start:story-branch": "bash scripts/start-story-branch.sh",
+    "quality-gates": "bash scripts/quality-gates.sh",
+    "quality-gates:epic0": "bash scripts/quality-gates-epic0.sh",
+    "ci:local": "bash scripts/ci-local.sh",
+    "promote:production": "bash scripts/promote-to-production.sh",
+    "cutover:rehearse:moneyshyft": "node scripts/moneyshyft/wp-cutover/rehearse-route-cutover.mjs",
+    "cutover:shutdown:wp-writes": "node scripts/moneyshyft/wp-cutover/shutdown-wp-direct-writes.mjs",
+    "nx": "node scripts/nx-shim.mjs",
+    "dev:admin-api": "nx run admin-api:dev",
+    "dev:admin-web": "nx run admin-web:dev",
+    "dev:moneyshyft-api": "nx run moneyshyft-api:dev",
+    "dev:moneyshyft-web": "nx run moneyshyft-web:dev",
+    "dev:connectshyft-api": "nx run connectshyft-api:dev",
+    "dev:connectshyft-web": "nx run connectshyft-web:dev",
+    "build": "nx run-many -t build",
+    "test": "nx run-many -t test --exclude=e2e,connectshyft-api",
+    "affected:build": "nx affected -t build",
+    "affected:test": "nx affected -t test",
+    "affected:lint": "nx affected -t lint"
+  },
+  "devDependencies": {
+    "@faker-js/faker": "^9.9.0",
+    "@nx/eslint-plugin": "^20.0.0",
+    "@playwright/test": "^1.58.2",
+    "@vue/test-utils": "^2.4.6",
+    "eslint": "^9.0.0",
+    "jsdom": "^29.0.0",
+    "nx": "^20.0.0",
+    "playwright": "^1.58.2",
+    "start-server-and-test": "^2.1.5",
+    "vitest": "^4.1.0"
+  },
+  "name": "moneyshyft-monorepo",
+  "private": true,
+  "packageManager": "pnpm@10.28.0",
+  "dependencies": {
+    "jsonwebtoken": "^9.0.3"
+  }
+}
+
+packages:
+  - "apps/*"
+  - "libs/*"
+  - "packages/*"
+  - "tools/*"
+
+{
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "useDaemonProcess": false,
+  "useInferencePlugins": false,
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "sharedGlobals": [
+      "{workspaceRoot}/pnpm-lock.yaml",
+      "{workspaceRoot}/nx.json",
+      "{workspaceRoot}/tsconfig.base.json",
+      "{workspaceRoot}/libs/**/*"
+    ]
+  },
+  "targetDefaults": {
+    "build": { "cache": true, "inputs": ["default"] },
+    "test": { "cache": true, "inputs": ["default"] },
+    "lint": { "cache": true, "inputs": ["default"] },
+    "typecheck": { "cache": true, "inputs": ["default"] }
+  }
+}
+
+=== TELEPHONY ROUTES ===
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:62:} from '../../../modules/connectshyft/http/inboundWebhookContext';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:98:} from '../../../modules/connectshyft/smsPreferenceOverrides';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:105:} from '../../../modules/connectshyft/providerRegistry';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:128:} from '../../../modules/connectshyft/inboundSms';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:144:} from '../../../modules/connectshyft/inboundVoice';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:161:} from '../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:166:} from '../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:204:  inboundSmsAppended: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:205:  inboundVoiceVoicemail: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:206:  inboundVoiceFallback: CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:207:  voicemailTranscriptionRequested: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:208:  voicemailTranscriptionAttached: CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:211:  callDispatched: 'connectshyft.thread.outbound_call_dispatched',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:212:  messageDispatched: 'connectshyft.thread.outbound_message_dispatched',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:225:  transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:237:const CONNECTSHYFT_CONNECTED_CALL_EVENT_TYPES = new Set(['voice.connected', 'call.connected', 'callconnected']);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:297:    summary: 'Closed thread awaiting explicit outbound reopen',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:309:    summary: 'Unclaimed intake ready for policy-safe outbound action',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:369:    summary: 'Unclaimed thread with explicit outbound guardrail controls.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:381:    summary: 'Claimed thread with deterministic policy-safe outbound controls.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:393:    summary: 'Closed thread requiring explicit same-thread reopen before outbound.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:465:    summary: 'F1 unclaimed thread for provider adapter registry contracts.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:477:    summary: 'F1 claimed thread for provider disabled refusal validation.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:489:    summary: 'F1 closed thread for same-thread reopen provider dispatch validation.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:916:  bridgeSessionId: aggregate.session.id,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:948:  bridgeSessionId: string;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1014:  providerNumberE164: string | null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1019:    providerNumberE164: string;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1032:  const candidateProviderNumberE164 = normalizeLifecycleString(input.providerNumberE164 || null) || null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1043:        providerNumberE164: mapping.mapping.twilioNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1051:        message: 'Inbound SMS sender number is ambiguous across scoped provider mappings.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1061:        : 'Inbound SMS sender number does not map to an active scoped provider number.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1073:      message: 'Inbound SMS alignment requires a mapped provider number.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1082:    channel: 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1109:    providerNumberE164: resolution.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1115:  providerName: string;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1117:  const providerLegId = normalizeLifecycleString(input.correlation.providerLegId);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1118:  if (!providerLegId) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1123:    providerName: input.providerName,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1124:    providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1375:  const outboundContextLabel = 'Provider-neutral dispatch line';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1376:  const inboundContextLabel = input.descriptor.lastInboundCsNumberId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1377:    ? 'cs-number inbound line configured'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1399:    last_inbound_cs_number_id: input.descriptor.lastInboundCsNumberId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1401:    preferred_outbound_cs_number_id: input.descriptor.preferredOutboundCsNumberId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1404:      label: outboundContextLabel,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1406:    preferred_outbound_context: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1408:      label: outboundContextLabel,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1410:    voicemailIndicator: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1411:    voicemailLabel: null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1418:      inboundContext: inboundContextLabel,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1419:      outboundContext: outboundContextLabel,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1421:      conferenceContext: `Conference context: ${outboundContextLabel}`,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1427:      voicemailLabel: '',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1496:  outboundAction: ConnectShyftOutboundAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1497:): 'outbound_call' | 'outbound_message' => {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1498:  return outboundAction === 'call' ? 'outbound_call' : 'outbound_message';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1502:  outboundAction: ConnectShyftOutboundAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1504:  return outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1780:  providerNumberE164: string;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1793:  const providerNumberE164 = normalizeLifecycleString(input.providerNumberE164);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1794:  if (!providerNumberE164) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1804:    lastInboundCsNumberId: providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1805:    preferredOutboundCsNumberId: providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1833:        last_inbound_cs_number_id: providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:1834:        preferred_outbound_cs_number_id: providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2455:  outboundAction: ConnectShyftOutboundAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2457:  return outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2463:  outboundAction: ConnectShyftOutboundAction;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2472:  const isSms = input.outboundAction === 'message';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2475:    direction: 'outbound',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2476:    channel: isSms ? 'sms' : 'voice',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2484:    outboundMessageArtifact: isSms
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2486:        channel: 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2487:        direction: 'outbound',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2498:  routingDecision: 'voicemail_only' | 'intake_fallback' | 'accepted';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2502:  direction: 'inbound',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2505:    || input.eventType.toLowerCase().includes('voice')
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2507:    ? 'voice'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2508:    : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2654:  providerName: string;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2655:  dispatch: ConnectShyftProviderDispatchResult;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2666:  const callLegMappingResult = input.dispatch.providerLegId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2671:      providerName: input.providerName,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2673:      providerIdentifier: input.dispatch.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2679:  const messageMappingResult = input.dispatch.providerMessageId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2684:      providerName: input.providerName,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2686:      providerIdentifier: input.dispatch.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2713:  conversationType: 'message' | 'voicemail' | 'lifecycle';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2720:): 'message' | 'voicemail' | 'lifecycle' => {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2723:    normalized.includes('voicemail')
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2725:    || normalized.includes('voice.')
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2727:    return 'voicemail';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2732:    || normalized.includes('sms')
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2769:      firstClass: conversationType === 'voicemail' || conversationType === 'message',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2807:    const voicemailArtifact = asRecord(payload?.voicemailArtifact);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2808:    const payloadArtifactId = normalizeLifecycleString(voicemailArtifact?.artifactId);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2811:      const transcription = asRecord(voicemailArtifact?.transcription);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2822:    if (event.eventName !== CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.voicemailTranscriptionAttached) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2829:      metadata?.voicemailArtifactId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2830:      || payload?.voicemailArtifactId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2831:      || voicemailArtifact?.artifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2840:      || asRecord(voicemailArtifact?.transcription)?.text,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2856:  voicemailArtifactId: string;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2901:            payload -> 'payload' -> 'transcription' -> 'callbackCorrelation' ->> 'providerEventId',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2902:            payload -> 'payload' -> 'transcription' -> 'callbackCorrelation' ->> 'provider_event_id',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2910:            payload -> 'payload' -> 'transcription' -> 'callbackCorrelation' ->> 'voicemailArtifactId',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2911:            payload -> 'payload' -> 'transcription' -> 'callbackCorrelation' ->> 'voicemail_artifact_id'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2913:          [input.voicemailArtifactId],
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2946:      callbackCorrelation?.voicemailArtifactId || callbackCorrelation?.voicemail_artifact_id,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2949:      callbackCorrelation?.providerEventId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2950:      || callbackCorrelation?.provider_event_id
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:2958:      && callbackArtifactId === input.voicemailArtifactId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3253:          | 'connectshyft.sms_target.invalid'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3254:          | 'connectshyft.sms_target.missing'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3255:          | 'connectshyft.sms_target.ambiguous'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3256:          | 'connectshyft.sms_target.unavailable';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3282:      alignedFrom: 'preferred_outbound' | 'last_inbound';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3319:          | 'connectshyft.sms_sender.required'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3320:          | 'connectshyft.sms_sender.ambiguous';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3331:  return value.length > 0 && validatePhoneForChannel(value, 'sms').ok;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3373:    | 'connectshyft.sms_target.invalid'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3374:    | 'connectshyft.sms_target.missing'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3375:    | 'connectshyft.sms_target.ambiguous'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3376:    | 'connectshyft.sms_target.unavailable';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3417:    | 'connectshyft.sms_sender.required'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3418:    | 'connectshyft.sms_sender.ambiguous';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3478:      ? 'connectshyft.sms_sender.ambiguous'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3479:      : 'connectshyft.sms_sender.required',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3487:      senderPhone: normalizeLifecycleString(mapping.providerNumberE164),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3493:      : 'Persist a valid mapped provider number on the thread before retrying.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3519:    messageKey: 'connectshyft.sms_target.missing',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3525:      ? 'Choose a valid phone number and resubmit the outbound message.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3526:      : 'Update the neighbor profile or choose a valid phone number before sending the outbound message.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3553:        messageKey: 'connectshyft.sms_target.invalid',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3558:        accessibilityHint: 'Choose a valid phone number and resubmit the outbound message.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3601:          messageKey: 'connectshyft.sms_target.ambiguous',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3607:          accessibilityHint: 'Choose one phone number for this neighbor before sending the outbound message.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3614:        messageKey: 'connectshyft.sms_target.missing',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3619:        accessibilityHint: 'Update the neighbor profile or choose a valid phone number before sending the outbound message.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3627:        messageKey: 'connectshyft.sms_target.unavailable',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3655:    messageKey: 'connectshyft.sms_target.missing',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3660:    accessibilityHint: 'Update the neighbor profile or choose a valid phone number before sending the outbound message.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3679:      channel: 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3696:    senderPhone: resolution.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3702:      alignedFrom: resolution.routingMetadata.alignedFrom || 'preferred_outbound',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3714:  outboundAction: ConnectShyftOutboundAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3715:): 'send_sms' | 'start_bridge_session' => (
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3716:  outboundAction === 'call' ? 'start_bridge_session' : 'send_sms'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3730:  actorType: 'user' | 'system' | 'provider';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3735:  channel: 'sms' | 'voice' | 'bridge' | 'webhook';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3741:  providerName?: string | null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3742:  providerReferenceId?: string | null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3760:    providerName: input.providerName ?? null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3761:    providerReferenceId: input.providerReferenceId ?? null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3793:      message: 'Outbound calls require bridge transport only.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3991:router.get('/admin/webhook-receipts/metrics', getConnectWebhookReceiptMetrics);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3993:router.post('/admin/webhook-receipts/cleanup', postConnectWebhookReceiptCleanup);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4182:      providerNeutral: true,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4399:  outboundAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4411:  const outboundCallPolicyRequest = outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4415:    outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4416:    && outboundCallPolicyRequest
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4417:    && !enforceOutboundCallPolicyRequest(req, res, outboundCallPolicyRequest)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4424:    req.header('x-test-connectshyft-enabled-providers'),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4438:  const providerSelection = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4440:    operation: outboundAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4443:  if (!providerSelection.ok) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4445:      code: providerSelection.refusal.code,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4446:      message: providerSelection.refusal.message,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4447:      refusalType: providerSelection.refusal.refusalType,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4448:      httpStatus: providerSelection.refusal.httpStatus,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4450:        ...providerSelection.refusal.data,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4459:  const outboundMessagePolicy = outboundAction === 'message'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4462:  const outboundDispatchIdempotencyKey = parseOutboundDispatchIdempotencyKey(req);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4463:  const outboundIdempotencyOperation = resolveOutboundIdempotencyOperationName(outboundAction);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4464:  const outboundCallDispatchPolicy: ConnectShyftOutboundCallDispatchPolicy | null = outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4466:      transport: outboundCallPolicyRequest?.transport || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4467:      autoRetry: outboundCallPolicyRequest?.autoRetry === true,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4468:      redialPolicy: outboundCallPolicyRequest?.redialPolicy || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4471:  let outboundDispatchReplayKey: string | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4478:  const outboundLifecycleAction = resolveOutboundLifecycleAction(outboundAction);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4480:  const dispatchEventName = resolveOutboundDispatchEventName(outboundAction);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4483:  let smsPreferenceDecision: ConnectShyftResolvedSmsPreference | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4488:  let outboundDispatch: ReturnType<typeof buildLifecycleSideEffects> | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4489:  let outboundMessageTargetPhone: string | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4490:  let outboundMessageSenderPhone: string | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4491:  let outboundCallSenderPhone: string | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4492:  let outboundSenderResolutionMetadata: Record<string, unknown> | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4496:  let bridgeSessionState: ConnectShyftBridgeSessionStateContract | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4497:  let bridgeCorrelationMapping: ConnectShyftBridgeCorrelationMapping | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4528:      action: outboundLifecycleAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4613:  if (outboundAction === 'message' && outboundMessagePolicy) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4617:    smsPreferenceDecision = await connectShyftSmsPreferenceOverrideService.resolvePreference({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4625:      prefersTexting: smsPreferenceDecision.prefersTexting,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4626:      overrideReason: outboundMessagePolicy.overrideReason,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4627:      overrideNote: outboundMessagePolicy.overrideNote,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4643:            prefersTexting: smsPreferenceDecision.prefersTexting,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4644:            source: smsPreferenceDecision.source,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4645:            overrideRequired: smsPreferenceDecision.prefersTexting === 'NO',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4658:            accessibilityHint: 'Open override reason selector and resubmit the outbound message.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4701:  if (outboundAction === 'call') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4702:    operatorContactPointId = outboundCallPolicyRequest?.operatorContactPointId || null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4713:        message: 'Outbound bridge calls require an operator callback number.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4717:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4718:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4719:            adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4720:            providerBranchingInDomain: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4723:            dispatchAttempted: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4733:    neighborContactPointId = outboundCallPolicyRequest?.targetPhone || null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4758:        message: 'Outbound bridge calls require a dialable neighbor phone.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4762:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4763:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4764:            adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4765:            providerBranchingInDomain: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4768:            dispatchAttempted: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4779:  if (outboundAction === 'message') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4780:    const smsTargetResolution = await resolveConnectShyftSmsTarget({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4786:      requestedTargetPhone: outboundMessagePolicy?.targetPhone || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4789:    if (!smsTargetResolution.ok) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4791:        code: smsTargetResolution.code,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4792:        message: smsTargetResolution.message,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4799:            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4800:            source: smsPreferenceDecision?.source || 'unknown',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4801:            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4802:            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4813:          ...smsTargetResolution.data,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4829:    outboundMessageTargetPhone = smsTargetResolution.targetPhone;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4830:    const dispatchReadySmsTarget = ensureConnectShyftDispatchReadySmsTarget({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4831:      resolvedTargetPhone: outboundMessageTargetPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4832:      requestedTargetPhone: outboundMessagePolicy?.targetPhone || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4835:    if (!dispatchReadySmsTarget.ok) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4837:        code: dispatchReadySmsTarget.code,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4838:        message: dispatchReadySmsTarget.message,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4845:            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4846:            source: smsPreferenceDecision?.source || 'unknown',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4847:            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4848:            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4859:          ...dispatchReadySmsTarget.data,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4875:    outboundMessageTargetPhone = dispatchReadySmsTarget.targetPhone;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4877:    const smsSenderResolution = await resolveConnectShyftSmsSender({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4883:    if (!smsSenderResolution.ok) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4885:        code: smsSenderResolution.code,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4886:        message: smsSenderResolution.message,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4893:            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4894:            source: smsPreferenceDecision?.source || 'unknown',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4895:            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4896:            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4907:          ...smsSenderResolution.data,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4923:    outboundMessageSenderPhone = smsSenderResolution.senderPhone;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4924:    outboundSenderResolutionMetadata = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4925:      source: smsSenderResolution.source,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4926:      channel: 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4927:      senderPhone: smsSenderResolution.senderPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4928:      orgUnitId: smsSenderResolution.metadata.orgUnitId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4929:      selectedMappingId: smsSenderResolution.metadata.selectedMappingId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4930:      selectedMappingLabel: smsSenderResolution.metadata.selectedMappingLabel,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4931:      alignedFrom: smsSenderResolution.metadata.alignedFrom,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4932:      threadHints: smsSenderResolution.metadata.threadHints,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4936:  if (outboundAction === 'call') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4937:    const voiceSenderResolution = await resolveSenderNumber(
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4942:        channel: 'voice',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4948:    if (!voiceSenderResolution.ok) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4949:      const voiceSenderCode = voiceSenderResolution.reason === 'sender_mapping_ambiguous'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4953:        code: voiceSenderCode,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4954:        message: voiceSenderResolution.reason === 'sender_mapping_ambiguous'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4955:          ? 'Resolve the mapped ConnectShyft outbound line so exactly one active scoped mapping remains before starting a call.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4956:          : 'Persist one valid mapped ConnectShyft outbound line on the thread before starting a call.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4963:            reason: voiceSenderResolution.reason,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4965:            channel: 'voice',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4966:            orgUnitId: voiceSenderResolution.routingMetadata.orgUnitId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4967:            candidateProviderNumberE164: voiceSenderResolution.routingMetadata.candidateProviderNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4984:    outboundCallSenderPhone = voiceSenderResolution.providerNumberE164;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4985:    outboundSenderResolutionMetadata = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4986:      source: voiceSenderResolution.routingMetadata.source,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4987:      channel: 'voice',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4988:      senderPhone: voiceSenderResolution.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4989:      orgUnitId: voiceSenderResolution.routingMetadata.orgUnitId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4990:      selectedMappingId: voiceSenderResolution.mappingId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4991:      selectedMappingLabel: voiceSenderResolution.routingMetadata.mappingLabel,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4992:      alignedFrom: voiceSenderResolution.routingMetadata.alignedFrom,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4996:  outboundDispatchReplayKey = buildTelephonyDispatchReplayKey({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5000:    providerKey: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5001:    action: outboundAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5002:    idempotencyKey: outboundDispatchIdempotencyKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5004:    targetPhone: outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5006:      : outboundMessageTargetPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5007:    senderPhone: outboundAction === 'message'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5008:      ? outboundMessageSenderPhone
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5009:      : outboundCallSenderPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5010:    operatorContactPointId: outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5013:    body: outboundMessagePolicy?.body || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5014:    callPolicy: outboundCallDispatchPolicy,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5020:  const outboundIdempotencyRecord = (
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5021:    outboundDispatchIdempotencyKey
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5022:    && outboundDispatchReplayKey
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5026:      idempotencyKey: outboundDispatchIdempotencyKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5027:      operationName: outboundIdempotencyOperation,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5030:      requestFingerprint: outboundDispatchReplayKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5032:        outboundAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5034:        providerKey: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5035:        targetPhone: outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5037:          : outboundMessageTargetPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5038:        senderPhone: outboundAction === 'message'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5039:          ? outboundMessageSenderPhone
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5040:          : outboundCallSenderPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5042:        senderResolution: outboundSenderResolutionMetadata,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5048:  if (outboundIdempotencyRecord?.decision === 'conflict') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5051:      message: 'Idempotency key cannot be reused for a materially different outbound request.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5058:          idempotencyKey: outboundDispatchIdempotencyKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5064:  if (outboundIdempotencyRecord?.decision === 'in_progress') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5067:      message: 'An identical outbound request is already in progress.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5075:          idempotencyKey: outboundDispatchIdempotencyKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5081:  if (outboundIdempotencyRecord?.decision === 'return_existing') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5083:      outboundIdempotencyRecord.record.responseSnapshot,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5103:        correlationId: outboundDispatchReplayKey || randomUUID(),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5106:        operationName: outboundIdempotencyOperation,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5107:        targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5109:        channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5112:        resultMessage: 'Duplicate outbound request replayed from durable idempotency state.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5113:        idempotencyKey: outboundDispatchIdempotencyKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5114:        requestFingerprint: outboundDispatchReplayKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5115:        providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5119:          senderResolution: outboundSenderResolutionMetadata,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5133:              replayKey: outboundDispatchReplayKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5142:      message: 'Idempotent replay state is unavailable for this completed outbound request.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5149:          idempotencyKey: outboundDispatchIdempotencyKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5156:    outboundAction === 'message'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5157:    && smsPreferenceDecision?.prefersTexting === 'NO'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5165:        neighborId: smsPreferenceDecision.neighborId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5169:        messageBody: outboundMessagePolicy?.body || '',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5170:        messageEventName: 'connectshyft.thread.outbound_message_dispatched',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5189:            prefersTexting: smsPreferenceDecision.prefersTexting,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5190:            source: smsPreferenceDecision.source,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5224:  let providerDispatch: ConnectShyftProviderDispatchResult;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5226:    providerDispatch = outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5228:        const bridgeStart = await startConnectShyftBridgeSession({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5236:          selectedOutboundContactPointId: outboundCallSenderPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5237:          providerKey: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5238:          providerAdapter: providerSelection.adapter,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5239:          idempotencyKey: outboundDispatchIdempotencyKey || undefined,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5240:          auditCorrelationId: outboundDispatchReplayKey || undefined,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5241:          callPolicy: outboundCallDispatchPolicy || undefined,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5244:        bridgeSessionState = buildProviderNeutralBridgeSessionState(bridgeStart.aggregate);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5245:        bridgeCorrelationMapping = bridgeStart.correlationMapping;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5248:          providerKey: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5250:          providerLegId: bridgeStart.aggregate.operatorLeg.providerCallId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5251:          providerMessageId: null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5253:          providerBranchingInDomain: false as const,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5254:          requestedAt: bridgeStart.aggregate.operatorLeg.updatedAt.toISOString(),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5258:        return providerSelection.adapter.sendSms({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5262:          providerKey: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5263:          idempotencyKey: outboundDispatchIdempotencyKey || undefined,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5264:          body: outboundMessagePolicy?.body || '',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5265:          targetPhone: outboundMessageTargetPhone || undefined,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5266:          senderPhone: outboundMessageSenderPhone || undefined,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5279:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5280:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5281:            adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5282:            providerBranchingInDomain: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5285:            dispatchAttempted: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5289:          providerCallPolicy: error.data,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5293:      if (outboundIdempotencyRecord?.decision === 'proceed') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5295:          record: outboundIdempotencyRecord.record,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5312:        correlationId: outboundDispatchReplayKey || randomUUID(),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5315:        operationName: outboundIdempotencyOperation,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5316:        targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5318:        channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5322:      idempotencyKey: outboundDispatchIdempotencyKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5323:      requestFingerprint: outboundDispatchReplayKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5324:      providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5327:        senderResolution: outboundSenderResolutionMetadata,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5335:    const providerFailureClassification = isTelephonyProviderFailure(error)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5340:      message: 'Provider dispatch failed before persistence.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5344:        providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5345:          ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5346:          adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5347:          providerBranchingInDomain: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5350:          dispatchAttempted: true,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5354:        providerFailureClassification,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5355:        error: error instanceof Error ? error.message : 'unknown-provider-dispatch-error',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5359:    if (outboundIdempotencyRecord?.decision === 'proceed') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5361:        record: outboundIdempotencyRecord.record,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5372:        failureSnapshot: providerFailureClassification,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5373:        failureMessage: error instanceof Error ? error.message : 'unknown-provider-dispatch-error',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5379:      correlationId: outboundDispatchReplayKey || randomUUID(),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5382:      operationName: outboundIdempotencyOperation,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5383:      targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5385:      channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5386:      resultState: providerFailureClassification?.retryable ? 'retrying' : 'failed',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5389:      idempotencyKey: outboundDispatchIdempotencyKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5390:      requestFingerprint: outboundDispatchReplayKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5391:      providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5392:      providerReferenceId: providerFailureClassification?.providerCode || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5394:        providerFailureClassification,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5395:        error: error instanceof Error ? error.message : 'unknown-provider-dispatch-error',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5396:        senderResolution: outboundSenderResolutionMetadata,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5404:  const resolvedSenderPhoneForThreadAlignment = outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5405:    ? outboundCallSenderPhone
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5406:    : outboundMessageSenderPhone;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5413:      providerNumberE164: resolvedSenderPhoneForThreadAlignment,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5433:  const outboundDispatchMetadata = buildLifecycleMetadata({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5440:    action: outboundLifecycleAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5447:    eventName: dispatchEventName,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5448:    metadata: outboundDispatchMetadata,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5455:    eventName: dispatchEventName,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5456:    metadata: outboundDispatchMetadata,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5464:    outboundDispatch = expectedDispatchSideEffects;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5466:      stage: 'outbound-side-effects',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5477:    outboundDispatch = persistedDispatch.sideEffects;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5486:      eventType: resolveCanonicalEventTypeForOutboundAction(outboundAction),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5488:        outboundAction,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5490:        lifecycleEvent: dispatchEventName,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5493:        messageBody: outboundMessagePolicy?.body || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5494:        senderPhone: outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5495:          ? outboundCallSenderPhone
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5496:          : outboundMessageSenderPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5497:        targetPhone: outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5498:          ? (outboundCallPolicyRequest?.targetPhone || neighborContactPointId || null)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5499:          : outboundMessageTargetPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5521:    bridgeCorrelationMapping as ConnectShyftBridgeCorrelationMapping | null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5523:  if (outboundAction === 'call' && resolvedBridgeCorrelationMapping) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5527:        stage: 'provider-correlation',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5537:      providerName: providerDispatch.providerKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5538:      dispatch: providerDispatch,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5541:    const outboundProviderCorrelation =
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5543:    if (outboundProviderCorrelation.error) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5545:        stage: 'provider-correlation',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5546:        code: outboundProviderCorrelation.error.code,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5547:        message: outboundProviderCorrelation.error.message,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5550:  } else if (providerDispatch.providerLegId || providerDispatch.providerMessageId) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5552:      stage: 'provider-correlation',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5560:  const dispatchContext = {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5561:    targetPhone: outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5562:      ? (outboundCallPolicyRequest?.targetPhone || neighborContactPointId || null)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5563:      : outboundMessageTargetPhone || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5564:    messageBodyProvided: outboundAction === 'message'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5565:      ? Boolean(outboundMessagePolicy?.body)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5569:    ? 'Outbound dispatch completed with persistence warnings. Review traceability details before retrying.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5571:      ? 'Conversation reopened on the same thread and outbound dispatch completed. Escalation and inactivity timers were reset.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5573:        ? 'Outbound dispatched. Escalation continues until claim; no reset was applied.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5574:        : 'Outbound dispatched from a claimed thread. Escalation remains stable unless ownership changes.';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5576:    ? 'Outbound dispatch completed with warnings.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5578:      ? 'Conversation reopened and outbound dispatch completed.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5579:      : 'Outbound dispatch completed.';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5582:    : outboundAction === 'message'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5583:      && smsPreferenceDecision?.prefersTexting === 'NO'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5585:      ? 'Override applied. Outbound message dispatched.'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5588:    ? 'connectshyft.outbound.dispatch_warning'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5590:      ? 'connectshyft.thread.reopened_dispatch_success'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5591:      : outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5592:        ? 'connectshyft.outbound.call.dispatched'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5593:        : 'connectshyft.outbound.message.dispatched';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5603:  const responseCode = outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5606:  const responseMessage = outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5607:    ? 'ConnectShyft outbound call dispatched'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5608:    : 'ConnectShyft outbound message dispatched';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5634:    providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5635:      ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5636:      adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5637:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5640:    ...(outboundSenderResolutionMetadata
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5642:        senderResolution: outboundSenderResolutionMetadata,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5645:    dispatch: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5646:      ...providerDispatch,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5647:      dispatchContext,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5652:      replayKey: outboundDispatchReplayKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5657:    ...(outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5661:          bridgeSession: bridgeSessionState,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5665:            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5666:            source: smsPreferenceDecision?.source || 'unknown',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5667:            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5668:            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5695:    ...(outboundDispatch ? { outboundDispatch } : {}),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5697:  const bridgeSessionId = (
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5698:    bridgeSessionState as ConnectShyftBridgeSessionStateContract | null
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5699:  )?.bridgeSessionId || null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5700:  if (outboundIdempotencyRecord?.decision === 'proceed') {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5702:      record: outboundIdempotencyRecord.record,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5713:      resourceType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5714:      resourceId: outboundAction === 'call'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5715:        ? normalizeLifecycleString(bridgeSessionId)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5722:    correlationId: outboundDispatchReplayKey || randomUUID(),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5725:    operationName: outboundIdempotencyOperation,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5726:    targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5728:    channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5732:    idempotencyKey: outboundDispatchIdempotencyKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5733:    requestFingerprint: outboundDispatchReplayKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5734:    providerName: providerDispatch.providerKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5735:    providerReferenceId: providerDispatch.providerLegId || providerDispatch.providerMessageId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5739:      bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5740:      senderResolution: outboundSenderResolutionMetadata,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5758:  providerSelection,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5769:  const webhookPersistenceDb = isConnectShyftTestOverrideEnabled()
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5775:    const callbackInboundProviderEventId = normalizeLifecycleString(correlation.providerEventId);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5779:        message: 'Transcription callback requires providerEventId for deterministic replay handling.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5783:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5784:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5793:            providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5794:            providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5795:            providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5796:            providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5808:            eventName: 'connectshyft.voicemail.transcription_refused',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5813:              reason: 'provider_event_id_missing',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5825:      providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5827:      providerEventId: callbackInboundProviderEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5828:      providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5829:      providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5834:        callbackProviderEventId: callbackPayload.correlation.providerEventId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5835:        voicemailArtifactId: callbackPayload.correlation.voicemailArtifactId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5837:      db: webhookPersistenceDb,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5842:        message: 'Inbound webhook correlation resolved but receipt persistence is unavailable.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5846:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5847:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5856:            providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5857:            providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5858:            providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5859:            providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5889:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5890:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5899:            providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5900:            providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5901:            providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5902:            providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5921:    const callbackProviderEventId = normalizeLifecycleString(callbackPayload.correlation.providerEventId);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5923:      callbackPayload.correlation.voicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5926:      callbackPayload.correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5942:        || !correlation.providerLegId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5943:        || callbackProviderLegId === correlation.providerLegId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5950:        voicemailArtifactId: callbackVoicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5959:        providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5962:        providerEventId: callbackInboundProviderEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5963:        providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5964:        providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5971:        db: webhookPersistenceDb,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5975:        message: 'Transcription callback correlation is invalid or unresolved for voicemail attachment.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5979:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5980:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5989:            providerEventId: callbackProviderEventId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5990:            voicemailArtifactId: callbackVoicemailArtifactId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6002:            eventName: 'connectshyft.voicemail.transcription_refused',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6007:              provider_event_id: callbackProviderEventId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6008:              voicemail_artifact_id: callbackVoicemailArtifactId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6030:          voicemailArtifactId: callbackVoicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6045:        providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6048:        providerEventId: callbackInboundProviderEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6049:        providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6050:        providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6053:        db: webhookPersistenceDb,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6067:            providerEventId: callbackProviderEventId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6068:            voicemailArtifactId: callbackVoicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6088:      providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6091:      providerEventId: callbackInboundProviderEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6092:      providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6093:      providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6095:      db: webhookPersistenceDb,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6100:      message: 'Transcription callback attached to voicemail artifact',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6103:        providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6104:          ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6113:          providerEventId: callbackProviderEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6114:          voicemailArtifactId: callbackVoicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6124:          voicemailArtifactId: callbackVoicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6127:          eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.voicemailTranscriptionAttached,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6140:  const webhookReceipt = await beginConnectShyftWebhookReceiptProcessing({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6144:    providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6146:    providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6147:    providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6148:    providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6153:      providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6154:      providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6155:      providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6156:      providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6158:    db: webhookPersistenceDb,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6160:  if (webhookReceipt.error) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6162:      code: webhookReceipt.error.code,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6163:      message: 'Inbound webhook correlation resolved but receipt persistence is unavailable.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6167:        providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6168:          ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6177:          providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6178:          providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6179:          providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6180:          providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6185:          dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6208:      providerCode?: string | null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6216:        providerCode: null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6223:          providerCode: null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6228:        attemptCount: webhookReceipt.attemptCount,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6245:      providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6246:      dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6248:      providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6249:      providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6250:      providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6255:      db: webhookPersistenceDb,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6259:      correlationId: webhookReceipt.dedupeKey || correlation.providerEventId || randomUUID(),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6260:      actorType: 'provider',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6261:      operationName: 'apply_provider_event',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6262:      targetEntityType: 'webhook_receipt',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6263:      targetEntityId: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6264:      channel: 'webhook',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6274:      providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6275:      providerReferenceId: correlation.providerEventId || correlation.providerLegId || correlation.providerMessageId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6279:        attemptCount: webhookReceipt.attemptCount,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6283:      db: webhookPersistenceDb,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6287:  const shouldSuppressWebhookDuplicate = webhookReceipt.alreadyApplied
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6288:    || webhookReceipt.previousStatus === 'RECEIVED'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6289:    || webhookReceipt.previousStatus === 'FAILED_TERMINAL';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6294:      correlationId: webhookReceipt.dedupeKey || correlation.providerEventId || randomUUID(),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6295:      actorType: 'provider',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6296:      operationName: 'apply_provider_event',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6297:      targetEntityType: 'webhook_receipt',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6298:      targetEntityId: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6299:      channel: 'webhook',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6302:      resultMessage: 'Duplicate webhook suppressed before domain side effects.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6303:      providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6304:      providerReferenceId: correlation.providerEventId || correlation.providerLegId || correlation.providerMessageId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6308:        attemptCount: webhookReceipt.attemptCount,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6310:      db: webhookPersistenceDb,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6314:      message: 'Inbound webhook accepted (duplicate suppressed)',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6320:        providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6321:          ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6330:          providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6331:          providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6332:          providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6333:          providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6338:          dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6350:  const bridgeWebhookProgression = await handleConnectShyftBridgeWebhookEvent({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6354:    providerKey: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6355:    providerAdapter: providerSelection.adapter,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6356:    providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6368:  if (bridgeWebhookProgression.handled && !isConnectedCallEvent) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6372:      message: 'Inbound webhook accepted',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6375:        providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6376:          ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6385:          providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6386:          providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6387:          providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6388:          providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6393:          dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6395:        bridgeSession: bridgeWebhookProgression.aggregate
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6396:          ? buildProviderNeutralBridgeSessionState(bridgeWebhookProgression.aggregate)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6398:        bridgeEvent: bridgeWebhookProgression.domainEvent,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6399:        correlationMapping: bridgeWebhookProgression.correlationMapping,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6410:  const isSmsEvent = normalizedEventType.includes('sms') || normalizedEventType.includes('message');
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6453:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6454:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6463:            providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6464:            providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6465:            providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6466:            providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6471:            dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6496:            providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6497:              ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6506:              providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6507:              providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6508:              providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6509:              providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6514:              dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6550:            correlationId: webhookReceipt.dedupeKey
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6551:              || correlation.providerMessageId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6552:              || correlation.providerEventId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6553:              || correlation.providerLegId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6555:            providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6556:            providerReferenceId: correlation.providerMessageId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6557:              || correlation.providerEventId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6558:              || correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6577:                providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6578:                  ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6587:                  providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6588:                  providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6589:                  providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6590:                  providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6595:                  dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6621:              providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6622:                ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6631:                providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6632:                providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6633:                providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6634:                providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6639:                dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6665:            providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6666:              ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6675:              providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6676:              providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6677:              providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6678:              providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6683:              dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6706:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6707:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6716:            providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6717:            providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6718:            providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6719:            providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6724:            dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6748:    const inboundAlignedProviderNumber = await resolveInboundAlignedProviderNumber({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6752:      providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6791:    if (!inboundAlignedProviderNumber.ok) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6793:        inboundAlignedProviderNumber.code === 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6796:        inboundAlignedProviderNumber.reason,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6799:        code: inboundAlignedProviderNumber.code,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6800:        message: inboundAlignedProviderNumber.message,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6804:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6805:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6815:            providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6816:            providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6817:            providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6818:            providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6823:            dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6834:          reason: inboundAlignedProviderNumber.reason,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6840:      webhookBody: req.body,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6842:      providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6843:      providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6844:      providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6856:        lastInboundCsNumberId: inboundAlignedProviderNumber.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6857:        preferredOutboundCsNumberId: inboundAlignedProviderNumber.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6858:        eventType: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.inboundSmsAppended,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6869:        await markWebhookReceipt('FAILED_TERMINAL', 'inbound_sms_ensure_refused');
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6876:            providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6877:              ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6887:              providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6888:              providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6889:              providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6890:              providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6895:              dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6912:        await markWebhookReceipt('FAILED_RETRYABLE', 'inbound_sms_thread_ensure_persistence_unavailable');
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6919:            providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6920:              ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6930:              providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6931:              providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6932:              providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6933:              providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6938:              dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6951:      await markWebhookReceipt('FAILED_RETRYABLE', 'inbound_sms_canonical_persistence_unavailable');
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6958:          providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6959:            ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6969:            providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6970:            providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6971:            providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6972:            providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6977:            dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6992:      await markWebhookReceipt('FAILED_RETRYABLE', 'inbound_sms_processing_incomplete');
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7004:      message: 'Inbound webhook accepted for processing',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7007:        from: domainEvent.inboundMessageArtifact.from,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7008:        to: domainEvent.inboundMessageArtifact.to,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7010:        providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7011:          ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7021:          providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7022:          providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7023:          providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7024:          providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7029:          dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7033:          providerBranchingInDomain: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7044:        inboundMessageArtifact: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7046:          ...domainEvent.inboundMessageArtifact,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7080:                  provider_event_id: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7081:                  provider_message_id: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7082:                  provider_leg_id: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7095:                  provider_event_id: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7096:                  provider_message_id: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7097:                  provider_leg_id: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7107:  const isVoiceEvent = normalizedEventType.startsWith('voice') || normalizedEventType.includes('call');
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7139:  const voiceNeighborId = resolvedVoiceNeighborId || candidateVoiceNeighborId;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7147:      providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7246:      neighborId: voiceNeighborId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7258:      fallbackNeighborId: voiceNeighborId || lifecycleContext.syntheticThread.neighborId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7266:  let routingDecision: 'voicemail_only' | 'intake_fallback' | 'accepted' = 'accepted';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7270:      : CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.inboundVoiceVoicemail;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7271:  let voiceRoutingPolicy: { claimedMode?: 'orgunit_configured_mode' } = {};
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7272:  let voiceDomainEvent: ReturnType<typeof mapConnectShyftInboundVoiceWebhookToDomainEvent> | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7281:    voiceRoutingPolicy = routing.routingPolicy;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7283:    voiceDomainEvent = mapConnectShyftInboundVoiceWebhookToDomainEvent({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7284:      webhookBody: req.body,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7288:      providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7289:      providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7290:      providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7296:    voiceDomainEvent && routingDecision !== 'intake_fallback',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7298:  const voicemailArtifactId = shouldCreateVoicemailArtifact
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7300:      correlation.providerEventId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7301:      || correlation.providerLegId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7305:  const transcription = shouldCreateVoicemailArtifact && voicemailArtifactId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7310:      providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7311:      providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7312:      voicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7315:  const voicemailArtifact = shouldCreateVoicemailArtifact && voicemailArtifactId && voiceDomainEvent
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7317:      artifactId: voicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7318:      ...voiceDomainEvent.inboundVoiceArtifact,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7329:      payload: voiceDomainEvent
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7331:          domainEvent: voiceDomainEvent,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7334:          voicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7346:    await markWebhookReceipt('FAILED_RETRYABLE', 'inbound_voice_canonical_persistence_unavailable');
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7349:      message: 'Inbound voice processing could not persist canonical event side effects.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7353:        providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7354:          ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7363:          ...(voiceNeighborId ? { neighborId: voiceNeighborId } : {}),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7364:          providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7365:          providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7366:          providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7367:          providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7372:          dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7390:  const responseThread = thread && voiceNeighborId
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7393:      neighborId: voiceNeighborId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7400:    message: 'Inbound webhook accepted for processing',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7403:      from: voiceDomainEvent?.inboundVoiceArtifact.from || (typeof req.body?.from === 'string' ? req.body.from : null),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7404:      to: voiceDomainEvent?.inboundVoiceArtifact.to || (typeof req.body?.to === 'string' ? req.body.to : null),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7406:      providerResolution: {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7407:        ...providerSelection.providerResolution,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7416:        ...(voiceNeighborId ? { neighborId: voiceNeighborId } : {}),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7417:        providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7418:        providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7419:        providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7420:        providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7425:        dedupeKey: webhookReceipt.dedupeKey,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7429:        providerBranchingInDomain: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7432:      ...(bridgeWebhookProgression.handled
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7434:            bridgeSession: bridgeWebhookProgression.aggregate
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7435:              ? buildProviderNeutralBridgeSessionState(bridgeWebhookProgression.aggregate)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7437:            bridgeEvent: bridgeWebhookProgression.domainEvent,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7438:            correlationMapping: bridgeWebhookProgression.correlationMapping,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7452:      ...(voiceRoutingPolicy.claimedMode
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7455:              claimedMode: voiceRoutingPolicy.claimedMode,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7459:      ...(voicemailArtifact ? { voicemailArtifact } : {}),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7482:          neighbor_id: voiceNeighborId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7486:          voicemail_artifact_id: voicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7492:          reopened_by_inbound: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7501:          neighbor_id: voiceNeighborId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7505:          voicemail_artifact_id: voicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7511:          reopened_by_inbound: false,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7517:              eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.voicemailTranscriptionRequested,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7523:                voicemail_artifact_id: transcription.callbackCorrelation.voicemailArtifactId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7524:                provider_event_id: transcription.callbackCorrelation.providerEventId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7525:                provider_leg_id: transcription.callbackCorrelation.providerLegId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7547:router.post('/webhooks/inbound', postConnectWebhookInbound);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7549:router.post('/webhooks/sms', postConnectWebhookSms);
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:15:import { recordConnectShyftBridgeLegProviderIdentifierMapping } from './providerCorrelationMappings'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:20:} from './providerRegistry'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:22:const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:23:const BRIDGE_LEGS_TABLE = 'cs_bridge_legs'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:34:  selected_outbound_contact_point_id?: string | null
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:35:  bridge_status: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:50:  bridge_session_id: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:53:  provider_call_id?: string | null
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:73:  providerKey: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:74:  providerAdapter: ConnectShyftProviderAdapter
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:84:  providerKey: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:85:  providerAdapter: ConnectShyftProviderAdapter
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:86:  providerLegId: string | null
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:155:  selectedOutboundContactPointId: normalizeString(row.selected_outbound_contact_point_id) || null,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:156:  status: row.bridge_status as BridgeSessionRecord['status'],
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:171:  bridgeSessionId: row.bridge_session_id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:174:  providerCallId: normalizeString(row.provider_call_id) || null,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:194:  selected_outbound_contact_point_id: session.selectedOutboundContactPointId ?? null,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:195:  bridge_status: session.status,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:210:  bridge_session_id: leg.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:213:  provider_call_id: leg.providerCallId ?? null,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:235:    const current = this.legsBySessionId.get(leg.bridgeSessionId) || new Map()
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:237:    this.legsBySessionId.set(leg.bridgeSessionId, current)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:238:    if (leg.providerCallId) {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:239:      this.sessionIdByProviderCallId.set(leg.providerCallId, leg.bridgeSessionId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:250:    if (aggregate.operatorLeg.providerCallId) {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:251:      this.sessionIdByProviderCallId.set(aggregate.operatorLeg.providerCallId, aggregate.session.id)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:253:    if (aggregate.neighborLeg.providerCallId) {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:254:      this.sessionIdByProviderCallId.set(aggregate.neighborLeg.providerCallId, aggregate.session.id)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:277:    providerCallId: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:279:    const sessionId = this.sessionIdByProviderCallId.get(input.providerCallId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:364:      .where({ bridge_session_id: sessionId })
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:369:        'bridge_session_id',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:372:        'provider_call_id',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:398:    providerCallId: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:403:      .join(`${BRIDGE_SESSIONS_TABLE} as bs`, 'bs.id', 'bl.bridge_session_id')
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:404:      .where('bl.provider_call_id', input.providerCallId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:412:      .first<{ bridgeSessionId?: string }>('bl.bridge_session_id as bridgeSessionId')
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:414:    const sessionId = normalizeString(legRow?.bridgeSessionId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:452:  transport: normalizeString(callPolicy?.transport) || 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:461:  providerKey: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:462:  providerAdapter: ConnectShyftProviderAdapter
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:467:    const startBridgeOutboundCall = input.providerAdapter.startBridgeOutboundCall
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:468:    const dispatchResult = startBridgeOutboundCall
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:473:        providerKey: input.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:474:        bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:481:      : await input.providerAdapter.startOutboundCall({
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:485:        providerKey: input.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:491:    const providerCallId = normalizeString(dispatchResult.providerLegId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:492:    if (!providerCallId) {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:493:      throw new Error('Bridge outbound call requires a provider call id.')
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:497:      providerCallId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:501:    if (!input.providerAdapter.startBridgeSession) {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:502:      throw new Error(`Provider ${input.providerKey} does not support bridge control.`)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:505:    await input.providerAdapter.startBridgeSession({
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:506:      providerKey: input.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:507:      bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:519:  providerName: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:522:  if (!input.leg.providerCallId) {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:530:    providerName: input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:531:    providerIdentifier: input.leg.providerCallId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:532:    bridgeLegId: input.leg.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:541:  providerName: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:548:      providerName: input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:555:      providerName: input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:582:  providerLegId: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:588:  const legRole = input.aggregate.operatorLeg.providerCallId === input.providerLegId
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:590:    : input.aggregate.neighborLeg.providerCallId === input.providerLegId
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:594:  if (normalizedEventType === 'callanswered' || normalizedEventType === 'voiceanswered') {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:598:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:599:        providerCallId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:607:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:608:        providerCallId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:615:    normalizedEventType === 'callbridged'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:619:      type: 'bridge_connected',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:620:      bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:630:    if (input.aggregate.session.status === 'bridged' || input.aggregate.session.status === 'completed') {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:633:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:634:        providerCallId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:642:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:643:        providerCallId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:652:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:653:        providerCallId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:668:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:669:        providerCallId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:678:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:679:        providerCallId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:794:  providerCallId: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:807:    providerKey: input.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:808:    providerAdapter: input.providerAdapter,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:835:      providerName: input.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:848:  const providerLegId = normalizeString(input.providerLegId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:849:  if (!providerLegId) {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:860:    providerCallId: providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:873:    providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:891:    providerKey: input.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:892:    providerAdapter: input.providerAdapter,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:915:      providerName: input.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:50:  'providerLegId',
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:51:  'providerMessageId',
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:52:  'providerPayload',
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:53:  'providerName',
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:54:  'providerKey',
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:55:  'providerEventId',
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:56:  'providerNumber',
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:57:  'providerNumberE164',
+apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts:124:      || key.toLowerCase().startsWith('provider')
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.thread.test.ts:8:} from '../../../../routes/api/v1/__tests__/connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:12:  - owns thread detail request handoff, response assembly, canonical timeline inclusion, voicemail artifact projection, and bridge-session payload shaping
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:24:- the current detail envelope with `thread`, `bridgeSession`, `voicemailArtifacts`, `actions`, and policy metadata
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:38:- later slices clarify how outbound, webhook, and neighboring identity flows should contribute to the canonical read surface
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:48:- outbound call and message extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:49:- inbound SMS and inbound voice extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:50:- webhook and provider-correlation extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:60:4. Do not pull outbound dispatch or webhook orchestration into the read surface.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:65:Lifecycle, outbound, and webhook extraction remain separate work.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:67:They should not be folded into the thread read family as part of follow-up cleanup. The next extraction target after Slice 5 is lifecycle actions, while outbound and webhook surfaces remain intentionally deferred.
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectWebhookReceiptMetrics.ts:5:} from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectWebhookReceiptMetrics.ts:7:import { resolveConnectShyftWebhookReceiptMetricsAccessContext } from '../http/webhookReceiptAdminContext';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:56:const CONNECTSHYFT_INBOUND_NEIGHBOR_AUDIT_OPERATION_NAME = 'connectshyft.inbound.neighbor_created';
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3128:  providerName?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3129:  providerReferenceId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3145:    channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3148:    resultMessage: 'Created inbound SMS neighbor from unmatched sender phone.',
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3150:    providerName: input.providerName ?? null,
+apps/connectshyft-api/src/modules/connectshyft/neighbors.ts:3151:    providerReferenceId: input.providerReferenceId ?? null,
+apps/connectshyft-api/src/modules/connectshyft/PEOPLECORE_IDENTITY_HOOKS_NOTES.md:6:- inbound subject resolution enables provisional-person creation on seam-level `no_match`
+apps/connectshyft-api/src/modules/connectshyft/PEOPLECORE_IDENTITY_HOOKS_NOTES.md:7:- inbound subject resolution enables resolver-review creation on seam-level `IDENTITY_MATCH_AMBIGUOUS`
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:388:      .table('cs_sms_preference_overrides')
+apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts:459:      .table('cs_sms_preference_overrides')
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:252:  last_inbound_cs_number_id: string;
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:253:  preferred_outbound_cs_number_id: string;
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:528:  lastInboundCsNumberId: normalizeThreadSenderAlignmentValue(row.last_inbound_cs_number_id),
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:529:  preferredOutboundCsNumberId: normalizeThreadSenderAlignmentValue(row.preferred_outbound_cs_number_id),
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:932:      'last_inbound_cs_number_id',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:933:      'preferred_outbound_cs_number_id',
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:965:            last_inbound_cs_number_id: lastInboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:966:            preferred_outbound_cs_number_id: preferredOutboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1008:          last_inbound_cs_number_id: lastInboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1009:          preferred_outbound_cs_number_id: preferredOutboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1060:              last_inbound_cs_number_id: lastInboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/threads.ts:1061:              preferred_outbound_cs_number_id: preferredOutboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectNumberMapping.ts:18:    twilioNumberE164: accessContext.payload.providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.identity.test.ts:9:} from '../../../../routes/api/v1/__tests__/connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:54:- outbound call extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:55:- outbound message extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:56:- inbound SMS extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:57:- inbound voice extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:58:- webhook and provider-correlation extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:59:- PeopleCore neighbor or identity bridge convergence work
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:69:4. Do not fold outbound dispatch logic into the lifecycle handlers.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:70:5. Do not pull webhook or inbound orchestration into the lifecycle helper boundary.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:75:Lifecycle extraction is now separate from outbound and webhook extraction.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:77:That separation should remain explicit. Follow-up cleanup should not use the lifecycle helper boundary as a place to absorb outbound reopen rules, provider dispatch concerns, inbound correlation work, or webhook processing. The next extraction target after Slice 6 is neighbors / identity bridge, while outbound and webhook surfaces remain intentionally deferred.
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:13:export type ConnectShyftSenderChannel = 'sms' | 'voice';
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:15:type SenderAlignmentSource = 'preferred_outbound' | 'last_inbound';
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:36:  providerNumberE164: string;
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:69:      providerNumberE164: string;
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:110:): { alignedFrom: SenderAlignmentSource | null; providerNumberE164: string | null; invalid: boolean } => {
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:116:      alignedFrom: 'preferred_outbound',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:117:      providerNumberE164: preferredOutbound,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:124:      alignedFrom: 'preferred_outbound',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:125:      providerNumberE164: preferredOutbound,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:132:      alignedFrom: 'last_inbound',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:133:      providerNumberE164: lastInbound,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:140:    providerNumberE164: null,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:175:          providerNumberE164: mapping.twilioNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:211:  if (!aligned.providerNumberE164) {
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:218:      message: 'Thread sender resolution requires a persisted provider-number alignment.',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:225:    || !validatePhoneForChannel(aligned.providerNumberE164, input.channel).ok
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:231:      candidateProviderNumberE164: aligned.providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:233:      message: 'Thread sender alignment must contain one valid provider number.',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:240:    twilioNumberE164: aligned.providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:248:      candidateProviderNumberE164: aligned.providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:250:      message: 'Thread sender alignment does not map to an active provider number in this tenant.',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:260:      candidateProviderNumberE164: aligned.providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:262:      message: 'Thread sender alignment is ambiguous across provider number mappings.',
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:273:      candidateProviderNumberE164: aligned.providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts:283:    providerNumberE164: mapping.mapping.twilioNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:5:The ConnectShyft neighbor / identity bridge surface is currently split across these files:
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:27:  - owns identity-match request handoff, identity bridge refusal mapping, and preserved identity-match response assembly
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:35:Slice 7 intentionally preserves the exact current response shapes for the full neighbor / identity bridge family.
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:47:This was deliberate. The goal of this slice was thin-router extraction and a cleaner bridge boundary, not payload redesign.
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:82:- the bridge boundary is documented as the seam where future PeopleCore convergence can swap internals without re-thickening the router
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:88:The following work remains deferred beyond the neighbor / identity bridge family:
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:90:- outbound call extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:91:- outbound message extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:92:- inbound SMS extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:93:- inbound voice extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:94:- webhook and provider-correlation extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:106:5. Do not fold outbound dispatch logic into the neighbor / identity handler family.
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:107:6. Do not pull inbound or webhook orchestration into the neighbor / identity helper boundary.
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:112:Neighbor / identity extraction is now separate from outbound and webhook extraction.
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:114:That separation should stay explicit. Follow-up cleanup should not use the neighbor / identity handler family as a place to absorb outbound action rules, provider dispatch concerns, inbound correlation work, or webhook processing. The next extraction target after Slice 7 is outbound actions, while inbound and webhook surfaces remain intentionally deferred.
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:4:import * as BridgeSessionsModule from '../../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:9:} from '../../../../routes/api/v1/__tests__/connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:15:    id: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:24:    status: 'bridged',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:35:    id: 'bridge-leg-operator-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:38:    bridgeSessionId: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:41:    providerCallId: 'provider-leg-operator-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:52:    id: 'bridge-leg-neighbor-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:55:    bridgeSessionId: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:58:    providerCallId: 'provider-leg-neighbor-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:70:describe('connectshyft ops bridge visibility route', () => {
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:75:  it('surfaces bridge runtime state from the existing bridge-session seam', async () => {
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:82:      .get('/api/v1/connectshyft/ops/bridge/bridge-session-ops-1001')
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:90:        bridgeId: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:100:        provider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:106:  it('maps operator dialing bridge state to ringing from the runtime seam', async () => {
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:130:      .get('/api/v1/connectshyft/ops/bridge/bridge-session-ops-1001')
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:138:        bridgeId: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:148:        provider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:6:import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from './inboundSms';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:12:} from './inboundVoice';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:16:export const CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME = 'connectshyft.outbound.sms_appended' as const;
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:17:export const CONNECTSHYFT_OUTBOUND_SMS_EVENT_NAME_ALIAS = 'connectshyft.thread.outbound_message_dispatched' as const;
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:19:  started: 'connectshyft.voice.started',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:20:  connected: 'connectshyft.voice.connected',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:21:  ended: 'connectshyft.voice.ended',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:22:  outboundDispatched: 'connectshyft.thread.outbound_call_dispatched',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:25:export type ConnectShyftThreadTimelineDirection = 'inbound' | 'outbound';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:26:export type ConnectShyftThreadTimelineChannel = 'sms' | 'voice' | 'voicemail';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:28:export type ConnectShyftThreadTimelineItemType = 'message' | 'voice_event' | 'voicemail';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:36:  providerMetadata: Record<string, unknown> | null;
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:42:  channel: 'sms';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:47:  type: 'voice_event';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:48:  channel: 'voice';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:53:  type: 'voicemail';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:54:  channel: 'voicemail';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:106:  return value === 'inbound' || value === 'outbound'
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:145:  providerMetadata: asRecord(input.payload.providerMetadata),
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:151:  artifactKey: 'inboundMessageArtifact' | 'outboundMessageArtifact',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:159:  return asRecord(payload.voicemailArtifact);
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:165:  outboundFallback?: 'system' | 'user';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:172:  if (input.fallbackDirection === 'inbound') {
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:176:  return input.outboundFallback || 'system';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:180:  const artifact = resolveMessageArtifact(payload, 'inboundMessageArtifact');
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:190:      direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:193:        fallbackDirection: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:197:    channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:203:  const artifact = resolveMessageArtifact(payload, 'outboundMessageArtifact');
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:213:      direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:216:        fallbackDirection: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:217:        outboundFallback: 'system',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:221:    channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:227:  const direction = normalizeDirection(payload.direction) || 'inbound';
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:239:    type: 'voice_event',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:240:    channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:254:      direction: normalizeDirection(payload.direction) || 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:257:        fallbackDirection: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:260:    type: 'voicemail',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:261:    channel: 'voicemail',
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts:278:  [CONNECTSHYFT_VOICE_TIMELINE_EVENT_NAMES.outboundDispatched, mapVoiceEventTimelineEvent],
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:1:import { loadConnectShyftBridgeAggregateBySessionId } from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:11:  bridgeId: string;
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:21:  provider: 'telnyx';
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:28:  if (status === 'bridged') {
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:79:  bridgeId: string;
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:82:  const aggregate = await loadConnectShyftBridgeAggregateBySessionId(input.bridgeId);
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:92:    bridgeId: aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:102:    provider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:12:  inboundContext: string;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:13:  outboundContext: string;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:17:  voicemailLabel: string;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:39:  last_inbound_cs_number_id: string;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:41:  preferred_outbound_cs_number_id: string;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:46:  preferred_outbound_context: {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:50:  voicemailIndicator: boolean;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:51:  voicemailLabel: string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:83:  voicemailIndicator: boolean;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:98:  last_inbound_cs_number_id?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:99:  preferred_outbound_cs_number_id?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:100:  preferred_outbound_label?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:101:  outbound_label?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:102:  voicemail_waiting?: boolean | number | string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:103:  voicemail_indicator?: boolean | number | string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:104:  unread_voicemail_count?: number | string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:105:  unread_voicemail_count_mine?: number | string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:185:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:201:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:217:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:233:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:234:    summary: 'Waiting for outbound follow-up',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:249:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:265:    voicemailIndicator: true,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:281:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:297:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:313:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:314:    summary: 'Closed thread awaiting explicit outbound reopen',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:329:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:330:    summary: 'Unclaimed thread awaiting policy-safe outbound action',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:345:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:361:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:377:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:393:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:409:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:425:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:441:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:442:    summary: 'Closed thread pending outbound confirmation',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:447:    threadId: 'thread-ux-r1-claimed-voicemail-1004',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:457:    voicemailIndicator: true,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:473:    voicemailIndicator: true,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:474:    summary: 'Voicemail received from inbound caller',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:489:    voicemailIndicator: true,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:490:    summary: 'Claimed voicemail remains with assigned owner',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:505:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:506:    summary: 'Closed thread locked against inbound auto-reopen',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:521:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:537:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:553:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:569:    voicemailIndicator: true,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:585:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:586:    summary: 'Unclaimed thread with explicit outbound guardrail actions',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:601:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:602:    summary: 'Claimed thread with deterministic outbound controls',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:617:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:633:    voicemailIndicator: true,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:649:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:650:    summary: 'Prefers texting NO requires explicit override before dispatch',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:665:    voicemailIndicator: false,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:823:  voicemailIndicator: boolean;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:826:  if (!input.voicemailIndicator) {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:875:  voicemailLabel: string | null;
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:884:  const outboundContext = normalizeString(input.preferredOutboundLabel)
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:886:      ? 'Mapped outbound number configured'
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:888:  const inboundContext = lastInboundProviderNumber
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:889:    ? 'Mapped inbound number configured'
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:897:    inboundContext,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:898:    outboundContext,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:900:    conferenceContext: `Conference context: ${outboundContext}`,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:906:    voicemailLabel: input.voicemailLabel || '',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:930:  const voicemailLabel = resolveVoicemailLabel({
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:931:    voicemailIndicator: seed.voicemailIndicator,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:959:    last_inbound_cs_number_id: lastInboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:961:    preferred_outbound_cs_number_id: preferredOutboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:966:    preferred_outbound_context: {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:970:    voicemailIndicator: seed.voicemailIndicator,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:971:    voicemailLabel,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:980:      voicemailLabel,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1133:    'last_inbound_cs_number_id',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1134:    'preferred_outbound_cs_number_id',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1135:    'preferred_outbound_label',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1136:    'outbound_label',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1137:    'voicemail_waiting',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1138:    'voicemail_indicator',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1139:    'unread_voicemail_count',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1140:    'unread_voicemail_count_mine',
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1286:    row.preferred_outbound_cs_number_id,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1292:    row.last_inbound_cs_number_id,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1295:    row.preferred_outbound_label ?? row.outbound_label,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1297:  const unreadVoicemailCount = normalizeFiniteNumber(row.unread_voicemail_count, 0);
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1298:  const unreadVoicemailCountMine = normalizeFiniteNumber(row.unread_voicemail_count_mine, 0);
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1300:  const voicemailIndicator = normalizeBoolean(row.voicemail_indicator)
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1301:    || normalizeBoolean(row.voicemail_waiting)
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1304:  const voicemailLabel = resolveVoicemailLabel({
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1305:    voicemailIndicator,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1328:    last_inbound_cs_number_id: normalizedLastInboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1330:    preferred_outbound_cs_number_id: normalizedPreferredOutboundCsNumberId,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1335:    preferred_outbound_context: {
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1339:    voicemailIndicator,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1340:    voicemailLabel,
+apps/connectshyft-api/src/modules/connectshyft/readContracts.ts:1349:      voicemailLabel,
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookInbound.ts:2:import { executeConnectShyftInboundWebhookRoute } from '../http/inboundWebhookContext';
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookInbound.ts:5:  executeConnectShyftInboundWebhookRoute(req, res, 'inbound');
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:7:  connectshyft_webhooks_enabled: boolean;
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:10:export type ConnectShyftCapability = 'module' | 'inbox' | 'escalation' | 'webhooks';
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:33:  connectshyft_webhooks_enabled: 'CONNECTSHYFT_WEBHOOKS_ENABLED',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:40:  connectshyft_webhooks_enabled: false,
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:63:  webhooks: {
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:65:    message: 'Inbound webhook processing is unavailable for this tenant.',
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:96:    connectshyft_webhooks_enabled: normalizeFlag(candidate.connectshyft_webhooks_enabled),
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:106:  connectshyft_webhooks_enabled: parseBooleanEnv(
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:107:    process.env[CONNECTSHYFT_FLAG_ENV_MAP.connectshyft_webhooks_enabled],
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:157:      connectshyft_webhooks_enabled: false,
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:165:    connectshyft_webhooks_enabled: flags.connectshyft_webhooks_enabled,
+apps/connectshyft-api/src/modules/connectshyft/featureFlags.ts:184:    webhooks: flags.connectshyft_webhooks_enabled,
+apps/connectshyft-api/src/modules/connectshyft/handlers/numberMappingContract.ts:15:      normalized.providerNumberE164 = normalizedEntry;
+apps/connectshyft-api/src/modules/connectshyft/handlers/numberMappingContract.ts:19:    if (key === 'providerNumberE164') {
+apps/connectshyft-api/src/modules/connectshyft/handlers/numberMappingContract.ts:20:      normalized.providerNumberE164 = normalizedEntry;
+apps/connectshyft-api/src/modules/connectshyft/handlers/numberMappingContract.ts:27:      normalized.providerField = 'providerNumberE164';
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:5:The ConnectShyft outbound thread surface is currently split across these files:
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:11:  - owns the currently registered outbound core execution path that preserves the existing call and message behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:13:  - owns call-route request handoff and delegates outbound execution through the shared helper boundary
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:15:  - owns message-route request handoff and delegates outbound execution through the shared helper boundary
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:17:  - owns shared outbound route-family context enforcement, `threadId` parsing, shared lifecycle prerequisite loading, capability and orgUnit-membership gating, prerequisite refusal mapping, and the shared execution wrapper that hands the request to the existing outbound core
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:21:Slice 8 intentionally did not move outbound business internals out of their existing homes.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:25:- provider selection and provider dispatch policy behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:26:  - still owned by the existing outbound core in `connectshyft.ts` and provider-facing modules such as `providerRegistry.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:27:- bridge session startup and bridge-session state orchestration
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:28:  - still owned by the existing outbound core in `connectshyft.ts` and `bridgeSessions.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:30:  - still owned by the existing outbound core in `connectshyft.ts` and `communicationReliability.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:32:  - still owned by the existing outbound core in `connectshyft.ts` and `communicationAuditLog.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:34:  - still owned by the existing outbound core in `connectshyft.ts` and `smsPreferenceOverrides.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:36:Slice 8 was an extraction slice, not a provider, bridge, reliability, or audit redesign.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:40:Slice 8 intentionally preserves the exact current outbound response shapes for both routes.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:46:- existing nested provider, bridge-session, idempotency, audit, override, and side-effect payload structure remains unchanged
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:48:This was deliberate. The goal of this slice was thin-router extraction and an explicit outbound helper boundary, not payload cleanup or response redesign.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:52:Slice 8 also intentionally preserves the exact current reopen behavior for closed-thread outbound flows.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:56:- the current same-thread reopen behavior for outbound calls
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:57:- the current same-thread reopen behavior for outbound messages
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:64:The following work remains deferred beyond the outbound thread family:
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:66:- inbound SMS extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:67:- inbound voice extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:68:- voicemail handling extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:70:- webhook entry extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:71:- webhook correlation and receipt orchestration extraction
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:72:- provider or bridge architecture redesign
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:77:When editing outbound handlers in later slices:
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:80:2. Keep shared outbound prerequisites and refusal mapping in `threadOutboundContext.ts`.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:83:5. Do not fold provider, bridge, reliability, audit, or SMS-override internals into the thin handlers or helper boundary.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:84:6. Do not pull inbound, webhook, or telephony callback orchestration into the outbound handler family.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:88:Outbound extraction is now separate from inbound, webhook, and telephony extraction.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:90:That separation should stay explicit. Follow-up cleanup should not use the outbound handlers or `threadOutboundContext.ts` as a place to absorb inbound message intake, webhook correlation, provider signature handling, bridge webhook progression, voicemail processing, or transcription callbacks. Those surfaces remain intentionally deferred to the next slice after Slice 8.
+apps/connectshyft-api/src/modules/connectshyft/http/numberMappingContext.ts:17:  providerNumberE164: string;
+apps/connectshyft-api/src/modules/connectshyft/http/numberMappingContext.ts:67:  providerNumberE164: typeof req.body?.providerNumberE164 === 'string'
+apps/connectshyft-api/src/modules/connectshyft/http/numberMappingContext.ts:68:    ? req.body.providerNumberE164
+apps/connectshyft-api/src/modules/connectshyft/handlers/putConnectNumberMapping.ts:19:    twilioNumberE164: accessContext.payload.providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectAvailability.ts:40:    webhooks: evaluateConnectShyftCapability(input.flags, 'webhooks').ok,
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:33:export const CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME = 'connectshyft.inbound.sms_appended' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:84:  webhookBody: unknown,
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:86:  const payload = asRecord(webhookBody);
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:87:  const providerPayload = asRecord(payload?.providerPayload);
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:91:  return [payload, providerPayload, dataPayload, data];
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:95:  channel: 'sms';
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:96:  direction: 'inbound';
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:97:  providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:98:  providerMessageId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:99:  providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:111:  inboundMessageArtifact: ConnectShyftInboundSmsArtifact;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:115:  webhookBody: unknown,
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:118:    readWebhookSources(webhookBody),
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:124:  webhookBody: unknown,
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:127:    readWebhookSources(webhookBody),
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:159:  webhookBody: unknown;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:161:  providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:162:  providerMessageId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:163:  providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:165:  const sources = readWebhookSources(input.webhookBody);
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:176:    inboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:177:      channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:178:      direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:179:      providerEventId: input.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:180:      providerMessageId: input.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:181:      providerLegId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:193:  direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:194:  channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts:202:  inboundMessageArtifact: input.domainEvent.inboundMessageArtifact,
+apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts:56:          provider_name: entry.providerName ?? null,
+apps/connectshyft-api/src/modules/connectshyft/communicationAuditLog.ts:57:          provider_reference_id: entry.providerReferenceId ?? null,
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:55:- provider registry behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:57:- sender-number and dispatch policy behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:64:Outbound, webhook, and telephony extraction is explicitly deferred in Slice 4.
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:68:- outbound call or message dispatch rewrites
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:69:- inbound SMS or voice rewrites
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:70:- webhook/provider orchestration rewrites
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:71:- bridge-session orchestration moves
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:83:4. keep deferred transport and provider concerns out unless that slice is explicitly about them
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:5:The ConnectShyft inbound webhook surface is currently split across these files:
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:9:    - `POST /webhooks/inbound`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:10:    - `POST /webhooks/sms`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:11:  - owns the currently registered inbound webhook core execution path that preserves the existing inbound SMS, inbound voice, voicemail, transcription callback, and auto-claim behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:13:  - owns inbound-webhook route handoff and delegates execution through the shared helper boundary with deterministic `inbound` route preparation
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:15:  - owns SMS-webhook route handoff and delegates execution through the shared helper boundary with deterministic `sms` route preparation
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:16:- `apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:17:  - owns shared inbound route-entry prerequisite handling
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:18:  - owns capability enforcement for webhook access
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:19:  - owns provider selection and signature verification at the route-entry seam
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:21:  - owns webhook correlation resolution and rollout-context validation
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:22:  - owns prerequisite refusal mapping and the shared execution wrapper that hands the request to the existing inbound core
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:26:Slice 9 intentionally did not move inbound telephony or provider internals out of their existing homes.
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:28:That means the following concerns remain outside the thin handlers and outside `inboundWebhookContext.ts`:
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:30:- provider internals
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:31:  - still owned by the existing inbound core in `connectshyft.ts` and provider-facing modules such as `providerRegistry.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:32:- correlation persistence and webhook-receipt orchestration internals
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:33:  - still owned by the existing inbound core in `connectshyft.ts` and `providerCorrelationMappings.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:35:  - still owned by the existing inbound core in `connectshyft.ts` and `canonicalEvents.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:36:- bridge-session webhook progression and bridge alignment behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:37:  - still owned by the existing inbound core in `connectshyft.ts` and `bridgeSessions.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:38:- inbound SMS domain mapping and neighbor-resolution behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:39:  - still owned by the existing inbound core in `connectshyft.ts` and `inboundSms.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:40:- inbound voice, voicemail artifact, and transcription internals
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:41:  - still owned by the existing inbound core in `connectshyft.ts` and `inboundVoice.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:43:Provider, correlation, canonical, bridge, and transcription internals remain intentionally deferred from the route-family extraction sequence.
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:47:Slice 9 intentionally preserves the exact current inbound webhook response shapes.
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:51:- `POST /webhooks/inbound` still returns the existing success and refusal envelopes
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:52:- `POST /webhooks/sms` still returns the existing success and refusal envelopes
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:53:- existing nested provider, correlation, canonical, bridge, voicemail, transcription, auto-claim, and side-effect payload structure remains unchanged
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:59:Slice 9 also intentionally locks the current operational inbound behavior.
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:63:- current inbound SMS handling and neighbor-resolution semantics
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:64:- current inbound voice behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:65:- current voice auto-claim behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:66:- current voicemail behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:71:## Telephony and provider redesign note
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:73:This slice did not redesign telephony behavior or provider behavior.
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:77:- re-architect webhook routing semantics
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:78:- redesign provider verification or translation behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:80:- redesign bridge handling
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:81:- redesign voicemail or transcription processing
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:87:That work should build on the current thin handlers and `inboundWebhookContext.ts` boundary rather than pulling deferred provider, correlation, canonical, bridge, or transcription internals into the route-family extraction seam.
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:53:      idempotencyKey: `inbound-subject:${input.tenantId}:${input.orgUnitId}:${input.contactPoint}`,
+apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts:63:        triggerSourceType: 'connectshyft_inbound_subject_resolution',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:7:import { loadConnectShyftBridgeAggregateByThreadId } from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:10:} from '../inboundVoice';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:32:  conversationType: 'message' | 'voicemail' | 'lifecycle';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:83:  bridgeSessionId: aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:106:): 'message' | 'voicemail' | 'lifecycle' => {
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:109:    normalized.includes('voicemail')
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:111:    || normalized.includes('voice.')
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:113:    return 'voicemail';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:118:    || normalized.includes('sms')
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:156:      firstClass: conversationType === 'voicemail' || conversationType === 'message',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:186:    const voicemailArtifact = asRecord(payload?.voicemailArtifact);
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:187:    const payloadArtifactId = normalizeString(voicemailArtifact?.artifactId);
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:190:      const transcription = asRecord(voicemailArtifact?.transcription);
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:208:      metadata?.voicemailArtifactId
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:209:      || payload?.voicemailArtifactId
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:210:      || voicemailArtifact?.artifactId,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:219:      || asRecord(voicemailArtifact?.transcription)?.text,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:289:  const shouldSynthesizeVoicemailTimeline = thread.voicemailIndicator
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:290:    || readContext.threadId.toLowerCase().includes('voicemail');
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:296:          eventId: `${thread.threadId}-voicemail-inline`,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:299:          eventType: 'connectshyft.voicemail.inline',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:301:            eventName: 'connectshyft.voicemail.inline',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:302:            summary: thread.display?.voicemailLabel || thread.voicemailLabel || 'Voicemail received',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:308:          eventName: 'connectshyft.voicemail.inline',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:312:          conversationType: 'voicemail' as const,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:318:  const voicemailArtifacts = resolveVoicemailArtifactsFromTimeline(resolvedTimeline);
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:322:    providerNeutral: true as const,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:337:      bridgeSession: activeBridgeSession
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:340:      voicemailArtifacts,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:345:      outboundPolicy: {
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookReceiptCleanup.ts:5:} from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookReceiptCleanup.ts:7:import { resolveConnectShyftWebhookReceiptCleanupAccessContext } from '../http/webhookReceiptAdminContext';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:10:} from '../providerRegistry';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:12:import { resolveConnectShyftProviderCorrelationByIdentifiers } from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:18:export type ConnectShyftInboundWebhookRouteKind = 'inbound' | 'sms';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:19:export type ConnectShyftWebhookCorrelationSource = 'metadata' | 'provider_fallback' | 'number_mapping';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:28:    providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:29:    providerMessageId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:30:    providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:31:    providerNumberE164: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:43:    providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:44:    providerMessageId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:45:    providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:46:    providerNumberE164: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:51:  providerSelection: ConnectShyftProviderResolutionSuccess;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:100:  return pathCandidates.some((value) => value.endsWith('/webhooks/sms') || value.endsWith('/sms'))
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:101:    ? 'sms'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:102:    : 'inbound';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:118:      message: 'Inbound webhook requires correlation metadata or provider identifiers.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:124:      message: 'Inbound webhook correlation is ambiguous across provider identifiers.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:130:      message: 'Inbound webhook correlation lookup is temporarily unavailable.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:136:    message: 'Inbound webhook correlation mapping not found for provider identifiers.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:142:  channelHint: 'sms' | 'voice';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:143:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:144:  providerCorrelation: {
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:145:    providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:146:    providerMessageId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:147:    providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:148:    providerNumber: string | null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:156:  const providerIdentifiers = {
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:157:    providerLegId: normalizeString(input.providerCorrelation.providerLegId) || null,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:158:    providerMessageId: normalizeString(input.providerCorrelation.providerMessageId) || null,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:159:    providerEventId: normalizeString(input.providerCorrelation.providerEventId) || null,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:161:  const providerNumberE164 = normalizeString(input.providerCorrelation.providerNumber) || null;
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:171:      providerName: input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:172:      providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:173:      providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:189:        message: 'Inbound webhook correlation metadata conflicts with provider identifier mapping.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:191:        providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:192:        providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:193:        providerEventId: providerIdentifiers.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:194:        providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:204:      providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:205:      providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:206:      providerEventId: providerIdentifiers.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:207:      providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:212:    providerName: input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:213:    providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:214:    providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:218:  if (!fallback.ok && providerNumberE164) {
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:222:        twilioNumberE164: providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:231:          providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:232:          providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:233:          providerEventId: providerIdentifiers.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:234:          providerNumberE164: numberMapping.mapping.twilioNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:242:          message: 'Inbound webhook correlation is ambiguous across provider number mappings.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:244:          providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:245:          providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:246:          providerEventId: providerIdentifiers.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:247:          providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:254:        message: 'Inbound webhook correlation lookup is temporarily unavailable.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:256:        providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:257:        providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:258:        providerEventId: providerIdentifiers.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:259:        providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:267:        message: 'Inbound webhook correlation mapping not found for provider identifiers.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:269:        providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:270:        providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:271:        providerEventId: providerIdentifiers.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:272:        providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:284:      providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:285:      providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:286:      providerEventId: providerIdentifiers.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:287:      providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:299:      message: 'Inbound webhook partial metadata conflicts with provider identifier mapping.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:301:      providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:302:      providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:303:      providerEventId: providerIdentifiers.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:304:      providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:310:    source: 'provider_fallback',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:314:    providerLegId: providerIdentifiers.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:315:    providerMessageId: providerIdentifiers.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:316:    providerEventId: providerIdentifiers.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:317:    providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:326:  if (!await enforceConnectShyftCapability(req, res, 'webhooks')) {
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:330:  const providerSelection = resolveConnectShyftProviderAdapter({
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:332:    operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:335:  if (!providerSelection.ok) {
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:337:      code: providerSelection.refusal.code,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:338:      message: providerSelection.refusal.message,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:339:      refusalType: providerSelection.refusal.refusalType,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:340:      httpStatus: providerSelection.refusal.httpStatus,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:341:      data: providerSelection.refusal.data,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:347:    providerSelection.adapter.verifyWebhook(
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:350:        providerKey: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:356:      ? 'connectshyft.webhook.signature.missing'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:358:        ? 'connectshyft.webhook.signature.not_configured'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:359:        : 'connectshyft.webhook.signature.invalid';
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:366:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:367:          ...providerSelection.providerResolution,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:373:          provider: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:379:          remediation: 'Ensure provider webhook signing is configured and include a valid signature.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:395:  const canonicalTranslation = providerSelection.adapter.translateProviderEvent({
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:396:    rawEventType: normalizeString(req.body?.eventType) || 'sms.inbound',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:404:      normalizedEventType.includes('sms') || normalizedEventType.includes('message')
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:405:        ? 'sms'
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:406:        : 'voice',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:407:    providerName: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:408:    providerCorrelation: canonicalTranslation.correlation,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:418:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:419:          ...providerSelection.providerResolution,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:427:          providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:428:          providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:429:          providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:430:          providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:435:          messageKey: 'connectshyft.webhook.correlation.unresolved',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:436:          remediation: 'Retry with thread metadata or provider identifiers that map to a prior outbound dispatch.',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:467:    operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:468:    requestedProvider: providerSelection.providerResolution.resolvedProvider,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:484:          providerLegId: correlation.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:485:          providerMessageId: correlation.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:486:          providerEventId: correlation.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:487:          providerNumberE164: correlation.providerNumberE164,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:496:    providerSelection,
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:524:    throw new Error('ConnectShyft inbound webhook core executor is not registered.');
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookSms.ts:2:import { executeConnectShyftInboundWebhookRoute } from '../http/inboundWebhookContext';
+apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookSms.ts:5:  executeConnectShyftInboundWebhookRoute(req, res, 'sms');
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:13:import { readConnectShyftBridgeVisibility } from '../ops/bridgeVisibility.service';
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:25:  surface: 'identity' | 'thread' | 'bridge';
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:40:  surface: 'identity' | 'thread' | 'bridge';
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:254:  const bridgeId = parseParam(req.params.bridgeId);
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:255:  if (!bridgeId) {
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:258:      message: 'bridgeId is required',
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:271:    surface: 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:274:    resourceId: bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:280:    bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:286:      surface: 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:289:      resourceId: bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:299:        bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:307:    surface: 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:310:    resourceId: bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:317:    message: 'ConnectShyft ops bridge visibility loaded',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:4:const PROVIDER_IDENTIFIER_MAPPINGS_TABLE = 'cs_provider_identifier_mappings';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:5:const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:18:  providerCode?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:31:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:33:  providerIdentifier: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:42:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:43:  providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:44:  providerMessageId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:52:    source: 'provider_leg_id' | 'provider_message_id' | 'provider_consensus';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:64:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:66:  providerIdentifier: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:75:  provider_name?: unknown;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:77:  provider_identifier?: unknown;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:88:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:141:  providerEventId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:142:  providerLegId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:143:  providerMessageId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:146:    normalizeString(input.providerEventId || null)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:147:    || normalizeString(input.providerLegId || null)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:148:    || normalizeString(input.providerMessageId || null)
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:158:  providerName: string,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:160:  providerIdentifier: string,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:162:  return `${tenantId}|${providerName}|${identifierKind}|${providerIdentifier}`;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:166:  providerName: string,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:168:  providerIdentifier: string,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:170:  return `${providerName}|${identifierKind}|${providerIdentifier}`;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:175:  providerName: string,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:179:  return `${tenantId}|${providerName}|${sid}|${eventType}`;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:236:  const providerName = normalizeProviderName(row.provider_name);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:237:  const providerIdentifier = normalizeString(row.provider_identifier);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:247:    !providerName
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:248:    || !providerIdentifier
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:262:    providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:264:    providerIdentifier,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:272:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:274:  providerIdentifier: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:278:    input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:280:    input.providerIdentifier,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:285:      record.providerName === input.providerName
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:287:      && record.providerIdentifier === input.providerIdentifier
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:290:        record.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:292:        record.providerIdentifier,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:307:    record.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:309:    record.providerIdentifier,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:340:      provider_name: input.record.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:342:      provider_identifier: input.record.providerIdentifier,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:346:    .onConflict(['tenant_id', 'provider_name', 'identifier_kind', 'provider_identifier'])
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:352:      'provider_name',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:354:      'provider_identifier',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:372:      provider_name: input.record.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:374:      provider_identifier: input.record.providerIdentifier,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:380:      'provider_name',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:382:      'provider_identifier',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:406:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:408:  providerIdentifier: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:414:      provider_name: input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:416:      provider_identifier: input.providerIdentifier,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:428:    'provider_name',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:430:    'provider_identifier',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:443:  source: 'provider_leg_id' | 'provider_message_id' | 'provider_consensus';
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:460:      providerName: resolvedBase.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:461:      providerLegId: input.callLegMapping?.providerIdentifier || null,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:462:      providerMessageId: input.messageMapping?.providerIdentifier || null,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:480:  providerEventId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:481:  providerLegId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:482:  providerMessageId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:485:  const providerEventId = normalizeString(input.providerEventId || null).toLowerCase();
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:486:  const providerLegId = normalizeString(input.providerLegId || null).toLowerCase();
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:487:  const providerMessageId = normalizeString(input.providerMessageId || null).toLowerCase();
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:489:  if (providerEventId) {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:490:    return `provider-event:${providerEventId}`;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:492:  if (providerLegId && canonicalEventType) {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:493:    return `call-leg:${providerLegId}|event:${canonicalEventType}`;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:495:  if (providerMessageId && canonicalEventType) {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:496:    return `message:${providerMessageId}|event:${canonicalEventType}`;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:503:  providerEventId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:504:  providerLegId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:505:  providerMessageId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:530:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:532:  providerIdentifier: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:542:  const providerName = normalizeProviderName(input.providerName);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:543:  const providerIdentifier = normalizeString(input.providerIdentifier);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:551:    !providerName
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:552:    || !providerIdentifier
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:568:    providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:570:    providerIdentifier,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:609:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:610:  providerIdentifier: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:611:  bridgeLegId: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:624:    providerName: input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:626:    providerIdentifier: input.providerIdentifier,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:627:    internalReferenceId: input.bridgeLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:634:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:635:  providerLegId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:636:  providerMessageId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:640:  const providerName = normalizeProviderName(input.providerName);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:641:  const providerLegId = normalizeString(input.providerLegId || null);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:642:  const providerMessageId = normalizeString(input.providerMessageId || null);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:645:  if (!providerName || (!providerLegId && !providerMessageId)) {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:659:  if (providerLegId) {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:662:      providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:664:      providerIdentifier: providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:668:  if (providerMessageId) {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:671:      providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:673:      providerIdentifier: providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:677:  if (canQueryDb && providerLegId && callLegMappings.length === 0) {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:682:        providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:684:        providerIdentifier: providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:694:  if (canQueryDb && providerMessageId && messageMappings.length === 0) {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:699:        providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:701:        providerIdentifier: providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:732:  const hasCallLegInput = Boolean(providerLegId);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:733:  const hasMessageInput = Boolean(providerMessageId);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:743:        source: 'provider_consensus',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:776:        source: 'provider_leg_id',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:784:        source: 'provider_message_id',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:806:        source: 'provider_leg_id',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:823:        source: 'provider_message_id',
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:838:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:840:  providerEventId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:841:  providerLegId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:842:  providerMessageId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:857:    providerName: input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:859:    providerEventId: input.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:860:    providerLegId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:861:    providerMessageId: input.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:895:    providerName: input.providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:898:    providerEventId: input.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:899:    providerLegId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:900:    providerMessageId: input.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:925:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:927:  providerEventId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:928:  providerLegId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:929:  providerMessageId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:946:  const providerName = normalizeProviderName(input.providerName);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:951:  const providerEventId = normalizeString(input.providerEventId || null);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:952:  const providerLegId = normalizeString(input.providerLegId || null);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:953:  const providerMessageId = normalizeString(input.providerMessageId || null);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:956:    providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:957:    providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:958:    providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:962:    providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:963:    providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:964:    providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:975:    !providerName
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:995:    providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1007:        providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1068:      provider_name: providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1079:        provider_name: providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1082:        provider_event_id: providerEventId || null,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1083:        provider_identifier_kind: providerLegId
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1085:          : providerMessageId
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1088:        provider_identifier: providerLegId || providerMessageId || null,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1101:      .onConflict(['tenant_id', 'provider_name', 'sid', 'event_type'])
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1144:        provider_event_id: providerEventId || null,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1145:        provider_identifier_kind: providerLegId
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1147:          : providerMessageId
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1150:        provider_identifier: providerLegId || providerMessageId || null,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1194:  providerName: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1197:  providerEventId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1198:  providerLegId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1199:  providerMessageId?: string | null;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1215:  const providerName = normalizeProviderName(input.providerName);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1218:  const providerEventId = normalizeString(input.providerEventId || null);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1219:  const providerLegId = normalizeString(input.providerLegId || null);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1220:  const providerMessageId = normalizeString(input.providerMessageId || null);
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1223:    providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1224:    providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1225:    providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1233:  if (!tenantId || !providerName || (!dedupeKey && !receiptIdentity)) {
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1250:      || existingInMemory.providerName !== providerName
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1286:      providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1294:      providerName,
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:1327:        provider_name: providerName,
+apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts:9:  type: 'message' | 'voice_event' | 'voicemail';
+apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts:10:  direction: 'inbound' | 'outbound';
+apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts:11:  channel: 'sms' | 'voice' | 'voicemail';
+apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts:15:  provider_metadata: Record<string, unknown> | null;
+apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts:43:    provider_metadata: item.providerMetadata,
+apps/connectshyft-api/src/modules/connectshyft/threadTimelineDto.ts:47:  if (item.type !== 'voicemail') {
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:33:    outboundAction: ConnectShyftThreadOutboundAction;
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:61:  outboundAction: ConnectShyftThreadOutboundAction,
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:64:    code: outboundAction === 'call'
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:67:    message: outboundAction === 'call'
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:87:  outboundAction: ConnectShyftThreadOutboundAction,
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:110:      outboundAction === 'call'
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:116:    sendThreadOutboundCapabilityRefusal(res, outboundAction);
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:180:  outboundAction: ConnectShyftThreadOutboundAction,
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:185:    outboundAction,
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:192:    throw new Error('ConnectShyft thread outbound core executor is not registered.');
+apps/connectshyft-api/src/modules/connectshyft/http/threadOutboundContext.ts:198:    outboundAction,
+apps/connectshyft-api/src/modules/connectshyft/http/webhookReceiptAdminContext.ts:4:import { CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS } from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:92:    summary: 'Closed thread awaiting explicit outbound reopen',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:104:    summary: 'Unclaimed intake ready for policy-safe outbound action',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:164:    summary: 'Unclaimed thread with explicit outbound guardrail controls.',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:176:    summary: 'Claimed thread with deterministic policy-safe outbound controls.',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:188:    summary: 'Closed thread requiring explicit same-thread reopen before outbound.',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:260:    summary: 'F1 unclaimed thread for provider adapter registry contracts.',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:272:    summary: 'F1 claimed thread for provider disabled refusal validation.',
+apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts:284:    summary: 'F1 closed thread for same-thread reopen provider dispatch validation.',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:16:const DEFAULT_ENABLED_PROVIDERS = ['telnyx'];
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:20:const TEST_ENABLED_PROVIDERS_HEADER = 'x-test-connectshyft-enabled-providers';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:21:const TEST_DISABLED_PROVIDERS_HEADER = 'x-test-connectshyft-disabled-providers';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:22:const TEST_REQUESTED_PROVIDER_HEADER = 'x-test-connectshyft-provider-requested';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:23:const TEST_PROVIDER_ROLLOUT_ALLOWLIST_HEADER = 'x-test-connectshyft-provider-rollout-allowlist';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:24:const TEST_ENFORCE_WEBHOOK_SIGNATURE_HEADER = 'x-test-connectshyft-enforce-webhook-signature';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:26:const TEST_PROVIDER_PUBLIC_KEY_HEADER = 'x-test-connectshyft-provider-public-key';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:27:const TEST_PROVIDER_PUBLIC_KEY_LEGACY_HEADER = 'x-test-connectshyft-telnyx-public-key';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:28:const CONNECTSHYFT_REQUIRED_CALL_TRANSPORT = 'bridge';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:31:export type ConnectShyftProviderOperation = 'call' | 'message' | 'webhook';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:33:  | 'provider-disabled'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:34:  | 'provider-not-allowlisted'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:35:  | 'provider-not-registered'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:36:  | 'no-enabled-provider';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:72:  dispatchAttempted: false;
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:80:  messageKey: 'connectshyft.provider.disabled' | 'connectshyft.provider.unavailable';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:90:    providerResolution: ConnectShyftProviderResolution;
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:146:  providerResolution: ConnectShyftProviderResolution & {
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:190:    const providers: string[] = [];
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:192:      appendUnique(providers, normalizeProviderKey(entry));
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:194:    return providers;
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:210:  const providers: string[] = [];
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:214:      appendUnique(providers, normalizeProviderKey(value));
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:222:      return providers;
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:224:    appendUnique(providers, normalizeProviderKey(parsed));
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:225:    return providers;
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:230:      .forEach((value) => appendUnique(providers, value));
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:231:    return providers;
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:293:  Object.entries(candidate as Record<string, unknown>).forEach(([providerKey, entry]) => {
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:294:    const normalizedProviderKey = normalizeProviderKey(providerKey);
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:419:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:429:            ? 'connectshyft.provider.disabled'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:430:            : 'connectshyft.provider.unavailable',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:432:            ? 'Choose an enabled provider and retry the comms action.'
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:433:            : 'Select a registered enabled provider and retry.',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:436:          dispatchAttempted: false,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:479:  providerKey: string;
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:484:  const rule = input.rolloutAllowlist[input.providerKey];
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:546:  if (normalized === 'call.connected' || normalized === 'voice.connected') {
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:554:  if (normalized === 'message.delivered' || normalized === 'sms.delivered') {
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:558:  if (normalized === 'message.sent' || normalized === 'sms.sent') {
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:562:  if (normalized === 'message.queued' || normalized === 'sms.inbound') {
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:601:  providerKey: string;
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:603:  providerKey: input.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:647:  providerKey: string,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:649:  providerKey,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:653:      providerKey,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:655:      providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:656:      providerMessageId: `${providerKey}-message-${command.threadId}`,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:658:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:663:      providerKey,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:665:      providerLegId: `${providerKey}-call-leg-${command.threadId}`,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:666:      providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:668:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:673:      providerKey,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:675:      providerLegId: `${providerKey}-bridge-leg-${command.legRole}-${command.bridgeSessionId}`,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:676:      providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:678:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:683:      providerKey,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:684:      bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:685:      bridgeEstablished: true,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:687:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:692:      providerKey,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:693:      providerLegId: command.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:696:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:710:        providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:711:        providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:712:        providerEventId: null,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:713:        providerNumber: null,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:715:      providerNeutral: true,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:716:      providerSpecificFieldsStripped: true,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:717:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:725:  providerKey: baseAdapter.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:738:        message: 'Outbound calls require bridge transport only.',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:774:        providerKey: command.providerKey,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:795:      throw new Error(`Provider ${baseAdapter.providerKey} does not support bridge control.`);
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:806:  providerKey: string,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:808:  if (providerKey === 'mock-sandbox') {
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:809:    return createGuardrailedAdapter(buildMockSandboxAdapter(providerKey));
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:812:  const baseAdapter = resolveTelephonyProviderAdapter(providerKey);
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:823:    normalizeProviderKey(body?.providerKey)
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:824:    || normalizeProviderKey(body?.provider);
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:849:    (provider) => !disabledProviderSet.has(provider),
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:856:      message: 'No enabled comms provider is configured for this operation.',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:858:      reason: 'no-enabled-provider',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:867:      reason: 'provider-disabled',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:874:      message: `Provider "${resolvedProvider}" is not registered in enabled provider policy.`,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:876:      reason: 'provider-not-registered',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:886:      reason: 'provider-not-registered',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:895:      reason: 'provider-not-allowlisted',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:900:    providerKey: resolvedProvider,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:903:    deferIfContextMissing: input.operation === 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:909:      reason: 'provider-not-allowlisted',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:916:    providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:47:  it('resolves tenant-scoped mapping context by provider number for webhook routing', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:70:  it('treats inactive mappings as non-routable for webhook routing', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:87:  it('resolves unscoped webhook routing by globally unique active number', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:112:  it('refuses unscoped webhook routing when active mappings are ambiguous across tenants', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:138:  it('keeps tenant-scoped routing deterministic even when the same provider number exists in another tenant', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:275:  it('treats a reassigned thread-alignment number as non-routable under the old provider number', () => {
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1560:// This helper intentionally keeps the neighbor/identity bridge ConnectShyft-local for now.
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:3:import { CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS } from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:7:} from '../http/webhookReceiptAdminContext';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:15:const TEST_TENANT_ID = 'tenant-webhook-admin-context';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:16:const TEST_ORG_UNIT_ID = 'org-webhook-admin-context-east';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:42:      userId: 'user-webhook-admin-context-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:47:      email: 'webhook-admin-context@test.local',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:59:        correlationId: 'corr-webhook-admin-context',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:73:describe('connectshyft webhook receipt admin helper boundary', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:86:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:183:  it('maps admin capability refusals to the current webhook-receipt admin refusal envelope', async () => {
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:32:  'voicemail_duration_seconds',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:38:export const CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME = 'connectshyft.inbound.voice_voicemail_recorded' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:39:export const CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME = 'connectshyft.inbound.voice_fallback_recorded' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:40:export const CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME = 'connectshyft.voicemail.transcription_requested' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:41:export const CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME = 'connectshyft.voicemail.transcription_attached' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:42:export const CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME = 'connectshyft.voicemail.transcription' as const;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:115:const readWebhookSources = (webhookBody: unknown): Array<Record<string, unknown> | null> => {
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:116:  const payload = asRecord(webhookBody);
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:117:  const providerPayload = asRecord(payload?.providerPayload);
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:121:  return [payload, providerPayload, dataPayload, data];
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:124:export type ConnectShyftInboundVoiceRoutingDecision = 'voicemail_only' | 'intake_fallback' | 'accepted';
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:131:  channel: 'voice';
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:132:  direction: 'inbound';
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:133:  providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:134:  providerMessageId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:135:  providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:150:  inboundVoiceArtifact: ConnectShyftInboundVoiceArtifact;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:160:    providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:162:    providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:163:    voicemailArtifactId: string;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:171:  providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:172:  providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:173:  voicemailArtifactId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:202:  webhookBody: unknown,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:205:    readWebhookSources(webhookBody),
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:223:  webhookBody: unknown,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:225:  const payload = asRecord(webhookBody);
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:226:  const providerPayload = asRecord(payload?.providerPayload);
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:229:  const sources = [payload, providerPayload, dataPayload, data];
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:253:      providerEventId: readFromSources(correlationSources, [
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:254:        'providerEventId',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:255:        'provider_event_id',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:259:      providerLegId: readFromSources(correlationSources, ['providerLegId', 'provider_leg_id']),
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:260:      voicemailArtifactId: readFromSources(correlationSources, [
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:261:        'voicemailArtifactId',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:262:        'voicemail_artifact_id',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:283:  const isFallbackEvent = normalizedEventType === 'voice.fallback' || normalizedEventType === 'voicefallback';
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:307:    routingDecision: 'voicemail_only',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:314:  webhookBody: unknown;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:320:  providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:321:  providerMessageId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:322:  providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:325:  const sources = readWebhookSources(input.webhookBody);
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:337:    inboundVoiceArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:338:      channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:339:      direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:340:      providerEventId: input.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:341:      providerMessageId: input.providerMessageId,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:342:      providerLegId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:355:  voicemailArtifactId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:358:  direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:359:  channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:366:  voicemailArtifact: input.voicemailArtifactId
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:368:      artifactId: input.voicemailArtifactId,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:369:      ...input.domainEvent.inboundVoiceArtifact,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:379:  providerEventId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:380:  providerLegId: string | null;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:381:  voicemailArtifactId: string;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:389:    providerEventId: input.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:390:    correlationEventId: input.providerEventId,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:391:    providerLegId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:392:    voicemailArtifactId: input.voicemailArtifactId,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:398:  voicemailArtifactId: string;
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:407:  direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:408:  channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:414:    voicemailArtifactId: input.voicemailArtifactId,
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:424:  voicemailArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts:425:    artifactId: input.voicemailArtifactId,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:2:import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../inboundSms';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:6:} from '../inboundVoice';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:20:  it('maps canonical inbound sms events into first-class inbound timeline items', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:22:      eventId: 'event-inbound-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:28:        direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:29:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:32:        inboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:41:      id: 'event-inbound-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:44:      direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:45:      channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:49:      providerMetadata: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:54:  it('maps canonical outbound sms events into first-class outbound timeline items', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:56:      eventId: 'event-outbound-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:62:        direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:63:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:66:        outboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:75:      id: 'event-outbound-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:78:      direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:79:      channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:83:      providerMetadata: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:94:        direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:95:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:99:        providerMetadata: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:106:        direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:107:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:111:        providerMetadata: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:118:        direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:119:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:123:        providerMetadata: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:145:            direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:146:            channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:149:            inboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:161:            direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:162:            channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:165:            outboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:177:            direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:178:            channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:181:            outboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:195:            direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:196:            channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:230:  it('maps explicit voice lifecycle and voicemail placeholder events without changing sms ordering semantics', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:233:        eventId: 'event-sms-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:234:        aggregateId: 'thread-timeline-voice-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:239:          direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:240:          channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:243:          inboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:244:            body: 'sms first',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:249:        eventId: 'event-voice-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:250:        aggregateId: 'thread-timeline-voice-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:255:          direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:256:          channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:262:        eventId: 'event-voicemail-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:263:        aggregateId: 'thread-timeline-voice-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:268:          direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:269:          channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:271:          voicemailArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:279:        eventId: 'event-voicemail-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:280:        aggregateId: 'thread-timeline-voice-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:285:          direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:286:          channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:291:          voicemailArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:305:      threadId: 'thread-timeline-voice-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:310:      'voice_event',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:311:      'voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:312:      'voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:315:      id: 'event-voice-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:316:      channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:317:      type: 'voice_event',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:320:      id: 'event-voicemail-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:321:      channel: 'voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:322:      type: 'voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:327:      id: 'event-voicemail-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:328:      channel: 'voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:329:      type: 'voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:7:} from '../bridgeSessions'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:8:import { resetConnectShyftProviderCorrelationStateForTests } from '../providerCorrelationMappings'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:9:import type { ConnectShyftProviderAdapter } from '../providerRegistry'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:14:  providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:16:  providerLegId: input.legRole === 'operator'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:17:    ? `provider-leg-operator-${input.threadId}`
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:18:    : `provider-leg-neighbor-${input.threadId}`,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:19:  providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:20:  providerRequestId: `req-${input.legRole}-${input.threadId}`,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:22:  providerBranchingInDomain: false as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:25:const startBridgeSessionMock = jest.fn(async (input: { bridgeSessionId: string }) => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:26:  providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:27:  bridgeSessionId: input.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:28:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:29:  providerRequestId: 'req-bridge-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:31:  providerBranchingInDomain: false as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:35:const endCallMock = jest.fn(async (input: { providerLegId: string }) => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:36:  providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:37:  providerLegId: input.providerLegId,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:39:  providerRequestId: 'req-end-call-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:41:  providerBranchingInDomain: false as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:48:    providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:49:    providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:50:    providerEventId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:51:    providerNumber: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:53:  providerNeutral: true as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:54:  providerSpecificFieldsStripped: true as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:55:  providerBranchingInDomain: false as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:58:const providerAdapter: ConnectShyftProviderAdapter = {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:59:  providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:79:  providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:80:  providerAdapter,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:83:describe('connectshyft bridgeSessions', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:109:  it('persists a created bridge session with operator and neighbor legs on startup', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:125:      providerCallId: result.aggregate.operatorLeg.providerCallId || '',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:148:  it('rehydrates by provider leg id and persists neighbor dialing after operator answer', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:155:  providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:156:      providerAdapter,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:157:      providerLegId: started.aggregate.operatorLeg.providerCallId || null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:187:      providerCallId: progressed.aggregate?.neighborLeg.providerCallId || '',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:195:        providerCallId: 'provider-leg-neighbor-thread-f1-unclaimed-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:206:  it('persists completed bridge sessions after both legs answer and the bridge ends', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:213:      providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:214:      providerAdapter,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:215:      providerLegId: started.aggregate.operatorLeg.providerCallId || null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:223:      providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:224:      providerAdapter,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:225:      providerLegId: afterOperatorAnswer.aggregate?.neighborLeg.providerCallId || null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:233:      providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:234:      providerAdapter,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:235:      providerLegId: afterNeighborAnswer.aggregate?.neighborLeg.providerCallId || null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:240:    expect(afterNeighborAnswer.aggregate?.session.status).toBe('bridged')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:264:  it('persists failed bridge sessions when the neighbor leg fails before bridge completion', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:271:      providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:272:      providerAdapter,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:273:      providerLegId: started.aggregate.operatorLeg.providerCallId || null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:281:      providerKey: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:282:      providerAdapter,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:283:      providerLegId: afterOperatorAnswer.aggregate?.neighborLeg.providerCallId || null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts:5:} from '../smsPreferenceOverrides';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts:7:describe('connectshyft sms preference overrides', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts:67:  it('resolves d-4 synthetic NO preferences for outbound policy UX flows', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts:99:  it('resolves ux-r4 synthetic NO preferences for outbound guardrail UI flows', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts:228:      new Error('relation "connectshyft.cs_sms_preference_overrides" does not exist'),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts:256:        messageEventName: 'connectshyft.thread.outbound_message_dispatched',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/smsPreferenceOverrides.test.ts:280:        messageEventName: 'connectshyft.thread.outbound_message_dispatched',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.escalationConfigContext.test.ts:83:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:66:        last_inbound_cs_number_id: 'cs-inbound-seeded',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:67:        preferred_outbound_cs_number_id: 'cs-outbound-seeded',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:76:      lastInboundCsNumberId: 'cs-inbound-updated',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:77:      preferredOutboundCsNumberId: 'cs-outbound-updated',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:92:    expect(result.thread.lastInboundCsNumberId).toBe('cs-inbound-updated');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:93:    expect(result.thread.preferredOutboundCsNumberId).toBe('cs-outbound-updated');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:128:        last_inbound_cs_number_id: 'cs-inbound-nullable',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:129:        preferred_outbound_cs_number_id: 'cs-outbound-nullable',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:149:      lastInboundCsNumberId: 'cs-inbound-actor-id',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:150:      preferredOutboundCsNumberId: 'cs-outbound-actor-id',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:193:      lastInboundCsNumberId: 'cs-inbound-thread-id',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:194:      preferredOutboundCsNumberId: 'cs-outbound-thread-id',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:219:  it('persists provider-number sender alignment without synthetic rewriting', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:221:    const tenantId = `${CONTRACT_TENANT_PREFIX}provider-alignment`;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:222:    const orgUnitId = 'org-contract-c1-provider-alignment';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:223:    const neighborId = 'neighbor-contract-c1-provider-alignment';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:240:      throw new Error('Expected ensureActiveThread with provider-number alignment to succeed');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:257:  it('lets resolver reuse stored provider-number alignment and refuse legacy synthetic tokens', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:283:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:309:      providerNumberE164: '+12605550192',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:334:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:369:        last_inbound_cs_number_id: 'cs-inbound-index-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:370:        preferred_outbound_cs_number_id: 'cs-outbound-index-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:383:        last_inbound_cs_number_id: 'cs-inbound-index-b',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:384:        preferred_outbound_cs_number_id: 'cs-outbound-index-b',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:6:} from '../inboundSms';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:8:describe('connectshyft inbound sms domain mapping', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:9:  it('maps provider payload fields into a canonical inbound sms domain event', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:11:      webhookBody: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:12:        providerPayload: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:19:      providerEventId: 'provider-event-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:20:      providerMessageId: 'provider-message-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:21:      providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:30:      inboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:31:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:32:        direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:33:        providerEventId: 'provider-event-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:34:        providerMessageId: 'provider-message-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:35:        providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:43:  it('resolves neighbor id only from the canonical webhook field', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:45:      neighborId: 'neighbor-connectshyft-e2-inbound-1002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:46:    })).toBe('neighbor-connectshyft-e2-inbound-1002');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:49:      providerPayload: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:55:  it('builds canonical payload with explicit sms append event naming for deterministic timeline reads', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:57:      webhookBody: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:67:      providerEventId: 'provider-event-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:68:      providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:69:      providerLegId: 'provider-leg-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:78:      direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:79:      channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:87:      inboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:8:} from '../http/inboundWebhookContext';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:9:import * as inboundWebhookContextModule from '../http/inboundWebhookContext';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:11:import * as providerRegistryModule from '../providerRegistry';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:12:import * as providerCorrelationMappingsModule from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:13:import * as bridgeSessionsModule from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:15:import * as inboundSmsModule from '../inboundSms';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:16:import * as inboundVoiceModule from '../inboundVoice';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:44:    path: '/api/v1/connect/webhooks/inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:45:    url: '/api/v1/connect/webhooks/inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:46:    originalUrl: '/api/v1/connect/webhooks/inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:63:      email: 'inbound-webhook-context@test.local',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:74:        correlationId: 'corr-inbound-webhook-context',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:98:      providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:99:      providerMessageId: 'provider-message-c9-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:100:      providerEventId: 'provider-event-c9-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:101:      providerNumber: '+12605550199',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:103:    providerNeutral: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:104:    providerSpecificFieldsStripped: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:105:    providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:109:    providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:117:    providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:118:      requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:119:      resolvedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:131:describe('connectshyft inbound webhook helper boundary', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:138:    jest.spyOn(providerRegistryModule, 'resolveConnectShyftRequestedProviderKey').mockReturnValue('telnyx');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:145:  it('returns the scoped webhook prerequisites for a valid SMS webhook request', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:148:      .spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:151:      .spyOn(providerCorrelationMappingsModule, 'resolveConnectShyftProviderCorrelationByIdentifiers')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:157:      path: '/api/v1/connect/webhooks/sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:158:      url: '/api/v1/connect/webhooks/sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:159:      originalUrl: '/api/v1/connect/webhooks/sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:166:      routeKind: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:167:      providerSelection: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:168:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:169:          requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:170:          resolvedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:182:        providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:183:        providerMessageId: 'provider-message-c9-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:184:        providerEventId: 'provider-event-c9-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:185:        providerNumberE164: '+12605550199',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:197:      'providerSelection',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:204:      operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:205:      requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:216:      operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:217:      requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:225:      providerName: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:226:      providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:227:      providerMessageId: 'provider-message-c9-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:236:  it('maps missing webhook signatures to the current refusal envelope', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:249:      providerCorrelationMappingsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:252:    jest.spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter').mockReturnValue(selection as any);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:255:    const context = await resolveConnectShyftInboundWebhookAccessContext(createRequest(), res, 'inbound');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:267:      correlationId: 'corr-inbound-webhook-context',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:270:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:271:          requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:272:          resolvedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:279:          provider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:284:          messageKey: 'connectshyft.webhook.signature.missing',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:285:          remediation: 'Ensure provider webhook signing is configured and include a valid signature.',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:300:  it('stays limited to prerequisite resolution and execution delegation without bridge or canonical side effects', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:302:    jest.spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter').mockReturnValue(selection as any);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:304:      providerCorrelationMappingsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:310:    const bridgeWebhookSpy = jest.spyOn(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:311:      bridgeSessionsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:314:      throw new Error('Bridge webhook handling should not run during inbound helper preparation.');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:320:      throw new Error('Canonical event persistence should not run during inbound helper preparation.');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:322:    const inboundSmsSpy = jest.spyOn(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:323:      inboundSmsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:326:      throw new Error('Inbound SMS domain mapping should not run during inbound helper preparation.');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:328:    const inboundVoiceSpy = jest.spyOn(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:329:      inboundVoiceModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:332:      throw new Error('Inbound voice domain mapping should not run during inbound helper preparation.');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:336:      path: '/api/v1/connect/webhooks/sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:337:      url: '/api/v1/connect/webhooks/sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:338:      originalUrl: '/api/v1/connect/webhooks/sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:344:    await executeConnectShyftInboundWebhookRoute(req, res, 'sms');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:350:      throw new Error('Expected inbound webhook core executor to receive execution input.');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:356:      routeKind: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:357:      providerSelection: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:358:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:359:          requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:360:          resolvedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:383:      'providerSelection',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:390:    expect(bridgeWebhookSpy).not.toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:392:    expect(inboundSmsSpy).not.toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:393:    expect(inboundVoiceSpy).not.toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:398:  it('prepares deterministic route kinds for the thin inbound webhook handlers', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:400:      .spyOn(inboundWebhookContextModule, 'executeConnectShyftInboundWebhookRoute')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:408:    expect(executeRouteSpy).toHaveBeenNthCalledWith(1, req, res, 'inbound');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:409:    expect(executeRouteSpy).toHaveBeenNthCalledWith(2, req, res, 'sms');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:26:  it('resolves a mapped provider number from persisted thread alignment', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:32:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:56:      providerNumberE164: '+12605550191',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:60:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:62:        alignedFrom: 'preferred_outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:73:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:102:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:131:        channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:171:          { mappingId: 'mapping-f1-a', providerNumberE164: '+12605550191' },
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:172:          { mappingId: 'mapping-f1-b', providerNumberE164: '+12605550191' },
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:69:      sourceContext: 'connectshyft_inbound_subject_resolution',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts:95:      sourceContext: 'connectshyft_inbound_subject_resolution',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.numberMappingContext.test.ts:34:      providerNumberE164: '+12605550111',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.numberMappingContext.test.ts:85:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.numberMappingContext.test.ts:108:        providerNumberE164: undefined,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.numberMappingContext.test.ts:125:        providerNumberE164: '+12605550119',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:14:} from '../inboundVoice';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:16:describe('connectshyft inbound voice domain mapping', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:17:  it('[E3-UNIT-001][P0] maps voicemail webhook payload fields into a canonical inbound voice domain event @P0', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:19:      webhookBody: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:20:        providerPayload: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:23:          recording_url: 'https://example.invalid/recordings/voice-001.mp3',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:24:          voicemail_duration_seconds: 47,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:29:      routingDecision: 'voicemail_only',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:30:      providerEventId: 'provider-event-e3-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:31:      providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:32:      providerLegId: 'provider-leg-e3-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:37:      routingDecision: 'voicemail_only',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:40:      inboundVoiceArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:41:        channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:42:        direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:43:        providerEventId: 'provider-event-e3-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:44:        providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:45:        providerLegId: 'provider-leg-e3-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:48:        recordingUrl: 'https://example.invalid/recordings/voice-001.mp3',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:52:    expect(domainEvent.inboundVoiceArtifact.to).toBe('+12605550171');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:53:    expect(domainEvent.inboundVoiceArtifact.to).not.toContain('cs-number');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:56:  it('[E3-UNIT-002][P0] resolves voice routing matrix across no-thread, unclaimed, claimed, and closed states @P0', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:58:      normalizedEventType: 'voice.voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:67:      normalizedEventType: 'voice.voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:71:      routingDecision: 'voicemail_only',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:76:      normalizedEventType: 'voice.voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:88:      normalizedEventType: 'voice.voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:97:  it('[E3-UNIT-003][P1] builds canonical payload and transcription callback correlation for voicemail artifacts @P1', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:99:      webhookBody: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:100:        providerPayload: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:103:          recording_url: 'https://example.invalid/recordings/voice-002.mp3',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:104:          voicemail_duration_seconds: '63',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:109:      routingDecision: 'voicemail_only',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:110:      providerEventId: 'provider-event-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:111:      providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:112:      providerLegId: 'provider-leg-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:119:      providerEventId: 'provider-event-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:120:      providerLegId: 'provider-leg-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:121:      voicemailArtifactId: 'vm-thread-connectshyft-e3-001-provider-event-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:128:      voicemailArtifactId: transcription.callbackCorrelation.voicemailArtifactId,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:139:        providerEventId: 'provider-event-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:140:        correlationEventId: 'provider-event-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:141:        providerLegId: 'provider-leg-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:142:        voicemailArtifactId: 'vm-thread-connectshyft-e3-001-provider-event-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:147:      direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:148:      channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:151:      routingDecision: 'voicemail_only',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:155:      voicemailArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:156:        artifactId: 'vm-thread-connectshyft-e3-001-provider-event-e3-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:157:        recordingUrl: 'https://example.invalid/recordings/voice-002.mp3',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:164:  it('[E3-UNIT-004][P1] extracts neighbor id from voice webhook envelope aliases @P1', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:170:      providerPayload: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:178:    expect(isConnectShyftVoicemailTranscriptionCallbackEventType('voice.transcription.completed')).toBe(true);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:183:  it('[E4-UNIT-002][P0] extracts callback correlation and transcript text from provider payload aliases @P0', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:189:        providerEventId: 'provider-event-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:190:        providerLegId: 'provider-leg-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:191:        voicemailArtifactId: 'vm-thread-connectshyft-e4-001-provider-event-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:196:      providerPayload: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:206:        providerEventId: 'provider-event-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:207:        providerLegId: 'provider-leg-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:208:        voicemailArtifactId: 'vm-thread-connectshyft-e4-001-provider-event-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:217:      voicemailArtifactId: 'vm-thread-connectshyft-e4-001-provider-event-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:223:        correlationEventId: 'provider-event-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:228:      direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:229:      channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:235:        voicemailArtifactId: 'vm-thread-connectshyft-e4-001-provider-event-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:242:          correlationEventId: 'provider-event-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:245:      voicemailArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:246:        artifactId: 'vm-thread-connectshyft-e4-001-provider-event-e4-seed',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:270:  it('passes hook context into the seam for inbound no-match handling', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:291:          key: 'inbound-subject:tenant-a:org-a:(260)555-1217',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/identityResolver.test.ts:315:        triggerSourceType: 'connectshyft_inbound_subject_resolution',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/peoplecoreIdentityAdapter.test.ts:135:        triggerSourceType: 'connectshyft_inbound_subject_resolution',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:278:  it('stays limited to neighbor identity prerequisites and does not execute bridge side effects', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadReadContext.test.ts:76:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:48:      connectshyft_webhooks_enabled: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:63:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:77:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:84:      connectshyft_webhooks_enabled: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:100:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:111:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:118:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:129:      connectshyft_webhooks_enabled: {},
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:136:      connectshyft_webhooks_enabled: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:147:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:163:      connectshyft_webhooks_enabled: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:182:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:191:      connectshyft_webhooks_enabled: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:200:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:209:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:218:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/featureFlags.test.ts:227:      connectshyft_webhooks_enabled: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadLifecycleContext.test.ts:85:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:10:import * as providerRegistryModule from '../providerRegistry';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:11:import * as bridgeSessionsModule from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:29:      threadId: 'thread-c8-outbound-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:38:      userId: 'user-thread-outbound-context-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:43:      email: 'thread-outbound-context@test.local',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:55:        correlationId: 'corr-thread-outbound-context',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:69:describe('connectshyft thread outbound helper boundary', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:78:      threadId: 'thread-c8-outbound-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:97:      connectshyft_webhooks_enabled: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:105:      'user-thread-outbound-context-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:122:  it('returns the scoped outbound prerequisites for a valid call request', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:131:      threadId: 'thread-c8-outbound-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:132:      actorUserId: 'user-thread-outbound-context-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:172:      threadId: 'thread-c8-outbound-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:173:      actorUserId: 'user-thread-outbound-context-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:197:      correlationId: 'corr-thread-outbound-context',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:265:  it('stays limited to prerequisite resolution and execution delegation without provider or bridge side effects', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:266:    const providerAdapterSpy = jest.spyOn(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:267:      providerRegistryModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:271:      bridgeSessionsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:277:        threadId: 'thread-c8-outbound-message-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:298:      throw new Error('Expected outbound core executor to receive execution input.');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:303:      outboundAction: 'message',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:305:      threadId: 'thread-c8-outbound-message-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:306:      actorUserId: 'user-thread-outbound-context-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:315:      'outboundAction',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:320:    expect(providerAdapterSpy).not.toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:30:    last_inbound_cs_number_id: {},
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:31:    preferred_outbound_cs_number_id: {},
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:32:    preferred_outbound_label: {},
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:97:  it('normalizes seeded sender-alignment tokens into provider-number outputs', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:112:      inboundContext: 'Mapped inbound number configured',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:113:      outboundContext: 'Primary East Dispatch',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:117:  it('relabels db-backed synthetic sender tokens into mapped inbound and outbound number context', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:129:          last_inbound_cs_number_id: 'cs-number-1005',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:130:          preferred_outbound_cs_number_id: 'cs-number-2005',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:131:          preferred_outbound_label: '',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:156:        inboundContext: 'Mapped inbound number configured',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:157:        outboundContext: 'Mapped outbound number configured',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:213:  it('keeps ux-r3 voicemail threads in deterministic mine/inbox buckets with explicit labels', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:233:      voicemailIndicator: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:234:      voicemailLabel: 'Voicemail',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:239:      voicemailIndicator: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:240:      voicemailLabel: 'Voicemail received',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:298:          last_inbound_cs_number_id: 'cs-number-1005',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:299:          preferred_outbound_cs_number_id: 'cs-number-2005',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:300:          preferred_outbound_label: 'Deleted Neighbor Queue',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:369:  it('resolves ux-r4 seeded thread-detail action matrix with explicit closed-thread outbound controls', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:431:          last_inbound_cs_number_id: 'cs-number-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:432:          preferred_outbound_cs_number_id: 'cs-number-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:433:          preferred_outbound_label: 'Primary Queue',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:445:          last_inbound_cs_number_id: 'cs-number-1002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:446:          preferred_outbound_cs_number_id: 'cs-number-2002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:447:          preferred_outbound_label: 'Secondary Queue',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:497:          last_inbound_cs_number_id: 'cs-number-3001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:498:          preferred_outbound_cs_number_id: 'cs-number-4001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts:499:          preferred_outbound_label: 'Deleted Detail Queue',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:25:      lastInboundCsNumberId: 'cs-inbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:26:      preferredOutboundCsNumberId: 'cs-outbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:39:          lastInboundCsNumberId: 'cs-inbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:40:          preferredOutboundCsNumberId: 'cs-outbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:72:      lastInboundCsNumberId: 'cs-inbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:73:      preferredOutboundCsNumberId: 'cs-outbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:90:      lastInboundCsNumberId: 'cs-inbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:91:      preferredOutboundCsNumberId: 'cs-outbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:101:      lastInboundCsNumberId: 'cs-inbound-c1-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:102:      preferredOutboundCsNumberId: 'cs-outbound-c1-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:138:      lastInboundCsNumberId: 'cs-inbound-c1-101',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:139:      preferredOutboundCsNumberId: 'cs-outbound-c1-101',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:149:      lastInboundCsNumberId: 'cs-inbound-c1-102',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:150:      preferredOutboundCsNumberId: 'cs-outbound-c1-102',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:173:      lastInboundCsNumberId: 'cs-inbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:174:      preferredOutboundCsNumberId: 'cs-outbound-c1-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:193:      lastInboundCsNumberId: 'cs-inbound-c1-010',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:194:      preferredOutboundCsNumberId: 'cs-outbound-c1-010',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:204:      lastInboundCsNumberId: 'cs-inbound-c1-011',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:205:      preferredOutboundCsNumberId: 'cs-outbound-c1-011',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:215:      lastInboundCsNumberId: 'cs-inbound-c1-012',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:216:      preferredOutboundCsNumberId: 'cs-outbound-c1-012',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:238:  it('stores and reloads provider-number sender alignment values for an ensured thread', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:243:      neighborId: 'neighbor-connectshyft-c1-provider-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:245:      threadId: 'thread-c1-provider-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:261:      threadId: 'thread-c1-provider-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:275:      lastInboundCsNumberId: 'cs-inbound-c1-020',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:276:      preferredOutboundCsNumberId: 'cs-outbound-c1-020',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:431:      lastInboundCsNumberId: 'cs-inbound-c1-030',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:432:      preferredOutboundCsNumberId: 'cs-outbound-c1-030',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:456:      lastInboundCsNumberId: 'cs-inbound-c1-031',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:457:      preferredOutboundCsNumberId: 'cs-outbound-c1-031',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:487:      lastInboundCsNumberId: 'cs-inbound-c1-5001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:488:      preferredOutboundCsNumberId: 'cs-outbound-c1-5001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:517:      lastInboundCsNumberId: 'cs-inbound-c5-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:518:      preferredOutboundCsNumberId: 'cs-outbound-c5-001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:611:      lastInboundCsNumberId: 'cs-inbound-c5-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:612:      preferredOutboundCsNumberId: 'cs-outbound-c5-002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:656:      lastInboundCsNumberId: 'cs-inbound-c5-003',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:657:      preferredOutboundCsNumberId: 'cs-outbound-c5-003',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:713:  it('reuses persisted provider-number alignment for sender resolution on the same thread', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:733:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:760:      providerNumberE164: '+12605550192',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:764:        alignedFrom: 'preferred_outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:789:        channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:11:} from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:13:describe('connectshyft provider correlation mappings', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:18:  it('records provider call/message mappings with provider-scoped uniqueness', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:23:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:25:      providerIdentifier: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:31:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:33:      providerIdentifier: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:42:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:44:      providerIdentifier: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:55:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:57:      providerIdentifier: 'provider-message-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:63:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:65:      providerIdentifier: 'provider-message-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:71:  it('records provider call-leg mappings against persisted bridge-leg ids', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:76:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:77:      providerIdentifier: 'provider-leg-bridge-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:78:      bridgeLegId: 'bridge-leg-neighbor-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:84:        providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:86:        providerIdentifier: 'provider-leg-bridge-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:87:        internalReferenceId: 'bridge-leg-neighbor-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:92:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:93:      providerLegId: 'provider-leg-bridge-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:98:      source: 'provider_leg_id',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:100:        internalCallReferenceId: 'bridge-leg-neighbor-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:105:  it('resolves metadata fallback via provider leg/message identifiers', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:110:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:112:      providerIdentifier: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:117:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:118:      providerLegId: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:123:      source: 'provider_leg_id',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:135:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:137:      providerIdentifier: 'provider-message-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:142:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:143:      providerMessageId: 'provider-message-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:148:      source: 'provider_message_id',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:162:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:164:      providerIdentifier: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:172:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:174:      providerIdentifier: 'provider-message-f3-1002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:179:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:180:      providerLegId: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:181:      providerMessageId: 'provider-message-f3-1002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:192:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:200:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:201:      providerLegId: 'provider-leg-f3-unknown',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:209:  it('suppresses duplicate webhook receipts using provider-scoped deterministic dedupe keys', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:214:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:216:      providerEventId: 'provider-event-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:217:      providerLegId: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:223:      dedupeKey: 'provider-event:provider-event-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:230:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:232:      providerEventId: 'provider-event-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:233:      providerLegId: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:239:      dedupeKey: 'provider-event:provider-event-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:243:  it('suppresses duplicate webhook receipts even before inbound processing has established a thread id', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:248:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:250:      providerEventId: 'provider-event-f3-no-thread-yet',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:251:      providerMessageId: 'provider-message-f3-no-thread-yet',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:258:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:260:      providerEventId: 'provider-event-f3-no-thread-yet',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:261:      providerMessageId: 'provider-message-f3-no-thread-yet',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:267:      dedupeKey: 'provider-event:provider-event-f3-no-thread-yet',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:272:      dedupeKey: 'provider-event:provider-event-f3-no-thread-yet',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:276:  it('scopes webhook replay identity by canonical event type for the same provider sid', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:281:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:283:      providerEventId: 'provider-event-f3-shared-by-type',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:284:      providerMessageId: 'provider-message-f3-shared-by-type',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:291:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:293:      providerEventId: 'provider-event-f3-shared-by-type',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:294:      providerLegId: 'provider-leg-f3-shared-by-type',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:301:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:303:      providerEventId: 'provider-event-f3-shared-by-type',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:304:      providerMessageId: 'provider-message-f3-shared-by-type',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:320:          providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:322:          providerEventId: 'provider-event-f3-concurrent-burst',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:323:          providerMessageId: 'provider-message-f3-concurrent-burst',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:336:  it('allows retry attempts for non-applied webhook receipts and only suppresses after applied', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:341:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:343:      providerEventId: 'provider-event-f3-transcription-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:344:      providerLegId: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:350:      dedupeKey: 'provider-event:provider-event-f3-transcription-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:357:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:368:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:370:      providerEventId: 'provider-event-f3-transcription-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:371:      providerLegId: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:377:      dedupeKey: 'provider-event:provider-event-f3-transcription-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:384:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:394:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:396:      providerEventId: 'provider-event-f3-transcription-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:397:      providerLegId: 'provider-leg-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:403:      dedupeKey: 'provider-event:provider-event-f3-transcription-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:414:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:416:      providerEventId: 'provider-event-f3-retry-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:417:      providerLegId: 'provider-leg-f3-retry-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:424:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:427:      providerEventId: 'provider-event-f3-retry-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:428:      providerLegId: 'provider-leg-f3-retry-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:430:      failureReason: 'temporary_provider_failure',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:433:        category: 'temporary_provider_failure',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:436:        providerCode: 'rate_limited',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:446:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:448:      providerEventId: 'provider-event-f3-retry-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:449:      providerLegId: 'provider-leg-f3-retry-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:458:        category: 'temporary_provider_failure',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:461:        providerCode: 'rate_limited',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:466:  it('allows duplicate provider identifiers across tenants and marks tenant-unspecified lookup as ambiguous', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:471:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:473:      providerIdentifier: 'provider-leg-f3-shared',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:481:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:483:      providerIdentifier: 'provider-leg-f3-shared',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:490:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:491:      providerLegId: 'provider-leg-f3-shared',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:500:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:501:      providerLegId: 'provider-leg-f3-shared',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:507:      source: 'provider_leg_id',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:515:  it('does not suppress duplicate receipts across tenants for the same provider event key', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:520:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:522:      providerEventId: 'provider-event-f3-shared-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:523:      providerMessageId: 'provider-message-f3-shared-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:531:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:533:      providerEventId: 'provider-event-f3-shared-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:534:      providerMessageId: 'provider-message-f3-shared-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:542:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:544:      providerEventId: 'provider-event-f3-shared-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:545:      providerMessageId: 'provider-message-f3-shared-2001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:570:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:572:      providerIdentifier: 'provider-leg-f3-db-failure',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:584:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:586:      providerEventId: 'provider-event-f3-db-failure',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:587:      providerLegId: 'provider-leg-f3-db-failure',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:594:      dedupeKey: 'provider-event:provider-event-f3-db-failure',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:606:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:608:      providerEventId: 'provider-event-f3-retention-1',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:609:      providerMessageId: 'provider-message-f3-retention-1',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:615:      providerName: 'provider-a',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:617:      providerEventId: 'provider-event-f3-retention-2',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:618:      providerMessageId: 'provider-message-f3-retention-2',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:21:  it('sanitizes provider-specific payload fields recursively', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:24:      providerPayload: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:25:        providerLegId: 'provider-leg-hidden',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:28:        providerMessageId: 'provider-message-hidden',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:31:      providerLegId: 'provider-leg-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:32:      providerMessageId: 'provider-message-1002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:43:  it('preserves projection-ready outbound sms artifact fields while stripping provider-specific keys', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:45:      direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:46:      channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:48:      eventName: 'connectshyft.outbound.sms_appended',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:49:      outboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:50:        body: 'Projection-ready outbound message',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:53:        providerMessageId: 'provider-message-hidden',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:55:      providerMetadata: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:56:        providerEventId: 'provider-event-hidden',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:61:      direction: 'outbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:62:      channel: 'sms',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:64:      eventName: 'connectshyft.outbound.sms_appended',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:65:      outboundMessageArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:66:        body: 'Projection-ready outbound message',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:80:      payload: { direction: 'outbound', channel: 'sms' },
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:90:        direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:91:        channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:92:        providerLegId: 'provider-leg-hidden',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:109:      direction: 'inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:110:      channel: 'voice',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/canonicalEvents.test.ts:180:      payload: { direction: 'outbound', channel: 'sms' },
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:8:} from '../providerRegistry';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:28:    originalUrl: '/api/v1/connectshyft/webhooks/inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:30:    url: '/api/v1/connectshyft/webhooks/inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:37:describe('connectshyft provider registry', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:61:  it('resolves deterministic default provider from enabled registry order', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:65:          'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx', 'mock-sandbox']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:66:          'x-test-connectshyft-disabled-providers': JSON.stringify(['twilio']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:74:      throw new Error('Expected deterministic provider resolution to succeed');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:77:    expect(result.providerResolution).toEqual({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:78:      requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:79:      resolvedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:84:  it('returns disabled-provider refusal metadata with explicit no-side-effect contract', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:88:          'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx', 'mock-sandbox']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:89:          'x-test-connectshyft-disabled-providers': JSON.stringify(['twilio']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:92:          providerKey: 'twilio',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:100:      throw new Error('Expected disabled provider resolution refusal');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:108:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:112:          reason: 'provider-disabled',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:117:          messageKey: 'connectshyft.provider.disabled',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:120:          dispatchAttempted: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:128:  it('returns unavailable-provider refusal with actionable metadata for missing adapters', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:132:          'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:135:          providerKey: 'legacy-provider',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:143:      throw new Error('Expected unavailable provider refusal');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:151:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:152:          requestedProvider: 'legacy-provider',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:155:          reason: 'provider-not-registered',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:160:          messageKey: 'connectshyft.provider.unavailable',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:163:          dispatchAttempted: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:175:          'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:176:          'x-test-connectshyft-provider-rollout-allowlist': JSON.stringify({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:177:            telnyx: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:185:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:203:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:204:          requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:207:          reason: 'provider-not-allowlisted',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:210:          dispatchAttempted: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:222:          'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:223:          'x-test-connectshyft-provider-rollout-allowlist': JSON.stringify({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:224:            telnyx: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:232:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:242:      throw new Error('Expected allow-listed provider resolution to succeed');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:245:    expect(result.providerResolution).toEqual({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:246:      requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:247:      resolvedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:256:          'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:257:          'x-test-connectshyft-provider-rollout-allowlist': '{not-valid-json',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:260:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:278:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:279:          requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:282:          reason: 'provider-not-allowlisted',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:288:  it('defers webhook allow-list gating without context and enforces after context is known', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:290:      'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:291:      'x-test-connectshyft-provider-rollout-allowlist': JSON.stringify({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:292:        telnyx: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:304:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:307:      operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:312:      throw new Error('Expected webhook provider resolution to defer allow-list gating before correlation context');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:319:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:324:      operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:329:      throw new Error('Expected webhook provider resolution to fail once correlation context is evaluated');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:337:        providerResolution: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:338:          requestedProvider: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:341:          reason: 'provider-not-allowlisted',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:347:  it('routes outbound call/message and webhook translation through the adapter interface', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:351:          'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx', 'mock-sandbox']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:354:          providerKey: 'mock-sandbox',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:369:      providerKey: 'mock-sandbox',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:373:      providerKey: 'mock-sandbox',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:375:      providerLegId: 'mock-sandbox-call-leg-thread-f1-unclaimed-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:376:      providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:378:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:385:      providerKey: 'mock-sandbox',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:389:      providerKey: 'mock-sandbox',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:391:      providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:392:      providerMessageId: 'mock-sandbox-message-thread-f1-unclaimed-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:394:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:399:        providerKey: 'mock-sandbox',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:418:        providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:419:        providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:420:        providerEventId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:421:        providerNumber: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:423:      providerNeutral: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:424:      providerSpecificFieldsStripped: true,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:425:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:430:        providerKey: 'mock-sandbox',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:431:        providerLegId: 'mock-sandbox-call-leg-thread-f1-unclaimed-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:434:      providerKey: 'mock-sandbox',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:435:      providerLegId: 'mock-sandbox-call-leg-thread-f1-unclaimed-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:438:      providerBranchingInDomain: false,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:442:  it('preserves targetPhone and senderPhone unchanged across providerRegistry.sendSms', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:444:      providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:446:      providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:447:      providerMessageId: 'provider-message-2002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:448:      providerRequestId: 'req-sms-2002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:450:      providerBranchingInDomain: false as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:455:        providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:464:            providerLegId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:465:            providerMessageId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:466:            providerEventId: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:467:            providerNumber: null,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:469:          providerNeutral: true as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:470:          providerSpecificFieldsStripped: true as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:471:          providerBranchingInDomain: false as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:479:          'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:482:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:490:      throw new Error('Expected telnyx adapter resolution to succeed');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:497:      providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:503:    expect(resolveAdapterSpy).toHaveBeenCalledWith('telnyx');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:512:  it('enforces bridge-only/manual retry policy at the adapter dispatch boundary', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:516:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:532:        providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:548:        providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:550:          transport: 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:558:  it('prefers body providerKey over test header provider request override', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:562:          'x-test-connectshyft-provider-requested': 'mock-sandbox',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:565:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:570:    expect(requested).toBe('telnyx');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:573:  it('enforces webhook signature validation in test override mode when explicitly requested', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:583:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:586:      operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:596:        providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:599:          eventType: 'voice.connected',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:602:          'x-test-connectshyft-enforce-webhook-signature': 'true',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:603:          'x-test-connectshyft-provider-public-key': testPublicKey,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:618:  it('accepts valid webhook signatures in test override mode when explicit signature enforcement is enabled', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:626:      eventType: 'voice.connected',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:642:      operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:652:        providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:657:          'x-test-connectshyft-enforce-webhook-signature': 'true',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:658:          'x-test-connectshyft-provider-public-key': testPublicKey,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:659:          'telnyx-timestamp': timestamp,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:660:          'telnyx-signature-ed25519': signature,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:669:  it('preserves rawBody buffers when building webhook verification input', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:671:      eventType: 'sms.inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:676:      providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:679:          eventType: 'sms.inbound',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:690:  it('rejects webhook signatures when Telnyx signature headers are missing outside override mode', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:696:          providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:699:      operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:714:        providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:717:          eventType: 'voice.connected',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:732:  it('accepts valid Telnyx webhook signatures outside override mode', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:742:      eventType: 'voice.connected',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:758:          'telnyx-timestamp': timestamp,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:759:          'telnyx-signature-ed25519': signature,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:762:      operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:772:        providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:777:          'telnyx-timestamp': timestamp,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:778:          'telnyx-signature-ed25519': signature,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:787:  it('rejects validly-signed webhooks when timestamp falls outside replay window', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:797:      eventType: 'voice.connected',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:813:          'telnyx-timestamp': staleTimestamp,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:814:          'telnyx-signature-ed25519': signature,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:817:      operation: 'webhook',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:827:        providerKey: 'telnyx',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:832:          'telnyx-timestamp': staleTimestamp,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:833:          'telnyx-signature-ed25519': signature,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:159:  it('creates minimal inbound neighbors with UNKNOWN texting preference and an active primary phone', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:187:  it('refuses inbound-create requests when another current neighbor already owns the canonical phone', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:207:    const inboundDuplicate = service.createNeighborFromInbound({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:213:    expect(inboundDuplicate).toMatchObject({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:735:  it('creates a new inbound neighbor after soft delete without resurrecting the deleted phone owner', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:766:    const inboundCreated = service.createNeighborFromInbound({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:772:    expect(inboundCreated).toMatchObject({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:789:    if (!inboundCreated.ok) {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:790:      throw new Error('Expected inbound neighbor creation to succeed after soft delete');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:793:    expect(inboundCreated.data.neighbor.neighborId).not.toBe(original.data.neighbor.neighborId);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:832:          matchedNeighborId: inboundCreated.data.neighbor.neighborId,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:833:          candidateNeighborIds: [inboundCreated.data.neighbor.neighborId],
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:839:  it('promotes UNKNOWN texting preference to YES on inbound SMS only', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/neighbors.test.ts:846:      throw new Error('Expected inbound neighbor create to succeed');
+
+=== TELNYX / PROVIDER SURFACE ===
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:4:const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions'
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:5:const BRIDGE_LEGS_TABLE = 'cs_bridge_legs'
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:21:      bridge_status TEXT NOT NULL,
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:30:      CONSTRAINT cs_bridge_sessions_status_ck CHECK (
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:31:        bridge_status IN (
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:33:          'operator_dialing',
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:35:          'neighbor_dialing',
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:37:          'bridged',
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:52:      bridge_session_id TEXT NOT NULL REFERENCES ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}(id) ON DELETE CASCADE,
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:64:      CONSTRAINT cs_bridge_legs_role_ck CHECK (leg_role IN ('operator', 'neighbor')),
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:65:      CONSTRAINT cs_bridge_legs_status_ck CHECK (
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:66:        leg_status IN ('created', 'dialing', 'ringing', 'answered', 'failed', 'completed', 'canceled')
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:68:      CONSTRAINT cs_bridge_legs_session_role_uq UNIQUE (bridge_session_id, leg_role)
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:73:    CREATE INDEX IF NOT EXISTS connectshyft_cs_bridge_sessions_scope_idx
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:78:    CREATE INDEX IF NOT EXISTS connectshyft_cs_bridge_legs_session_idx
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:79:    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_LEGS_TABLE} (bridge_session_id, leg_role, id)
+apps/connectshyft-api/src/migrations/20260311110000_create_connectshyft_bridge_sessions.ts:83:    CREATE UNIQUE INDEX IF NOT EXISTS connectshyft_cs_bridge_legs_provider_call_id_uq
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:4:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:25:  providerRequestId: 'req-sms-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:44:const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:46:  bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:47:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:48:  providerRequestId: 'req-bridge-3001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:185:  it('returns the current outbound call success envelope and bridge-session response shape', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:315:          transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:317:          redialPolicy: 'manual_only',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:325:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:326:          bridgeSessionId: expect.any(String),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:327:          status: 'operator_dialing',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:380:      'bridgeSession',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:493:          transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:495:          redialPolicy: 'manual_only',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:503:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:504:          bridgeSessionId: expect.any(String),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:505:          status: 'operator_dialing',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:560:      'bridgeSession',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:586:  it('returns the current operator-callback-required refusal shape for outbound bridge calls', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:600:      message: 'Outbound bridge calls require an operator callback number.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:626:  it('returns the current neighbor-phone-required refusal shape for outbound bridge calls', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:640:      message: 'Outbound bridge calls require a dialable neighbor phone.',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:4:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:28:  providerRequestId: 'req-sms-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:47:const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:49:  bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:50:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:51:  providerRequestId: 'req-bridge-3001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:318:          providerRequestId: 'req-sms-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:119:  const previousTelnyxPublicKey = process.env.TELNYX_PUBLIC_KEY;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:152:    process.env.TELNYX_PUBLIC_KEY = previousTelnyxPublicKey;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.neighbors.test.ts:5:import * as BridgeSessionsModule from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/migrations/20260312120000_add_connectshyft_communication_reliability.ts:79:        channel IN ('sms', 'voice', 'bridge', 'webhook')
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:12:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:63:  providerRequestId: 'req-sms-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:81:const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:83:  bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:84:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:85:  providerRequestId: 'req-bridge-3001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1123:  it('starts a persisted bridge session for outbound calls and returns bridge-session state', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1145:          transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1147:          redialPolicy: 'manual_only',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1149:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1150:          status: 'operator_dialing',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1168:    expect((response.body as any).data.bridgeSession.bridgeSessionId).toBeTruthy();
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1174:        transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1176:        redialPolicy: 'manual_only',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:1217:  it('refuses outbound bridge calls when no operator callback number is provided', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:4:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:100:  providerEventId: 'provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:101:  providerLegId: 'provider-leg-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:172:          providerLegId: 'provider-leg-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:174:          providerEventId: 'provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:180:          dedupeKey: 'provider-event:provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:227:          artifactId: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:230:          providerEventId: 'provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:232:          providerLegId: 'provider-leg-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:245:            providerEventId: 'provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:246:            correlationEventId: 'provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:247:            providerLegId: 'provider-leg-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:248:            voicemailArtifactId: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:255:          redialPolicy: 'manual_only',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:276:            voicemail_artifact_id: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:295:            voicemail_artifact_id: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:296:            provider_event_id: 'provider-event-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:297:            provider_leg_id: 'provider-leg-voice-voicemail-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:355:        providerEventId: 'provider-event-voice-fallback-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:356:        providerLegId: 'provider-leg-voice-fallback-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:373:          providerLegId: 'provider-leg-voice-fallback-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:374:          providerEventId: 'provider-event-voice-fallback-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:380:          dedupeKey: 'provider-event:provider-event-voice-fallback-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:395:          redialPolicy: 'manual_only',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:458:          providerEventId: 'provider-event-voice-connected-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:459:          providerLegId: 'provider-leg-voice-connected-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:462:          transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:484:            providerLegId: 'provider-leg-voice-connected-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:485:            providerEventId: 'provider-event-voice-connected-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:491:            dedupeKey: 'provider-event:provider-event-voice-connected-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:531:            transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:533:            redialPolicy: 'manual_only',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:550:              call_transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:575:        providerEventId: 'provider-event-voice-error-1004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:576:        providerLegId: 'provider-leg-voice-error-1004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:599:          providerLegId: 'provider-leg-voice-error-1004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:600:          providerEventId: 'provider-event-voice-error-1004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:606:          dedupeKey: 'provider-event:provider-event-voice-error-1004',
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:1:import { down, up } from '../20260311110000_create_connectshyft_bridge_sessions'
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:23:describe('20260311110000_create_connectshyft_bridge_sessions migration', () => {
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:24:  it('creates bridge session and bridge leg persistence with scope and provider-call indexes', async () => {
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:34:    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_bridge_sessions'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:35:    expect(rawCalls.some((sql: string) => sql.includes('bridge_status TEXT NOT NULL'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:36:    expect(rawCalls.some((sql: string) => sql.includes('CONSTRAINT cs_bridge_sessions_status_ck CHECK'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:38:    expect(rawCalls.some((sql: string) => sql.includes('CREATE TABLE IF NOT EXISTS connectshyft.cs_bridge_legs'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:39:    expect(rawCalls.some((sql: string) => sql.includes("CONSTRAINT cs_bridge_legs_role_ck CHECK (leg_role IN ('operator', 'neighbor'))"))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:40:    expect(rawCalls.some((sql: string) => sql.includes("leg_status IN ('created', 'dialing', 'ringing', 'answered', 'failed', 'completed', 'canceled')"))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:41:    expect(rawCalls.some((sql: string) => sql.includes('CONSTRAINT cs_bridge_legs_session_role_uq UNIQUE'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:42:    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_bridge_sessions_scope_idx'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:43:    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_bridge_legs_session_idx'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:44:    expect(rawCalls.some((sql: string) => sql.includes('connectshyft_cs_bridge_legs_provider_call_id_uq'))).toBe(true)
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:47:  it('drops bridge leg and bridge session tables in down migration', async () => {
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:53:      'connectshyft.cs_bridge_legs',
+apps/connectshyft-api/src/migrations/__tests__/connectShyftBridgeSessionsMigration.test.ts:54:      'connectshyft.cs_bridge_sessions',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:144:  providerEventId: 'provider-event-sms-characterization-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:145:  providerMessageId: 'provider-message-sms-characterization-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:297:          providerEventId: 'provider-event-sms-success-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:298:          providerMessageId: 'provider-message-sms-success-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:325:            providerMessageId: 'provider-message-sms-success-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:326:            providerEventId: 'provider-event-sms-success-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:332:            dedupeKey: 'provider-event:provider-event-sms-success-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:360:            providerEventId: 'provider-event-sms-success-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:361:            providerMessageId: 'provider-message-sms-success-1001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:452:        providerEventId: 'provider-event-sms-duplicate-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:453:        providerMessageId: 'provider-message-sms-duplicate-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:488:            providerMessageId: 'provider-message-sms-duplicate-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:489:            providerEventId: 'provider-event-sms-duplicate-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:495:            dedupeKey: 'provider-event:provider-event-sms-duplicate-1002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:525:        providerEventId: 'provider-event-sms-missing-phone-1003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:526:        providerMessageId: 'provider-message-sms-missing-phone-1003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:537:        providerEventId: 'provider-event-sms-invalid-phone-1004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:538:        providerMessageId: 'provider-message-sms-invalid-phone-1004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:632:          providerEventId: 'provider-event-sms-ambiguous-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:633:          providerMessageId: 'provider-message-sms-ambiguous-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:656:            providerMessageId: 'provider-message-sms-ambiguous-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:657:            providerEventId: 'provider-event-sms-ambiguous-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:663:            dedupeKey: 'provider-event:provider-event-sms-ambiguous-2003',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:715:          providerEventId: 'provider-event-sms-conflict-2004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:716:          providerMessageId: 'provider-message-sms-conflict-2004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:733:            providerMessageId: 'provider-message-sms-conflict-2004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:734:            providerEventId: 'provider-event-sms-conflict-2004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:740:            dedupeKey: 'provider-event:provider-event-sms-conflict-2004',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:773:          providerEventId: 'provider-event-sms-peoplecore-multi-2005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:774:          providerMessageId: 'provider-message-sms-peoplecore-multi-2005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:791:            providerMessageId: 'provider-message-sms-peoplecore-multi-2005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:792:            providerEventId: 'provider-event-sms-peoplecore-multi-2005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:798:            dedupeKey: 'provider-event:provider-event-sms-peoplecore-multi-2005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:833:          providerEventId: 'provider-event-sms-single-match-2002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:834:          providerMessageId: 'provider-message-sms-single-match-2002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:854:            providerMessageId: 'provider-message-sms-single-match-2002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:855:            providerEventId: 'provider-event-sms-single-match-2002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:861:            dedupeKey: 'provider-event:provider-event-sms-single-match-2002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:877:            providerEventId: 'provider-event-sms-single-match-2002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:878:            providerMessageId: 'provider-message-sms-single-match-2002',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:926:          providerEventId: 'provider-event-sms-created-2011',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:927:          providerMessageId: 'provider-message-sms-created-2011',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:947:            providerMessageId: 'provider-message-sms-created-2011',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:948:            providerEventId: 'provider-event-sms-created-2011',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:954:            dedupeKey: 'provider-event:provider-event-sms-created-2011',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:970:            providerEventId: 'provider-event-sms-created-2011',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:971:            providerMessageId: 'provider-message-sms-created-2011',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1023:          providerEventId: 'provider-event-sms-no-current-link-2014',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1024:          providerMessageId: 'provider-message-sms-no-current-link-2014',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1082:          providerEventId: 'provider-event-sms-peoplecore-unavailable-2015',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1083:          providerMessageId: 'provider-message-sms-peoplecore-unavailable-2015',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1137:          providerEventId: 'provider-event-sms-unresolved-2012',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1138:          providerMessageId: 'provider-message-sms-unresolved-2012',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1161:            providerMessageId: 'provider-message-sms-unresolved-2012',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1162:            providerEventId: 'provider-event-sms-unresolved-2012',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1168:            dedupeKey: 'provider-event:provider-event-sms-unresolved-2012',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1209:          providerEventId: 'provider-event-sms-ensure-error-1005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1210:          providerMessageId: 'provider-message-sms-ensure-error-1005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1233:            providerMessageId: 'provider-message-sms-ensure-error-1005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1234:            providerEventId: 'provider-event-sms-ensure-error-1005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1240:            dedupeKey: 'provider-event:provider-event-sms-ensure-error-1005',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1275:          providerEventId: 'provider-event-sms-canonical-error-1006',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1276:          providerMessageId: 'provider-message-sms-canonical-error-1006',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1299:            providerMessageId: 'provider-message-sms-canonical-error-1006',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1300:            providerEventId: 'provider-event-sms-canonical-error-1006',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:1306:            dedupeKey: 'provider-event:provider-event-sms-canonical-error-1006',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:105:} from '../../../modules/connectshyft/providerRegistry';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:166:} from '../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:225:  transport: 'bridge',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:227:  redialPolicy: 'manual_only',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:236:const CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY = CONNECTSHYFT_OUTBOUND_CALL_POLICY.redialPolicy;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:916:  bridgeSessionId: aggregate.session.id,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:948:  bridgeSessionId: string;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3125:  redialPolicy: string | null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3145:  const redialPolicy = normalizeLifecycleString(resolveField('redialPolicy')).toLowerCase();
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3161:    redialPolicy: redialPolicy || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3715:): 'send_sms' | 'start_bridge_session' => (
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3716:  outboundAction === 'call' ? 'start_bridge_session' : 'send_sms'
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3735:  channel: 'sms' | 'voice' | 'bridge' | 'webhook';
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3793:      message: 'Outbound calls require bridge transport only.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3808:      callPolicy.redialPolicy !== null
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3809:      && callPolicy.redialPolicy !== CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3815:      message: 'Automatic redial/retry is disabled. Operators must re-initiate calls manually.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3820:        redialPolicy: callPolicy.redialPolicy,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:3822:        allowedRedialPolicy: CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4468:      redialPolicy: outboundCallPolicyRequest?.redialPolicy || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4496:  let bridgeSessionState: ConnectShyftBridgeSessionStateContract | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4497:  let bridgeCorrelationMapping: ConnectShyftBridgeCorrelationMapping | null = null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4713:        message: 'Outbound bridge calls require an operator callback number.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4758:        message: 'Outbound bridge calls require a dialable neighbor phone.',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:4927:      senderPhone: smsSenderResolution.senderPhone,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5107:        targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5109:        channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5228:        const bridgeStart = await startConnectShyftBridgeSession({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5244:        bridgeSessionState = buildProviderNeutralBridgeSessionState(bridgeStart.aggregate);
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5245:        bridgeCorrelationMapping = bridgeStart.correlationMapping;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5250:          providerLegId: bridgeStart.aggregate.operatorLeg.providerCallId || null,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5254:          requestedAt: bridgeStart.aggregate.operatorLeg.updatedAt.toISOString(),
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5316:        targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5318:        channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5383:      targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5385:      channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5521:    bridgeCorrelationMapping as ConnectShyftBridgeCorrelationMapping | null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5661:          bridgeSession: bridgeSessionState,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5697:  const bridgeSessionId = (
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5698:    bridgeSessionState as ConnectShyftBridgeSessionStateContract | null
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5699:  )?.bridgeSessionId || null;
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5713:      resourceType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5715:        ? normalizeLifecycleString(bridgeSessionId)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5726:    targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5728:    channel: outboundAction === 'call' ? 'bridge' : 'sms',
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:5739:      bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6350:  const bridgeWebhookProgression = await handleConnectShyftBridgeWebhookEvent({
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6368:  if (bridgeWebhookProgression.handled && !isConnectedCallEvent) {
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6395:        bridgeSession: bridgeWebhookProgression.aggregate
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6396:          ? buildProviderNeutralBridgeSessionState(bridgeWebhookProgression.aggregate)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6398:        bridgeEvent: bridgeWebhookProgression.domainEvent,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:6399:        correlationMapping: bridgeWebhookProgression.correlationMapping,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7432:      ...(bridgeWebhookProgression.handled
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7434:            bridgeSession: bridgeWebhookProgression.aggregate
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7435:              ? buildProviderNeutralBridgeSessionState(bridgeWebhookProgression.aggregate)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7437:            bridgeEvent: bridgeWebhookProgression.domainEvent,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7438:            correlationMapping: bridgeWebhookProgression.correlationMapping,
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts:7465:        redialPolicy: CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY,
+apps/connectshyft-api/src/routes/api/v1/connectshyft/ops.routes.ts:12:router.get('/bridge/:bridgeId', getConnectOpsBridgeVisibility);
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:3:import * as BridgeSessionsModule from '../../../../modules/connectshyft/bridgeSessions';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:133:        bridgeSession: null,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:183:      'bridgeSession',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:259:        bridgeSession: null,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:11:import * as ProviderRegistry from '../../../../modules/connectshyft/providerRegistry';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:181:  it('fails closed when Telnyx rollout allow-list excludes tenant/orgUnit context', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:17:const TEST_CALLBACK_PROVIDER_EVENT_ID = 'provider-event-voice-seed-1001';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:18:const TEST_CALLBACK_VOICEMAIL_ARTIFACT_ID = 'vm-thread-f1-claimed-1002-provider-event-voice-seed-1001';
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:20:} from './providerRegistry'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:22:const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:23:const BRIDGE_LEGS_TABLE = 'cs_bridge_legs'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:35:  bridge_status: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:50:  bridge_session_id: string
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:156:  status: row.bridge_status as BridgeSessionRecord['status'],
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:171:  bridgeSessionId: row.bridge_session_id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:195:  bridge_status: session.status,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:210:  bridge_session_id: leg.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:235:    const current = this.legsBySessionId.get(leg.bridgeSessionId) || new Map()
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:237:    this.legsBySessionId.set(leg.bridgeSessionId, current)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:239:      this.sessionIdByProviderCallId.set(leg.providerCallId, leg.bridgeSessionId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:364:      .where({ bridge_session_id: sessionId })
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:369:        'bridge_session_id',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:403:      .join(`${BRIDGE_SESSIONS_TABLE} as bs`, 'bs.id', 'bl.bridge_session_id')
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:412:      .first<{ bridgeSessionId?: string }>('bl.bridge_session_id as bridgeSessionId')
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:414:    const sessionId = normalizeString(legRow?.bridgeSessionId)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:452:  transport: normalizeString(callPolicy?.transport) || 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:454:  redialPolicy: normalizeString(callPolicy?.redialPolicy) || 'manual_only',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:474:        bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:502:      throw new Error(`Provider ${input.providerKey} does not support bridge control.`)
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:507:      bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:532:    bridgeLegId: input.leg.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:598:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:607:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:615:    normalizedEventType === 'callbridged'
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:619:      type: 'bridge_connected',
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:620:      bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:630:    if (input.aggregate.session.status === 'bridged' || input.aggregate.session.status === 'completed') {
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:633:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:642:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:652:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:668:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts:678:        bridgeSessionId: input.aggregate.session.id,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:2:import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:43:  bridgeSessionId: string
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:48:  bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:49:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:50:  providerRequestId: 'req-bridge-3001',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:206:describe('connectshyft bridge webhook flow', () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:259:  it('creates a persisted bridge session on call start with operator-first dialing', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:279:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:280:          bridgeSessionId: expect.any(String),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:281:          status: 'operator_dialing',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:282:          sessionState: 'operator_dialing',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:339:  it('rejects unverified webhooks before receipt processing or bridge side effects', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:398:  it('advances operator answered to neighbor dialing and bridges on neighbor answered', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:429:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:430:          status: 'neighbor_dialing',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:431:          sessionState: 'neighbor_dialing',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:443:        bridgeEvent: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:470:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:471:          status: 'bridged',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:472:          sessionState: 'bridged',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:484:        bridgeEvent: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:496:  it('suppresses duplicate webhook receipts before bridge side effects are re-applied', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:541:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:542:          sessionState: 'neighbor_dialing',
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:634:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:648:        bridgeEvent: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:667:  it('persists terminal bridge failure when the neighbor leg fails before bridge completion', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:708:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:721:        bridgeEvent: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:729:  it('loads persisted bridge state from a fresh thread detail read after completion', async () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:786:        bridgeSession: {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:787:          bridgeSessionId: expect.any(String),
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:611:  bridgeLegId: string;
+apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts:627:    internalReferenceId: input.bridgeLegId,
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:4:import * as BridgeSessionsModule from '../../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:15:    id: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:24:    status: 'bridged',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:35:    id: 'bridge-leg-operator-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:38:    bridgeSessionId: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:52:    id: 'bridge-leg-neighbor-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:55:    bridgeSessionId: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:70:describe('connectshyft ops bridge visibility route', () => {
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:75:  it('surfaces bridge runtime state from the existing bridge-session seam', async () => {
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:82:      .get('/api/v1/connectshyft/ops/bridge/bridge-session-ops-1001')
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:90:        bridgeId: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:106:  it('maps operator dialing bridge state to ringing from the runtime seam', async () => {
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:114:        status: 'operator_dialing',
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:130:      .get('/api/v1/connectshyft/ops/bridge/bridge-session-ops-1001')
+apps/connectshyft-api/src/modules/connectshyft/ops/__tests__/ops.bridge.test.ts:138:        bridgeId: 'bridge-session-ops-1001',
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:5:The ConnectShyft neighbor / identity bridge surface is currently split across these files:
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:27:  - owns identity-match request handoff, identity bridge refusal mapping, and preserved identity-match response assembly
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:35:Slice 7 intentionally preserves the exact current response shapes for the full neighbor / identity bridge family.
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:47:This was deliberate. The goal of this slice was thin-router extraction and a cleaner bridge boundary, not payload redesign.
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:82:- the bridge boundary is documented as the seam where future PeopleCore convergence can swap internals without re-thickening the router
+apps/connectshyft-api/src/modules/connectshyft/handlers/NEIGHBOR_IDENTITY_BRIDGE_NOTES.md:88:The following work remains deferred beyond the neighbor / identity bridge family:
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:28:const CONNECTSHYFT_REQUIRED_CALL_TRANSPORT = 'bridge';
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:675:      providerLegId: `${providerKey}-bridge-leg-${command.legRole}-${command.bridgeSessionId}`,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:684:      bridgeSessionId: command.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:685:      bridgeEstablished: true,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:738:        message: 'Outbound calls require bridge transport only.',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:746:    const requestedRedialPolicy = normalizeString(command.callPolicy?.redialPolicy).toLowerCase();
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:751:        requestedRedialPolicy.length > 0
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:752:        && requestedRedialPolicy !== CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:757:        message: 'Automatic redial/retry is disabled. Operators must re-initiate calls manually.',
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:760:          requestedRedialPolicy: requestedRedialPolicy || null,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:761:          allowedRedialPolicy: CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:780:          redialPolicy: CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY,
+apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts:795:      throw new Error(`Provider ${baseAdapter.providerKey} does not support bridge control.`);
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:1:import { loadConnectShyftBridgeAggregateBySessionId } from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:11:  bridgeId: string;
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:28:  if (status === 'bridged') {
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:41:    status === 'operator_dialing'
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:43:    || status === 'neighbor_dialing'
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:79:  bridgeId: string;
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:82:  const aggregate = await loadConnectShyftBridgeAggregateBySessionId(input.bridgeId);
+apps/connectshyft-api/src/modules/connectshyft/ops/bridgeVisibility.service.ts:92:    bridgeId: aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:13:import { readConnectShyftBridgeVisibility } from '../ops/bridgeVisibility.service';
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:25:  surface: 'identity' | 'thread' | 'bridge';
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:40:  surface: 'identity' | 'thread' | 'bridge';
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:254:  const bridgeId = parseParam(req.params.bridgeId);
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:255:  if (!bridgeId) {
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:258:      message: 'bridgeId is required',
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:271:    surface: 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:274:    resourceId: bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:280:    bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:286:      surface: 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:289:      resourceId: bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:299:        bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:307:    surface: 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:310:    resourceId: bridgeId,
+apps/connectshyft-api/src/modules/connectshyft/http/ops.handlers.ts:317:    message: 'ConnectShyft ops bridge visibility loaded',
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:7:import { loadConnectShyftBridgeAggregateByThreadId } from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:83:  bridgeSessionId: aggregate.session.id,
+apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts:337:      bridgeSession: activeBridgeSession
+apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts:10:} from '../providerRegistry';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:8:} from '../providerRegistry';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:40:  let previousTelnyxPublicKey: string | undefined;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:47:    previousTelnyxPublicKey = process.env.TELNYX_PUBLIC_KEY;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:57:    process.env.TELNYX_PUBLIC_KEY = previousTelnyxPublicKey;
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:442:  it('preserves targetPhone and senderPhone unchanged across providerRegistry.sendSms', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:448:      providerRequestId: 'req-sms-2002',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:512:  it('enforces bridge-only/manual retry policy at the adapter dispatch boundary', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:536:          redialPolicy: 'manual_only',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:550:          transport: 'bridge',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:552:          redialPolicy: 'manual_only',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:690:  it('rejects webhook signatures when Telnyx signature headers are missing outside override mode', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:707:    process.env.TELNYX_PUBLIC_KEY = generateKeyPairSync('ed25519').publicKey.export({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:732:  it('accepts valid Telnyx webhook signatures outside override mode', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:736:    process.env.TELNYX_PUBLIC_KEY = publicKey.export({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerRegistry.test.ts:791:    process.env.TELNYX_PUBLIC_KEY = publicKey.export({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:11:import * as providerRegistryModule from '../providerRegistry';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:13:import * as bridgeSessionsModule from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:138:    jest.spyOn(providerRegistryModule, 'resolveConnectShyftRequestedProviderKey').mockReturnValue('telnyx');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:148:      .spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:252:    jest.spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter').mockReturnValue(selection as any);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:300:  it('stays limited to prerequisite resolution and execution delegation without bridge or canonical side effects', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:302:    jest.spyOn(providerRegistryModule, 'resolveConnectShyftProviderAdapter').mockReturnValue(selection as any);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:310:    const bridgeWebhookSpy = jest.spyOn(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:311:      bridgeSessionsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:390:    expect(bridgeWebhookSpy).not.toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/http/neighborIdentityContext.ts:1560:// This helper intentionally keeps the neighbor/identity bridge ConnectShyft-local for now.
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:10:import * as providerRegistryModule from '../providerRegistry';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:11:import * as bridgeSessionsModule from '../bridgeSessions';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:265:  it('stays limited to prerequisite resolution and execution delegation without provider or bridge side effects', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:267:      providerRegistryModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.threadOutboundContext.test.ts:271:      bridgeSessionsModule,
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:31:  - still owned by the existing inbound core in `connectshyft.ts` and provider-facing modules such as `providerRegistry.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:36:- bridge-session webhook progression and bridge alignment behavior
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:37:  - still owned by the existing inbound core in `connectshyft.ts` and `bridgeSessions.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:43:Provider, correlation, canonical, bridge, and transcription internals remain intentionally deferred from the route-family extraction sequence.
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:53:- existing nested provider, correlation, canonical, bridge, voicemail, transcription, auto-claim, and side-effect payload structure remains unchanged
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:80:- redesign bridge handling
+apps/connectshyft-api/src/modules/connectshyft/handlers/INBOUND_WEBHOOK_NOTES.md:87:That work should build on the current thin handlers and `inboundWebhookContext.ts` boundary rather than pulling deferred provider, correlation, canonical, bridge, or transcription internals into the route-family extraction seam.
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:7:} from '../bridgeSessions'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:9:import type { ConnectShyftProviderAdapter } from '../providerRegistry'
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:25:const startBridgeSessionMock = jest.fn(async (input: { bridgeSessionId: string }) => ({
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:27:  bridgeSessionId: input.bridgeSessionId,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:28:  bridgeEstablished: true as const,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:29:  providerRequestId: 'req-bridge-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:83:describe('connectshyft bridgeSessions', () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:109:  it('persists a created bridge session with operator and neighbor legs on startup', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:112:    expect(result.aggregate.session.status).toBe('operator_dialing')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:131:        status: 'operator_dialing',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:148:  it('rehydrates by provider leg id and persists neighbor dialing after operator answer', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:169:          status: 'neighbor_dialing',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:192:        status: 'neighbor_dialing',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:206:  it('persists completed bridge sessions after both legs answer and the bridge ends', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:240:    expect(afterNeighborAnswer.aggregate?.session.status).toBe('bridged')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:264:  it('persists failed bridge sessions when the neighbor leg fails before bridge completion', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:9:  it('maps provider payload fields into a canonical inbound sms domain event', () => {
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:26:  - still owned by the existing outbound core in `connectshyft.ts` and provider-facing modules such as `providerRegistry.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:27:- bridge session startup and bridge-session state orchestration
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:28:  - still owned by the existing outbound core in `connectshyft.ts` and `bridgeSessions.ts`
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:36:Slice 8 was an extraction slice, not a provider, bridge, reliability, or audit redesign.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:46:- existing nested provider, bridge-session, idempotency, audit, override, and side-effect payload structure remains unchanged
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:72:- provider or bridge architecture redesign
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:83:5. Do not fold provider, bridge, reliability, audit, or SMS-override internals into the thin handlers or helper boundary.
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_OUTBOUND_NOTES.md:90:That separation should stay explicit. Follow-up cleanup should not use the outbound handlers or `threadOutboundContext.ts` as a place to absorb inbound message intake, webhook correlation, provider signature handling, bridge webhook progression, voicemail processing, or transcription callbacks. Those surfaces remain intentionally deferred to the next slice after Slice 8.
+apps/connectshyft-api/src/modules/connectshyft/handlers/README.md:71:- bridge-session orchestration moves
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.neighborIdentityContext.test.ts:278:  it('stays limited to neighbor identity prerequisites and does not execute bridge side effects', async () => {
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:12:  - owns thread detail request handoff, response assembly, canonical timeline inclusion, voicemail artifact projection, and bridge-session payload shaping
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_READ_NOTES.md:24:- the current detail envelope with `thread`, `bridgeSession`, `voicemailArtifacts`, `actions`, and policy metadata
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:59:- PeopleCore neighbor or identity bridge convergence work
+apps/connectshyft-api/src/modules/connectshyft/handlers/THREAD_LIFECYCLE_NOTES.md:77:That separation should remain explicit. Follow-up cleanup should not use the lifecycle helper boundary as a place to absorb outbound reopen rules, provider dispatch concerns, inbound correlation work, or webhook processing. The next extraction target after Slice 6 is neighbors / identity bridge, while outbound and webhook surfaces remain intentionally deferred.
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:71:  it('records provider call-leg mappings against persisted bridge-leg ids', async () => {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:77:      providerIdentifier: 'provider-leg-bridge-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:78:      bridgeLegId: 'bridge-leg-neighbor-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:86:        providerIdentifier: 'provider-leg-bridge-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:87:        internalReferenceId: 'bridge-leg-neighbor-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:93:      providerLegId: 'provider-leg-bridge-f3-1001',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:100:        internalCallReferenceId: 'bridge-leg-neighbor-f3-1001',
+
+=== INBOUND SMS / VOICE ENTRYPOINTS ===
+      message: 'Transcription callback attached to voicemail artifact',
+      data: {
+        eventType,
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: correlation.source,
+          deterministic: true,
+          threadId,
+          tenantId,
+          orgUnitId,
+          providerEventId: callbackProviderEventId,
+          voicemailArtifactId: callbackVoicemailArtifactId,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: transcriptionReceipt.dedupeKey,
+        },
+        transcriptionAttachment: {
+          applied: true,
+          transcriptText,
+          voicemailArtifactId: callbackVoicemailArtifactId,
+        },
+        timeline: {
+          eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.voicemailTranscriptionAttached,
+          routingDecision: 'accepted',
+        },
+        sideEffects: {
+          transcriptMutationApplied: true,
+          timelineMutationApplied: true,
+        },
+        canonicalEvent,
+      },
+    });
+    return;
+  }
+
+  const webhookReceipt = await beginConnectShyftWebhookReceiptProcessing({
+    tenantId,
+    orgUnitId,
+    threadId,
+    providerName: providerSelection.providerResolution.resolvedProvider,
+    canonicalEventType: eventType,
+    providerEventId: correlation.providerEventId,
+    providerLegId: correlation.providerLegId,
+    providerMessageId: correlation.providerMessageId,
+    correlationKeys: {
+      tenantId,
+      orgUnitId,
+      threadId,
+      providerEventId: correlation.providerEventId,
+      providerLegId: correlation.providerLegId,
+      providerMessageId: correlation.providerMessageId,
+      providerNumberE164: correlation.providerNumberE164,
+    },
+    db: webhookPersistenceDb,
+  });
+  if (webhookReceipt.error) {
+    refusal(res, {
+      code: webhookReceipt.error.code,
+      message: 'Inbound webhook correlation resolved but receipt persistence is unavailable.',
+      refusalType: 'business',
+      httpStatus: 200,
+      data: {
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: correlation.source,
+          deterministic: true,
+          threadId,
+          tenantId,
+          orgUnitId,
+          providerLegId: correlation.providerLegId,
+          providerMessageId: correlation.providerMessageId,
+          providerEventId: correlation.providerEventId,
+          providerNumberE164: correlation.providerNumberE164,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: webhookReceipt.dedupeKey,
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+        timelineOutcome: {
+          eventName: null,
+          routingDecision: 'refused',
+        },
+      },
+    });
+    return;
+  }
+
+  const markWebhookReceipt = async (
+    status: 'APPLIED' | 'FAILED_RETRYABLE' | 'FAILED_TERMINAL',
+    failureReason?: string,
+    failureClassification?: {
+      category: string;
+      retryable: boolean;
+      httpStatus?: number | null;
+      providerCode?: string | null;
+    } | null,
+  ): Promise<void> => {
+    const normalizedFailureClassification = failureClassification || (status === 'FAILED_RETRYABLE'
+      ? {
+        category: 'temporary_processing_failure',
+        retryable: true,
+        httpStatus: null,
+        providerCode: null,
+      }
+      : status === 'FAILED_TERMINAL'
+        ? {
+          category: 'terminal_processing_failure',
+          retryable: false,
+          httpStatus: null,
+          providerCode: null,
+        }
+        : null);
+    const retryDisposition = status === 'FAILED_RETRYABLE'
+      ? resolveWebhookRetryDisposition({
+        attemptCount: webhookReceipt.attemptCount,
+        retryable: normalizedFailureClassification?.retryable === true,
+      })
+      : null;
+    const persistedStatus = status === 'FAILED_RETRYABLE'
+      ? retryDisposition?.decision === 'retry'
+        ? 'FAILED_RETRYABLE'
+        : 'FAILED_TERMINAL'
+      : status;
+    const nextRetryAtUtc = persistedStatus === 'FAILED_RETRYABLE'
+      && retryDisposition?.decision === 'retry'
+      ? retryDisposition.nextAttemptAt.toISOString()
+      : null;
+
+    await markConnectShyftWebhookReceiptProcessingResult({
+      tenantId,
+      threadId,
+      providerName: providerSelection.providerResolution.resolvedProvider,
+      dedupeKey: webhookReceipt.dedupeKey,
+      canonicalEventType: eventType,
+      providerEventId: correlation.providerEventId,
+      providerLegId: correlation.providerLegId,
+      providerMessageId: correlation.providerMessageId,
+      status: persistedStatus,
+      failureReason: failureReason || null,
+      nextRetryAtUtc,
+      lastFailureClassification: normalizedFailureClassification,
+      db: webhookPersistenceDb,
+    });
+    await appendConnectShyftCommunicationAudit({
+      tenantId,
+      correlationId: webhookReceipt.dedupeKey || correlation.providerEventId || randomUUID(),
+      actorType: 'provider',
+      operationName: 'apply_provider_event',
+      targetEntityType: 'webhook_receipt',
+      targetEntityId: webhookReceipt.dedupeKey,
+      channel: 'webhook',
+      resultState: persistedStatus === 'APPLIED'
+        ? 'succeeded'
+        : persistedStatus === 'FAILED_RETRYABLE'
+          ? 'retrying'
+          : retryDisposition?.decision === 'exhausted'
+            ? 'exhausted'
+            : 'failed',
+      resultCode: persistedStatus,
+      resultMessage: failureReason || null,
+      providerName: providerSelection.providerResolution.resolvedProvider,
+      providerReferenceId: correlation.providerEventId || correlation.providerLegId || correlation.providerMessageId || null,
+      metadata: {
+        threadId,
+        eventType,
+        attemptCount: webhookReceipt.attemptCount,
+        nextRetryAtUtc,
+        failureClassification: normalizedFailureClassification,
+      },
+      db: webhookPersistenceDb,
+    });
+  };
+
+  const shouldSuppressWebhookDuplicate = webhookReceipt.alreadyApplied
+    || webhookReceipt.previousStatus === 'RECEIVED'
+    || webhookReceipt.previousStatus === 'FAILED_TERMINAL';
+
+  if (shouldSuppressWebhookDuplicate) {
+    await appendConnectShyftCommunicationAudit({
+      tenantId,
+      correlationId: webhookReceipt.dedupeKey || correlation.providerEventId || randomUUID(),
+      actorType: 'provider',
+      operationName: 'apply_provider_event',
+      targetEntityType: 'webhook_receipt',
+      targetEntityId: webhookReceipt.dedupeKey,
+      channel: 'webhook',
+      resultState: 'ignored_duplicate',
+      resultCode: 'CONNECTSHYFT_WEBHOOK_DUPLICATE_SUPPRESSED',
+      resultMessage: 'Duplicate webhook suppressed before domain side effects.',
+      providerName: providerSelection.providerResolution.resolvedProvider,
+      providerReferenceId: correlation.providerEventId || correlation.providerLegId || correlation.providerMessageId || null,
+      metadata: {
+        threadId,
+        eventType,
+        attemptCount: webhookReceipt.attemptCount,
+      },
+      db: webhookPersistenceDb,
+    });
+    success(res, {
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      message: 'Inbound webhook accepted (duplicate suppressed)',
+      data: {
+        sid: typeof req.body?.sid === 'string' ? req.body.sid : null,
+        from: typeof req.body?.from === 'string' ? req.body.from : null,
+        to: typeof req.body?.to === 'string' ? req.body.to : null,
+        eventType,
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: correlation.source,
+          deterministic: true,
+          threadId,
+          tenantId,
+          orgUnitId,
+          providerLegId: correlation.providerLegId,
+          providerMessageId: correlation.providerMessageId,
+          providerEventId: correlation.providerEventId,
+          providerNumberE164: correlation.providerNumberE164,
+        },
+        replaySafe: {
+          duplicate: true,
+          suppressedDomainWrites: true,
+          dedupeKey: webhookReceipt.dedupeKey,
+        },
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+      },
+    });
+    return;
+  }
+
+  const bridgeWebhookProgression = await handleConnectShyftBridgeWebhookEvent({
+    tenantId,
+    orgUnitId,
+    threadId,
+    providerKey: providerSelection.providerResolution.resolvedProvider,
+    providerAdapter: providerSelection.adapter,
+    providerLegId: correlation.providerLegId,
+    eventType,
+    occurredAt: isStrictUtcIsoTimestamp(normalizeLifecycleString(req.body?.occurredAt))
+      ? new Date(normalizeLifecycleString(req.body?.occurredAt))
+      : undefined,
+    reason:
+      normalizeLifecycleString(req.body?.reason)
+      || normalizeLifecycleString(req.body?.hangupCause)
+      || normalizeLifecycleString(req.body?.hangup_cause)
+      || null,
+    callPolicy: CONNECTSHYFT_OUTBOUND_CALL_POLICY,
+  });
+  if (bridgeWebhookProgression.handled && !isConnectedCallEvent) {
+    await markWebhookReceipt('APPLIED');
+    success(res, {
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      message: 'Inbound webhook accepted',
+      data: {
+        eventType,
+        providerResolution: {
+          ...providerSelection.providerResolution,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: correlation.source,
+          deterministic: true,
+          threadId,
+          tenantId,
+          orgUnitId,
+          providerLegId: correlation.providerLegId,
+          providerMessageId: correlation.providerMessageId,
+          providerEventId: correlation.providerEventId,
+          providerNumberE164: correlation.providerNumberE164,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: webhookReceipt.dedupeKey,
+        },
+        bridgeSession: bridgeWebhookProgression.aggregate
+          ? buildProviderNeutralBridgeSessionState(bridgeWebhookProgression.aggregate)
+          : null,
+        bridgeEvent: bridgeWebhookProgression.domainEvent,
+        correlationMapping: bridgeWebhookProgression.correlationMapping,
+        sideEffects: {
+          lifecycleMutationApplied: false,
+          canonicalEventPersisted: false,
+          outboxPersisted: false,
+        },
+      },
+    });
+    return;
+  }
+
+  const isSmsEvent = normalizedEventType.includes('sms') || normalizedEventType.includes('message');
+  if (isSmsEvent) {
+    const extractedNeighborId = normalizeConnectShyftNeighborIdentifier(
+      extractConnectShyftInboundSmsNeighborId(req.body) || '',
+    );
+    const explicitNeighborId = extractedNeighborId
+      && isValidConnectShyftNeighborIdentifier(extractedNeighborId)
+      ? extractedNeighborId
+      : null;
+    let neighborId: string | null = null;
+    let normalizedSenderPhone: string | null = null;
+
+    try {
+      if (explicitNeighborId) {
+        const resolvedExplicitNeighborId = await resolveInboundReusableNeighborId({
+          tenantId,
+          neighborId: explicitNeighborId,
+        });
+        neighborId = resolvedExplicitNeighborId;
+      }
+
+      if (!neighborId) {
+        const correlatedNeighborId = await resolveNeighborIdForThreadCorrelation({
+          tenantId,
+          orgUnitId,
+          threadId,
+        });
+        if (correlatedNeighborId) {
+          const resolvedCorrelatedNeighborId = await resolveInboundReusableNeighborId({
+            tenantId,
+            neighborId: correlatedNeighborId,
+          });
+          neighborId = resolvedCorrelatedNeighborId;
+        }
+      }
+    } catch (error) {
+      await markWebhookReceipt('FAILED_RETRYABLE', 'neighbor_resolution_unavailable');
+      refusal(res, {
+        code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+        message: error instanceof Error ? error.message : 'Neighbor resolution is temporarily unavailable.',
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          providerResolution: {
+            ...providerSelection.providerResolution,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: correlation.source,
+            deterministic: true,
+            threadId,
+            tenantId,
+            orgUnitId,
+            providerLegId: correlation.providerLegId,
+            providerMessageId: correlation.providerMessageId,
+            providerEventId: correlation.providerEventId,
+            providerNumberE164: correlation.providerNumberE164,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: webhookReceipt.dedupeKey,
+          },
+          sideEffects: {
+            lifecycleMutationApplied: false,
+            canonicalEventPersisted: false,
+            outboxPersisted: false,
+          },
+          reason: 'neighbor_resolution_unavailable',
+        },
+      });
+      return;
+    }
+
+    if (!neighborId) {
+      const senderPhone = resolveConnectShyftInboundSmsSenderPhone(req.body);
+      if (!senderPhone.ok) {
+        await markWebhookReceipt('FAILED_TERMINAL', senderPhone.code === 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED'
+          ? 'sender_phone_required'
+          : 'sender_phone_invalid');
+        refusal(res, {
+          code: senderPhone.code,
+          message: senderPhone.message,
+          refusalType: 'business',
+          httpStatus: 200,
+          data: {
+            providerResolution: {
+              ...providerSelection.providerResolution,
+              adapterInvoked: true,
+            },
+            correlation: {
+              source: correlation.source,
+              deterministic: true,
+              threadId,
+              tenantId,
+              orgUnitId,
+              providerLegId: correlation.providerLegId,
+              providerMessageId: correlation.providerMessageId,
+              providerEventId: correlation.providerEventId,
+              providerNumberE164: correlation.providerNumberE164,
+            },
+            replaySafe: {
+              duplicate: false,
+              suppressedDomainWrites: false,
+              dedupeKey: webhookReceipt.dedupeKey,
+            },
+            sideEffects: {
+              lifecycleMutationApplied: false,
+              canonicalEventPersisted: false,
+              outboxPersisted: false,
+            },
+            timelineOutcome: {
+              eventName: null,
+              routingDecision: 'refused',
+            },
+            reason: senderPhone.code === 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED'
+              ? 'sender_phone_required'
+              : 'sender_phone_invalid',
+          },
+        });
+        return;
+      }
+
+      normalizedSenderPhone = senderPhone.normalizedPhone;
+
+      try {
+        const subjectResolution = await resolveSubjectByContactPoint({
+          tenantId,
+          orgUnitId,
+          contactPoint: senderPhone.normalizedPhone,
+        });
+        normalizedSenderPhone = subjectResolution.normalizedContactPoint;
+
+        if (subjectResolution.type === 'single_match') {
+          neighborId = subjectResolution.neighborId;
+        } else if (subjectResolution.type === 'no_match') {
+          const createdNeighbor = await createNeighborFromInbound({
+            tenantId,
+            orgUnitId,
+            phone: subjectResolution.normalizedContactPoint,
+            correlationId: webhookReceipt.dedupeKey
+              || correlation.providerMessageId
+              || correlation.providerEventId
+              || correlation.providerLegId
+              || randomUUID(),
+            providerName: providerSelection.providerResolution.resolvedProvider,
+            providerReferenceId: correlation.providerMessageId
+              || correlation.providerEventId
+              || correlation.providerLegId,
+            requestFingerprint: createHash('sha256')
+              .update(subjectResolution.normalizedContactPoint)
+              .digest('hex'),
+          });
+          if (!createdNeighbor.ok) {
+            const lifecycleReason = createdNeighbor.code.includes('PERSISTENCE_UNAVAILABLE')
+              ? 'neighbor_resolution_unavailable'
+              : 'neighbor_create_refused';
+            await markWebhookReceipt(
+              createdNeighbor.code.includes('PERSISTENCE_UNAVAILABLE') ? 'FAILED_RETRYABLE' : 'FAILED_TERMINAL',
+              lifecycleReason,
+            );
+            refusal(res, {
+              code: createdNeighbor.code,
+              message: createdNeighbor.message,
+              refusalType: 'business',
+              httpStatus: 200,
+              data: {
+                providerResolution: {
+                  ...providerSelection.providerResolution,
+                  adapterInvoked: true,
+                },
+                correlation: {
+                  source: correlation.source,
+                  deterministic: true,
+                  threadId,
+                  tenantId,
+                  orgUnitId,
+                  providerLegId: correlation.providerLegId,
+                  providerMessageId: correlation.providerMessageId,
+                  providerEventId: correlation.providerEventId,
+                  providerNumberE164: correlation.providerNumberE164,
+                },
+                replaySafe: {
+                  duplicate: false,
+                  suppressedDomainWrites: false,
+                  dedupeKey: webhookReceipt.dedupeKey,
+                },
+                sideEffects: {
+                  lifecycleMutationApplied: false,
+                  canonicalEventPersisted: false,
+                  outboxPersisted: false,
+                },
+                timelineOutcome: {
+                  eventName: null,
+                  routingDecision: 'refused',
+                },
+                senderPhone: subjectResolution.normalizedContactPoint,
+                reason: lifecycleReason,
+              },
+            });
+            return;
+          }
+          neighborId = createdNeighbor.data.neighbor.neighborId;
+        } else {
+          await markWebhookReceipt('FAILED_TERMINAL', 'neighbor_ambiguous');
+          refusal(res, {
+            code: IDENTITY_MATCH_AMBIGUOUS_CODE,
+            message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
+            refusalType: 'business',
+            httpStatus: 200,
+            data: {
+              providerResolution: {
+                ...providerSelection.providerResolution,
+                adapterInvoked: true,
+              },
+              correlation: {
+                source: correlation.source,
+                deterministic: true,
+                threadId,
+                tenantId,
+                orgUnitId,
+                providerLegId: correlation.providerLegId,
+                providerMessageId: correlation.providerMessageId,
+                providerEventId: correlation.providerEventId,
+                providerNumberE164: correlation.providerNumberE164,
+              },
+              replaySafe: {
+                duplicate: false,
+                suppressedDomainWrites: false,
+                dedupeKey: webhookReceipt.dedupeKey,
+              },
+              sideEffects: {
+                lifecycleMutationApplied: false,
+                canonicalEventPersisted: false,
+                outboxPersisted: false,
+              },
+              timelineOutcome: {
+                eventName: null,
+                routingDecision: 'refused',
+              },
+              senderPhone: subjectResolution.normalizedContactPoint,
+              candidateNeighborIds: subjectResolution.candidateNeighborIds,
+              reason: 'neighbor_ambiguous',
+            },
+          });
+          return;
+        }
+      } catch (error) {
+        await markWebhookReceipt('FAILED_RETRYABLE', 'neighbor_resolution_unavailable');
+        refusal(res, {
+          code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
+          message: error instanceof Error ? error.message : 'Neighbor resolution is temporarily unavailable.',
+          refusalType: 'business',
+          httpStatus: 200,
+          data: {
+            providerResolution: {
+              ...providerSelection.providerResolution,
+              adapterInvoked: true,
+            },
+            correlation: {
+              source: correlation.source,
+              deterministic: true,
+              threadId,
+              tenantId,
+              orgUnitId,
+              providerLegId: correlation.providerLegId,
+              providerMessageId: correlation.providerMessageId,
+              providerEventId: correlation.providerEventId,
+              providerNumberE164: correlation.providerNumberE164,
+            },
+            replaySafe: {
+              duplicate: false,
+              suppressedDomainWrites: false,
+              dedupeKey: webhookReceipt.dedupeKey,
+            },
+            sideEffects: {
+              lifecycleMutationApplied: false,
+              canonicalEventPersisted: false,
+              outboxPersisted: false,
+            },
+            senderPhone: normalizedSenderPhone,
+            reason: 'neighbor_resolution_unavailable',
+          },
+        });
+        return;
+      }
+    }
+
+    if (!neighborId) {
+      await markWebhookReceipt('FAILED_TERMINAL', 'neighbor_unresolved');
+      refusal(res, {
+        code: 'CONNECTSHYFT_WEBHOOK_NEIGHBOR_UNRESOLVED',
+        message: 'Inbound SMS processing requires a resolvable neighbor context.',
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          providerResolution: {
+            ...providerSelection.providerResolution,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: correlation.source,
+            deterministic: true,
+            threadId,
+            tenantId,
+            orgUnitId,
+            providerLegId: correlation.providerLegId,
+            providerMessageId: correlation.providerMessageId,
+            providerEventId: correlation.providerEventId,
+            providerNumberE164: correlation.providerNumberE164,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: webhookReceipt.dedupeKey,
+          },
+          sideEffects: {
+            lifecycleMutationApplied: false,
+            canonicalEventPersisted: false,
+            outboxPersisted: false,
+          },
+          timelineOutcome: {
+            eventName: null,
+            routingDecision: 'refused',
+          },
+          senderPhone: normalizedSenderPhone,
+          reason: 'neighbor_unresolved',
+        },
+      });
+      return;
+    }
+
+    const existingActiveThreadId = await resolveExistingActiveThreadIdForScope({
+      tenantId,
+      orgUnitId,
+      neighborId,
+    });
+    const actorUserId = resolveWebhookActorUserId(req);
+    const inboundAlignedProviderNumber = await resolveInboundAlignedProviderNumber({
+      tenantId,
+      orgUnitId,
+      threadId: existingActiveThreadId || threadId || null,
+      providerNumberE164: correlation.providerNumberE164,
+      loadThread: async () => {
+        const alignedThreadId = normalizeLifecycleString(existingActiveThreadId || threadId || null);
+        if (!alignedThreadId) {
+          return null;
+        }
+
+        const lifecycleContext = await resolveLifecycleContext({
+          tenantId,
+          orgUnitId,
+          threadId: alignedThreadId,
+          actorUserId,
+        });
+        if (lifecycleContext.detail) {
+          return buildThreadFromDetailRecord(lifecycleContext.detail, {
+            neighborId,
+          });
+        }
+
+        if (!lifecycleContext.currentState) {
+          return null;
+        }
+
+        return buildSyntheticThread({
+          tenantId,
+          orgUnitId,
+          threadId: alignedThreadId,
+          currentState: lifecycleContext.currentState,
+          nextState: lifecycleContext.currentState,
+          actorUserId,
+          fallbackSummary: lifecycleContext.syntheticThread?.summary,
+          fallbackNeighborId: neighborId || lifecycleContext.syntheticThread?.neighborId,
+          fallbackLastInboundCsNumberId: lifecycleContext.syntheticThread?.lastInboundCsNumberId,
+          fallbackPreferredOutboundCsNumberId: lifecycleContext.syntheticThread?.preferredOutboundCsNumberId,
+          fallbackEscalationStage: lifecycleContext.syntheticThread?.escalationStage,
+          fallbackNextEvaluationAtUtc: lifecycleContext.syntheticThread?.nextEvaluationAtUtc,
+        });
+      },
+    });
+    if (!inboundAlignedProviderNumber.ok) {
+      await markWebhookReceipt(
+        inboundAlignedProviderNumber.code === 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS'
+          ? 'FAILED_TERMINAL'
+          : 'FAILED_TERMINAL',
+        inboundAlignedProviderNumber.reason,
+      );
+      refusal(res, {
+        code: inboundAlignedProviderNumber.code,
+        message: inboundAlignedProviderNumber.message,
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          providerResolution: {
+            ...providerSelection.providerResolution,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: correlation.source,
+            deterministic: true,
+            threadId,
+            tenantId,
+            orgUnitId,
+            neighborId,
+            providerLegId: correlation.providerLegId,
+            providerMessageId: correlation.providerMessageId,
+            providerEventId: correlation.providerEventId,
+            providerNumberE164: correlation.providerNumberE164,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: webhookReceipt.dedupeKey,
+          },
+          sideEffects: {
+            lifecycleMutationApplied: false,
+            canonicalEventPersisted: false,
+            outboxPersisted: false,
+          },
+          timelineOutcome: {
+            eventName: null,
+            routingDecision: 'refused',
+          },
+          reason: inboundAlignedProviderNumber.reason,
+        },
+      });
+      return;
+    }
+    const domainEvent = mapConnectShyftInboundSmsWebhookToDomainEvent({
+      webhookBody: req.body,
+      canonicalEventType: eventType,
+      providerEventId: correlation.providerEventId,
+      providerMessageId: correlation.providerMessageId,
+      providerLegId: correlation.providerLegId,
+    });
+    let ensuredThread: ConnectShyftThread | null = null;
+    let canonicalEvent: ConnectShyftCanonicalEventRecord | null = null;
+    let sideEffectsPersisted = false;
+    try {
+      const persisted = await persistInboundSmsEnsureAndCanonicalEvent({
+        actorRoles: resolveWebhookActorRoles(req),
+        tenantId,
+        orgUnitId,
+        neighborId,
+        actorUserId,
+        lastInboundCsNumberId: inboundAlignedProviderNumber.providerNumberE164,
+        preferredOutboundCsNumberId: inboundAlignedProviderNumber.providerNumberE164,
+        eventType: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.inboundSmsAppended,
+        buildCanonicalPayload: (threadState) => buildConnectShyftInboundSmsCanonicalPayload({
+          domainEvent,
+          threadState,
+        }),
+      });
+      ensuredThread = persisted.thread;
+      canonicalEvent = persisted.canonicalEvent;
+      sideEffectsPersisted = persisted.sideEffectsPersisted;
+    } catch (error) {
+      if (error instanceof InboundSmsEnsureRefusalError) {
+        await markWebhookReceipt('FAILED_TERMINAL', 'inbound_sms_ensure_refused');
+        refusal(res, {
+          code: error.code,
+          message: error.message,
+          refusalType: 'business',
+          httpStatus: 200,
+          data: {
+            providerResolution: {
+              ...providerSelection.providerResolution,
+              adapterInvoked: true,
+            },
+            correlation: {
+              source: correlation.source,
+              deterministic: true,
+              threadId,
+              tenantId,
+              orgUnitId,
+              neighborId,
+              providerLegId: correlation.providerLegId,
+              providerMessageId: correlation.providerMessageId,
+              providerEventId: correlation.providerEventId,
+              providerNumberE164: correlation.providerNumberE164,
+            },
+            replaySafe: {
+              duplicate: false,
+              suppressedDomainWrites: false,
+              dedupeKey: webhookReceipt.dedupeKey,
+            },
+            sideEffects: {
+              lifecycleMutationApplied: false,
+              canonicalEventPersisted: false,
+              outboxPersisted: false,
+
+=== OUTBOUND / DISPATCH ENTRYPOINTS ===
+
+router.post('/internal/escalation/evaluate', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'escalation')) {
+    return;
+  }
+
+  const payload = parseSchedulerEvaluateBody(req);
+  const context = await enforceOrgUnitContext(req, res, payload.orgUnitId);
+  if (!context) {
+    return;
+  }
+
+  if (!enforceThreadViewCapability(req, res, context)) {
+    return;
+  }
+
+  const asOfUtc = payload.asOfUtc || nowIsoUtc();
+  if (!isStrictUtcIsoTimestamp(asOfUtc)) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_ESCALATION_AS_OF_INVALID',
+      message: 'asOfUtc must be a strict UTC ISO-8601 timestamp.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  let baselineHours = DEFAULT_ESCALATION_BASELINE_HOURS;
+  try {
+    const config = await connectShyftEscalationConfigService.getConfig(
+      context.tenantId,
+      context.orgUnitId,
+    );
+    baselineHours = normalizeEscalationBaselineHours(config.escalationBaselineHours);
+  } catch (_error) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_ESCALATION_CONFIG_UNAVAILABLE',
+      message: 'Escalation configuration is temporarily unavailable. Please retry.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  const actorRoles = resolveConnectShyftActorRoles(req, context);
+  const evaluated = await connectShyftThreadServiceAsync.evaluateEscalations({
+    actorRoles,
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    asOfUtc,
+    limit: payload.limit,
+    baselineHours,
+    actorUserId: resolveConnectShyftRequestedActorUserId(req),
+  });
+
+  if (!evaluated.ok) {
+    refusal(res, {
+      code: evaluated.code,
+      message: evaluated.message,
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  const syntheticOverrideMode = isConnectShyftTestOverrideEnabled()
+    && !UUID_PATTERN.test(context.tenantId);
+  let transitions = syntheticOverrideMode ? [] : evaluated.data.transitions;
+
+  if (isConnectShyftTestOverrideEnabled()) {
+    const syntheticTransitions = evaluateSyntheticEscalations({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      asOfUtc,
+      baselineHours,
+      limit: payload.limit,
+      threadId: payload.threadId,
+    });
+    if (syntheticTransitions.length > 0) {
+      transitions = syntheticOverrideMode
+        ? syntheticTransitions
+        : [...transitions, ...syntheticTransitions];
+    }
+  }
+
+  return success(res, {
+    code: evaluated.code,
+    message: 'ConnectShyft escalation scheduler evaluated due threads',
+    httpStatus: evaluated.httpStatus,
+    data: {
+      asOfUtc,
+      baselineHours,
+      transitions,
+      effects: {
+        emittedCount: transitions.length,
+      },
+      replaySafe: transitions.length === 0,
+      skippedAlreadyProcessed: transitions.length === 0,
+    },
+  });
+});
+
+router.get('/internal/threads/due', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'inbox')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res, parseOrgUnitIdFromQuery(req));
+  if (!context) {
+    return;
+  }
+
+  if (!enforceThreadViewCapability(req, res, context)) {
+    return;
+  }
+
+  const actorRoles = resolveConnectShyftActorRoles(req, context);
+  const listed = await connectShyftThreadServiceAsync.listDueThreads({
+    actorRoles,
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    limit: parseThreadDueLimit(req),
+  });
+
+  if (!listed.ok) {
+    refusal(res, {
+      code: listed.code,
+      message: listed.message,
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  return success(res, {
+    code: listed.code,
+    message: 'ConnectShyft due threads listed',
+    httpStatus: listed.httpStatus,
+    data: {
+      threads: listed.data.threads.map((thread) => ({
+        ...thread,
+        nextEvaluationAtUtc: thread.escalation.nextEvaluationAtUtc,
+      })),
+    },
+  });
+});
+
+router.get('/events', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'inbox')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res, parseOrgUnitIdFromQuery(req));
+  if (!context) {
+    return;
+  }
+
+  if (!enforceThreadViewCapability(req, res, context)) {
+    return;
+  }
+
+  const filters = parseCanonicalEventFilters(req);
+  const events = await listConnectShyftCanonicalEvents({
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    aggregateId: filters.aggregateId,
+    aggregateType: filters.aggregateType,
+    eventType: filters.eventType,
+    limit: filters.limit,
+    db: loadPlatformDb(),
+  });
+
+  return success(res, {
+    code: 'CONNECTSHYFT_CANONICAL_EVENTS_LISTED',
+    message: 'ConnectShyft canonical events listed',
+    data: {
+      filters: {
+        aggregateId: filters.aggregateId,
+        aggregateType: filters.aggregateType,
+        eventType: filters.eventType,
+      },
+      deterministic: true,
+      providerNeutral: true,
+      events,
+    },
+  });
+});
+
+router.get('/identity-ambiguities', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const filters = parseIdentityAmbiguityFilters(req);
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  const readScope = resolveIdentityAmbiguityReadScope(
+    req,
+    res,
+    context,
+    filters.orgUnitId,
+  );
+  if (!readScope) {
+    return;
+  }
+
+  const listed = await listIdentityAmbiguityEvents({
+    tenantId: context.tenantId,
+    orgUnitId: readScope.orgUnitId,
+    status: filters.status,
+    normalizedContactPoint: filters.normalizedContactPoint,
+    sourceContext: filters.sourceContext,
+    limit: filters.limit,
+    cursor: filters.cursor,
+  });
+
+  return success(res, {
+    code: 'CONNECTSHYFT_IDENTITY_AMBIGUITIES_RESOLVED',
+    message: 'ConnectShyft identity ambiguities resolved',
+    httpStatus: 200,
+    data: {
+      events: listed.events,
+      nextCursor: listed.nextCursor,
+    },
+  });
+});
+
+router.patch('/identity-ambiguities/:ambiguityEventId', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  if (!resolveIdentityAmbiguityTenantPrivilegedScope(req, res, context)) {
+    return;
+  }
+
+  const ambiguityEventId = parseIdentityAmbiguityEventIdParam(req);
+  if (!ambiguityEventId) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_ID_REQUIRED',
+      message: 'ambiguityEventId is required',
+    });
+    return;
+  }
+
+  if (!parseIdentityAmbiguityStatusUpdate(req)) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_STATUS_INVALID',
+      message: 'status must be reviewed.',
+      data: {
+        fieldErrors: [
+          {
+            field: 'status',
+            reason: 'INVALID',
+            message: 'status must be reviewed.',
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  const event = await markIdentityAmbiguityEventReviewed({
+    tenantId: context.tenantId,
+    ambiguityEventId,
+  });
+
+  if (!event) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_NOT_FOUND',
+      message: 'Identity ambiguity event is unavailable for the active tenant context.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  return success(res, {
+    code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_REVIEWED',
+    message: 'ConnectShyft identity ambiguity reviewed',
+    httpStatus: 200,
+    data: {
+      event,
+    },
+  });
+});
+
+router.get('/threads/:threadId/timeline', getConnectThreadTimeline);
+
+router.get('/threads/:threadId', getConnectThreadDetail);
+
+router.post('/threads', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'inbox')) {
+    return;
+  }
+
+  const payload = parseThreadEnsureBody(req);
+  const context = await enforceOrgUnitContext(req, res, payload.orgUnitId);
+  if (!context) {
+    return;
+  }
+
+  if (!enforceThreadViewCapability(req, res, context)) {
+    return;
+  }
+
+  if (!payload.neighborId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_NEIGHBOR_ID_REQUIRED',
+      message: 'neighborId is required',
+      refusalType: 'client',
+      httpStatus: 400,
+    });
+    return;
+  }
+
+  if (!isValidConnectShyftNeighborIdentifier(payload.neighborId)) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_NEIGHBOR_ID_INVALID',
+      message: 'neighborId must be a canonical identifier (UUID or slug).',
+      data: {
+        fieldErrors: [
+          {
+            field: 'neighborId',
+            reason: 'INVALID',
+            message: 'neighborId must be a canonical identifier (UUID or slug).',
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  const requestedThreadId = parseThreadIdFromBody(req);
+  if (requestedThreadId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_THREAD_ID_FORBIDDEN',
+      message: 'threadId is server-assigned and cannot be provided.',
+      refusalType: 'client',
+      httpStatus: 400,
+      data: {
+        fieldErrors: [
+          {
+            field: 'threadId',
+            reason: 'FORBIDDEN',
+            message: 'threadId is server-assigned and cannot be provided.',
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  const actorRoles = resolveConnectShyftActorRoles(req, context);
+  const ensured = await connectShyftThreadServiceAsync.ensureThread({
+    actorRoles,
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    neighborId: payload.neighborId,
+    source: payload.source,
+    forcedState: payload.forcedState,
+    lastInboundCsNumberId: payload.lastInboundCsNumberId,
+    preferredOutboundCsNumberId: payload.preferredOutboundCsNumberId,
+    actorUserId: resolveConnectShyftRequestedActorUserId(req),
+    nextEvaluationAtUtc: payload.nextEvaluationAtUtc,
+  });
+
+  if (!ensured.ok) {
+    refusal(res, {
+      code: ensured.code,
+      message: ensured.message,
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  return success(res, {
+    code: ensured.code,
+    message: 'ConnectShyft thread ensured',
+    httpStatus: ensured.httpStatus,
+    data: {
+      thread: ensured.data.thread,
+      lifecycle: ensured.data.lifecycle,
+    },
+  });
+});
+
+const performOutboundAction = async ({
+  req,
+  res,
+  outboundAction,
+  context,
+  threadId,
+  actorUserId,
+  actorRoles,
+  lifecycleContext,
+}: ConnectShyftThreadOutboundCoreExecutionInput): Promise<void> => {
+  if (!lifecycleContext.currentState) {
+    return;
+  }
+
+  const currentState = lifecycleContext.currentState;
+  const outboundCallPolicyRequest = outboundAction === 'call'
+    ? parseOutboundCallRequestPolicy(req)
+    : null;
+  if (
+    outboundAction === 'call'
+    && outboundCallPolicyRequest
+    && !enforceOutboundCallPolicyRequest(req, res, outboundCallPolicyRequest)
+  ) {
+    return;
+  }
+
+  const requestedProvider = resolveConnectShyftRequestedProviderKey(req);
+  const enabledProvidersHeader = normalizeLifecycleString(
+    req.header('x-test-connectshyft-enabled-providers'),
+  );
+  const hasExplicitEnabledProviderPolicy = enabledProvidersHeader.length > 0;
+  const explicitEnabledProvidersIncludeMockSandbox =
+    enabledProvidersHeader.toLowerCase().includes('mock-sandbox');
+  const allowImplicitTestPhoneFallback =
+    !requestedProvider && !hasExplicitEnabledProviderPolicy;
+  const allowPhoneFallback =
+    isConnectShyftTestOverrideEnabled()
+    && (
+      requestedProvider === 'mock-sandbox'
+      || allowImplicitTestPhoneFallback
+      || explicitEnabledProvidersIncludeMockSandbox
+    );
+  const providerSelection = resolveConnectShyftProviderAdapter({
+    req,
+    operation: outboundAction,
+    requestedProvider,
+  });
+  if (!providerSelection.ok) {
+    refusal(res, {
+      code: providerSelection.refusal.code,
+      message: providerSelection.refusal.message,
+      refusalType: providerSelection.refusal.refusalType,
+      httpStatus: providerSelection.refusal.httpStatus,
+      data: {
+        ...providerSelection.refusal.data,
+        context,
+        threadId,
+      },
+    });
+    return;
+  }
+
+  const actorScopeKey = buildConnectShyftActorScopeKey(actorUserId, actorRoles);
+  const outboundMessagePolicy = outboundAction === 'message'
+    ? parseOutboundMessagePolicyRequest(req)
+    : null;
+  const outboundDispatchIdempotencyKey = parseOutboundDispatchIdempotencyKey(req);
+  const outboundIdempotencyOperation = resolveOutboundIdempotencyOperationName(outboundAction);
+  const outboundCallDispatchPolicy: ConnectShyftOutboundCallDispatchPolicy | null = outboundAction === 'call'
+    ? {
+      transport: outboundCallPolicyRequest?.transport || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_TRANSPORT,
+      autoRetry: outboundCallPolicyRequest?.autoRetry === true,
+      redialPolicy: outboundCallPolicyRequest?.redialPolicy || CONNECTSHYFT_OUTBOUND_CALL_ALLOWED_REDIAL_POLICY,
+    }
+    : null;
+  let outboundDispatchReplayKey: string | null = null;
+  const resolvedThreadNeighborId = await resolveNeighborIdForThreadCorrelation({
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    threadId,
+  });
+
+  const outboundLifecycleAction = resolveOutboundLifecycleAction(outboundAction);
+  const priorState = currentState;
+  const dispatchEventName = resolveOutboundDispatchEventName(outboundAction);
+  const postDispatchWarnings: Array<{ stage: string; code: string; message: string }> = [];
+
+  let smsPreferenceDecision: ConnectShyftResolvedSmsPreference | null = null;
+  let validatedSmsOverride: ConnectShyftValidatedSmsOverride | null = null;
+  let thread: ConnectShyftThread;
+  let lifecycleEvent: string | null = null;
+  let sideEffects: ReturnType<typeof buildLifecycleSideEffects> | null = null;
+  let outboundDispatch: ReturnType<typeof buildLifecycleSideEffects> | null = null;
+  let outboundMessageTargetPhone: string | null = null;
+  let outboundMessageSenderPhone: string | null = null;
+  let outboundCallSenderPhone: string | null = null;
+  let outboundSenderResolutionMetadata: Record<string, unknown> | null = null;
+  let persistedSmsOverride: ConnectShyftPersistedSmsOverride | null = null;
+  let sideEffectsPersisted = false;
+  let escalationReset: { stage: number; inactivityWindow: 'reset' } | null = null;
+  let bridgeSessionState: ConnectShyftBridgeSessionStateContract | null = null;
+  let bridgeCorrelationMapping: ConnectShyftBridgeCorrelationMapping | null = null;
+
+  if (lifecycleContext.detail) {
+    thread = buildThreadFromDetailRecord(lifecycleContext.detail, {
+      neighborId: resolvedThreadNeighborId,
+    });
+  } else {
+    thread = buildSyntheticThread({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      threadId,
+      currentState,
+      nextState: currentState,
+      actorUserId,
+      fallbackSummary: lifecycleContext.syntheticThread?.summary,
+      fallbackNeighborId: resolvedThreadNeighborId || lifecycleContext.syntheticThread?.neighborId,
+      fallbackLastInboundCsNumberId: lifecycleContext.syntheticThread?.lastInboundCsNumberId,
+      fallbackPreferredOutboundCsNumberId: lifecycleContext.syntheticThread?.preferredOutboundCsNumberId,
+      fallbackEscalationStage: lifecycleContext.syntheticThread?.escalationStage,
+      fallbackNextEvaluationAtUtc: lifecycleContext.syntheticThread?.nextEvaluationAtUtc,
+    });
+  }
+
+  if (priorState === 'CLOSED') {
+    const reopenedMetadata = buildLifecycleMetadata({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      actorUserId,
+      threadId,
+      priorState: 'CLOSED',
+      newState: 'UNCLAIMED',
+      action: outboundLifecycleAction,
+      threadReopenedByUser: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+      lifecycleLineage: {
+        prior_state: 'CLOSED',
+        new_state: 'UNCLAIMED',
+        thread_reopened_by_user: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+      },
+    });
+    const transitioned = await transitionThreadWithSideEffects({
+      actorRoles,
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      threadId,
+      actorUserId,
+      currentState: priorState,
+      nextState: 'UNCLAIMED',
+      syntheticThread: lifecycleContext.syntheticThread,
+      detail: lifecycleContext.detail,
+      sideEffects: {
+        eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+        metadata: reopenedMetadata,
+      },
+    });
+
+    sideEffects = buildLifecycleSideEffects({
+      eventName: CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser,
+      metadata: reopenedMetadata,
+    });
+
+    if (!transitioned.ok) {
+      respondConnectShyftBusinessRefusal(res, {
+        code: transitioned.code,
+        message: transitioned.message,
+        data: {
+          context,
+          threadId,
+          lifecycle: {
+            priorState: 'CLOSED',
+            nextState: 'CLOSED',
+            reopenedFromClosed: false,
+          },
+          sideEffectsPersisted: false,
+          ...sideEffects,
+        },
+      });
+      return;
+    }
+
+    thread = transitioned.thread;
+    sideEffectsPersisted = transitioned.sideEffectsPersisted;
+    lifecycleEvent = CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser;
+    escalationReset = {
+      stage: 0,
+      inactivityWindow: 'reset',
+    };
+  }
+
+  const lifecycleMutationApplied =
+    lifecycleEvent === CONNECTSHYFT_LIFECYCLE_EVENT_NAMES.reopenedByUser;
+  const buildReopenLifecycleData = (): Record<string, unknown> => {
+    if (!lifecycleMutationApplied) {
+      return {};
+    }
+
+    return {
+      thread: {
+        threadId,
+        priorState: 'CLOSED',
+        state: thread.state,
+      },
+      lifecycleEvent,
+      lifecycle: {
+        priorState: 'CLOSED',
+        nextState: thread.state,
+        reopenedFromClosed: true,
+        reopenedByInbound: false,
+        sameThreadId: true,
+        noInboundAutoReopenSideEffects: true,
+      },
+      escalationReset,
+      sideEffectsPersisted,
+      ...(sideEffects || {}),
+    };
+  };
+
+  if (outboundAction === 'message' && outboundMessagePolicy) {
+    const preferenceNeighborId = lifecycleContext.syntheticThread?.neighborId
+      || resolvedThreadNeighborId
+      || null;
+    smsPreferenceDecision = await connectShyftSmsPreferenceOverrideService.resolvePreference({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      threadId,
+      neighborId: preferenceNeighborId,
+    });
+
+    const overrideValidation = connectShyftSmsPreferenceOverrideService.validateOverride({
+      prefersTexting: smsPreferenceDecision.prefersTexting,
+      overrideReason: outboundMessagePolicy.overrideReason,
+      overrideNote: outboundMessagePolicy.overrideNote,
+    });
+
+    if (!overrideValidation.ok) {
+      const isOverrideRequired = overrideValidation.reason === 'required';
+      refusal(res, {
+        code: isOverrideRequired
+          ? 'CONNECTSHYFT_SMS_OVERRIDE_REASON_REQUIRED'
+          : 'CONNECTSHYFT_SMS_OVERRIDE_REASON_INVALID',
+        message: overrideValidation.message,
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          context,
+          threadId,
+          preferencePolicy: {
+            prefersTexting: smsPreferenceDecision.prefersTexting,
+            source: smsPreferenceDecision.source,
+            overrideRequired: smsPreferenceDecision.prefersTexting === 'NO',
+            overrideAccepted: false,
+            allowedOverrideReasons: overrideValidation.allowedReasons,
+          },
+          uiFeedback: {
+            severity: 'warning',
+            ariaLive: 'assertive',
+            messageKey: isOverrideRequired
+              ? 'connectshyft.override.required'
+              : 'connectshyft.override.invalid',
+            presentation: 'contextual-action-feedback',
+            requiresAction: true,
+            actionLabel: 'Add override reason',
+            accessibilityHint: 'Open override reason selector and resubmit the outbound message.',
+            message: overrideValidation.message,
+          },
+          chrome: {
+            persistentOperationsBannerVisible: false,
+            heavyOperationsDefaultLayout: false,
+          },
+          sideEffects: {
+            messageDispatched: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+
+    validatedSmsOverride = overrideValidation.overrideRequired
+      ? overrideValidation.override
+      : null;
+  }
+
+  const rollbackPersistedSmsOverride = async (): Promise<void> => {
+    if (!persistedSmsOverride) {
+      return;
+    }
+
+    try {
+      await connectShyftSmsPreferenceOverrideService.rollbackApprovedOverride({
+        tenantId: context.tenantId,
+        orgUnitId: context.orgUnitId,
+        threadId,
+        overrideId: persistedSmsOverride.overrideId,
+      });
+      persistedSmsOverride = null;
+    } catch {
+      // Best effort rollback; keep persisted state reporting truthful in refusal payloads.
+    }
+  };
+
+  let operatorContactPointId: string | null = null;
+  let neighborContactPointId: string | null = null;
+  if (outboundAction === 'call') {
+    operatorContactPointId = outboundCallPolicyRequest?.operatorContactPointId || null;
+    if (!operatorContactPointId) {
+      operatorContactPointId = resolveTestOverridePhoneFallback({
+        allowTestFallback: allowPhoneFallback,
+        primarySeed: actorUserId,
+        secondarySeed: threadId,
+      });
+    }
+    if (!operatorContactPointId) {
+      respondConnectShyftBusinessRefusal(res, {
+        code: 'CONNECTSHYFT_OPERATOR_CALLBACK_REQUIRED',
+        message: 'Outbound bridge calls require an operator callback number.',
+        data: {
+          context,
+          threadId,
+          providerResolution: {
+            ...providerSelection.providerResolution,
+            adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+            providerBranchingInDomain: false,
+          },
+          sideEffects: {
+            dispatchAttempted: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+
+    neighborContactPointId = outboundCallPolicyRequest?.targetPhone || null;
+    if (!neighborContactPointId && thread.neighborId && UUID_PATTERN.test(thread.neighborId)) {
+      const resolvedNeighbor = await connectShyftNeighborServiceAsync.resolveNeighbor({
+        tenantId: context.tenantId,
+        neighborId: thread.neighborId,
+        actorRoles,
+      });
+      if (resolvedNeighbor.ok) {
+        neighborContactPointId = resolvedNeighbor.data.neighbor.phones
+          .filter((phone) => phone.isActive !== false)
+          .sort((left, right) => left.sortOrder - right.sortOrder)
+          [0]?.value || null;
+      }
+    }
+    if (!neighborContactPointId) {
+      neighborContactPointId = resolveTestOverridePhoneFallback({
+        allowTestFallback: allowPhoneFallback,
+        primarySeed: thread.neighborId,
+        secondarySeed: threadId,
+      });
+    }
+
+    if (!neighborContactPointId) {
+      respondConnectShyftBusinessRefusal(res, {
+        code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+        message: 'Outbound bridge calls require a dialable neighbor phone.',
+        data: {
+          context,
+          threadId,
+          providerResolution: {
+            ...providerSelection.providerResolution,
+            adapterInterfaceVersion: providerSelection.adapter.adapterInterfaceVersion,
+            providerBranchingInDomain: false,
+          },
+          sideEffects: {
+            dispatchAttempted: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+  }
+
+  if (outboundAction === 'message') {
+    const smsTargetResolution = await resolveConnectShyftSmsTarget({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      threadId,
+      thread,
+      actorRoles,
+      requestedTargetPhone: outboundMessagePolicy?.targetPhone || null,
+      allowTestFallback: allowPhoneFallback,
+    });
+    if (!smsTargetResolution.ok) {
+      refusal(res, {
+        code: smsTargetResolution.code,
+        message: smsTargetResolution.message,
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          context,
+          threadId,
+          preferencePolicy: {
+            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
+            source: smsPreferenceDecision?.source || 'unknown',
+            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
+            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
+              || Boolean(validatedSmsOverride),
+            ...(validatedSmsOverride
+              ? {
+                override: {
+                  reason: validatedSmsOverride.reason,
+                  note: validatedSmsOverride.note,
+                },
+              }
+              : {}),
+          },
+          ...smsTargetResolution.data,
+          chrome: {
+            persistentOperationsBannerVisible: false,
+            heavyOperationsDefaultLayout: false,
+          },
+          sideEffects: {
+            messageDispatched: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+
+    outboundMessageTargetPhone = smsTargetResolution.targetPhone;
+    const dispatchReadySmsTarget = ensureConnectShyftDispatchReadySmsTarget({
+      resolvedTargetPhone: outboundMessageTargetPhone,
+      requestedTargetPhone: outboundMessagePolicy?.targetPhone || null,
+      threadNeighborId: thread.neighborId,
+    });
+    if (!dispatchReadySmsTarget.ok) {
+      refusal(res, {
+        code: dispatchReadySmsTarget.code,
+        message: dispatchReadySmsTarget.message,
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          context,
+          threadId,
+          preferencePolicy: {
+            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
+            source: smsPreferenceDecision?.source || 'unknown',
+            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
+            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
+              || Boolean(validatedSmsOverride),
+            ...(validatedSmsOverride
+              ? {
+                override: {
+                  reason: validatedSmsOverride.reason,
+                  note: validatedSmsOverride.note,
+                },
+              }
+              : {}),
+          },
+          ...dispatchReadySmsTarget.data,
+          chrome: {
+            persistentOperationsBannerVisible: false,
+            heavyOperationsDefaultLayout: false,
+          },
+          sideEffects: {
+            messageDispatched: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+
+    outboundMessageTargetPhone = dispatchReadySmsTarget.targetPhone;
+
+    const smsSenderResolution = await resolveConnectShyftSmsSender({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      thread,
+      preferredOutboundLabel: lifecycleContext.detail?.preferredOutboundContext.label || null,
+    });
+    if (!smsSenderResolution.ok) {
+      refusal(res, {
+        code: smsSenderResolution.code,
+        message: smsSenderResolution.message,
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          context,
+          threadId,
+          preferencePolicy: {
+            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
+            source: smsPreferenceDecision?.source || 'unknown',
+            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
+            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
+              || Boolean(validatedSmsOverride),
+            ...(validatedSmsOverride
+              ? {
+                override: {
+                  reason: validatedSmsOverride.reason,
+                  note: validatedSmsOverride.note,
+                },
+              }
+              : {}),
+          },
+          ...smsSenderResolution.data,
+          chrome: {
+            persistentOperationsBannerVisible: false,
+            heavyOperationsDefaultLayout: false,
+          },
+          sideEffects: {
+            messageDispatched: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+
+    outboundMessageSenderPhone = smsSenderResolution.senderPhone;
+    outboundSenderResolutionMetadata = {
+      source: smsSenderResolution.source,
+      channel: 'sms',
+      senderPhone: smsSenderResolution.senderPhone,
+      orgUnitId: smsSenderResolution.metadata.orgUnitId,
+      selectedMappingId: smsSenderResolution.metadata.selectedMappingId,
+      selectedMappingLabel: smsSenderResolution.metadata.selectedMappingLabel,
+      alignedFrom: smsSenderResolution.metadata.alignedFrom,
+      threadHints: smsSenderResolution.metadata.threadHints,
+    };
+  }
+
+  if (outboundAction === 'call') {
+    const voiceSenderResolution = await resolveSenderNumber(
+      {
+        tenantId: context.tenantId,
+        orgUnitId: context.orgUnitId,
+        threadId,
+        channel: 'voice',
+      },
+      {
+        loadThread: async () => thread,
+      },
+    );
+    if (!voiceSenderResolution.ok) {
+      const voiceSenderCode = voiceSenderResolution.reason === 'sender_mapping_ambiguous'
+        ? 'CONNECTSHYFT_CALL_SENDER_AMBIGUOUS'
+        : 'CONNECTSHYFT_CALL_SENDER_REQUIRED';
+      refusal(res, {
+        code: voiceSenderCode,
+        message: voiceSenderResolution.reason === 'sender_mapping_ambiguous'
+          ? 'Resolve the mapped ConnectShyft outbound line so exactly one active scoped mapping remains before starting a call.'
+          : 'Persist one valid mapped ConnectShyft outbound line on the thread before starting a call.',
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          context,
+          threadId,
+          senderResolution: {
+            reason: voiceSenderResolution.reason,
+            source: 'thread_alignment',
+            channel: 'voice',
+            orgUnitId: voiceSenderResolution.routingMetadata.orgUnitId,
+            candidateProviderNumberE164: voiceSenderResolution.routingMetadata.candidateProviderNumberE164,
+          },
+          chrome: {
+            persistentOperationsBannerVisible: false,
+            heavyOperationsDefaultLayout: false,
+          },
+          sideEffects: {
+            messageDispatched: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+
+    outboundCallSenderPhone = voiceSenderResolution.providerNumberE164;
+    outboundSenderResolutionMetadata = {
+      source: voiceSenderResolution.routingMetadata.source,
+      channel: 'voice',
+      senderPhone: voiceSenderResolution.providerNumberE164,
+      orgUnitId: voiceSenderResolution.routingMetadata.orgUnitId,
+      selectedMappingId: voiceSenderResolution.mappingId,
+      selectedMappingLabel: voiceSenderResolution.routingMetadata.mappingLabel,
+      alignedFrom: voiceSenderResolution.routingMetadata.alignedFrom,
+    };
+  }
+
+  outboundDispatchReplayKey = buildTelephonyDispatchReplayKey({
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    threadId,
+    providerKey: providerSelection.providerResolution.resolvedProvider,
+    action: outboundAction,
+    idempotencyKey: outboundDispatchIdempotencyKey,
+    actorId: actorUserId,
+    targetPhone: outboundAction === 'call'
+      ? neighborContactPointId
+      : outboundMessageTargetPhone,
+    senderPhone: outboundAction === 'message'
+      ? outboundMessageSenderPhone
+      : outboundCallSenderPhone,
+    operatorContactPointId: outboundAction === 'call'
+      ? operatorContactPointId
+      : null,
+    body: outboundMessagePolicy?.body || null,
+    callPolicy: outboundCallDispatchPolicy,
+  });
+
+  const communicationReliabilityDb = isConnectShyftTestOverrideEnabled()
+    ? undefined
+    : loadPlatformDb();
+  const outboundIdempotencyRecord = (
+    outboundDispatchIdempotencyKey
+    && outboundDispatchReplayKey
+  )
+    ? await beginConnectShyftCommunicationIdempotency({
+      tenantId: context.tenantId,
+      idempotencyKey: outboundDispatchIdempotencyKey,
+      operationName: outboundIdempotencyOperation,
+      actorId: actorUserId,
+      actorScopeKey,
+      requestFingerprint: outboundDispatchReplayKey,
+      requestSummary: JSON.stringify({
+        outboundAction,
+        threadId,
+        providerKey: providerSelection.providerResolution.resolvedProvider,
+        targetPhone: outboundAction === 'call'
+          ? neighborContactPointId
+          : outboundMessageTargetPhone,
+        senderPhone: outboundAction === 'message'
+          ? outboundMessageSenderPhone
+          : outboundCallSenderPhone,
+        operatorContactPointId,
+        senderResolution: outboundSenderResolutionMetadata,
+      }),
+      expiresAt: new Date(Date.now() + CONNECTSHYFT_COMMUNICATION_IDEMPOTENCY_TTL_MS),
+      db: communicationReliabilityDb,
+    })
+    : null;
+  if (outboundIdempotencyRecord?.decision === 'conflict') {
+    respondConnectShyftBusinessRefusal(res, {
+      code: 'CONNECTSHYFT_IDEMPOTENCY_KEY_REUSED_WITH_DIFFERENT_PAYLOAD',
+      message: 'Idempotency key cannot be reused for a materially different outbound request.',
+      data: {
+        context,
+        threadId,
+        idempotency: {
+          duplicate: false,
+          conflict: true,
+          idempotencyKey: outboundDispatchIdempotencyKey,
+        },
+      },
+    });
+    return;
+  }
+  if (outboundIdempotencyRecord?.decision === 'in_progress') {
+    respondConnectShyftBusinessRefusal(res, {
+      code: 'CONNECTSHYFT_IDEMPOTENT_OPERATION_IN_PROGRESS',
+      message: 'An identical outbound request is already in progress.',
+      data: {
+        context,
+        threadId,
+        idempotency: {
+          duplicate: false,
+          conflict: false,
+          inProgress: true,
+          idempotencyKey: outboundDispatchIdempotencyKey,
+        },
+      },
+    });
+    return;
+  }
+  if (outboundIdempotencyRecord?.decision === 'return_existing') {
+    const replaySnapshot = parseConnectShyftIdempotencyResponseSnapshot(
+      outboundIdempotencyRecord.record.responseSnapshot,
+    );
+    if (replaySnapshot) {
+      const replayBody = (
+        replaySnapshot.body
+        && typeof replaySnapshot.body === 'object'
+        && !Array.isArray(replaySnapshot.body)
+      )
+        ? replaySnapshot.body as {
+          ok?: unknown;
+          code?: unknown;
+          message?: unknown;
+          data?: Record<string, unknown>;
+        }
+        : null;
+      const replayData = replayBody?.data && typeof replayBody.data === 'object'
+        ? replayBody.data
+        : {};
+      await appendConnectShyftCommunicationAudit({
+        tenantId: context.tenantId,
+        correlationId: outboundDispatchReplayKey || randomUUID(),
+        actorType: actorUserId ? 'user' : 'system',
+        actorId: actorUserId,
+        operationName: outboundIdempotencyOperation,
+        targetEntityType: outboundAction === 'call' ? 'bridge_session' : 'message_dispatch',
+        targetEntityId: threadId,
+        channel: outboundAction === 'call' ? 'bridge' : 'sms',
+        resultState: 'ignored_duplicate',
+        resultCode: 'CONNECTSHYFT_DUPLICATE_REQUEST_REPLAYED',
+        resultMessage: 'Duplicate outbound request replayed from durable idempotency state.',
+        idempotencyKey: outboundDispatchIdempotencyKey,
+        requestFingerprint: outboundDispatchReplayKey,
+        providerName: providerSelection.providerResolution.resolvedProvider,
+        metadata: {
+          duplicate: true,
+          threadId,
+          senderResolution: outboundSenderResolutionMetadata,
+        },
+        db: communicationReliabilityDb,
+      });
+      res.status(replaySnapshot.httpStatus).json(replayBody
+        ? {
+          ...replayBody,
+          data: {
+            ...replayData,
+            replaySafe: {
+              ...(replayData.replaySafe && typeof replayData.replaySafe === 'object'
+                ? replayData.replaySafe
+                : {}),
+              duplicate: true,
+              replayKey: outboundDispatchReplayKey,
+            },
+          },
+        }
+        : replaySnapshot.body);
+      return;
+    }
+    respondConnectShyftBusinessRefusal(res, {
+      code: 'CONNECTSHYFT_IDEMPOTENT_REPLAY_UNAVAILABLE',
+      message: 'Idempotent replay state is unavailable for this completed outbound request.',
+      data: {
+        context,
+        threadId,
+        idempotency: {
+          duplicate: true,
+          replayUnavailable: true,
+          idempotencyKey: outboundDispatchIdempotencyKey,
+        },
+      },
+    });
+    return;
+  }
+  if (
+    outboundAction === 'message'
+    && smsPreferenceDecision?.prefersTexting === 'NO'
+    && validatedSmsOverride
+  ) {
+    try {
+      persistedSmsOverride = await connectShyftSmsPreferenceOverrideService.persistApprovedOverride({
+        tenantId: context.tenantId,
+        orgUnitId: context.orgUnitId,
+        threadId,
+        neighborId: smsPreferenceDecision.neighborId,
+        actorUserId,
+        preferenceValue: 'NO',
+        override: validatedSmsOverride,
+        messageBody: outboundMessagePolicy?.body || '',
+        messageEventName: 'connectshyft.thread.outbound_message_dispatched',
+      });
+    } catch (error) {
+      const persistenceMessage = error instanceof Error
+        ? error.message
+        : 'Outbound SMS override persistence is unavailable.';
+      const persistenceCode = error instanceof ConnectShyftSmsOverridePersistenceUnavailableError
+        ? error.code
+        : 'CONNECTSHYFT_SMS_OVERRIDE_AUDIT_UNAVAILABLE';
+
+      refusal(res, {
+        code: persistenceCode,
+        message: 'Outbound SMS cannot be sent because override persistence is unavailable.',
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          context,
+          threadId,
+          preferencePolicy: {
+            prefersTexting: smsPreferenceDecision.prefersTexting,
+            source: smsPreferenceDecision.source,
+            overrideRequired: true,
+            overrideAccepted: false,
+            override: {
+              reason: validatedSmsOverride.reason,
+              note: validatedSmsOverride.note,
+            },
+          },
+          uiFeedback: {
+            severity: 'warning',
+            ariaLive: 'assertive',
+
+=== IDENTITY + THREAD ROUTING DEPENDENCIES ===
+import {
+  type ConnectShyftIdentityBoundaryAdapter,
+} from './identityBoundary';
+import { KnexConnectShyftNeighborStore } from './neighbors';
+import { AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter } from './peoplecoreIdentityAdapter';
+
+const SYSTEM_RESOLVER_ACTOR_ROLES = ['SYSTEM_ADMIN'];
+
+const uniqueSortedStrings = (values: string[]): string[] =>
+  Array.from(new Set(values.filter((value) => value.trim().length > 0))).sort((left, right) =>
+    left.localeCompare(right));
+
+export type ResolveSubjectByContactPointInput = {
+  tenantId: string;
+  orgUnitId: string;
+  contactPoint: string;
+};
+
+export type ResolveSubjectByContactPointResult =
+  | {
+    type: 'single_match';
+    neighborId: string;
+    normalizedContactPoint: string;
+  }
+  | {
+    type: 'no_match';
+    normalizedContactPoint: string;
+  }
+  | {
+    type: 'multiple_matches';
+    candidateNeighborIds: string[];
+    normalizedContactPoint: string;
+  };
+
+export interface ConnectShyftSubjectResolverBoundary {
+  resolveSubjectByContactPoint(
+    input: ResolveSubjectByContactPointInput,
+  ): Promise<ResolveSubjectByContactPointResult>;
+}
+
+export class ConnectShyftSubjectResolver implements ConnectShyftSubjectResolverBoundary {
+  constructor(
+    private readonly identityBoundary: ConnectShyftIdentityBoundaryAdapter,
+  ) {}
+
+  async resolveSubjectByContactPoint(
+    input: ResolveSubjectByContactPointInput,
+  ): Promise<ResolveSubjectByContactPointResult> {
+    const result = await this.identityBoundary.evaluateMatch({
+      actorRoles: SYSTEM_RESOLVER_ACTOR_ROLES,
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      idempotencyKey: `inbound-subject:${input.tenantId}:${input.orgUnitId}:${input.contactPoint}`,
+      contactPoint: {
+        label: 'mobile',
+        value: input.contactPoint,
+        isShared: false,
+        verificationStatus: 'verified',
+      },
+      hookContext: {
+        createProvisionalOnNoMatch: true,
+        createResolverReviewOnAmbiguous: true,
+        triggerSourceType: 'connectshyft_inbound_subject_resolution',
+        requestedByUserId: 'system-connectshyft-identity-seam',
+      },
+    });
+
+    const normalizedContactPoint = result.ok
+      ? result.data.identityMatch.contactPoint.value
+      : result.data?.identityMatch?.contactPoint.value
+        || input.contactPoint;
+
+    if (!result.ok) {
+      if (result.code === 'IDENTITY_MATCH_AMBIGUOUS') {
+        return {
+          type: 'multiple_matches',
+          candidateNeighborIds: uniqueSortedStrings([
+            ...(result.data?.identityMatch?.candidateNeighborIds || []),
+            ...(result.data?.manualResolution?.candidateNeighborIds || []),
+          ]),
+          normalizedContactPoint,
+        };
+      }
+
+      throw new Error(`Identity resolver failed with ${result.code}`);
+    }
+
+    const matchedNeighborId = result.data.identityMatch.matchedNeighborId;
+    if (matchedNeighborId) {
+      return {
+        type: 'single_match',
+        neighborId: matchedNeighborId,
+        normalizedContactPoint,
+      };
+    }
+
+    return {
+      type: 'no_match',
+      normalizedContactPoint,
+    };
+  }
+}
+
+const defaultNeighborStore = new KnexConnectShyftNeighborStore();
+
+const defaultIdentityBoundary = new AsyncConnectShyftPeopleCoreIdentityBoundaryAdapter(
+  async (tenantId) => defaultNeighborStore.listActiveIdentityBoundaryNeighborsByTenant(tenantId),
+  async (tenantId, normalizedContactPointValue) =>
+    defaultNeighborStore.listActiveIdentityBoundaryNeighborsByPhoneValue(
+      tenantId,
+      normalizedContactPointValue,
+    ),
+);
+
+const defaultSubjectResolver = new ConnectShyftSubjectResolver(defaultIdentityBoundary);
+
+export const resolveSubjectByContactPoint = (
+  input: ResolveSubjectByContactPointInput,
+): Promise<ResolveSubjectByContactPointResult> =>
+  defaultSubjectResolver.resolveSubjectByContactPoint(input);
+
+import { normalizePhone } from '../../../../../domains/communication';
+import { resolveConnectShyftPhoneNormalizationContext } from './phoneIdentityContext';
+
+const CONNECTSHYFT_INBOUND_SMS_MESSAGE_BODY_KEYS = [
+  'body',
+  'message',
+  'text',
+  'content',
+] as const;
+
+const CONNECTSHYFT_INBOUND_SMS_FROM_KEYS = [
+  'from',
+  'fromNumber',
+  'from_number',
+  'sender',
+  'senderNumber',
+  'sender_number',
+] as const;
+
+const CONNECTSHYFT_INBOUND_SMS_TO_KEYS = [
+  'to',
+  'toNumber',
+  'to_number',
+  'recipient',
+  'recipientNumber',
+  'recipient_number',
+] as const;
+
+const CONNECTSHYFT_INBOUND_SMS_NEIGHBOR_KEYS = [
+  'neighborId',
+] as const;
+
+export const CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME = 'connectshyft.inbound.sms_appended' as const;
+
+export type ConnectShyftInboundSmsSenderPhoneResult =
+  | {
+    ok: true;
+    rawPhone: string;
+    normalizedPhone: string;
+  }
+  | {
+    ok: false;
+    code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED' | 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT';
+    message: string;
+  };
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+};
+
+const readFromSources = (
+  sources: Array<Record<string, unknown> | null>,
+  keys: readonly string[],
+): string | null => {
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+
+    for (const key of keys) {
+      const normalized = normalizeString(source[key]);
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  return null;
+};
+
+const readWebhookSources = (
+  webhookBody: unknown,
+): Array<Record<string, unknown> | null> => {
+  const payload = asRecord(webhookBody);
+  const providerPayload = asRecord(payload?.providerPayload);
+  const data = asRecord(payload?.data);
+  const dataPayload = asRecord(data?.payload);
+
+  return [payload, providerPayload, dataPayload, data];
+};
+
+export type ConnectShyftInboundSmsArtifact = {
+  channel: 'sms';
+  direction: 'inbound';
+  providerEventId: string | null;
+  providerMessageId: string | null;
+  providerLegId: string | null;
+  body: string;
+  from: string | null;
+  to: string | null;
+};
+
+export type ConnectShyftInboundSmsDomainEvent = {
+  eventName: typeof CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME;
+  routingDecision: 'accepted';
+  deterministicOrdering: true;
+  canonicalEventType: string;
+  actor: 'neighbor';
+  inboundMessageArtifact: ConnectShyftInboundSmsArtifact;
+};
+
+export const extractConnectShyftInboundSmsNeighborId = (
+  webhookBody: unknown,
+): string | null => {
+  return readFromSources(
+    readWebhookSources(webhookBody),
+    CONNECTSHYFT_INBOUND_SMS_NEIGHBOR_KEYS,
+  );
+};
+
+export const resolveConnectShyftInboundSmsSenderPhone = (
+  webhookBody: unknown,
+): ConnectShyftInboundSmsSenderPhoneResult => {
+  const rawPhone = readFromSources(
+    readWebhookSources(webhookBody),
+    CONNECTSHYFT_INBOUND_SMS_FROM_KEYS,
+  );
+
+  if (!rawPhone) {
+    return {
+      ok: false,
+      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+      message: 'Inbound SMS processing requires a sender phone number.',
+    };
+  }
+
+  const normalizedPhone = normalizePhone(
+    rawPhone,
+    resolveConnectShyftPhoneNormalizationContext('system_generated'),
+  );
+  if (!normalizedPhone.ok) {
+    return {
+      ok: false,
+      code: 'CONNECTSHYFT_NEIGHBOR_PHONE_INVALID_FORMAT',
+      message: 'Inbound SMS processing requires a valid sender phone number.',
+    };
+  }
+
+  return {
+    ok: true,
+    rawPhone,
+    normalizedPhone: normalizedPhone.phone.normalizedE164,
+  };
+};
+
+export const mapConnectShyftInboundSmsWebhookToDomainEvent = (input: {
+  webhookBody: unknown;
+  canonicalEventType: string;
+  providerEventId: string | null;
+  providerMessageId: string | null;
+  providerLegId: string | null;
+}): ConnectShyftInboundSmsDomainEvent => {
+  const sources = readWebhookSources(input.webhookBody);
+  const body = readFromSources(sources, CONNECTSHYFT_INBOUND_SMS_MESSAGE_BODY_KEYS) || '';
+  const from = readFromSources(sources, CONNECTSHYFT_INBOUND_SMS_FROM_KEYS);
+  const to = readFromSources(sources, CONNECTSHYFT_INBOUND_SMS_TO_KEYS);
+
+  return {
+    eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+    routingDecision: 'accepted',
+    deterministicOrdering: true,
+    canonicalEventType: normalizeString(input.canonicalEventType) || 'MessageDelivered',
+    actor: 'neighbor',
+    inboundMessageArtifact: {
+      channel: 'sms',
+      direction: 'inbound',
+      providerEventId: input.providerEventId,
+      providerMessageId: input.providerMessageId,
+      providerLegId: input.providerLegId,
+      body,
+      from,
+      to,
+    },
+  };
+};
+
+export const buildConnectShyftInboundSmsCanonicalPayload = (input: {
+  domainEvent: ConnectShyftInboundSmsDomainEvent;
+  threadState: string;
+}): Record<string, unknown> => ({
+  direction: 'inbound',
+  channel: 'sms',
+  eventType: input.domainEvent.canonicalEventType,
+  eventName: input.domainEvent.eventName,
+  actor: input.domainEvent.actor,
+  routingDecision: input.domainEvent.routingDecision,
+  deterministicOrdering: input.domainEvent.deterministicOrdering,
+  threadState: input.threadState,
+  autoClaimApplied: false,
+  inboundMessageArtifact: input.domainEvent.inboundMessageArtifact,
+});
+
+import type { ConnectShyftThreadState } from './threads';
+
+const CONNECTSHYFT_INBOUND_VOICE_FROM_KEYS = [
+  'from',
+  'fromNumber',
+  'from_number',
+  'caller',
+  'callerNumber',
+  'caller_number',
+] as const;
+
+const CONNECTSHYFT_INBOUND_VOICE_TO_KEYS = [
+  'to',
+  'toNumber',
+  'to_number',
+  'recipient',
+  'recipientNumber',
+  'recipient_number',
+] as const;
+
+const CONNECTSHYFT_INBOUND_VOICE_NEIGHBOR_KEYS = [
+  'neighborId',
+  'neighbor_id',
+] as const;
+
+const CONNECTSHYFT_INBOUND_VOICE_RECORDING_URL_KEYS = [
+  'recordingUrl',
+  'recording_url',
+] as const;
+
+const CONNECTSHYFT_INBOUND_VOICE_DURATION_KEYS = [
+  'voicemail_duration_seconds',
+  'duration_seconds',
+  'durationSeconds',
+  'duration',
+] as const;
+
+export const CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME = 'connectshyft.inbound.voice_voicemail_recorded' as const;
+export const CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME = 'connectshyft.inbound.voice_fallback_recorded' as const;
+export const CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME = 'connectshyft.voicemail.transcription_requested' as const;
+export const CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME = 'connectshyft.voicemail.transcription_attached' as const;
+export const CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME = 'connectshyft.voicemail.transcription' as const;
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const normalizeDurationSeconds = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.trunc(value));
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value.trim());
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.trunc(parsed));
+    }
+  }
+
+  return null;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+};
+
+const readFromSources = (
+  sources: Array<Record<string, unknown> | null>,
+  keys: readonly string[],
+): string | null => {
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+
+    for (const key of keys) {
+      const normalized = normalizeString(source[key]);
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  return null;
+};
+
+const readDurationFromSources = (
+  sources: Array<Record<string, unknown> | null>,
+  keys: readonly string[],
+): number | null => {
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+
+    for (const key of keys) {
+      const normalized = normalizeDurationSeconds(source[key]);
+      if (normalized !== null) {
+        return normalized;
+      }
+    }
+  }
+
+  return null;
+};
+
+const readWebhookSources = (webhookBody: unknown): Array<Record<string, unknown> | null> => {
+  const payload = asRecord(webhookBody);
+  const providerPayload = asRecord(payload?.providerPayload);
+  const data = asRecord(payload?.data);
+  const dataPayload = asRecord(data?.payload);
+
+  return [payload, providerPayload, dataPayload, data];
+};
+
+export type ConnectShyftInboundVoiceRoutingDecision = 'voicemail_only' | 'intake_fallback' | 'accepted';
+
+export type ConnectShyftInboundVoiceRoutingPolicy = {
+  claimedMode?: 'orgunit_configured_mode';
+};
+
+export type ConnectShyftInboundVoiceArtifact = {
+  channel: 'voice';
+  direction: 'inbound';
+  providerEventId: string | null;
+  providerMessageId: string | null;
+  providerLegId: string | null;
+  from: string | null;
+  to: string | null;
+  recordingUrl: string | null;
+  durationSeconds: number | null;
+};
+
+export type ConnectShyftInboundVoiceDomainEvent = {
+  eventName:
+    | typeof CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME
+    | typeof CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME;
+  routingDecision: ConnectShyftInboundVoiceRoutingDecision;
+  deterministicOrdering: true;
+  canonicalEventType: string;
+  routingPolicy: ConnectShyftInboundVoiceRoutingPolicy;
+  inboundVoiceArtifact: ConnectShyftInboundVoiceArtifact;
+};
+
+export type ConnectShyftVoicemailTranscriptionRequest = {
+  requestQueued: true;
+  queueName: typeof CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_QUEUE_NAME;
+  callbackCorrelation: {
+    tenantId: string;
+    orgUnitId: string;
+    threadId: string;
+    providerEventId: string | null;
+    correlationEventId: string | null;
+    providerLegId: string | null;
+    voicemailArtifactId: string;
+  };
+};
+
+export type ConnectShyftVoicemailTranscriptionCallbackCorrelation = {
+  tenantId: string | null;
+  orgUnitId: string | null;
+  threadId: string | null;
+  providerEventId: string | null;
+  providerLegId: string | null;
+  voicemailArtifactId: string | null;
+};
+
+export type ConnectShyftVoicemailTranscriptionCallbackPayload = {
+  correlation: ConnectShyftVoicemailTranscriptionCallbackCorrelation;
+  transcriptText: string | null;
+};
+
+const readRecordFromSources = (
+  sources: Array<Record<string, unknown> | null>,
+  keys: readonly string[],
+): Record<string, unknown> | null => {
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+
+    for (const key of keys) {
+      const nested = asRecord(source[key]);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+
+  return null;
+};
+
+export const extractConnectShyftInboundVoiceNeighborId = (
+  webhookBody: unknown,
+): string | null => {
+  return readFromSources(
+    readWebhookSources(webhookBody),
+    CONNECTSHYFT_INBOUND_VOICE_NEIGHBOR_KEYS,
+  );
+};
+
+export const isConnectShyftVoicemailTranscriptionCallbackEventType = (
+  canonicalEventType: string,
+): boolean => {
+  const normalized = normalizeString(canonicalEventType).toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  return normalized.includes('transcription')
+    && (normalized.includes('completed') || normalized.includes('callback'));
+};
+
+export const extractConnectShyftVoicemailTranscriptionCallbackPayload = (
+  webhookBody: unknown,
+): ConnectShyftVoicemailTranscriptionCallbackPayload => {
+  const payload = asRecord(webhookBody);
+  const providerPayload = asRecord(payload?.providerPayload);
+  const data = asRecord(payload?.data);
+  const dataPayload = asRecord(data?.payload);
+  const sources = [payload, providerPayload, dataPayload, data];
+
+  const callbackCorrelation = readRecordFromSources(sources, [
+    'callbackCorrelation',
+    'callback_correlation',
+  ]);
+  const correlationSources = [callbackCorrelation, ...sources];
+  const transcriptRecord = readRecordFromSources(sources, ['transcript']);
+  const transcriptText = readFromSources(
+    [transcriptRecord, ...sources],
+    [
+      'text',
+      'transcriptText',
+      'transcript_text',
+      'transcriptionText',
+      'transcription_text',
+    ],
+  );
+
+  return {
+    correlation: {
+      tenantId: readFromSources(correlationSources, ['tenantId', 'tenant_id']),
+      orgUnitId: readFromSources(correlationSources, ['orgUnitId', 'org_unit_id']),
+      threadId: readFromSources(correlationSources, ['threadId', 'thread_id']),
+      providerEventId: readFromSources(correlationSources, [
+        'providerEventId',
+        'provider_event_id',
+        'correlationEventId',
+        'correlation_event_id',
+      ]),
+      providerLegId: readFromSources(correlationSources, ['providerLegId', 'provider_leg_id']),
+      voicemailArtifactId: readFromSources(correlationSources, [
+        'voicemailArtifactId',
+        'voicemail_artifact_id',
+        'artifactId',
+        'artifact_id',
+      ]),
+    },
+    transcriptText,
+  };
+};
+
+export const resolveConnectShyftInboundVoiceRouting = (input: {
+  normalizedEventType: string;
+  threadState: ConnectShyftThreadState | null;
+}): {
+  eventName:
+    | typeof CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME
+    | typeof CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME;
+  routingDecision: ConnectShyftInboundVoiceRoutingDecision;
+  deterministicOrdering: true;
+  routingPolicy: ConnectShyftInboundVoiceRoutingPolicy;
+} => {
+  const normalizedEventType = normalizeString(input.normalizedEventType).toLowerCase();
+  const isFallbackEvent = normalizedEventType === 'voice.fallback' || normalizedEventType === 'voicefallback';
+
+  if (isFallbackEvent || !input.threadState || input.threadState === 'CLOSED') {
+    return {
+      eventName: CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
+      routingDecision: 'intake_fallback',
+      deterministicOrdering: true,
+      routingPolicy: {},
+    };
+  }
+
+  if (input.threadState === 'CLAIMED') {
+    return {
+      eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+      routingDecision: 'accepted',
+      deterministicOrdering: true,
+      routingPolicy: {
+        claimedMode: 'orgunit_configured_mode',
+      },
+    };
+  }
+
+  return {
+    eventName: CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
+    routingDecision: 'voicemail_only',
+    deterministicOrdering: true,
+    routingPolicy: {},
+  };
+};
+
+export const mapConnectShyftInboundVoiceWebhookToDomainEvent = (input: {
+  webhookBody: unknown;
+  canonicalEventType: string;
+  eventName:
+    | typeof CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME
+    | typeof CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME;
+  routingDecision: ConnectShyftInboundVoiceRoutingDecision;
+  providerEventId: string | null;
+  providerMessageId: string | null;
+  providerLegId: string | null;
+  routingPolicy?: ConnectShyftInboundVoiceRoutingPolicy;
+}): ConnectShyftInboundVoiceDomainEvent => {
+  const sources = readWebhookSources(input.webhookBody);
+  const from = readFromSources(sources, CONNECTSHYFT_INBOUND_VOICE_FROM_KEYS);
+  const to = readFromSources(sources, CONNECTSHYFT_INBOUND_VOICE_TO_KEYS);
+  const recordingUrl = readFromSources(sources, CONNECTSHYFT_INBOUND_VOICE_RECORDING_URL_KEYS);
+  const durationSeconds = readDurationFromSources(sources, CONNECTSHYFT_INBOUND_VOICE_DURATION_KEYS);
+
+  return {
+    eventName: input.eventName,
+    routingDecision: input.routingDecision,
+    deterministicOrdering: true,
+    canonicalEventType: normalizeString(input.canonicalEventType) || 'VoiceVoicemail',
+    routingPolicy: input.routingPolicy || {},
+    inboundVoiceArtifact: {
+      channel: 'voice',
+      direction: 'inbound',
+      providerEventId: input.providerEventId,
+
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+import { CAPABILITIES, hasCapability } from '../../platform/rbac/capabilities';
+import { isStrictUtcIsoTimestamp } from '../../platform/time/timezoneService';
+
+const CONNECTSHYFT_CANONICAL_THREAD_STATES = ['UNCLAIMED', 'CLAIMED', 'CLOSED'] as const;
+const CONNECTSHYFT_CANONICAL_THREAD_STATE_SET = new Set<string>(CONNECTSHYFT_CANONICAL_THREAD_STATES);
+const DEFAULT_THREAD_SOURCE = 'VOICE';
+const DEFAULT_DUE_THREAD_LIMIT = 50;
+const MAX_DUE_THREAD_LIMIT = 250;
+const DEFAULT_ESCALATION_BASELINE_HOURS = 24;
+const MIN_ESCALATION_BASELINE_HOURS = 1;
+const MAX_ESCALATION_BASELINE_HOURS = 24;
+const MAX_ESCALATION_STAGE = 3;
+const HOUR_MS = 60 * 60 * 1000;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type ConnectShyftThreadState = (typeof CONNECTSHYFT_CANONICAL_THREAD_STATES)[number];
+export type ConnectShyftLifecycleAction = 'claim' | 'takeover' | 'close';
+
+export type ConnectShyftLifecyclePolicyDecision =
+  | {
+    ok: true;
+    nextState: ConnectShyftThreadState;
+  }
+  | {
+    ok: false;
+    code: 'CONNECTSHYFT_THREAD_TRANSITION_INVALID' | 'CONNECTSHYFT_THREAD_OWNERSHIP_REQUIRED';
+    message: string;
+  };
+
+export type ConnectShyftThread = {
+  threadId: string;
+  tenantId: string;
+  orgUnitId: string;
+  neighborId: string;
+  source: string;
+  state: ConnectShyftThreadState;
+  lastInboundCsNumberId: string;
+  preferredOutboundCsNumberId: string;
+  claimedByUserId: string | null;
+  claimedAtUtc: string | null;
+  closedByUserId: string | null;
+  closedAtUtc: string | null;
+  createdAtUtc: string;
+  updatedAtUtc: string;
+  escalation: {
+    stage: number;
+    nextEvaluationAtUtc: string | null;
+  };
+};
+
+type ThreadLifecycleFields = Pick<
+  ConnectShyftThread,
+  'claimedByUserId' | 'claimedAtUtc' | 'closedByUserId' | 'closedAtUtc'
+>;
+
+type ThreadStoreEnsureInput = {
+  tenantId: string;
+  orgUnitId: string;
+  neighborId: string;
+  source: string;
+  state: ConnectShyftThreadState;
+  lastInboundCsNumberId: string;
+  preferredOutboundCsNumberId: string;
+  threadId?: string;
+  actorUserId?: string | null;
+  nextEvaluationAtUtc?: string | null;
+};
+
+type ThreadStoreListDueInput = {
+  tenantId: string;
+  orgUnitId: string;
+  limit: number;
+};
+
+type ThreadStoreEvaluateInput = {
+  tenantId: string;
+  orgUnitId: string;
+  asOfUtc: string;
+  limit: number;
+  baselineHours: number;
+  actorUserId?: string | null;
+};
+
+type ThreadStoreTransitionInput = {
+  tenantId: string;
+  threadId: string;
+  nextState: ConnectShyftThreadState;
+  actorUserId?: string | null;
+};
+
+type ThreadStoreFindByIdInput = {
+  tenantId: string;
+  threadId: string;
+};
+
+export type ConnectShyftEscalationTransition = {
+  threadId: string;
+  previousStage: number;
+  stage: number;
+  dueAtUtc: string;
+  nextDueAtUtc: string;
+  nextDueOffsetHours: number;
+};
+
+type ThreadEscalationTransition = ConnectShyftEscalationTransition;
+
+type ThreadPersistenceEnsureResult =
+  | {
+    ok: true;
+    thread: ConnectShyftThread;
+    createdNewThread: boolean;
+  }
+  | {
+    ok: false;
+    reason: 'TRANSITION_ACTOR_REQUIRED';
+  };
+
+type ThreadPersistenceTransitionResult =
+  | {
+    ok: true;
+    thread: ConnectShyftThread;
+  }
+  | {
+    ok: false;
+    reason: 'THREAD_NOT_FOUND' | 'TRANSITION_ACTOR_REQUIRED';
+  };
+
+type ThreadRefusalResult = {
+  ok: false;
+  code:
+    | 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN'
+    | 'CONNECTSHYFT_THREAD_TRANSITION_FORBIDDEN'
+    | 'CONNECTSHYFT_THREAD_STATE_INVALID'
+    | 'CONNECTSHYFT_THREAD_NEXT_EVALUATION_INVALID'
+    | 'CONNECTSHYFT_ESCALATION_AS_OF_INVALID'
+    | 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_INTEGER'
+    | 'CONNECTSHYFT_ESCALATION_BASELINE_INVALID_RANGE'
+    | 'CONNECTSHYFT_THREAD_TRANSITION_INVALID'
+    | 'CONNECTSHYFT_THREAD_NOT_FOUND'
+    | 'CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE'
+    | 'CONNECTSHYFT_THREAD_PERSISTENCE_UNAVAILABLE';
+  message: string;
+};
+
+export type ConnectShyftEnsureThreadCommand = {
+  actorRoles: Array<string | null | undefined>;
+  tenantId: string;
+  orgUnitId: string;
+  neighborId: string;
+  source?: string;
+  forcedState?: string | null;
+  lastInboundCsNumberId: string;
+  preferredOutboundCsNumberId: string;
+  threadId?: string;
+  actorUserId?: string | null;
+  nextEvaluationAtUtc?: string;
+};
+
+export type ConnectShyftListDueThreadsCommand = {
+  actorRoles: Array<string | null | undefined>;
+  tenantId: string;
+  orgUnitId: string;
+  limit?: number;
+};
+
+export type ConnectShyftEvaluateEscalationsCommand = {
+  actorRoles: Array<string | null | undefined>;
+  tenantId: string;
+  orgUnitId: string;
+  asOfUtc?: string;
+  limit?: number;
+  baselineHours?: number;
+  actorUserId?: string | null;
+};
+
+export type ConnectShyftTransitionThreadStateCommand = {
+  actorRoles: Array<string | null | undefined>;
+  tenantId: string;
+  threadId: string;
+  nextState: ConnectShyftThreadState;
+  actorUserId?: string | null;
+};
+
+export type ConnectShyftEnsureThreadResult =
+  | {
+    ok: true;
+    code: 'CONNECTSHYFT_THREAD_ENSURED';
+    httpStatus: 201;
+    data: {
+      thread: ConnectShyftThread;
+      lifecycle: {
+        ensuredActiveThread: true;
+        createdNewThread: boolean;
+        reusedThreadId?: string;
+      };
+    };
+  }
+  | ThreadRefusalResult;
+
+export type ConnectShyftListDueThreadsResult =
+  | {
+    ok: true;
+    code: 'CONNECTSHYFT_DUE_THREADS_LISTED';
+    httpStatus: 200;
+    data: {
+      threads: ConnectShyftThread[];
+    };
+  }
+  | ThreadRefusalResult;
+
+export type ConnectShyftTransitionThreadStateResult =
+  | {
+    ok: true;
+    code: 'CONNECTSHYFT_THREAD_TRANSITIONED';
+    httpStatus: 200;
+    data: {
+      thread: ConnectShyftThread;
+    };
+  }
+  | ThreadRefusalResult;
+
+export type ConnectShyftEvaluateEscalationsResult =
+  | {
+    ok: true;
+    code: 'CONNECTSHYFT_ESCALATION_EVALUATED';
+    httpStatus: 200;
+    data: {
+      asOfUtc: string;
+      baselineHours: number;
+      transitions: ConnectShyftEscalationTransition[];
+      effects: {
+        emittedCount: number;
+      };
+      replaySafe: boolean;
+      skippedAlreadyProcessed: boolean;
+    };
+  }
+  | ThreadRefusalResult;
+
+type DbThreadRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  neighbor_id: string;
+  source: string;
+  state: ConnectShyftThreadState;
+  escalation_stage: number;
+  next_evaluation_at_utc: string | Date | null;
+  last_inbound_cs_number_id: string;
+  preferred_outbound_cs_number_id: string;
+  claimed_by_user_id: string | null;
+  claimed_at_utc: string | Date | null;
+  closed_by_user_id: string | null;
+  closed_at_utc: string | Date | null;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const normalizeThreadSenderAlignmentValue = (value: unknown): string => normalizeString(value);
+
+const nowIsoUtc = (): string => new Date().toISOString();
+
+const toIsoUtc = (value: string | Date): string => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toISOString();
+  }
+
+  return value;
+};
+
+const toNullableIsoUtc = (value: string | Date | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  return toIsoUtc(value);
+};
+
+const normalizeUuid = (value: unknown): string | null => {
+  const normalized = normalizeString(value);
+  if (!normalized || !UUID_PATTERN.test(normalized)) {
+    return null;
+  }
+
+  return normalized;
+};
+
+const isCanonicalThreadState = (value: string): value is ConnectShyftThreadState => {
+  return CONNECTSHYFT_CANONICAL_THREAD_STATE_SET.has(value);
+};
+
+const normalizeThreadState = (forcedState: string | null | undefined): ConnectShyftThreadState | null => {
+  const normalized = normalizeString(forcedState).toUpperCase();
+  if (!normalized) {
+    return 'UNCLAIMED';
+  }
+
+  if (!isCanonicalThreadState(normalized)) {
+    return null;
+  }
+
+  return normalized;
+};
+
+const normalizeDueThreadLimit = (value: number | undefined): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_DUE_THREAD_LIMIT;
+  }
+
+  const normalized = Math.trunc(value);
+  if (normalized <= 0) {
+    return DEFAULT_DUE_THREAD_LIMIT;
+  }
+
+  return Math.min(normalized, MAX_DUE_THREAD_LIMIT);
+};
+
+const normalizeEscalationBaselineHours = (
+  value: number | undefined,
+): { ok: true; baselineHours: number } | ThreadRefusalResult => {
+  if (value === undefined) {
+    return {
+      ok: true,
+      baselineHours: DEFAULT_ESCALATION_BASELINE_HOURS,
+    };
+  }
+
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    return buildEscalationBaselineInvalidIntegerRefusal();
+  }
+
+  if (value < MIN_ESCALATION_BASELINE_HOURS || value > MAX_ESCALATION_BASELINE_HOURS) {
+    return buildEscalationBaselineInvalidRangeRefusal();
+  }
+
+  return {
+    ok: true,
+    baselineHours: value,
+  };
+};
+
+const resolveEscalationAsOfUtc = (
+  value: string | undefined,
+): { ok: true; asOfUtc: string } | ThreadRefusalResult => {
+  const normalized = normalizeString(value) || nowIsoUtc();
+  if (!isStrictUtcIsoTimestamp(normalized)) {
+    return buildEscalationAsOfInvalidRefusal();
+  }
+
+  return {
+    ok: true,
+    asOfUtc: normalized,
+  };
+};
+
+const normalizeEscalationStage = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.trunc(value));
+};
+
+const resolveEscalationDueTimeMs = (dueAtUtc: string, asOfUtc: string): number => {
+  const dueAtMs = Date.parse(dueAtUtc);
+  if (!Number.isNaN(dueAtMs)) {
+    return dueAtMs;
+  }
+
+  const asOfMs = Date.parse(asOfUtc);
+  if (!Number.isNaN(asOfMs)) {
+    return asOfMs;
+  }
+
+  return Date.now();
+};
+
+const buildEscalationTransition = (input: {
+  threadId: string;
+  previousStage: number;
+  dueAtUtc: string;
+  asOfUtc: string;
+  baselineHours: number;
+}): ThreadEscalationTransition => {
+  const nextStage = Math.min(
+    Math.max(normalizeEscalationStage(input.previousStage), 0) + 1,
+    MAX_ESCALATION_STAGE,
+  );
+  const nextDueOffsetHours = input.baselineHours * nextStage;
+  const nextDueAtUtc = new Date(
+    resolveEscalationDueTimeMs(input.dueAtUtc, input.asOfUtc) + (nextDueOffsetHours * HOUR_MS),
+  ).toISOString();
+
+  return {
+    threadId: input.threadId,
+    previousStage: normalizeEscalationStage(input.previousStage),
+    stage: nextStage,
+    dueAtUtc: input.dueAtUtc,
+    nextDueAtUtc,
+    nextDueOffsetHours,
+  };
+};
+
+const compareDueThreads = (left: ConnectShyftThread, right: ConnectShyftThread): number => {
+
+import { randomUUID } from 'node:crypto'
+import type { Knex } from 'knex'
+import db from '../../config/knex'
+import {
+  buildHandleProviderBridgeEvent,
+  buildStartBridgeSession,
+  type BridgeSessionAggregate,
+  type BridgeLegRecord,
+  type BridgeSessionRecord,
+  type BridgeSessionRepository,
+  type BridgeTelephonyProvider,
+  type ProviderBridgeEvent,
+  type StartBridgeSessionCommand,
+} from '../../../../../domains/communication'
+import { recordConnectShyftBridgeLegProviderIdentifierMapping } from './providerCorrelationMappings'
+import { isConnectShyftTestOverrideEnabled } from './featureFlags'
+import type {
+  ConnectShyftOutboundCallDispatchPolicy,
+  ConnectShyftProviderAdapter,
+} from './providerRegistry'
+
+const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions'
+const BRIDGE_LEGS_TABLE = 'cs_bridge_legs'
+
+type DbBridgeSessionRow = {
+  id: string
+  tenant_id: string
+  org_unit_id: string
+  thread_id: string
+  operator_participant_id: string
+  neighbor_participant_id: string
+  operator_contact_point_id: string
+  neighbor_contact_point_id: string
+  selected_outbound_contact_point_id?: string | null
+  bridge_status: string
+  failure_code?: string | null
+  failure_message?: string | null
+  ended_by?: string | null
+  idempotency_key?: string | null
+  audit_correlation_id?: string | null
+  created_at_utc: string | Date
+  updated_at_utc: string | Date
+  completed_at_utc?: string | Date | null
+}
+
+type DbBridgeLegRow = {
+  id: string
+  tenant_id: string
+  org_unit_id: string
+  bridge_session_id: string
+  leg_role: 'operator' | 'neighbor'
+  contact_point_id: string
+  provider_call_id?: string | null
+  leg_status: string
+  started_at_utc?: string | Date | null
+  answered_at_utc?: string | Date | null
+  ended_at_utc?: string | Date | null
+  failure_code?: string | null
+  failure_message?: string | null
+  created_at_utc: string | Date
+  updated_at_utc: string | Date
+}
+
+type StartConnectShyftBridgeSessionInput = {
+  tenantId: string
+  orgUnitId: string
+  threadId: string
+  operatorParticipantId: string
+  neighborParticipantId: string
+  operatorContactPointId: string
+  neighborContactPointId: string
+  selectedOutboundContactPointId?: string | null
+  providerKey: string
+  providerAdapter: ConnectShyftProviderAdapter
+  idempotencyKey?: string | null
+  auditCorrelationId?: string | null
+  callPolicy?: ConnectShyftOutboundCallDispatchPolicy
+}
+
+type HandleConnectShyftBridgeWebhookEventInput = {
+  tenantId: string
+  orgUnitId: string
+  threadId: string
+  providerKey: string
+  providerAdapter: ConnectShyftProviderAdapter
+  providerLegId: string | null
+  eventType: string
+  occurredAt?: Date
+  reason?: string | null
+  callPolicy?: ConnectShyftOutboundCallDispatchPolicy
+}
+
+type BridgeMappingStatus = 'created' | 'duplicate' | 'ignored' | 'error'
+
+type BridgeMappingResult = {
+  deterministic: true
+  operatorLegMapping: BridgeMappingStatus
+  neighborLegMapping: BridgeMappingStatus
+  error: {
+    code: 'CONNECTSHYFT_PROVIDER_CORRELATION_PERSISTENCE_UNAVAILABLE'
+    message: string
+  } | null
+}
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim()
+}
+
+const toIsoString = (value: string | Date | null | undefined): string | null => {
+  if (!value) {
+    return null
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  const parsed = new Date(value)
+  if (!Number.isNaN(parsed.valueOf())) {
+    return parsed.toISOString()
+  }
+
+  return normalizeString(value) || null
+}
+
+const toDate = (value: string | Date | null | undefined): Date | null => {
+  const iso = toIsoString(value)
+  return iso ? new Date(iso) : null
+}
+
+const isMissingPersistenceError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const candidate = error as { code?: string }
+  return candidate.code === '42P01'
+    || candidate.code === '3F000'
+    || candidate.code === '42703'
+}
+
+const mapSessionRow = (row: DbBridgeSessionRow): BridgeSessionRecord => ({
+  id: row.id,
+  tenantId: row.tenant_id,
+  orgUnitId: row.org_unit_id,
+  threadId: row.thread_id,
+  operatorParticipantId: row.operator_participant_id,
+  neighborParticipantId: row.neighbor_participant_id,
+  operatorContactPointId: row.operator_contact_point_id,
+  neighborContactPointId: row.neighbor_contact_point_id,
+  selectedOutboundContactPointId: normalizeString(row.selected_outbound_contact_point_id) || null,
+  status: row.bridge_status as BridgeSessionRecord['status'],
+  failureCode: normalizeString(row.failure_code) as BridgeSessionRecord['failureCode'],
+  failureMessage: normalizeString(row.failure_message) || null,
+  endedBy: normalizeString(row.ended_by) || null,
+  idempotencyKey: normalizeString(row.idempotency_key) || null,
+  auditCorrelationId: normalizeString(row.audit_correlation_id) || null,
+  createdAt: new Date(toIsoString(row.created_at_utc) || new Date().toISOString()),
+  updatedAt: new Date(toIsoString(row.updated_at_utc) || new Date().toISOString()),
+  completedAt: toDate(row.completed_at_utc),
+})
+
+const mapLegRow = (row: DbBridgeLegRow): BridgeLegRecord => ({
+  id: row.id,
+  tenantId: row.tenant_id,
+  orgUnitId: row.org_unit_id,
+  bridgeSessionId: row.bridge_session_id,
+  legRole: row.leg_role,
+  contactPointId: row.contact_point_id,
+  providerCallId: normalizeString(row.provider_call_id) || null,
+  status: row.leg_status as BridgeLegRecord['status'],
+  startedAt: toDate(row.started_at_utc),
+  answeredAt: toDate(row.answered_at_utc),
+  endedAt: toDate(row.ended_at_utc),
+  failureCode: normalizeString(row.failure_code) as BridgeLegRecord['failureCode'],
+  failureMessage: normalizeString(row.failure_message) || null,
+  createdAt: new Date(toIsoString(row.created_at_utc) || new Date().toISOString()),
+  updatedAt: new Date(toIsoString(row.updated_at_utc) || new Date().toISOString()),
+})
+
+const sessionToRow = (session: BridgeSessionRecord) => ({
+  id: session.id,
+  tenant_id: session.tenantId,
+  org_unit_id: session.orgUnitId,
+  thread_id: session.threadId,
+  operator_participant_id: session.operatorParticipantId,
+  neighbor_participant_id: session.neighborParticipantId,
+  operator_contact_point_id: session.operatorContactPointId,
+  neighbor_contact_point_id: session.neighborContactPointId,
+  selected_outbound_contact_point_id: session.selectedOutboundContactPointId ?? null,
+  bridge_status: session.status,
+  failure_code: session.failureCode ?? null,
+  failure_message: session.failureMessage ?? null,
+  ended_by: session.endedBy ?? null,
+  idempotency_key: session.idempotencyKey ?? null,
+  audit_correlation_id: session.auditCorrelationId ?? null,
+  created_at_utc: session.createdAt.toISOString(),
+  updated_at_utc: session.updatedAt.toISOString(),
+  completed_at_utc: session.completedAt ? session.completedAt.toISOString() : null,
+})
+
+const legToRow = (leg: BridgeLegRecord) => ({
+  id: leg.id,
+  tenant_id: leg.tenantId,
+  org_unit_id: leg.orgUnitId,
+  bridge_session_id: leg.bridgeSessionId,
+  leg_role: leg.legRole,
+  contact_point_id: leg.contactPointId,
+  provider_call_id: leg.providerCallId ?? null,
+  leg_status: leg.status,
+  started_at_utc: leg.startedAt ? leg.startedAt.toISOString() : null,
+  answered_at_utc: leg.answeredAt ? leg.answeredAt.toISOString() : null,
+  ended_at_utc: leg.endedAt ? leg.endedAt.toISOString() : null,
+  failure_code: leg.failureCode ?? null,
+  failure_message: leg.failureMessage ?? null,
+  created_at_utc: leg.createdAt.toISOString(),
+  updated_at_utc: leg.updatedAt.toISOString(),
+})
+
+class InMemoryConnectShyftBridgeSessionStore implements BridgeSessionRepository {
+  private sessions = new Map<string, BridgeSessionRecord>()
+  private legsBySessionId = new Map<string, Map<'operator' | 'neighbor', BridgeLegRecord>>()
+  private sessionIdByProviderCallId = new Map<string, string>()
+
+  createSession(session: BridgeSessionRecord): Promise<void> {
+    this.sessions.set(session.id, { ...session })
+    return Promise.resolve()
+  }
+
+  createLeg(leg: BridgeLegRecord): Promise<void> {
+    const current = this.legsBySessionId.get(leg.bridgeSessionId) || new Map()
+    current.set(leg.legRole, { ...leg })
+    this.legsBySessionId.set(leg.bridgeSessionId, current)
+    if (leg.providerCallId) {
+      this.sessionIdByProviderCallId.set(leg.providerCallId, leg.bridgeSessionId)
+    }
+    return Promise.resolve()
+  }
+
+  saveAggregate(aggregate: BridgeSessionAggregate): Promise<void> {
+    this.sessions.set(aggregate.session.id, { ...aggregate.session })
+    const legs = new Map<'operator' | 'neighbor', BridgeLegRecord>()
+    legs.set('operator', { ...aggregate.operatorLeg })
+    legs.set('neighbor', { ...aggregate.neighborLeg })
+    this.legsBySessionId.set(aggregate.session.id, legs)
+    if (aggregate.operatorLeg.providerCallId) {
+      this.sessionIdByProviderCallId.set(aggregate.operatorLeg.providerCallId, aggregate.session.id)
+    }
+    if (aggregate.neighborLeg.providerCallId) {
+      this.sessionIdByProviderCallId.set(aggregate.neighborLeg.providerCallId, aggregate.session.id)
+    }
+    return Promise.resolve()
+  }
+
+  getAggregateBySessionId(sessionId: string): Promise<BridgeSessionAggregate | null> {
+    const session = this.sessions.get(sessionId)
+    const legs = this.legsBySessionId.get(sessionId)
+    const operatorLeg = legs?.get('operator')
+    const neighborLeg = legs?.get('neighbor')
+    if (!session || !operatorLeg || !neighborLeg) {
+      return Promise.resolve(null)
+    }
+
+    return Promise.resolve({
+      session: { ...session },
+      operatorLeg: { ...operatorLeg },
+      neighborLeg: { ...neighborLeg },
+    })
+  }
+
+  getAggregateByProviderCallId(input: {
+    tenantId?: string | null
+    providerCallId: string
+  }): Promise<BridgeSessionAggregate | null> {
+    const sessionId = this.sessionIdByProviderCallId.get(input.providerCallId)
+    if (!sessionId) {
+      return Promise.resolve(null)
+    }
+
+    return this.getAggregateBySessionId(sessionId)
+  }
+
+  getAggregateByThreadId(input: {
+    tenantId?: string | null
+    threadId: string
+  }): Promise<BridgeSessionAggregate | null> {
+    const tenantId = normalizeString(input.tenantId || null)
+    const latestSession = Array.from(this.sessions.values())
+      .filter((session) => {
+        if (session.threadId !== input.threadId) {
+          return false
+        }
+        return !tenantId || session.tenantId === tenantId
+      })
+      .sort((left, right) => right.updatedAt.getTime() - left.updatedAt.getTime())[0]
+
+    if (!latestSession) {
+      return Promise.resolve(null)
+    }
+
+    return this.getAggregateBySessionId(latestSession.id)
+  }
+
+  reset(): void {
+    this.sessions.clear()
+    this.legsBySessionId.clear()
+    this.sessionIdByProviderCallId.clear()
+  }
+}
+
+class KnexConnectShyftBridgeSessionStore implements BridgeSessionRepository {
+  constructor(private readonly knexClient: Knex = db) {}
+
+  async createSession(session: BridgeSessionRecord): Promise<void> {
+    await this.knexClient
+      .withSchema('connectshyft')
+      .table(BRIDGE_SESSIONS_TABLE)
+      .insert(sessionToRow(session))
+  }
+
+  async createLeg(leg: BridgeLegRecord): Promise<void> {
+    await this.knexClient
+      .withSchema('connectshyft')
+      .table(BRIDGE_LEGS_TABLE)
+      .insert(legToRow(leg))
+  }
+
+  async saveAggregate(aggregate: BridgeSessionAggregate): Promise<void> {
+    await this.knexClient.transaction(async (trx) => {
+      await trx
+        .withSchema('connectshyft')
+        .table(BRIDGE_SESSIONS_TABLE)
+        .insert(sessionToRow(aggregate.session))
+        .onConflict(['id'])
+        .merge()
+
+      await trx
+        .withSchema('connectshyft')
+        .table(BRIDGE_LEGS_TABLE)
+        .insert([legToRow(aggregate.operatorLeg), legToRow(aggregate.neighborLeg)])
+        .onConflict(['id'])
+        .merge()
+    })
+  }
+
+  async getAggregateBySessionId(sessionId: string): Promise<BridgeSessionAggregate | null> {
+    const sessionRow = await this.knexClient
+      .withSchema('connectshyft')
+      .table(BRIDGE_SESSIONS_TABLE)
+      .where({ id: sessionId })
+      .first<DbBridgeSessionRow>()
+
+    if (!sessionRow) {
+      return null
+    }
+
+
+=== PROVIDER REGISTRY / CORRELATION / NUMBER MAPPINGS ===
+import {
+  assertValidCallDispatchResult,
+  assertValidEndCallResult,
+  assertValidSmsDispatchResult,
+  type TelephonyEndCallResult,
+  type TelephonyDispatchResult,
+  type TelephonyOutboundCallPolicy,
+  type TelephonyProviderAdapter,
+  type TelephonyProviderEvent,
+  type TelephonyWebhookVerificationInput,
+  type TelephonyWebhookVerificationResult,
+} from '../../../../../domains/communication';
+import { resolveTelephonyProviderAdapter } from '../../../../../infrastructure/communications';
+import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+
+const DEFAULT_ENABLED_PROVIDERS = ['telnyx'];
+const ENABLED_PROVIDERS_ENV = 'CONNECTSHYFT_ENABLED_PROVIDERS';
+const DISABLED_PROVIDERS_ENV = 'CONNECTSHYFT_DISABLED_PROVIDERS';
+const PROVIDER_ROLLOUT_ALLOWLIST_ENV = 'CONNECTSHYFT_PROVIDER_ROLLOUT_ALLOWLIST';
+const TEST_ENABLED_PROVIDERS_HEADER = 'x-test-connectshyft-enabled-providers';
+const TEST_DISABLED_PROVIDERS_HEADER = 'x-test-connectshyft-disabled-providers';
+const TEST_REQUESTED_PROVIDER_HEADER = 'x-test-connectshyft-provider-requested';
+const TEST_PROVIDER_ROLLOUT_ALLOWLIST_HEADER = 'x-test-connectshyft-provider-rollout-allowlist';
+const TEST_ENFORCE_WEBHOOK_SIGNATURE_HEADER = 'x-test-connectshyft-enforce-webhook-signature';
+const CONNECTSHYFT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS_ENV = 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MAX_AGE_SECONDS';
+const TEST_PROVIDER_PUBLIC_KEY_HEADER = 'x-test-connectshyft-provider-public-key';
+const TEST_PROVIDER_PUBLIC_KEY_LEGACY_HEADER = 'x-test-connectshyft-telnyx-public-key';
+const CONNECTSHYFT_REQUIRED_CALL_TRANSPORT = 'bridge';
+const CONNECTSHYFT_REQUIRED_CALL_REDIAL_POLICY = 'manual_only';
+
+export type ConnectShyftProviderOperation = 'call' | 'message' | 'webhook';
+export type ConnectShyftProviderResolutionReason =
+  | 'provider-disabled'
+  | 'provider-not-allowlisted'
+  | 'provider-not-registered'
+  | 'no-enabled-provider';
+
+export type ConnectShyftProviderResolution = {
+  requestedProvider: string | null;
+  resolvedProvider: string | null;
+  deterministic: true;
+  reason?: ConnectShyftProviderResolutionReason;
+};
+
+export type ConnectShyftProviderDispatchResult = TelephonyDispatchResult;
+
+export type ConnectShyftOutboundCallDispatchPolicy = TelephonyOutboundCallPolicy;
+
+export class ConnectShyftProviderDispatchPolicyError extends Error {
+  readonly code:
+    | 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED'
+    | 'CONNECTSHYFT_OUTBOUND_CALL_RETRY_FORBIDDEN';
+  readonly data: Record<string, unknown>;
+
+  constructor(input: {
+    code:
+      | 'CONNECTSHYFT_OUTBOUND_CALL_TRANSPORT_UNSUPPORTED'
+      | 'CONNECTSHYFT_OUTBOUND_CALL_RETRY_FORBIDDEN';
+    message: string;
+    data: Record<string, unknown>;
+  }) {
+    super(input.message);
+    this.name = 'ConnectShyftProviderDispatchPolicyError';
+    this.code = input.code;
+    this.data = input.data;
+  }
+}
+
+export type ConnectShyftProviderCanonicalEvent = TelephonyProviderEvent;
+
+export type ConnectShyftProviderSideEffectsContract = {
+  dispatchAttempted: false;
+  lifecycleMutationApplied: false;
+  auditPersisted: false;
+};
+
+export type ConnectShyftProviderOperatorFeedbackMeta = {
+  actionable: true;
+  hiddenTransition: false;
+  messageKey: 'connectshyft.provider.disabled' | 'connectshyft.provider.unavailable';
+  remediation: string;
+};
+
+export type ConnectShyftProviderResolutionRefusal = {
+  code: 'CONNECTSHYFT_PROVIDER_DISABLED' | 'CONNECTSHYFT_PROVIDER_UNAVAILABLE';
+  message: string;
+  refusalType: 'business';
+  httpStatus: 200;
+  data: {
+    providerResolution: ConnectShyftProviderResolution;
+    operatorFeedbackMeta: ConnectShyftProviderOperatorFeedbackMeta;
+    sideEffects: ConnectShyftProviderSideEffectsContract;
+  };
+};
+
+export type ConnectShyftWebhookSignatureRefusal = {
+  code:
+    | 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED'
+    | 'CONNECTSHYFT_WEBHOOK_SIGNATURE_MISSING'
+    | 'CONNECTSHYFT_WEBHOOK_SIGNATURE_INVALID';
+  message: string;
+  refusalType: 'business' | 'client';
+  httpStatus: 401 | 503;
+};
+
+export type ConnectShyftWebhookSignatureResult =
+  | { ok: true }
+  | { ok: false; refusal: ConnectShyftWebhookSignatureRefusal };
+
+type ConnectShyftHeaderValue = string | string[] | undefined;
+
+type ConnectShyftHeaderReader = {
+  header(name: string): ConnectShyftHeaderValue;
+};
+
+type ConnectShyftWebhookRequest = ConnectShyftHeaderReader & {
+  body: unknown;
+  rawBody?: Buffer | string;
+  originalUrl?: string;
+  protocol?: string;
+  url?: string;
+  tenantId?: string | null;
+  orgUnitId?: string | null;
+  headers?: Record<string, unknown>;
+};
+
+type ConnectShyftProviderRolloutAllowlistRule = {
+  tenantIds: string[];
+  orgUnitIds: string[];
+  tenantOrgUnitPairs: string[];
+};
+
+type ConnectShyftProviderRolloutAllowlist = Record<string, ConnectShyftProviderRolloutAllowlistRule>;
+
+type ConnectShyftProviderRolloutAllowlistParseResult = {
+  allowlist: ConnectShyftProviderRolloutAllowlist;
+  configured: boolean;
+  invalid: boolean;
+};
+
+export type ConnectShyftProviderAdapter = TelephonyProviderAdapter;
+
+export type ConnectShyftProviderResolutionSuccess = {
+  ok: true;
+  adapter: ConnectShyftProviderAdapter;
+  providerResolution: ConnectShyftProviderResolution & {
+    resolvedProvider: string;
+  };
+};
+
+export type ConnectShyftProviderResolutionFailure = {
+  ok: false;
+  refusal: ConnectShyftProviderResolutionRefusal;
+};
+
+export type ConnectShyftProviderResolutionResult =
+  | ConnectShyftProviderResolutionSuccess
+  | ConnectShyftProviderResolutionFailure;
+
+const normalizeString = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    const firstValue = value.find((entry) => typeof entry === 'string');
+    if (typeof firstValue === 'string') {
+      return firstValue.trim();
+    }
+    return '';
+  }
+
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const normalizeProviderKey = (value: unknown): string | null => {
+  const normalized = normalizeString(value).toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+};
+
+const appendUnique = (target: string[], candidate: string | null): void => {
+  if (!candidate || target.includes(candidate)) {
+    return;
+  }
+  target.push(candidate);
+};
+
+const parseProviderList = (raw: unknown): string[] => {
+  if (Array.isArray(raw)) {
+    const providers: string[] = [];
+    raw.forEach((entry) => {
+      appendUnique(providers, normalizeProviderKey(entry));
+    });
+    return providers;
+  }
+
+  if (typeof raw !== 'string') {
+    return [];
+  }
+
+  if (!raw) {
+    return [];
+  }
+
+  const normalizedRaw = raw.trim();
+  if (!normalizedRaw) {
+    return [];
+  }
+
+  const providers: string[] = [];
+
+  const appendFromArray = (values: unknown[]): void => {
+    values.forEach((value) => {
+      appendUnique(providers, normalizeProviderKey(value));
+    });
+  };
+
+  try {
+    const parsed = JSON.parse(normalizedRaw);
+    if (Array.isArray(parsed)) {
+      appendFromArray(parsed);
+      return providers;
+    }
+    appendUnique(providers, normalizeProviderKey(parsed));
+    return providers;
+  } catch (_error) {
+    normalizedRaw
+      .split(',')
+      .map((value) => normalizeProviderKey(value))
+      .forEach((value) => appendUnique(providers, value));
+    return providers;
+  }
+};
+
+const parseNormalizedStringList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const resolved: string[] = [];
+  value.forEach((entry) => {
+    const normalized = normalizeString(entry);
+    if (!normalized || resolved.includes(normalized)) {
+      return;
+    }
+    resolved.push(normalized);
+  });
+  return resolved;
+};
+
+const resolveProviderRolloutAllowlist = (raw: unknown): ConnectShyftProviderRolloutAllowlistParseResult => {
+  let candidate: unknown = raw;
+
+  if (typeof candidate === 'string') {
+    const normalized = candidate.trim();
+    if (!normalized) {
+      return {
+        allowlist: {},
+        configured: false,
+        invalid: false,
+      };
+    }
+
+    try {
+      candidate = JSON.parse(normalized);
+    } catch (_error) {
+      return {
+        allowlist: {},
+        configured: true,
+        invalid: true,
+      };
+    }
+  }
+
+  if (candidate === null || typeof candidate === 'undefined') {
+    return {
+      allowlist: {},
+      configured: false,
+      invalid: false,
+    };
+  }
+
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    return {
+      allowlist: {},
+      configured: true,
+      invalid: true,
+    };
+  }
+
+  const resolved: ConnectShyftProviderRolloutAllowlist = {};
+  let invalid = false;
+  Object.entries(candidate as Record<string, unknown>).forEach(([providerKey, entry]) => {
+    const normalizedProviderKey = normalizeProviderKey(providerKey);
+    if (!normalizedProviderKey || !entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      invalid = true;
+      return;
+    }
+
+    const rule = entry as Record<string, unknown>;
+    if (
+      ('tenantIds' in rule && !Array.isArray(rule.tenantIds))
+      || ('orgUnitIds' in rule && !Array.isArray(rule.orgUnitIds))
+      || ('tenantOrgUnitPairs' in rule && !Array.isArray(rule.tenantOrgUnitPairs))
+    ) {
+      invalid = true;
+      return;
+    }
+    resolved[normalizedProviderKey] = {
+      tenantIds: parseNormalizedStringList(rule.tenantIds),
+      orgUnitIds: parseNormalizedStringList(rule.orgUnitIds),
+      tenantOrgUnitPairs: parseNormalizedStringList(rule.tenantOrgUnitPairs),
+    };
+  });
+
+  return {
+    allowlist: resolved,
+    configured: true,
+    invalid,
+  };
+};
+
+const parseBooleanEnv = (value: string | undefined): boolean => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === 'true'
+    || normalized === '1'
+    || normalized === 'on'
+    || normalized === 'enabled';
+};
+
+const parsePositiveInteger = (value: string | undefined): number | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    return null;
+  }
+  const parsed = Number.parseInt(normalized, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+};
+
+const parseBooleanHeaderValue = (value: unknown): boolean => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === 'true'
+    || normalized === '1'
+    || normalized === 'on'
+    || normalized === 'enabled';
+};
+
+
+import type { Knex } from 'knex';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PROVIDER_IDENTIFIER_MAPPINGS_TABLE = 'cs_provider_identifier_mappings';
+const WEBHOOK_RECEIPTS_TABLE = 'cs_webhook_receipts';
+const WEBHOOK_RECEIPT_RETENTION_DEFAULT_DAYS = 180;
+
+export type ConnectShyftProviderIdentifierKind = 'call_leg' | 'message';
+export type ConnectShyftWebhookReceiptProcessingStatus =
+  | 'RECEIVED'
+  | 'APPLIED'
+  | 'FAILED_RETRYABLE'
+  | 'FAILED_TERMINAL';
+export type ConnectShyftWebhookFailureClassification = {
+  category: string;
+  retryable: boolean;
+  httpStatus?: number | null;
+  providerCode?: string | null;
+};
+export type ConnectShyftProviderCorrelationRefusalReason =
+  | 'missing-identifiers'
+  | 'not-found'
+  | 'ambiguous'
+  | 'unavailable';
+export const CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS = WEBHOOK_RECEIPT_RETENTION_DEFAULT_DAYS;
+
+export type ConnectShyftProviderIdentifierMapping = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  identifierKind: ConnectShyftProviderIdentifierKind;
+  providerIdentifier: string;
+  internalReferenceId: string;
+  createdAtUtc: string;
+};
+
+export type ConnectShyftProviderCorrelationResolution = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  providerLegId: string | null;
+  providerMessageId: string | null;
+  internalCallReferenceId: string | null;
+  internalMessageReferenceId: string | null;
+};
+
+export type ConnectShyftProviderCorrelationLookupResult =
+  | {
+    ok: true;
+    source: 'provider_leg_id' | 'provider_message_id' | 'provider_consensus';
+    correlation: ConnectShyftProviderCorrelationResolution;
+  }
+  | {
+    ok: false;
+    reason: ConnectShyftProviderCorrelationRefusalReason;
+  };
+
+type ConnectShyftProviderIdentifierMappingRecord = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  identifierKind: ConnectShyftProviderIdentifierKind;
+  providerIdentifier: string;
+  internalReferenceId: string;
+  createdAtUtc: string;
+};
+
+type ConnectShyftProviderMappingRow = {
+  tenant_id?: unknown;
+  org_unit_id?: unknown;
+  thread_id?: unknown;
+  provider_name?: unknown;
+  identifier_kind?: unknown;
+  provider_identifier?: unknown;
+  internal_reference_id?: unknown;
+  created_at_utc?: unknown;
+};
+
+const inMemoryProviderIdentifierMappings =
+  new Map<string, ConnectShyftProviderIdentifierMappingRecord>();
+const inMemoryWebhookReceiptStates = new Map<string, {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  providerName: string;
+  sid: string;
+  eventType: string;
+  dedupeKey: string;
+  status: ConnectShyftWebhookReceiptProcessingStatus;
+  firstSeenAtUtc: string;
+  lastSeenAtUtc: string;
+  attemptCount: number;
+  correlationKeys: Record<string, unknown> | null;
+  failureReason: string | null;
+  nextRetryAtUtc: string | null;
+  lastFailureClassification: ConnectShyftWebhookFailureClassification | null;
+}>();
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim();
+};
+
+const normalizeProviderName = (value: unknown): string => {
+  return normalizeString(value).toLowerCase();
+};
+
+const normalizeIdentifierKind = (value: unknown): ConnectShyftProviderIdentifierKind | null => {
+  const normalized = normalizeString(value).toLowerCase();
+  if (normalized === 'call_leg') {
+    return 'call_leg';
+  }
+  if (normalized === 'message') {
+    return 'message';
+  }
+  return null;
+};
+
+const normalizeWebhookReceiptProcessingStatus = (
+  value: unknown,
+): ConnectShyftWebhookReceiptProcessingStatus => {
+  const normalized = normalizeString(value).toUpperCase();
+  if (normalized === 'APPLIED') {
+    return 'APPLIED';
+  }
+  if (normalized === 'FAILED_RETRYABLE') {
+    return 'FAILED_RETRYABLE';
+  }
+  if (normalized === 'FAILED_TERMINAL') {
+    return 'FAILED_TERMINAL';
+  }
+  return 'RECEIVED';
+};
+
+const normalizeWebhookReceiptSid = (input: {
+  providerEventId?: string | null;
+  providerLegId?: string | null;
+  providerMessageId?: string | null;
+}): string => {
+  return (
+    normalizeString(input.providerEventId || null)
+    || normalizeString(input.providerLegId || null)
+    || normalizeString(input.providerMessageId || null)
+  ).toLowerCase();
+};
+
+const normalizeWebhookReceiptEventType = (canonicalEventType: string): string => {
+  return normalizeString(canonicalEventType).toLowerCase();
+};
+
+const buildMappingKey = (
+  tenantId: string,
+  providerName: string,
+  identifierKind: ConnectShyftProviderIdentifierKind,
+  providerIdentifier: string,
+): string => {
+  return `${tenantId}|${providerName}|${identifierKind}|${providerIdentifier}`;
+};
+
+const buildMappingLookupKey = (
+  providerName: string,
+  identifierKind: ConnectShyftProviderIdentifierKind,
+  providerIdentifier: string,
+): string => {
+  return `${providerName}|${identifierKind}|${providerIdentifier}`;
+};
+
+const buildInMemoryWebhookReceiptStateKey = (
+  tenantId: string,
+  providerName: string,
+  sid: string,
+  eventType: string,
+): string => {
+  return `${tenantId}|${providerName}|${sid}|${eventType}`;
+};
+
+const parseAttemptCount = (value: unknown): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(1, Math.trunc(value));
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return Math.max(1, parsed);
+    }
+  }
+
+  return 1;
+};
+
+const shouldUseDb = (
+  input: {
+    tenantId: string;
+    threadId: string;
+  },
+  db?: Knex,
+): boolean => {
+  return Boolean(
+    db
+    && UUID_PATTERN.test(input.tenantId)
+    && UUID_PATTERN.test(input.threadId),
+  );
+};
+
+const shouldUseDbForWebhookReceipt = (
+  input: {
+    tenantId: string;
+    threadId: string;
+  },
+  db?: Knex,
+): boolean => {
+  return Boolean(
+    db
+    && input.tenantId.length > 0,
+  );
+};
+
+const mapDbRowToRecord = (
+  row: ConnectShyftProviderMappingRow | null,
+): ConnectShyftProviderIdentifierMappingRecord | null => {
+  if (!row) {
+    return null;
+  }
+
+  const identifierKind = normalizeIdentifierKind(row.identifier_kind);
+  if (!identifierKind) {
+    return null;
+  }
+
+  const providerName = normalizeProviderName(row.provider_name);
+  const providerIdentifier = normalizeString(row.provider_identifier);
+  const tenantId = normalizeString(row.tenant_id);
+  const orgUnitId = normalizeString(row.org_unit_id);
+  const threadId = normalizeString(row.thread_id);
+  const internalReferenceId = normalizeString(row.internal_reference_id);
+  const createdAtUtc = row.created_at_utc instanceof Date
+    ? row.created_at_utc.toISOString()
+    : normalizeString(row.created_at_utc);
+
+  if (
+    !providerName
+    || !providerIdentifier
+    || !tenantId
+    || !orgUnitId
+    || !threadId
+    || !internalReferenceId
+    || !createdAtUtc
+  ) {
+    return null;
+  }
+
+  return {
+    tenantId,
+    orgUnitId,
+    threadId,
+    providerName,
+    identifierKind,
+    providerIdentifier,
+    internalReferenceId,
+    createdAtUtc,
+  };
+};
+
+const findInMemoryMappings = (input: {
+  tenantId?: string | null;
+  providerName: string;
+  identifierKind: ConnectShyftProviderIdentifierKind;
+  providerIdentifier: string;
+}): ConnectShyftProviderIdentifierMappingRecord[] => {
+  const tenantId = normalizeString(input.tenantId || null);
+  const lookupKey = buildMappingLookupKey(
+    input.providerName,
+    input.identifierKind,
+    input.providerIdentifier,
+  );
+  const matches: ConnectShyftProviderIdentifierMappingRecord[] = [];
+  for (const record of inMemoryProviderIdentifierMappings.values()) {
+    if (
+      record.providerName === input.providerName
+      && record.identifierKind === input.identifierKind
+      && record.providerIdentifier === input.providerIdentifier
+      && (!tenantId || record.tenantId === tenantId)
+      && buildMappingLookupKey(
+        record.providerName,
+        record.identifierKind,
+        record.providerIdentifier,
+      ) === lookupKey
+    ) {
+      matches.push(record);
+    }
+  }
+  return matches;
+};
+
+const saveInMemoryMapping = (record: ConnectShyftProviderIdentifierMappingRecord): {
+  status: 'created' | 'duplicate';
+  mapping: ConnectShyftProviderIdentifierMapping;
+} => {
+  const key = buildMappingKey(
+    record.tenantId,
+    record.providerName,
+    record.identifierKind,
+    record.providerIdentifier,
+  );
+  const existing = inMemoryProviderIdentifierMappings.get(key);
+  if (existing) {
+    return {
+      status: 'duplicate',
+      mapping: { ...existing },
+    };
+  }
+
+  inMemoryProviderIdentifierMappings.set(key, record);
+  return {
+    status: 'created',
+    mapping: { ...record },
+  };
+};
+
+const saveDbMapping = async (input: {
+  db: Knex;
+  record: ConnectShyftProviderIdentifierMappingRecord;
+}): Promise<{
+  status: 'created' | 'duplicate';
+  mapping: ConnectShyftProviderIdentifierMapping;
+}> => {
+  const insertedRows = await input.db
+    .withSchema('connectshyft')
+    .table(PROVIDER_IDENTIFIER_MAPPINGS_TABLE)
+    .insert({
+      tenant_id: input.record.tenantId,
+      org_unit_id: input.record.orgUnitId,
+      thread_id: input.record.threadId,
+      provider_name: input.record.providerName,
+      identifier_kind: input.record.identifierKind,
+      provider_identifier: input.record.providerIdentifier,
+      internal_reference_id: input.record.internalReferenceId,
+      created_at_utc: input.record.createdAtUtc,
+    })
+    .onConflict(['tenant_id', 'provider_name', 'identifier_kind', 'provider_identifier'])
+    .ignore()
+    .returning([
+      'tenant_id',
+      'org_unit_id',
+      'thread_id',
+      'provider_name',
+      'identifier_kind',
+      'provider_identifier',
+      'internal_reference_id',
+      'created_at_utc',
+    ]);
+
+  const inserted = mapDbRowToRecord(insertedRows[0] as ConnectShyftProviderMappingRow | undefined || null);
+  if (inserted) {
+
+import { validatePhoneForChannel } from '../../../../../domains/communication';
+import {
+  connectShyftNumberMappingServiceAsync,
+  type AsyncConnectShyftNumberMappingService,
+  type ConnectShyftNumberMapping,
+} from './numberMappings';
+import {
+  connectShyftThreadServiceAsync,
+  type AsyncConnectShyftThreadService,
+  type ConnectShyftThread,
+} from './threads';
+
+export type ConnectShyftSenderChannel = 'sms' | 'voice';
+
+type SenderAlignmentSource = 'preferred_outbound' | 'last_inbound';
+
+type SenderAlignmentMetadata = {
+  threadId: string;
+  tenantId: string;
+  orgUnitId: string;
+  preferredOutboundCsNumberId: string | null;
+  lastInboundCsNumberId: string | null;
+  alignedFrom: SenderAlignmentSource | null;
+  candidateProviderNumberE164: string | null;
+};
+
+export type ResolveSenderNumberInput = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  channel: ConnectShyftSenderChannel;
+};
+
+export type ResolveSenderNumberSuccess = {
+  ok: true;
+  providerNumberE164: string;
+  mappingId: string;
+  routingMetadata: SenderAlignmentMetadata & {
+    deterministic: true;
+    channel: ConnectShyftSenderChannel;
+    source: 'thread_alignment';
+    mappingLabel: string | null;
+  };
+};
+
+export type ResolveSenderNumberRefusal = {
+  ok: false;
+  code:
+    | 'CONNECTSHYFT_THREAD_NOT_FOUND'
+    | 'CONNECTSHYFT_SENDER_ALIGNMENT_REQUIRED'
+    | 'CONNECTSHYFT_SENDER_ALIGNMENT_INVALID'
+    | 'CONNECTSHYFT_SENDER_MAPPING_REQUIRED'
+    | 'CONNECTSHYFT_SENDER_MAPPING_AMBIGUOUS'
+    | 'CONNECTSHYFT_SENDER_SCOPE_MISMATCH';
+  message: string;
+  reason:
+    | 'thread_not_found'
+    | 'sender_alignment_missing'
+    | 'sender_alignment_invalid'
+    | 'sender_mapping_missing'
+    | 'sender_mapping_ambiguous'
+    | 'sender_scope_mismatch';
+  routingMetadata: SenderAlignmentMetadata & {
+    deterministic: true;
+    channel: ConnectShyftSenderChannel;
+    source: 'thread_alignment';
+    candidateMappings?: Array<{
+      mappingId: string;
+      providerNumberE164: string;
+      label: string | null;
+      isActive: boolean;
+    }>;
+  };
+};
+
+export type ResolveSenderNumberResult =
+  | ResolveSenderNumberSuccess
+  | ResolveSenderNumberRefusal;
+
+type ResolveSenderNumberDependencies = {
+  loadThread?: (input: ResolveSenderNumberInput) => Promise<ConnectShyftThread | null>;
+  numberMappingService?: Pick<AsyncConnectShyftNumberMappingService, 'resolveRoutingMappingByNumber'>;
+};
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const buildAlignmentMetadata = (input: {
+  request: ResolveSenderNumberInput;
+  thread: ConnectShyftThread | null;
+  alignedFrom: SenderAlignmentSource | null;
+  candidateProviderNumberE164: string | null;
+}) => ({
+  threadId: input.request.threadId,
+  tenantId: input.request.tenantId,
+  orgUnitId: input.request.orgUnitId,
+  preferredOutboundCsNumberId: normalizeString(input.thread?.preferredOutboundCsNumberId) || null,
+  lastInboundCsNumberId: normalizeString(input.thread?.lastInboundCsNumberId) || null,
+  alignedFrom: input.alignedFrom,
+  candidateProviderNumberE164: input.candidateProviderNumberE164,
+});
+
+const resolveAlignedThreadNumber = (
+  thread: ConnectShyftThread,
+): { alignedFrom: SenderAlignmentSource | null; providerNumberE164: string | null; invalid: boolean } => {
+  const preferredOutbound = normalizeString(thread.preferredOutboundCsNumberId);
+  const lastInbound = normalizeString(thread.lastInboundCsNumberId);
+
+  if (preferredOutbound && lastInbound && preferredOutbound !== lastInbound) {
+    return {
+      alignedFrom: 'preferred_outbound',
+      providerNumberE164: preferredOutbound,
+      invalid: true,
+    };
+  }
+
+  if (preferredOutbound) {
+    return {
+      alignedFrom: 'preferred_outbound',
+      providerNumberE164: preferredOutbound,
+      invalid: false,
+    };
+  }
+
+  if (lastInbound) {
+    return {
+      alignedFrom: 'last_inbound',
+      providerNumberE164: lastInbound,
+      invalid: false,
+    };
+  }
+
+  return {
+    alignedFrom: null,
+    providerNumberE164: null,
+    invalid: false,
+  };
+};
+
+const buildRefusal = (
+  input: {
+    request: ResolveSenderNumberInput;
+    thread: ConnectShyftThread | null;
+    alignedFrom: SenderAlignmentSource | null;
+    candidateProviderNumberE164: string | null;
+    code: ResolveSenderNumberRefusal['code'];
+    message: string;
+    reason: ResolveSenderNumberRefusal['reason'];
+    candidateMappings?: ConnectShyftNumberMapping[];
+  },
+): ResolveSenderNumberRefusal => ({
+  ok: false,
+  code: input.code,
+  message: input.message,
+  reason: input.reason,
+  routingMetadata: {
+    deterministic: true,
+    channel: input.request.channel,
+    source: 'thread_alignment',
+    ...buildAlignmentMetadata({
+      request: input.request,
+      thread: input.thread,
+      alignedFrom: input.alignedFrom,
+      candidateProviderNumberE164: input.candidateProviderNumberE164,
+    }),
+    ...(input.candidateMappings && input.candidateMappings.length > 0
+      ? {
+        candidateMappings: input.candidateMappings.map((mapping) => ({
+          mappingId: mapping.mappingId,
+          providerNumberE164: mapping.twilioNumberE164,
+          label: normalizeString(mapping.label) || null,
+          isActive: mapping.isActive === true,
+        })),
+      }
+      : {}),
+  },
+});
+
+export const resolveSenderNumber = async (
+  input: ResolveSenderNumberInput,
+  dependencies: ResolveSenderNumberDependencies = {},
+): Promise<ResolveSenderNumberResult> => {
+  const loadThread = dependencies.loadThread
+    || (async (request: ResolveSenderNumberInput) => (
+      connectShyftThreadServiceAsync.findThreadById({
+        tenantId: request.tenantId,
+        threadId: request.threadId,
+      })
+    ));
+  const numberMappingService = dependencies.numberMappingService || connectShyftNumberMappingServiceAsync;
+  const thread = await loadThread(input);
+
+  if (!thread || thread.orgUnitId !== input.orgUnitId) {
+    return buildRefusal({
+      request: input,
+      thread,
+      alignedFrom: null,
+      candidateProviderNumberE164: null,
+      code: 'CONNECTSHYFT_THREAD_NOT_FOUND',
+      message: 'Thread sender resolution requires an existing tenant-scoped thread.',
+      reason: 'thread_not_found',
+    });
+  }
+
+  const aligned = resolveAlignedThreadNumber(thread);
+  if (!aligned.providerNumberE164) {
+    return buildRefusal({
+      request: input,
+      thread,
+      alignedFrom: aligned.alignedFrom,
+      candidateProviderNumberE164: null,
+      code: 'CONNECTSHYFT_SENDER_ALIGNMENT_REQUIRED',
+      message: 'Thread sender resolution requires a persisted provider-number alignment.',
+      reason: 'sender_alignment_missing',
+    });
+  }
+
+  if (
+    aligned.invalid
+    || !validatePhoneForChannel(aligned.providerNumberE164, input.channel).ok
+  ) {
+    return buildRefusal({
+      request: input,
+      thread,
+      alignedFrom: aligned.alignedFrom,
+      candidateProviderNumberE164: aligned.providerNumberE164,
+      code: 'CONNECTSHYFT_SENDER_ALIGNMENT_INVALID',
+      message: 'Thread sender alignment must contain one valid provider number.',
+      reason: 'sender_alignment_invalid',
+    });
+  }
+
+  const mapping = await numberMappingService.resolveRoutingMappingByNumber({
+    tenantId: input.tenantId,
+    twilioNumberE164: aligned.providerNumberE164,
+  });
+
+  if (mapping.status === 'not-found') {
+    return buildRefusal({
+      request: input,
+      thread,
+      alignedFrom: aligned.alignedFrom,
+      candidateProviderNumberE164: aligned.providerNumberE164,
+      code: 'CONNECTSHYFT_SENDER_MAPPING_REQUIRED',
+      message: 'Thread sender alignment does not map to an active provider number in this tenant.',
+      reason: 'sender_mapping_missing',
+    });
+  }
+
+  if (mapping.status === 'ambiguous') {
+    return buildRefusal({
+      request: input,
+      thread,
+      alignedFrom: aligned.alignedFrom,
+      candidateProviderNumberE164: aligned.providerNumberE164,
+      code: 'CONNECTSHYFT_SENDER_MAPPING_AMBIGUOUS',
+      message: 'Thread sender alignment is ambiguous across provider number mappings.',
+      reason: 'sender_mapping_ambiguous',
+      candidateMappings: mapping.mappings,
+    });
+  }
+
+  if (mapping.mapping.orgUnitId !== input.orgUnitId || mapping.mapping.tenantId !== input.tenantId) {
+    return buildRefusal({
+      request: input,
+      thread,
+      alignedFrom: aligned.alignedFrom,
+      candidateProviderNumberE164: aligned.providerNumberE164,
+      code: 'CONNECTSHYFT_SENDER_SCOPE_MISMATCH',
+      message: 'Thread sender alignment resolves outside the requested tenant or orgUnit scope.',
+      reason: 'sender_scope_mismatch',
+      candidateMappings: [mapping.mapping],
+    });
+  }
+
+  return {
+    ok: true,
+    providerNumberE164: mapping.mapping.twilioNumberE164,
+    mappingId: mapping.mapping.mappingId,
+    routingMetadata: {
+      deterministic: true,
+      channel: input.channel,
+      source: 'thread_alignment',
+      mappingLabel: normalizeString(mapping.mapping.label) || null,
+      ...buildAlignmentMetadata({
+        request: input,
+        thread,
+        alignedFrom: aligned.alignedFrom,
+        candidateProviderNumberE164: mapping.mapping.twilioNumberE164,
+      }),
+    },
+  };
+};
+
+export const loadThreadForSenderNumberResolution = async (
+  threadService: Pick<AsyncConnectShyftThreadService, 'findThreadById'>,
+  input: ResolveSenderNumberInput,
+): Promise<ConnectShyftThread | null> => {
+  return threadService.findThreadById({
+    tenantId: input.tenantId,
+    threadId: input.threadId,
+  });
+};
+
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+import { CAPABILITIES, hasCapability } from '../../platform/rbac/capabilities';
+import db from '../../config/knex';
+
+const TWILIO_E164_PATTERN = /^\+[1-9]\d{1,14}$/;
+
+export type ConnectShyftNumberMapping = {
+  mappingId: string;
+  tenantId: string;
+  orgUnitId: string;
+  twilioNumberE164: string;
+  label: string;
+  isActive: boolean;
+  createdAtUtc: string;
+  updatedAtUtc: string;
+};
+
+type NumberMappingCreateInput = {
+  tenantId: string;
+  orgUnitId: string;
+  twilioNumberE164: string;
+  label: string;
+  isActive: boolean;
+  mappingId?: string;
+};
+
+type NumberMappingUpdateInput = {
+  tenantId: string;
+  orgUnitId: string;
+  mappingId: string;
+  twilioNumberE164: string;
+  label: string;
+  isActive: boolean;
+};
+
+type NumberMappingActorContext = {
+  actorRoles: Array<string | null | undefined>;
+};
+
+export type NumberMappingCreateCommand = NumberMappingCreateInput & NumberMappingActorContext;
+export type NumberMappingUpdateCommand = NumberMappingUpdateInput & NumberMappingActorContext;
+
+type NumberMappingPersistenceResult =
+  | {
+    ok: true;
+    mapping: ConnectShyftNumberMapping;
+  }
+  | {
+    ok: false;
+    reason: 'DUPLICATE_TENANT_NUMBER' | 'MAPPING_ID_CONFLICT' | 'NOT_FOUND';
+  };
+
+export type NumberMappingFieldError = {
+  field: 'twilioNumberE164';
+  reason: 'INVALID_E164' | 'DUPLICATE_TENANT_NUMBER';
+  message: string;
+};
+
+type NumberMappingRefusalResult = {
+  ok: false;
+  code:
+    | 'CONNECTSHYFT_NUMBER_MAPPING_FORBIDDEN'
+    | 'CONNECTSHYFT_NUMBER_MAPPING_INVALID_E164'
+    | 'CONNECTSHYFT_NUMBER_MAPPING_DUPLICATE'
+    | 'CONNECTSHYFT_NUMBER_MAPPING_ID_CONFLICT'
+    | 'CONNECTSHYFT_NUMBER_MAPPING_NOT_FOUND'
+    | 'CONNECTSHYFT_NUMBER_MAPPING_SCOPE_VIOLATION';
+  message: string;
+  data?: {
+    fieldErrors?: NumberMappingFieldError[];
+  };
+};
+
+export type NumberMappingSaveResult =
+  | {
+    ok: true;
+    code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED' | 'CONNECTSHYFT_NUMBER_MAPPING_UPDATED';
+    httpStatus: 200 | 201;
+    data: {
+      mappingId: string;
+      orgUnitId: string;
+      twilioNumberE164: string;
+      label: string;
+      isActive: boolean;
+      mappings: ConnectShyftNumberMapping[];
+    };
+  }
+  | NumberMappingRefusalResult;
+
+export type NumberMappingRoutingResolution =
+  | {
+    status: 'found';
+    mapping: ConnectShyftNumberMapping;
+  }
+  | {
+    status: 'not-found';
+  }
+  | {
+    status: 'ambiguous';
+    mappings: ConnectShyftNumberMapping[];
+  };
+
+const normalizeTwilioNumber = (value: string): string => value.trim();
+
+const normalizeLabel = (value: string): string => value.trim();
+
+const buildTenantNumberKey = (tenantId: string, twilioNumberE164: string): string =>
+  `${tenantId}::${twilioNumberE164}`;
+
+const buildTenantOrgUnitKey = (tenantId: string, orgUnitId: string): string =>
+  `${tenantId}::${orgUnitId}`;
+
+const nowIsoUtc = (): string => new Date().toISOString();
+
+export const isValidTwilioE164 = (value: string): boolean =>
+  TWILIO_E164_PATTERN.test(normalizeTwilioNumber(value));
+
+const buildInvalidE164Refusal = (): NumberMappingRefusalResult => ({
+  ok: false,
+  code: 'CONNECTSHYFT_NUMBER_MAPPING_INVALID_E164',
+  message: 'Use a valid Twilio E.164 number (for example, +12605550111).',
+  data: {
+    fieldErrors: [
+      {
+        field: 'twilioNumberE164',
+        reason: 'INVALID_E164',
+        message: 'Use a valid Twilio E.164 number (for example, +12605550111).',
+      },
+    ],
+  },
+});
+
+const buildDuplicateRefusal = (): NumberMappingRefusalResult => ({
+  ok: false,
+  code: 'CONNECTSHYFT_NUMBER_MAPPING_DUPLICATE',
+  message: 'This Twilio number is already mapped in this tenant.',
+  data: {
+    fieldErrors: [
+      {
+        field: 'twilioNumberE164',
+        reason: 'DUPLICATE_TENANT_NUMBER',
+        message: 'This Twilio number is already mapped in this tenant.',
+      },
+    ],
+  },
+});
+
+const buildMappingIdConflictRefusal = (): NumberMappingRefusalResult => ({
+  ok: false,
+  code: 'CONNECTSHYFT_NUMBER_MAPPING_ID_CONFLICT',
+  message: 'Unable to save number mapping right now. Please retry.',
+});
+
+const buildNotFoundRefusal = (): NumberMappingRefusalResult => ({
+  ok: false,
+  code: 'CONNECTSHYFT_NUMBER_MAPPING_NOT_FOUND',
+  message: 'Number mapping not found for this tenant and orgUnit.',
+});
+
+const buildCapabilityRefusal = (): NumberMappingRefusalResult => ({
+  ok: false,
+  code: 'CONNECTSHYFT_NUMBER_MAPPING_FORBIDDEN',
+  message: 'Number mapping management requires an authorized ConnectShyft role.',
+});
+
+type DbNumberMappingRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  twilio_number_e164: string;
+  label: string;
+  is_active: boolean;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+const isMissingPersistenceError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const record = error as { code?: string };
+  return record.code === '42P01' || record.code === '3F000';
+};
+
+const mapDbRowToMapping = (row: DbNumberMappingRow): ConnectShyftNumberMapping => ({
+  mappingId: row.id,
+  tenantId: row.tenant_id,
+  orgUnitId: row.org_unit_id,
+  twilioNumberE164: row.twilio_number_e164,
+  label: row.label,
+  isActive: row.is_active,
+  createdAtUtc: row.created_at_utc instanceof Date ? row.created_at_utc.toISOString() : String(row.created_at_utc),
+  updatedAtUtc: row.updated_at_utc instanceof Date ? row.updated_at_utc.toISOString() : String(row.updated_at_utc),
+});
+
+export class InMemoryConnectShyftNumberMappingStore {
+  private mappingsById = new Map<string, ConnectShyftNumberMapping>();
+
+  private mappingIdsByTenantOrgUnit = new Map<string, Set<string>>();
+
+  private mappingIdByTenantNumber = new Map<string, string>();
+
+  listByOrgUnit(tenantId: string, orgUnitId: string): ConnectShyftNumberMapping[] {
+    const tenantOrgUnitKey = buildTenantOrgUnitKey(tenantId, orgUnitId);
+    const mappingIds = this.mappingIdsByTenantOrgUnit.get(tenantOrgUnitKey);
+    if (!mappingIds || mappingIds.size === 0) {
+      return [];
+    }
+
+    return Array.from(mappingIds)
+      .map((mappingId) => this.mappingsById.get(mappingId))
+      .filter((mapping): mapping is ConnectShyftNumberMapping => !!mapping)
+      .sort((a, b) => {
+        if (a.twilioNumberE164 < b.twilioNumberE164) {
+          return -1;
+        }
+        if (a.twilioNumberE164 > b.twilioNumberE164) {
+          return 1;
+        }
+        return a.mappingId.localeCompare(b.mappingId);
+      });
+  }
+
+  findById(tenantId: string, mappingId: string): ConnectShyftNumberMapping | null {
+    const mapping = this.mappingsById.get(mappingId);
+    if (!mapping || mapping.tenantId !== tenantId) {
+      return null;
+    }
+    return mapping;
+  }
+
+  findByTenantNumber(tenantId: string, twilioNumberE164: string): ConnectShyftNumberMapping | null {
+    const mappingId = this.mappingIdByTenantNumber.get(
+      buildTenantNumberKey(tenantId, twilioNumberE164),
+    );
+    if (!mappingId) {
+      return null;
+    }
+
+    const mapping = this.mappingsById.get(mappingId);
+    return mapping || null;
+  }
+
+  listActiveByNumber(twilioNumberE164: string): ConnectShyftNumberMapping[] {
+    return Array.from(this.mappingsById.values())
+      .filter((mapping) => mapping.twilioNumberE164 === twilioNumberE164 && mapping.isActive)
+      .sort((left, right) => {
+        if (left.tenantId !== right.tenantId) {
+          return left.tenantId.localeCompare(right.tenantId);
+        }
+        if (left.orgUnitId !== right.orgUnitId) {
+          return left.orgUnitId.localeCompare(right.orgUnitId);
+        }
+        return left.mappingId.localeCompare(right.mappingId);
+      });
+  }
+
+  createMapping(input: NumberMappingCreateInput): NumberMappingPersistenceResult {
+    const mappingId = input.mappingId || randomUUID();
+    const now = nowIsoUtc();
+    const tenantNumberKey = buildTenantNumberKey(input.tenantId, input.twilioNumberE164);
+
+    if (this.mappingsById.has(mappingId)) {
+      return {
+        ok: false,
+        reason: 'MAPPING_ID_CONFLICT',
+      };
+    }
+
+    if (this.mappingIdByTenantNumber.has(tenantNumberKey)) {
+      return {
+        ok: false,
+        reason: 'DUPLICATE_TENANT_NUMBER',
+      };
+    }
+
+    const mapping: ConnectShyftNumberMapping = {
+      mappingId,
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      twilioNumberE164: input.twilioNumberE164,
+      label: input.label,
+      isActive: input.isActive,
+      createdAtUtc: now,
+      updatedAtUtc: now,
+    };
+
+    this.mappingsById.set(mappingId, mapping);
+    this.mappingIdByTenantNumber.set(tenantNumberKey, mappingId);
+
+    const tenantOrgUnitKey = buildTenantOrgUnitKey(input.tenantId, input.orgUnitId);
+    const orgUnitMappings = this.mappingIdsByTenantOrgUnit.get(tenantOrgUnitKey) || new Set<string>();
+    orgUnitMappings.add(mappingId);
+    this.mappingIdsByTenantOrgUnit.set(tenantOrgUnitKey, orgUnitMappings);
+
+    return {
+      ok: true,
+      mapping,
+    };
+  }
+
+  updateMapping(input: NumberMappingUpdateInput): NumberMappingPersistenceResult {
+    const existing = this.findById(input.tenantId, input.mappingId);
+    if (!existing) {
+      return {
+        ok: false,
+        reason: 'NOT_FOUND',
+      };
+    }
+
+    const existingTenantNumberKey = buildTenantNumberKey(
+      existing.tenantId,
+      existing.twilioNumberE164,
+    );
+    const nextTenantNumberKey = buildTenantNumberKey(input.tenantId, input.twilioNumberE164);
+
+    if (existingTenantNumberKey !== nextTenantNumberKey && this.mappingIdByTenantNumber.has(nextTenantNumberKey)) {
+      return {
+
+=== TELEPHONY NOTES / ARCHITECTURE DOCS ===
+# ConnectShyft Router Refactor Plan
+
+## Status
+
+- Slices 4 through 11 complete.
+- ConnectShyft route-family extraction sequence complete.
+- Frontend build/test surface separation completed in Slice 11.
+- Slice 12 PeopleCore persistence foundation and identity seam complete.
+- Slice 13 PeopleCore ambiguity precedence documentation and handler-preservation rules complete.
+- Slice 14 operational ambiguity visibility and review-status documentation complete.
+
+## Purpose
+
+This document records the completed extraction of `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` into a thin route-registration shell with module-owned handlers and helper boundaries.
+
+It also captures the post-Slice 13 stop point so future work does not treat the extraction sequence as still in progress.
+
+## Non-negotiable rules
+
+1. Preserve exact current response shapes unless a later explicit slice redesigns them.
+2. Preserve current behavioral semantics unless a later explicit decision changes them.
+3. Keep route-family orchestration in handlers, not in `connectshyft.ts`.
+4. Keep HTTP prerequisite parsing and refusal mapping in helper boundaries, not in the router or deep domain modules.
+5. Keep provider, bridge, canonical-event, and correlation internals in their existing domain/infrastructure modules unless a later intentional slice changes ownership.
+6. Treat Slice 11 as stabilization and architecture lock, not behavior redesign.
+7. Treat Slice 12 seam work as identity foundation behind the extracted handlers, not as a reason to re-thicken `connectshyft.ts`.
+8. Treat Slice 13 as authority refinement behind the seam, not as reconciliation or router redesign.
+
+## Completed sequence
+
+The broader slice program through Slice 11 is complete. The list below captures the router-focused milestones that materially changed ConnectShyft route ownership and the frontend build boundary.
+
+### Slice 4
+
+Extracted the first thin-router family:
+
+- settings/navigation
+- availability
+- context
+- inbox
+
+Added:
+
+- handler files for that route family
+- `http/accessContext.ts`
+- focused helper tests
+- handler ownership notes
+
+### Slice 5
+
+Extracted the thread read surface:
+
+- thread detail
+- thread timeline
+
+Added:
+
+- thread read handlers
+- `http/threadReadContext.ts`
+- thread read helper tests
+- thread read notes
+
+Preserved:
+
+- current thread detail shape
+- current timeline DTO shape
+- current single canonical thread-detail payload direction for UI
+
+### Slice 6
+
+Extracted lifecycle actions:
+
+- claim
+- takeover
+- close
+
+Added:
+
+- lifecycle handlers
+- `http/threadLifecycleContext.ts`
+- lifecycle helper tests
+- lifecycle notes
+
+Preserved:
+
+- exact current lifecycle response shapes
+- current claim behavior where claimed threads move into My Conversations while remaining visible in Inbox and recognizable as claimed
+- current takeover and close behavior exactly
+
+### Slice 7
+
+Extracted the neighbor and identity bridge surface:
+
+- neighbor create
+- neighbor list
+- neighbor detail
+- neighbor update
+- neighbor soft delete
+- identity match
+- merge
+
+Added:
+
+- neighbor/identity handlers
+- `http/neighborIdentityContext.ts`
+- neighbor/identity helper tests
+- neighbor identity bridge notes
+
+Preserved:
+
+- exact current response shapes
+- exact current merge behavior
+- ConnectShyft-local merge semantics until future PeopleCore seam work is clearer
+
+Light seam prep only:
+
+- cleaner extraction boundary for future PeopleCore convergence
+- no convergence rewrite yet
+
+### Slice 8
+
+Extracted the outbound action surface:
+
+- `POST /threads/:threadId/call`
+- `POST /threads/:threadId/messages`
+
+Added:
+
+- outbound handlers
+- `http/threadOutboundContext.ts`
+- outbound characterization tests
+- outbound helper-boundary tests
+
+Preserved:
+
+- exact current outbound response shapes
+- exact current reopen behavior
+
+Guardrails preserved:
+
+- helper boundary stays limited to route-family context enforcement, thread id parsing, shared prerequisite loading, and shared outbound execution delegation
+- provider adapter, bridge session, reliability, audit, SMS override, and inbound/webhook internals remain outside the helper boundary
+
+### Slice 9
+
+Extracted inbound webhook route-family seams:
+
+- `POST /webhooks/inbound`
+- `POST /webhooks/sms`
+- route-entry prerequisite handling for provider selection, signature verification, canonical translation, correlation resolution, and execution delegation
+
+Added:
+
+- inbound webhook handlers
+- `http/inboundWebhookContext.ts`
+- inbound webhook characterization locks
+- inbound webhook helper-boundary tests
+
+Preserved:
+
+- exact current inbound webhook response shapes
+- exact current inbound SMS, inbound voice, voicemail, and transcription callback behavior
+
+Deferred intentionally:
+
+- provider / correlation / canonical / bridge internals remain intentionally deferred from the route-family extraction sequence
+- the operational inbound webhook core remains in `connectshyft.ts` pending the next consolidation step
+
+### Slice 11
+
+Closed the remaining router-owned route families and frontend build boundary:
+
+- `GET /numbers`
+- `POST /numbers`
+- `PUT /numbers/:mappingId`
+- `GET /admin/webhook-receipts/metrics`
+- `POST /admin/webhook-receipts/cleanup`
+- `GET /escalation/recipients`
+- `GET /escalation/config`
+- `PUT /escalation/config`
+
+Added:
+
+- number-mapping, escalation-config, and webhook-receipt-admin helper boundaries
+- named handlers for the remaining route families
+- characterization locks and helper-boundary tests for the final extracted families
+- frontend build/test surface separation via production `tsconfig.json`, `tsconfig.vitest.json`, and Vitest dependency wiring
+
+Preserved:
+
+- exact current response shapes and refusal envelopes
+- current webhook metrics and cleanup behavior
+- current provider, bridge, canonical-event, and correlation ownership
+
+Completed:
+
+- thin-router delegation for all in-scope ConnectShyft route families
+- production frontend build independence from test-only TypeScript surface
+
+### Slice 12
+
+Introduced the PeopleCore identity foundation beneath the already-extracted ConnectShyft route family:
+
+- PeopleCore persistence-backed identity tables and contracts
+- app-facing PeopleCore stores and services
+- ConnectShyft-to-PeopleCore identity seam adapter
+- best-effort provisional identity and resolver-review hooks behind the seam
+- architecture documentation locking current ownership and deferred work
+
+Preserved:
+
+- exact current ConnectShyft route envelopes
+- current identity-match semantics
+- current inbound subject-resolution semantics
+- current router/handler/helper ownership boundaries
+
+Completed:
+
+- identity convergence foundation without undoing the thin-router extraction
+- a future-safe seam for later identity authority migration
+
+### Slice 13
+
+Documented and locked the PeopleCore ambiguity-precedence rule behind the extracted handlers:
+
+- PeopleCore is consulted first for identity read authority
+- PeopleCore can invalidate certainty, but cannot assert person-to-neighbor equivalence
+- no current PeopleCore link or unavailable PeopleCore -> preserve legacy behavior
+- multiple current PeopleCore links -> ambiguous
+- single PeopleCore link plus legacy disagreement -> ambiguous
+- single aligned winner -> preserve current exact-match behavior
+- inbound SMS create-new remains blocked under ambiguity and unchanged for true `no_match`
+
+Preserved:
+
+- exact current route envelopes
+- current thin-router and handler ownership boundaries
+- current provider, bridge, canonical-event, and correlation ownership
+
+Did not add:
+
+- reconciliation
+- crosswalk infrastructure
+- auto-linking
+- merge engine behavior
+- scoring engine behavior
+
+### Slice 14
+
+Locked the narrow operational ambiguity layer without broadening router or identity scope:
+
+- `GET /api/v1/connectshyft/identity-ambiguities` for ops visibility
+- `PATCH /api/v1/connectshyft/identity-ambiguities/:ambiguityEventId` for reviewed-status updates
+- ambiguity persistence remains observational only
+- reviewed status remains operational only
+
+Did not add:
+
+- reconciliation
+- crosswalk infrastructure
+
+# Identity Resolution Model
+
+## Status
+
+Authoritative for the Slice 14 identity-resolution architecture and seam behavior.
+
+---
+
+## 1. Approach
+
+Identity resolution is:
+
+- deterministic
+- explainable
+- tunable
+- non-ML (v1)
+
+Current Slice 12 behavior also requires:
+
+- preserving existing ConnectShyft route and module outcomes
+- introducing a seam before replacing ConnectShyft-local ownership
+- allowing work to continue when identity is unresolved
+
+Slice 13 adds the governing precedence rule:
+
+- PeopleCore can block certainty
+- PeopleCore cannot assert person-to-neighbor identity equivalence in this slice
+- disagreement becomes explicit ambiguity
+
+---
+
+## 2. Signals
+
+### Strong signals
+
+- exact phone match
+- exact email match
+- SSN (if present)
+- resolver-confirmed link
+
+### Moderate signals
+
+- name (first + last)
+- DOB
+- address
+- household membership
+
+### Supporting signals
+
+- recent activity
+- manual confirmation
+
+---
+
+## 3. Penalties
+
+- shared contact (possible or confirmed)
+- stale contact
+- reassignment suspected
+- conflicting name or DOB
+
+---
+
+## 4. Confidence Bands
+
+- very_low
+- low
+- medium
+- high
+- very_high
+
+---
+
+## 5. Current ConnectShyft Seam Outcomes
+
+The Slice 13 seam preserves these ConnectShyft outcomes for exact contact-point resolution:
+
+- verified non-shared exact match -> auto-merge allowed only when the legacy winner stays aligned with the PeopleCore-backed read path
+- no exact match -> no match when PeopleCore is unavailable, has no current person link, or has one current person link and legacy resolution still has no winner
+- multiple exact matches -> ambiguous with manual-resolution context
+- PeopleCore multi-person current-link result -> ambiguous with manual-resolution context
+- cross-system disagreement between a single current PeopleCore person and a different legacy concrete winner -> ambiguous with manual-resolution context
+- shared or unverified conditions -> no-auto-merge
+- deleted-only lookup exclusion where characterized
+
+The seam does not redesign these outputs. It routes identity consultation through PeopleCore-backed lookup and hook foundations while keeping the current ConnectShyft outward behavior stable.
+
+### 5.1 Ambiguity categories
+
+Slice 13 documents three distinct ambiguity categories:
+
+- legacy multi-neighbor ambiguity
+- PeopleCore multi-person ambiguity
+- cross-system disagreement ambiguity
+
+### 5.2 Decision flow
+
+```text
+PeopleCore available?
+  NO -> preserve legacy behavior
+  YES -> current person links?
+    0 -> preserve legacy behavior
+    >1 -> ambiguous
+    1 -> legacy outcome?
+      multiple -> ambiguous
+      single aligned -> preserve current exact-match behavior
+      single disagreement -> ambiguous
+      none -> no-match (unchanged in Slice 13)
+```
+
+### 5.3 Slice 14 operational ambiguity layer
+
+Slice 14 adds a narrow operational layer on top of ambiguous outcomes:
+
+- ambiguity events are persisted for ops visibility only
+- ambiguity-event persistence is observational only and does not alter the returned identity decision
+- reviewed status is operational only and does not change PeopleCore or ConnectShyft identity records
+- no reconciliation or automatic winner selection exists in this slice
+
+---
+
+## 6. Confidence Reasons
+
+System MUST expose:
+
+- why a match is suggested
+- which signals contributed
+- which penalties applied
+
+No opaque scoring allowed.
+
+---
+
+## 7. Friction Model
+
+### very_low
+
+- create new freely
+
+### low
+
+- light warning
+
+### medium
+
+- show candidates prominently
+- explicit choice required
+
+### high
+
+- strong warning
+- existing match is primary
+- create-new is intentionally difficult
+
+### very_high
+
+- resolver override required
+- normal users cannot create new
+
+---
+
+## 8. Resolver Workflow
+
+Resolvers handle:
+
+- merge decisions
+- duplicate resolution
+- reassignment
+- shared contact confirmation
+- conflict resolution
+
+---
+
+## 9. Resolver Review Object
+
+Must include:
+
+- review_type
+- status
+- confidence_band
+- confidence_reasons
+- risk_flags
+- candidate_people
+- context (conversation/work)
+- resolution_type
+- resolution_reason
+- impact_summary
+
+Slice 12 now persists `ResolverReview` records in PeopleCore and can create them through non-breaking seam hooks on ambiguous ConnectShyft paths.
+
+---
+
+## 10. Provisional Identity
+
+- created under uncertainty
+- fully usable
+- subject to later resolution
+
+Slice 12 now includes best-effort provisional-person creation hooks behind the seam for safe inbound `no_match` flows. These hooks do not replace ConnectShyft neighbor creation at the API boundary and do not auto-link a PeopleCore person to a ConnectShyft neighbor.
+
+---
+
+## 11. Create-New Requirements
+
+Required:
+
+- first name
+- last name
+- contact point
+- DOB capture status
+
+Plus at least one:
+
+- DOB
+- email
+- address
+- household
+
+---
+
+## 12. Operational Conditions
+
+ContactPoint states influence confidence:
+
+- shared_possible
+- shared_confirmed
+- stale
+- reassignment_suspected
+
+---
+
+## 13. Deferred Work
+
+Still deferred beyond Slice 13:
+
+- broad PeopleCore-driven candidate scoring inside ConnectShyft flows
+- resolver UI
+- full rebinding mechanics
+- replacement of ConnectShyft neighbor APIs with PeopleCore person APIs
+- Application Shell work
+- reconciliation or crosswalk infrastructure between PeopleCore persons and ConnectShyft neighbors
+- automated merge or scoring engines for cross-system identity decisions
+
+---
+
+## 14. Non-Goals
+
+- full automation
+- silent identity decisions
+- blocking work until resolved
+- reconciliation
+- crosswalk
+- automatic PeopleCore-to-neighbor linking
+- merge engine
+- scoring engine
+
+---
+
+## 15. Next Slice
+
+
+# ConnectShyft Inbound Webhook Notes
+
+## Current ownership
+
+The ConnectShyft inbound webhook surface is currently split across these files:
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+  - owns only route registration for:
+    - `POST /webhooks/inbound`
+    - `POST /webhooks/sms`
+  - owns the currently registered inbound webhook core execution path that preserves the existing inbound SMS, inbound voice, voicemail, transcription callback, and auto-claim behavior
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookInbound.ts`
+  - owns inbound-webhook route handoff and delegates execution through the shared helper boundary with deterministic `inbound` route preparation
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectWebhookSms.ts`
+  - owns SMS-webhook route handoff and delegates execution through the shared helper boundary with deterministic `sms` route preparation
+- `apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts`
+  - owns shared inbound route-entry prerequisite handling
+  - owns capability enforcement for webhook access
+  - owns provider selection and signature verification at the route-entry seam
+  - owns canonical event translation needed to prepare the existing core
+  - owns webhook correlation resolution and rollout-context validation
+  - owns prerequisite refusal mapping and the shared execution wrapper that hands the request to the existing inbound core
+
+## What remains outside the handler boundary
+
+Slice 9 intentionally did not move inbound telephony or provider internals out of their existing homes.
+
+That means the following concerns remain outside the thin handlers and outside `inboundWebhookContext.ts`:
+
+- provider internals
+  - still owned by the existing inbound core in `connectshyft.ts` and provider-facing modules such as `providerRegistry.ts`
+- correlation persistence and webhook-receipt orchestration internals
+  - still owned by the existing inbound core in `connectshyft.ts` and `providerCorrelationMappings.ts`
+- canonical event persistence and canonical payload assembly
+  - still owned by the existing inbound core in `connectshyft.ts` and `canonicalEvents.ts`
+- bridge-session webhook progression and bridge alignment behavior
+  - still owned by the existing inbound core in `connectshyft.ts` and `bridgeSessions.ts`
+- inbound SMS domain mapping and neighbor-resolution behavior
+  - still owned by the existing inbound core in `connectshyft.ts` and `inboundSms.ts`
+- inbound voice, voicemail artifact, and transcription internals
+  - still owned by the existing inbound core in `connectshyft.ts` and `inboundVoice.ts`
+
+Provider, correlation, canonical, bridge, and transcription internals remain intentionally deferred from the route-family extraction sequence.
+
+## Response shape preservation rule
+
+Slice 9 intentionally preserves the exact current inbound webhook response shapes.
+
+That means:
+
+- `POST /webhooks/inbound` still returns the existing success and refusal envelopes
+- `POST /webhooks/sms` still returns the existing success and refusal envelopes
+- existing nested provider, correlation, canonical, bridge, voicemail, transcription, auto-claim, and side-effect payload structure remains unchanged
+
+This was deliberate. The goal of this slice was thin-router extraction, helper-boundary coverage, and ownership notes, not payload cleanup or response redesign.
+
+## Behavior lock
+
+Slice 9 also intentionally locks the current operational inbound behavior.
+
+That includes:
+
+- current inbound SMS handling and neighbor-resolution semantics
+- current inbound voice behavior
+- current voice auto-claim behavior
+- current voicemail behavior
+- current transcription callback behavior
+
+Follow-up cleanup should treat these behaviors as locked unless characterization coverage and helper-boundary expectations are intentionally updated in a later slice.
+
+## Telephony and provider redesign note
+
+This slice did not redesign telephony behavior or provider behavior.
+
+It did not:
+
+- re-architect webhook routing semantics
+- redesign provider verification or translation behavior
+- redesign correlation or dedupe behavior
+- redesign bridge handling
+- redesign voicemail or transcription processing
+
+## Next step
+
+Architecture consolidation for PeopleCore / Identity Resolution / ConnectShyft model lock-in is next.
+
+That work should build on the current thin handlers and `inboundWebhookContext.ts` boundary rather than pulling deferred provider, correlation, canonical, bridge, or transcription internals into the route-family extraction seam.
+
+# ConnectShyft Thread Lifecycle Notes
+
+## Current ownership
+
+The ConnectShyft lifecycle action surface is currently split across these files:
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+  - owns only route registration for:
+    - `POST /threads/:threadId/claim`
+    - `POST /threads/:threadId/takeover`
+    - `POST /threads/:threadId/close`
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClaim.ts`
+  - owns request handoff for claim and delegates lifecycle execution through the shared helper boundary
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadTakeover.ts`
+  - owns request handoff for takeover and delegates lifecycle execution through the shared helper boundary
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postConnectThreadClose.ts`
+  - owns request handoff for close and delegates lifecycle execution through the shared helper boundary
+- `apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts`
+  - owns lifecycle prerequisite resolution, capability and membership gating, `threadId` parsing, lifecycle-context loading, refusal mapping, side-effect orchestration, and preserved response assembly for claim/takeover/close
+
+## Response shape preservation rule
+
+Slice 6 intentionally preserves the exact current lifecycle response shapes.
+
+That means claim, takeover, and close still return the existing envelope structure, including:
+
+- `threadId`
+- `context`
+- `reason`
+- `resolution`
+- `thread`
+- `lifecycleEvent`
+- `sideEffectsPersisted`
+- `escalation`
+- `audit`
+- `outbox`
+
+This was deliberate. The goal of this slice was thin-router extraction and a cleaner lifecycle boundary, not payload redesign.
+
+## Claim visibility rule
+
+Claim semantics remain unchanged in this slice:
+
+- a claimed thread moves into My Conversations
+- the same thread may still appear in Inbox
+- the thread should remain visibly recognized as claimed wherever it is rendered
+
+This behavior is preserved by characterization coverage and should not be tightened casually in follow-up cleanup.
+
+## Deferred scope
+
+The following work remains deferred beyond the lifecycle family:
+
+- outbound call extraction
+- outbound message extraction
+- inbound SMS extraction
+- inbound voice extraction
+- webhook and provider-correlation extraction
+- PeopleCore neighbor or identity bridge convergence work
+- lifecycle semantic redesign or response reshaping
+
+## Guardrails for future work
+
+When editing lifecycle handlers in later slices:
+
+1. Keep route registration thin in `connectshyft.ts`.
+2. Keep shared lifecycle prerequisite and refusal behavior in `threadLifecycleContext.ts`.
+3. Preserve the current response shapes unless characterization coverage is intentionally updated.
+4. Do not fold outbound dispatch logic into the lifecycle handlers.
+5. Do not pull webhook or inbound orchestration into the lifecycle helper boundary.
+6. Treat claim visibility semantics as locked until a later slice explicitly changes them.
+
+## Explicit separation note
+
+Lifecycle extraction is now separate from outbound and webhook extraction.
+
+That separation should remain explicit. Follow-up cleanup should not use the lifecycle helper boundary as a place to absorb outbound reopen rules, provider dispatch concerns, inbound correlation work, or webhook processing. The next extraction target after Slice 6 is neighbors / identity bridge, while outbound and webhook surfaces remain intentionally deferred.
+
+=== TELEPHONY TEST SURFACE ===
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.webhookReceiptAdminContext.test.ts:3:import { CONNECTSHYFT_WEBHOOK_RECEIPT_RETENTION_POLICY_DAYS } from '../providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:3:import * as SenderNumberResolverModule from '../../../../modules/connectshyft/senderNumberResolver';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:8:import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts:13:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:3:import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared.ts:54:  'x-correlation-id': 'corr-connectshyft-f1-provider-registry',
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:14:} from '../inboundVoice';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:40:      inboundVoiceArtifact: {
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:52:    expect(domainEvent.inboundVoiceArtifact.to).toBe('+12605550171');
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts:53:    expect(domainEvent.inboundVoiceArtifact.to).not.toContain('cs-number');
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:6:import * as providerCorrelationMappingsModule from '../../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:7:import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:12:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts:434:      providerCorrelationMappingsModule,
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.number-mappings.characterization.test.ts:4:import { connectShyftNumberMappingServiceAsync } from '../../../../modules/connectshyft/numberMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:7:import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../../../../modules/connectshyft/inboundSms';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:8:import { CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME } from '../../../../modules/connectshyft/inboundVoice';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-timeline.characterization.test.ts:15:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts:7:import { resolveSenderNumber } from '../senderNumberResolver';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:9:import { connectShyftNumberMappingServiceAsync } from '../../../../modules/connectshyft/numberMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts:16:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts:11:} from '../providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:5:import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-transcription.characterization.test.ts:10:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:10:} from '../../../../modules/connectshyft/inboundSms';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.timeline.test.ts:19:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts:4:} from '../numberMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:11:} from '../../../../modules/connectshyft/numberMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:20:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:201:  let numberMappingsByScope: Map<string, ConnectShyftNumberMapping[]>;
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:208:    numberMappingsByScope = buildDefaultNumberMappingState();
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:212:        cloneMappings(numberMappingsByScope.get(buildTenantOrgUnitKey(tenantId, orgUnitId)) || []),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:217:    ).mockImplementation(async (input) => resolveRoutingMappingByNumberFromState(numberMappingsByScope, input));
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:231:          ...(numberMappingsByScope.get(scopeKey) || []),
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:234:        numberMappingsByScope.set(scopeKey, nextMappings);
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:255:        const currentMappings = numberMappingsByScope.get(scopeKey) || [];
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts:277:        numberMappingsByScope.set(scopeKey, nextMappings);
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:12:import * as providerCorrelationMappingsModule from '../providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:15:import * as inboundSmsModule from '../inboundSms';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:16:import * as inboundVoiceModule from '../inboundVoice';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:151:      .spyOn(providerCorrelationMappingsModule, 'resolveConnectShyftProviderCorrelationByIdentifiers')
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:249:      providerCorrelationMappingsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:304:      providerCorrelationMappingsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:322:    const inboundSmsSpy = jest.spyOn(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:323:      inboundSmsModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:328:    const inboundVoiceSpy = jest.spyOn(
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:329:      inboundVoiceModule,
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:392:    expect(inboundSmsSpy).not.toHaveBeenCalled();
+apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts:393:    expect(inboundVoiceSpy).not.toHaveBeenCalled();
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts:10:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:2:import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../inboundSms';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts:6:} from '../inboundVoice';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:11:} from '../../../../modules/connectshyft/numberMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:13:import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts:19:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts:2:// ConnectShyft provider-registry route integration entrypoint kept for command compatibility.
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts:4:import './connectshyft.provider-registry.dispatch-events.test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.ts:5:import './connectshyft.provider-registry.guardrails.test';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:8:import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../../../../modules/connectshyft/inboundSms';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts:14:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-receipts-admin.characterization.test.ts:4:import * as ProviderCorrelationMappings from '../../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:1:import { resolveSenderNumber } from '../senderNumberResolver';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts:25:describe('connectshyft senderNumberResolver', () => {
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-takeover.characterization.test.ts:10:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:22:} from '../../../../modules/connectshyft/numberMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts:23:import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts:8:import { resetConnectShyftProviderCorrelationStateForTests } from '../providerCorrelationMappings'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:4:import { connectShyftNumberMappingServiceAsync } from '../../../../modules/connectshyft/numberMappings'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts:5:import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings'
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:3:import * as SenderNumberResolverModule from '../../../../modules/connectshyft/senderNumberResolver';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:8:import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts:16:} from './connectshyft.provider-registry.test.shared';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts:6:} from '../inboundSms';
+apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts:4:import { resolveSenderNumber } from '../senderNumberResolver';
+apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-close.characterization.test.ts:10:} from './connectshyft.provider-registry.test.shared';
+
+=== KEY TELEPHONY TEST FILES ===
+// @ts-nocheck
+import request from 'supertest';
+import db from '../../../../config/knex';
+import * as canonicalEventsModule from '../../../../modules/connectshyft/canonicalEvents';
+import * as identityResolverModule from '../../../../modules/connectshyft/identityResolver';
+import * as neighborsModule from '../../../../modules/connectshyft/neighbors';
+import { AsyncConnectShyftNeighborService } from '../../../../modules/connectshyft/neighbors';
+import {
+  connectShyftNumberMappingServiceAsync,
+  type ConnectShyftNumberMapping,
+} from '../../../../modules/connectshyft/numberMappings';
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import { AsyncConnectShyftThreadService } from '../../../../modules/connectshyft/threads';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TENANT_ID = 'tenant-connectshyft-f1';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-f1-east';
+const TEST_PROVIDER_NUMBER = '+12605550191';
+const TEST_TIMESTAMP = '2026-03-18T12:00:00.000Z';
+
+const readString = (...values: unknown[]): string | null => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+};
+
+const sendSmsMock = jest.fn();
+const startOutboundCallMock = jest.fn();
+const startBridgeSessionMock = jest.fn();
+const endCallMock = jest.fn();
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const translateProviderEventMock = jest.fn(({ rawEventType, payload }: {
+  rawEventType: string;
+  payload: unknown;
+}) => {
+  const source = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {};
+
+  return {
+    eventType: readString(rawEventType) || 'sms.inbound',
+    payload: source,
+    correlation: {
+      providerLegId: readString(source.providerLegId, source.provider_leg_id),
+      providerMessageId: readString(
+        source.providerMessageId,
+        source.provider_message_id,
+        source.messageId,
+        source.message_id,
+        source.sid,
+      ),
+      providerEventId: readString(
+        source.providerEventId,
+        source.provider_event_id,
+        source.eventId,
+        source.event_id,
+      ),
+      providerNumber: readString(source.to, source.toNumber, source.to_number),
+    },
+    providerNeutral: true as const,
+    providerSpecificFieldsStripped: true as const,
+    providerBranchingInDomain: false as const,
+  };
+});
+
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}));
+
+const buildSmsHeaders = (
+  overrides: Record<string, string> = {},
+): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': TEST_TENANT_ID,
+  'x-test-connectshyft-orgunit-id': TEST_ORG_UNIT_ID,
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-f1-operator',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([TEST_ORG_UNIT_ID]),
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+  ...overrides,
+});
+
+const buildNumberMapping = (
+  overrides: Partial<ConnectShyftNumberMapping> & Pick<
+    ConnectShyftNumberMapping,
+    'mappingId' | 'tenantId' | 'orgUnitId' | 'twilioNumberE164' | 'label'
+  >,
+): ConnectShyftNumberMapping => ({
+  mappingId: overrides.mappingId,
+  tenantId: overrides.tenantId,
+  orgUnitId: overrides.orgUnitId,
+  twilioNumberE164: overrides.twilioNumberE164,
+  label: overrides.label,
+  isActive: overrides.isActive ?? true,
+  createdAtUtc: overrides.createdAtUtc ?? TEST_TIMESTAMP,
+  updatedAtUtc: overrides.updatedAtUtc ?? TEST_TIMESTAMP,
+});
+
+const buildEnsuredThread = (overrides: Record<string, unknown> = {}) => ({
+  threadId: 'thread-sms-characterization-1001',
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  neighborId: 'neighbor-connectshyft-f1-1001',
+  source: 'SMS',
+  state: 'UNCLAIMED',
+  lastInboundCsNumberId: TEST_PROVIDER_NUMBER,
+  preferredOutboundCsNumberId: TEST_PROVIDER_NUMBER,
+  claimedByUserId: null,
+  claimedAtUtc: null,
+  closedByUserId: null,
+  closedAtUtc: null,
+  createdAtUtc: TEST_TIMESTAMP,
+  updatedAtUtc: TEST_TIMESTAMP,
+  escalation: {
+    stage: 0,
+    nextEvaluationAtUtc: null,
+  },
+  ...overrides,
+});
+
+const buildInboundSmsBody = (overrides: Record<string, unknown> = {}) => ({
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  threadId: 'thread-f1-unclaimed-1001',
+  eventType: 'sms.inbound',
+  sid: 'sms-sid-characterization-1001',
+  providerEventId: 'provider-event-sms-characterization-1001',
+  providerMessageId: 'provider-message-sms-characterization-1001',
+  from: '+12605552001',
+  to: TEST_PROVIDER_NUMBER,
+  body: 'Please call me back when you can.',
+  ...overrides,
+});
+
+const mockInboundSmsPersistence = (input?: {
+  ensuredNeighborId?: string;
+  ensuredThreadId?: string;
+  ensureThreadError?: Error;
+  canonicalEventError?: Error;
+}) => {
+  const originalTransaction = db.transaction;
+  const mockedTransaction = jest.fn(async (handler: any) =>
+    handler({
+      fn: {
+        now: () => new Date(TEST_TIMESTAMP),
+      },
+    }));
+  Object.defineProperty(db, 'transaction', {
+    value: mockedTransaction,
+  });
+
+  const ensureThreadSpy = jest.spyOn(
+    AsyncConnectShyftThreadService.prototype,
+    'ensureThread',
+  );
+  if (input?.ensureThreadError) {
+    ensureThreadSpy.mockRejectedValue(input.ensureThreadError);
+  } else {
+    ensureThreadSpy.mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_ENSURED',
+      httpStatus: 200,
+      data: {
+        thread: buildEnsuredThread({
+          threadId: input?.ensuredThreadId || 'thread-sms-characterization-1001',
+          neighborId: input?.ensuredNeighborId || 'neighbor-connectshyft-f1-1001',
+        }),
+      },
+    } as any);
+  }
+
+  const canonicalEventSpy = jest.spyOn(
+    canonicalEventsModule,
+    'recordConnectShyftCanonicalEvent',
+  );
+  if (input?.canonicalEventError) {
+    canonicalEventSpy.mockRejectedValue(input.canonicalEventError);
+  } else {
+    canonicalEventSpy.mockImplementation(async (eventInput) => ({
+      eventId: 'canonical-event-sms-characterization-1001',
+      aggregateId: eventInput.aggregateId,
+      aggregateType: eventInput.aggregateType,
+      eventType: eventInput.eventType,
+      payload: eventInput.payload,
+      occurredAtUtc: TEST_TIMESTAMP,
+    }) as any);
+  }
+
+  const textingPreferenceSpy = jest.spyOn(
+    AsyncConnectShyftNeighborService.prototype,
+    'applyInboundSmsTextingPreference',
+  ).mockResolvedValue({
+    ok: true,
+    updated: true,
+    neighbor: {
+      neighborId: input?.ensuredNeighborId || 'neighbor-connectshyft-f1-1001',
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      firstName: '',
+      lastName: '',
+      prefersTexting: 'YES',
+      phones: [],
+      createdAtUtc: TEST_TIMESTAMP,
+      updatedAtUtc: TEST_TIMESTAMP,
+    },
+  } as any);
+
+  return {
+    canonicalEventSpy,
+    ensureThreadSpy,
+    textingPreferenceSpy,
+    restore: () => {
+      textingPreferenceSpy.mockRestore();
+      canonicalEventSpy.mockRestore();
+      ensureThreadSpy.mockRestore();
+      Object.defineProperty(db, 'transaction', {
+        value: originalTransaction,
+      });
+    },
+  };
+};
+
+describe('connectshyft inbound sms webhook route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  let resolveRoutingMappingByNumberSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sendSmsMock.mockClear();
+    startOutboundCallMock.mockClear();
+    startBridgeSessionMock.mockClear();
+    endCallMock.mockClear();
+    verifyWebhookMock.mockClear();
+    translateProviderEventMock.mockClear();
+    resetConnectShyftCanonicalEventsForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+
+    resolveRoutingMappingByNumberSpy = jest.spyOn(
+      connectShyftNumberMappingServiceAsync,
+      'resolveRoutingMappingByNumber',
+    ).mockImplementation(async (input) => {
+      if (
+        input.twilioNumberE164 === TEST_PROVIDER_NUMBER
+
+// @ts-nocheck
+import request from 'supertest';
+import * as canonicalEventsModule from '../../../../modules/connectshyft/canonicalEvents';
+import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
+import * as providerCorrelationMappingsModule from '../../../../modules/connectshyft/providerCorrelationMappings';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TIMESTAMP = '2026-03-18T12:00:00.000Z';
+const TEST_PROVIDER_NUMBER_F1 = '+12605550191';
+const TEST_PROVIDER_NUMBER_F2 = '+12605550192';
+const CONNECTSHYFT_SYSTEM_ACTOR_USER_ID = '00000000-0000-4000-8000-000000000001';
+
+const readString = (...values: unknown[]): string | null => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+};
+
+const sendSmsMock = jest.fn();
+const startOutboundCallMock = jest.fn();
+const startBridgeSessionMock = jest.fn();
+const endCallMock = jest.fn();
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const translateProviderEventMock = jest.fn(({ rawEventType, payload }: {
+  rawEventType: string;
+  payload: unknown;
+}) => {
+  const source = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {};
+
+  return {
+    eventType: readString(rawEventType) || 'voice.voicemail',
+    payload: source,
+    correlation: {
+      providerLegId: readString(source.providerLegId, source.provider_leg_id),
+      providerMessageId: readString(
+        source.providerMessageId,
+        source.provider_message_id,
+        source.messageId,
+        source.message_id,
+      ),
+      providerEventId: readString(
+        source.providerEventId,
+        source.provider_event_id,
+        source.eventId,
+        source.event_id,
+      ),
+      providerNumber: readString(source.to, source.toNumber, source.to_number),
+    },
+    providerNeutral: true as const,
+    providerSpecificFieldsStripped: true as const,
+    providerBranchingInDomain: false as const,
+  };
+});
+
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}));
+
+const buildVoiceHeaders = (input?: {
+  tenantId?: string;
+  orgUnitId?: string;
+}): Record<string, string> => buildHeaders({
+  'x-test-connectshyft-tenant-id': input?.tenantId || 'tenant-connectshyft-f1',
+  'x-test-connectshyft-orgunit-id': input?.orgUnitId || 'org-connectshyft-f1-east',
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-voice-characterization',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify([
+    input?.orgUnitId || 'org-connectshyft-f1-east',
+  ]),
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+});
+
+const buildVoiceWebhookBody = (overrides: Record<string, unknown> = {}) => ({
+  tenantId: 'tenant-connectshyft-f1',
+  orgUnitId: 'org-connectshyft-f1-east',
+  threadId: 'thread-f1-unclaimed-1001',
+  eventType: 'voice.voicemail',
+  sid: 'voice-sid-characterization-1001',
+  providerEventId: 'provider-event-voice-voicemail-1001',
+  providerLegId: 'provider-leg-voice-voicemail-1001',
+  from: '+12605552021',
+  to: TEST_PROVIDER_NUMBER_F1,
+  recordingUrl: 'https://connectshyft.test/voicemail-characterization-1001.mp3',
+  voicemail_duration_seconds: 47,
+  ...overrides,
+});
+
+describe('connectshyft inbound voice webhook route characterization', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  let recordCanonicalEventSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sendSmsMock.mockClear();
+    startOutboundCallMock.mockClear();
+    startBridgeSessionMock.mockClear();
+    endCallMock.mockClear();
+    verifyWebhookMock.mockClear();
+    translateProviderEventMock.mockClear();
+    resetConnectShyftBridgeSessionStateForTests();
+    resetConnectShyftCanonicalEventsForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+
+    recordCanonicalEventSpy = jest.spyOn(
+      canonicalEventsModule,
+      'recordConnectShyftCanonicalEvent',
+    ).mockImplementation(async (eventInput) => ({
+      eventId: `canonical-event-${String(eventInput.aggregateId)}-${String(eventInput.eventType)}`,
+      aggregateId: eventInput.aggregateId,
+      aggregateType: eventInput.aggregateType,
+      eventType: eventInput.eventType,
+      payload: eventInput.payload,
+      occurredAtUtc: TEST_TIMESTAMP,
+    }) as any);
+  });
+
+  afterEach(() => {
+    recordCanonicalEventSpy.mockRestore();
+  });
+
+  it('returns the current inbound voice success envelope and voicemail routing shape', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildVoiceHeaders())
+      .send(buildVoiceWebhookBody());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+      message: 'Inbound webhook accepted for processing',
+      data: {
+        sid: 'voice-sid-characterization-1001',
+        from: '+12605552021',
+        to: TEST_PROVIDER_NUMBER_F1,
+        eventType: 'voice.voicemail',
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: 'telnyx',
+          deterministic: true,
+          adapterInvoked: true,
+        },
+        correlation: {
+          source: 'metadata',
+          deterministic: true,
+          threadId: 'thread-f1-unclaimed-1001',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          neighborId: 'neighbor-connectshyft-f1-1001',
+          providerLegId: 'provider-leg-voice-voicemail-1001',
+          providerMessageId: null,
+          providerEventId: 'provider-event-voice-voicemail-1001',
+          providerNumberE164: TEST_PROVIDER_NUMBER_F1,
+        },
+        replaySafe: {
+          duplicate: false,
+          suppressedDomainWrites: false,
+          dedupeKey: 'provider-event:provider-event-voice-voicemail-1001',
+        },
+        canonicalTranslation: {
+          eventType: 'voice.voicemail',
+          providerNeutral: true,
+          providerSpecificFieldsStripped: true,
+          providerBranchingInDomain: false,
+        },
+        domainHandlers: {
+          providerBranchingInDomain: false,
+        },
+        canonicalEvent: {
+          aggregateId: 'thread-f1-unclaimed-1001',
+          aggregateType: 'Thread',
+          eventType: 'voice.voicemail',
+        },
+        threadId: 'thread-f1-unclaimed-1001',
+        threadState: 'UNCLAIMED',
+        thread: {
+          threadId: 'thread-f1-unclaimed-1001',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          neighborId: 'neighbor-connectshyft-f1-1001',
+          source: 'VOICE',
+          state: 'UNCLAIMED',
+          lastInboundCsNumberId: TEST_PROVIDER_NUMBER_F1,
+          preferredOutboundCsNumberId: TEST_PROVIDER_NUMBER_F1,
+          claimedByUserId: null,
+          claimedAtUtc: null,
+          closedByUserId: null,
+          closedAtUtc: null,
+          createdAtUtc: expect.any(String),
+          updatedAtUtc: expect.any(String),
+          escalation: {
+            stage: 0,
+            nextEvaluationAtUtc: '2026-03-01T00:00:00.000Z',
+          },
+        },
+        lifecycle: {
+          ensuredActiveThread: true,
+          reusedThreadId: 'thread-f1-unclaimed-1001',
+          reopenedByInbound: false,
+          escalationResetApplied: false,
+          inactivityResetApplied: false,
+          autoClaimedByConnectedEvent: false,
+        },
+        voicemailArtifact: {
+          artifactId: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+          channel: 'voice',
+          direction: 'inbound',
+          providerEventId: 'provider-event-voice-voicemail-1001',
+          providerMessageId: null,
+          providerLegId: 'provider-leg-voice-voicemail-1001',
+          from: '+12605552021',
+          to: TEST_PROVIDER_NUMBER_F1,
+          recordingUrl: 'https://connectshyft.test/voicemail-characterization-1001.mp3',
+          durationSeconds: 47,
+        },
+        transcription: {
+          requestQueued: true,
+          queueName: 'connectshyft.voicemail.transcription',
+          callbackCorrelation: {
+            tenantId: 'tenant-connectshyft-f1',
+            orgUnitId: 'org-connectshyft-f1-east',
+            threadId: 'thread-f1-unclaimed-1001',
+            providerEventId: 'provider-event-voice-voicemail-1001',
+            correlationEventId: 'provider-event-voice-voicemail-1001',
+            providerLegId: 'provider-leg-voice-voicemail-1001',
+            voicemailArtifactId: 'vm-thread-f1-unclaimed-1001-provider-event-voice-voicemail-1001',
+          },
+        },
+        autoClaim: null,
+        callPolicy: {
+          transport: null,
+          autoRetry: false,
+          redialPolicy: 'manual_only',
+        },
+        timeline: {
+          eventName: 'connectshyft.inbound.voice_voicemail_recorded',
+          routingDecision: 'voicemail_only',
+          deterministicOrdering: true,
+
+import connectShyftRouter, {
+  ensureConnectShyftDispatchReadySmsTargetForTests,
+  resetConnectShyftOutboundDispatchReplayLedgerForTests,
+  resolveConnectShyftSmsSenderForTests,
+  resolveConnectShyftSmsTargetForTests,
+} from '../connectshyft';
+import { TelephonyProviderFailure } from '../../../../../../../domains/communication';
+import {
+  listConnectShyftCommunicationAuditEntriesForTests,
+  resetConnectShyftCommunicationAuditLogForTests,
+} from '../../../../modules/connectshyft/communicationAuditLog';
+import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
+import {
+  connectShyftNeighborServiceAsync,
+  type ConnectShyftNeighborPhone,
+  type ConnectShyftResolveNeighborResult,
+} from '../../../../modules/connectshyft/neighbors';
+import {
+  connectShyftNumberMappingServiceAsync,
+  type ConnectShyftNumberMapping,
+} from '../../../../modules/connectshyft/numberMappings';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import {
+  connectShyftSmsPreferenceOverrideServiceAsync,
+  type ConnectShyftResolvedSmsPreference,
+} from '../../../../modules/connectshyft/smsPreferenceOverrides';
+import { resetConnectShyftCommunicationReliabilityStateForTests } from '../../../../modules/connectshyft/communicationReliability';
+import type { ConnectShyftThread } from '../../../../modules/connectshyft/threads';
+
+const toCanonicalEventType = (rawEventType: string): string => rawEventType
+  .split(/[._-]+/)
+  .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : ''))
+  .join('');
+
+const toProviderCorrelation = (payload: unknown) => {
+  const source = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {};
+
+  return {
+    providerLegId: typeof source.providerLegId === 'string' ? source.providerLegId : null,
+    providerMessageId: typeof source.providerMessageId === 'string' ? source.providerMessageId : null,
+    providerEventId: typeof source.providerEventId === 'string' ? source.providerEventId : null,
+    providerNumber: typeof source.providerNumber === 'string'
+      ? source.providerNumber
+      : (typeof source.to === 'string'
+        ? source.to
+        : (typeof source.to_number === 'string' ? source.to_number : null)),
+  };
+};
+
+const sendSmsMock = jest.fn(async (command: {
+  threadId: string;
+  targetPhone?: string;
+  senderPhone?: string;
+  body?: string;
+}) => ({
+  providerKey: 'telnyx',
+  channel: 'message' as const,
+  providerLegId: null,
+  providerMessageId: `provider-message-${command.threadId}`,
+  providerRequestId: 'req-sms-1001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:00:00.000Z',
+}));
+
+const startOutboundCallMock = jest.fn(async (command: { threadId: string; targetPhone?: string }) => ({
+  providerKey: 'telnyx',
+  channel: 'call' as const,
+  providerLegId: command.targetPhone === '+12605550155'
+    ? `provider-leg-operator-${command.threadId}`
+    : `provider-leg-neighbor-${command.threadId}`,
+  providerMessageId: null,
+  providerRequestId: 'req-call-2001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:05:00.000Z',
+}));
+const startBridgeSessionMock = jest.fn(async (command: { bridgeSessionId: string }) => ({
+  providerKey: 'telnyx',
+  bridgeSessionId: command.bridgeSessionId,
+  bridgeEstablished: true as const,
+  providerRequestId: 'req-bridge-3001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:06:00.000Z',
+}));
+
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const endCallMock = jest.fn(async (command: { providerLegId: string }) => ({
+  providerKey: 'telnyx',
+  providerLegId: command.providerLegId,
+  ended: true as const,
+  providerRequestId: 'req-end-call-4001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:07:00.000Z',
+}));
+const translateProviderEventMock = jest.fn(({ rawEventType, payload }: { rawEventType: string; payload: unknown }) => ({
+  eventType: toCanonicalEventType(rawEventType),
+  payload: (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>,
+  correlation: toProviderCorrelation(payload),
+  providerNeutral: true as const,
+  providerSpecificFieldsStripped: true as const,
+  providerBranchingInDomain: false as const,
+}));
+
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}));
+
+const buildHeaders = (extra: Record<string, string> = {}): Record<string, string> => ({
+  'x-test-connectshyft-tenant-id': 'tenant-connectshyft-f1',
+  'x-test-connectshyft-orgunit-id': 'org-connectshyft-f1-east',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify(['org-connectshyft-f1-east']),
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-f1-primary-operator',
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+  'x-test-connectshyft-flags': JSON.stringify({
+    connectshyft_enabled: true,
+    connectshyft_inbox_enabled: true,
+    connectshyft_escalation_enabled: true,
+    connectshyft_webhooks_enabled: true,
+  }),
+  ...extra,
+});
+
+const invokeRoute = async (input: {
+  url: string;
+  body?: Record<string, unknown>;
+  headers?: Record<string, string>;
+}): Promise<{ status: number; body: unknown }> => {
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(input.headers || {}).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+    const req = {
+      method: 'POST',
+      url: input.url,
+      originalUrl: input.url,
+      path: input.url,
+      protocol: 'https',
+      body: input.body || {},
+      headers: normalizedHeaders,
+      params: {},
+      query: {},
+      tenantContext: undefined,
+      tenantId: undefined,
+      orgUnitId: undefined,
+      user: undefined,
+      header(name: string): string | undefined {
+        return normalizedHeaders[name.toLowerCase()];
+      },
+      get(name: string): string | undefined {
+        return normalizedHeaders[name.toLowerCase()];
+      },
+    } as any;
+
+    const res = {
+      locals: {},
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: unknown) {
+        resolved = true;
+        resolve({
+          status: this.statusCode,
+          body: payload,
+        });
+        return this;
+      },
+      send(payload: unknown) {
+        resolved = true;
+        resolve({
+          status: this.statusCode,
+          body: payload,
+        });
+        return this;
+      },
+      setHeader() {
+        return this;
+      },
+      getHeader() {
+        return undefined;
+      },
+      end(payload?: unknown) {
+        if (!resolved) {
+          resolved = true;
+          resolve({
+            status: this.statusCode,
+            body: payload,
+          });
+        }
+        return this;
+      },
+    } as any;
+
+    (connectShyftRouter as any).handle(req, res, (error?: unknown) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      if (!resolved) {
+        resolve({
+          status: res.statusCode,
+          body: null,
+        });
+      }
+    });
+  });
+};
+
+const buildResolvedNeighborPhone = (
+  overrides: Partial<ConnectShyftNeighborPhone> & Pick<ConnectShyftNeighborPhone, 'phoneId' | 'value'>,
+): ConnectShyftNeighborPhone => ({
+  phoneId: overrides.phoneId,
+  label: overrides.label ?? 'mobile',
+  value: overrides.value,
+  rawInput: overrides.rawInput ?? overrides.value,
+  displayNational: overrides.displayNational ?? '(260) 555-0111',
+  countryCode: overrides.countryCode ?? '1',
+  nationalNumber: overrides.nationalNumber ?? '2605550111',
+  extension: overrides.extension ?? null,
+  validationStatus: overrides.validationStatus ?? 'valid',
+  usageType: overrides.usageType ?? 'mobile',
+  source: overrides.source ?? 'user_entered',
+  sortOrder: overrides.sortOrder ?? 0,
+  isPrimary: overrides.isPrimary ?? false,
+  isShared: overrides.isShared ?? false,
+  verificationStatus: overrides.verificationStatus ?? 'verified',
+  isActive: overrides.isActive ?? true,
+  createdAtUtc: overrides.createdAtUtc ?? '2026-03-11T12:00:00.000Z',
+  updatedAtUtc: overrides.updatedAtUtc ?? '2026-03-11T12:00:00.000Z',
+});
+
+const buildResolvedNeighborResult = (
+  phones: ConnectShyftNeighborPhone[],
+): ConnectShyftResolveNeighborResult => ({
+  ok: true,
+  code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+  httpStatus: 200,
+  data: {
+    neighbor: {
+      neighborId: 'neighbor-connectshyft-f1-1001',
+
+// @ts-nocheck
+import request from 'supertest';
+import db from '../../../../config/knex';
+import * as canonicalEventsModule from '../../../../modules/connectshyft/canonicalEvents';
+import * as identityResolverModule from '../../../../modules/connectshyft/identityResolver';
+import * as neighborsModule from '../../../../modules/connectshyft/neighbors';
+import { AsyncConnectShyftNeighborService } from '../../../../modules/connectshyft/neighbors';
+import {
+  connectShyftNumberMappingServiceAsync,
+  type ConnectShyftNumberMapping,
+} from '../../../../modules/connectshyft/numberMappings';
+import { AsyncConnectShyftThreadService } from '../../../../modules/connectshyft/threads';
+import {
+  buildApp,
+  buildHeaders,
+  type CanonicalEventRecord,
+  expectProviderSpecificLeakageRemoved,
+  registerProviderRegistryRouteIntegrationHooks,
+  sortCanonical,
+} from './connectshyft.provider-registry.test.shared';
+
+const mockInboundSmsPersistence = (input?: {
+  ensuredNeighborId?: string;
+  ensuredThreadId?: string;
+  failOnTextingPreferenceCall?: boolean;
+}) => {
+  const originalTransaction = db.transaction;
+  const mockedTransaction = jest.fn(async (handler: any) =>
+    handler({
+      fn: {
+        now: () => new Date('2026-03-18T12:00:00.000Z'),
+      },
+    }));
+  Object.defineProperty(db, 'transaction', {
+    value: mockedTransaction,
+  });
+  const ensureThreadSpy = jest.spyOn(
+    AsyncConnectShyftThreadService.prototype,
+    'ensureThread',
+  ).mockResolvedValue({
+    ok: true,
+    code: 'CONNECTSHYFT_THREAD_ENSURED',
+    httpStatus: 200,
+    data: {
+      thread: {
+        threadId: input?.ensuredThreadId || '00000000-0000-4000-8000-000000000111',
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        neighborId: input?.ensuredNeighborId || 'neighbor-inbound',
+        state: 'UNCLAIMED',
+        summary: '',
+        escalationStage: 0,
+        nextEvaluationAtUtc: null,
+        lastInboundCsNumberId: '+12605550191',
+        preferredOutboundCsNumberId: '+12605550191',
+        claimedByUserId: null,
+        createdAtUtc: '2026-03-18T12:00:00.000Z',
+        updatedAtUtc: '2026-03-18T12:00:00.000Z',
+      },
+    },
+  } as any);
+  const canonicalEventSpy = jest.spyOn(
+    canonicalEventsModule,
+    'recordConnectShyftCanonicalEvent',
+  ).mockResolvedValue({
+    eventId: 'canonical-event-inbound-1',
+    aggregateId: input?.ensuredThreadId || '00000000-0000-4000-8000-000000000111',
+    aggregateType: 'Thread',
+    eventType: 'connectshyft.inbound.sms_appended',
+    payload: {},
+    occurredAtUtc: '2026-03-18T12:00:00.000Z',
+  } as any);
+  const textingPreferenceSpy = jest.spyOn(
+    AsyncConnectShyftNeighborService.prototype,
+    'applyInboundSmsTextingPreference',
+  ).mockImplementation(async () => {
+    if (input?.failOnTextingPreferenceCall) {
+      throw new Error('synthetic neighbor IDs must not trigger texting-preference promotion');
+    }
+
+    return {
+      ok: true,
+      updated: true,
+      neighbor: {
+        neighborId: input?.ensuredNeighborId || 'neighbor-inbound',
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        firstName: '',
+        lastName: '',
+        prefersTexting: 'YES',
+        phones: [],
+        createdAtUtc: '2026-03-18T12:00:00.000Z',
+        updatedAtUtc: '2026-03-18T12:00:00.000Z',
+      },
+    } as any;
+  });
+
+  return {
+    textingPreferenceSpy,
+    restore: () => {
+      textingPreferenceSpy.mockRestore();
+      canonicalEventSpy.mockRestore();
+      ensureThreadSpy.mockRestore();
+      Object.defineProperty(db, 'transaction', {
+        value: originalTransaction,
+      });
+    },
+  };
+};
+
+const buildNumberMapping = (
+  overrides: Partial<ConnectShyftNumberMapping> & Pick<
+    ConnectShyftNumberMapping,
+    'mappingId' | 'tenantId' | 'orgUnitId' | 'twilioNumberE164' | 'label'
+  >,
+): ConnectShyftNumberMapping => ({
+  mappingId: overrides.mappingId,
+  tenantId: overrides.tenantId,
+  orgUnitId: overrides.orgUnitId,
+  twilioNumberE164: overrides.twilioNumberE164,
+  label: overrides.label,
+  isActive: overrides.isActive ?? true,
+  createdAtUtc: overrides.createdAtUtc ?? '2026-03-18T12:00:00.000Z',
+  updatedAtUtc: overrides.updatedAtUtc ?? '2026-03-18T12:00:00.000Z',
+});
+
+const buildTenantOrgUnitKey = (tenantId: string, orgUnitId: string): string =>
+  `${tenantId}::${orgUnitId}`;
+
+const cloneMappings = (
+  mappings: readonly ConnectShyftNumberMapping[],
+): ConnectShyftNumberMapping[] => [...mappings]
+  .map((mapping) => ({ ...mapping }))
+  .sort((left, right) => {
+    if (left.twilioNumberE164 !== right.twilioNumberE164) {
+      return left.twilioNumberE164.localeCompare(right.twilioNumberE164);
+    }
+    return left.mappingId.localeCompare(right.mappingId);
+  });
+
+const resolveRoutingMappingByNumberFromState = (
+  mappingsByScope: Map<string, ConnectShyftNumberMapping[]>,
+  input: {
+    tenantId: string | null;
+    twilioNumberE164: string;
+  },
+) => {
+  const tenantId = typeof input.tenantId === 'string' ? input.tenantId : null;
+  const matches = Array.from(mappingsByScope.values())
+    .flat()
+    .filter((mapping) => mapping.isActive && mapping.twilioNumberE164 === input.twilioNumberE164)
+    .filter((mapping) => tenantId ? mapping.tenantId === tenantId : true);
+
+  if (matches.length === 1) {
+    return {
+      status: 'found' as const,
+      mapping: { ...matches[0] },
+    };
+  }
+
+  if (matches.length > 1) {
+    return {
+      status: 'ambiguous' as const,
+      mappings: matches.map((mapping) => ({ ...mapping })),
+    };
+  }
+
+  return {
+    status: 'not-found' as const,
+  };
+};
+
+const buildDefaultNumberMappingState = (): Map<string, ConnectShyftNumberMapping[]> => new Map([
+  [
+    buildTenantOrgUnitKey('tenant-connectshyft-f1', 'org-connectshyft-f1-east'),
+    cloneMappings([
+      buildNumberMapping({
+        mappingId: 'mapping-f1-001',
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        twilioNumberE164: '+12605550191',
+        label: 'Front Desk',
+      }),
+    ]),
+  ],
+  [
+    buildTenantOrgUnitKey('tenant-connectshyft-f2', 'org-connectshyft-f2-east'),
+    cloneMappings([
+      buildNumberMapping({
+        mappingId: 'mapping-f2-001',
+        tenantId: 'tenant-connectshyft-f2',
+        orgUnitId: 'org-connectshyft-f2-east',
+        twilioNumberE164: '+12605550192',
+        label: 'F2 East Primary',
+      }),
+    ]),
+  ],
+]);
+describe('connectshyft provider adapter registry route integration - dispatch and canonical events', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+  let numberMappingsByScope: Map<string, ConnectShyftNumberMapping[]>;
+  let listMappingsSpy: jest.SpyInstance;
+  let resolveRoutingMappingByNumberSpy: jest.SpyInstance;
+  let createMappingSpy: jest.SpyInstance;
+  let updateMappingSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    numberMappingsByScope = buildDefaultNumberMappingState();
+
+    listMappingsSpy = jest.spyOn(connectShyftNumberMappingServiceAsync, 'listMappings').mockImplementation(
+      async (tenantId: string, orgUnitId: string) =>
+        cloneMappings(numberMappingsByScope.get(buildTenantOrgUnitKey(tenantId, orgUnitId)) || []),
+    );
+    resolveRoutingMappingByNumberSpy = jest.spyOn(
+      connectShyftNumberMappingServiceAsync,
+      'resolveRoutingMappingByNumber',
+    ).mockImplementation(async (input) => resolveRoutingMappingByNumberFromState(numberMappingsByScope, input));
+
+    createMappingSpy = jest.spyOn(connectShyftNumberMappingServiceAsync, 'createMapping').mockImplementation(
+      async (input) => {
+        const scopeKey = buildTenantOrgUnitKey(input.tenantId, input.orgUnitId);
+        const nextMapping = buildNumberMapping({
+          mappingId: input.mappingId || `mapping-${input.tenantId}-${input.orgUnitId}-${input.twilioNumberE164}`,
+          tenantId: input.tenantId,
+          orgUnitId: input.orgUnitId,
+          twilioNumberE164: input.twilioNumberE164,
+          label: input.label,
+          isActive: input.isActive,
+        });
+        const nextMappings = cloneMappings([
+          ...(numberMappingsByScope.get(scopeKey) || []),
+          nextMapping,
+        ]);
+        numberMappingsByScope.set(scopeKey, nextMappings);
+
+        return {
+          ok: true as const,
+          code: 'CONNECTSHYFT_NUMBER_MAPPING_SAVED' as const,
+          httpStatus: 201 as const,
+          data: {
+            mappingId: nextMapping.mappingId,
+            orgUnitId: nextMapping.orgUnitId,
+            twilioNumberE164: nextMapping.twilioNumberE164,
+            label: nextMapping.label,
+            isActive: nextMapping.isActive,
+            mappings: cloneMappings(nextMappings),
+          },
+        };
+      },
+    );
+
+    updateMappingSpy = jest.spyOn(connectShyftNumberMappingServiceAsync, 'updateMapping').mockImplementation(
+      async (input) => {
+        const scopeKey = buildTenantOrgUnitKey(input.tenantId, input.orgUnitId);
+        const currentMappings = numberMappingsByScope.get(scopeKey) || [];
+        const existing = currentMappings.find((mapping) => mapping.mappingId === input.mappingId);
+        if (!existing) {
+          return {
+            ok: false as const,
+            code: 'CONNECTSHYFT_NUMBER_MAPPING_NOT_FOUND' as const,
+
+// @ts-nocheck
+import { randomUUID } from 'node:crypto';
+import request from 'supertest';
+import db from '../../../../config/knex';
+import * as canonicalEventsModule from '../../../../modules/connectshyft/canonicalEvents';
+import * as identityResolverModule from '../../../../modules/connectshyft/identityResolver';
+import * as neighborsModule from '../../../../modules/connectshyft/neighbors';
+import { AsyncConnectShyftNeighborService } from '../../../../modules/connectshyft/neighbors';
+import { connectShyftNumberMappingServiceAsync } from '../../../../modules/connectshyft/numberMappings';
+import { AsyncConnectShyftThreadService } from '../../../../modules/connectshyft/threads';
+import * as ProviderRegistry from '../../../../modules/connectshyft/providerRegistry';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const mockInboundSmsPersistence = (neighborId: string) => {
+  const originalTransaction = db.transaction;
+  const mockedTransaction = jest.fn(async (handler: any) =>
+    handler({
+      fn: {
+        now: () => new Date('2026-03-18T12:00:00.000Z'),
+      },
+    }));
+  Object.defineProperty(db, 'transaction', {
+    value: mockedTransaction,
+  });
+  const ensureThreadSpy = jest.spyOn(
+    AsyncConnectShyftThreadService.prototype,
+    'ensureThread',
+  ).mockResolvedValue({
+    ok: true,
+    code: 'CONNECTSHYFT_THREAD_ENSURED',
+    httpStatus: 200,
+    data: {
+      thread: {
+        threadId: '00000000-0000-4000-8000-000000000222',
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        neighborId,
+        state: 'UNCLAIMED',
+        summary: '',
+        escalationStage: 0,
+        nextEvaluationAtUtc: null,
+        lastInboundCsNumberId: '+12605550191',
+        preferredOutboundCsNumberId: '+12605550191',
+        claimedByUserId: null,
+        createdAtUtc: '2026-03-18T12:00:00.000Z',
+        updatedAtUtc: '2026-03-18T12:00:00.000Z',
+      },
+    },
+  } as any);
+  const canonicalEventSpy = jest.spyOn(
+    canonicalEventsModule,
+    'recordConnectShyftCanonicalEvent',
+  ).mockResolvedValue({
+    eventId: 'canonical-event-inbound-2',
+    aggregateId: '00000000-0000-4000-8000-000000000222',
+    aggregateType: 'Thread',
+    eventType: 'connectshyft.inbound.sms_appended',
+    payload: {},
+    occurredAtUtc: '2026-03-18T12:00:00.000Z',
+  } as any);
+  const textingPreferenceSpy = jest.spyOn(
+    AsyncConnectShyftNeighborService.prototype,
+    'applyInboundSmsTextingPreference',
+  ).mockResolvedValue({
+    ok: true,
+    updated: false,
+    neighbor: {
+      neighborId,
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      firstName: '',
+      lastName: '',
+      prefersTexting: 'YES',
+      phones: [],
+      createdAtUtc: '2026-03-18T12:00:00.000Z',
+      updatedAtUtc: '2026-03-18T12:00:00.000Z',
+    },
+  } as any);
+
+  return {
+    ensureThreadSpy,
+    restore: () => {
+      textingPreferenceSpy.mockRestore();
+      canonicalEventSpy.mockRestore();
+      ensureThreadSpy.mockRestore();
+      Object.defineProperty(db, 'transaction', {
+        value: originalTransaction,
+      });
+    },
+  };
+};
+
+const resolveRoutingMappingByNumberForTests = async (input: {
+  tenantId: string | null;
+  twilioNumberE164: string;
+}) => {
+  if (input.tenantId === 'tenant-connectshyft-f1' && input.twilioNumberE164 === '+12605550191') {
+    return {
+      status: 'found' as const,
+      mapping: {
+        mappingId: 'mapping-f1-001',
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        twilioNumberE164: '+12605550191',
+        label: 'Front Desk',
+        isActive: true,
+        createdAtUtc: '2026-03-18T12:00:00.000Z',
+        updatedAtUtc: '2026-03-18T12:00:00.000Z',
+      },
+    };
+  }
+
+  if (input.tenantId === 'tenant-connectshyft-f2' && input.twilioNumberE164 === '+12605550192') {
+    return {
+      status: 'found' as const,
+      mapping: {
+        mappingId: 'mapping-f2-001',
+        tenantId: 'tenant-connectshyft-f2',
+        orgUnitId: 'org-connectshyft-f2-east',
+        twilioNumberE164: '+12605550192',
+        label: 'F2 East Primary',
+        isActive: true,
+        createdAtUtc: '2026-03-18T12:00:00.000Z',
+        updatedAtUtc: '2026-03-18T12:00:00.000Z',
+      },
+    };
+  }
+
+  return {
+    status: 'not-found' as const,
+  };
+};
+
+describe('connectshyft provider adapter registry route integration - guardrails', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  beforeEach(() => {
+    jest.spyOn(connectShyftNumberMappingServiceAsync, 'resolveRoutingMappingByNumber')
+      .mockImplementation(resolveRoutingMappingByNumberForTests);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fails closed when requested provider is disabled and confirms no partial-write side effects', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/threads/thread-f1-claimed-1002/call')
+      .set(buildHeaders())
+      .send({
+        orgUnitId: 'org-connectshyft-f1-east',
+        providerKey: 'twilio',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+      refusalType: 'business',
+      data: {
+        providerResolution: {
+          requestedProvider: 'twilio',
+          resolvedProvider: null,
+          deterministic: true,
+          reason: 'provider-disabled',
+        },
+        sideEffects: {
+          dispatchAttempted: false,
+          lifecycleMutationApplied: false,
+          auditPersisted: false,
+        },
+      },
+    });
+  });
+
+  it('fails closed when Telnyx rollout allow-list excludes tenant/orgUnit context', async () => {
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/threads/thread-f1-unclaimed-1001/call')
+      .set(buildHeaders({
+        'x-test-connectshyft-provider-rollout-allowlist': JSON.stringify({
+          telnyx: {
+            tenantIds: ['tenant-connectshyft-allowlist-only'],
+            orgUnitIds: ['org-connectshyft-allowlist-only'],
+            tenantOrgUnitPairs: ['tenant-connectshyft-allowlist-only::org-connectshyft-allowlist-only'],
+          },
+        }),
+      }))
+      .send({
+        orgUnitId: 'org-connectshyft-f1-east',
+        providerKey: 'telnyx',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_PROVIDER_DISABLED',
+      refusalType: 'business',
+      data: {
+        providerResolution: {
+          requestedProvider: 'telnyx',
+          resolvedProvider: null,
+          deterministic: true,
+          reason: 'provider-not-allowlisted',
+        },
+        sideEffects: {
+          dispatchAttempted: false,
+          lifecycleMutationApplied: false,
+          auditPersisted: false,
+        },
+      },
+    });
+  });
+
+  it('revalidates rollout allow-list against correlated webhook context before side effects', async () => {
+    const app = buildApp();
+    const f2Headers = buildHeaders({
+      'x-test-connectshyft-tenant-id': 'tenant-connectshyft-f2',
+      'x-test-connectshyft-orgunit-id': 'org-connectshyft-f2-east',
+      'x-test-connectshyft-user-id': 'user-connectshyft-f2-operator',
+      'x-test-connectshyft-orgunit-memberships': JSON.stringify(['org-connectshyft-f2-east']),
+    });
+    const callResponse = await request(app)
+      .post('/api/v1/connectshyft/threads/thread-f2-unclaimed-1001/call')
+      .set(f2Headers)
+      .send({
+        orgUnitId: 'org-connectshyft-f2-east',
+        providerKey: 'telnyx',
+      });
+
+    expect(callResponse.status).toBe(200);
+    const providerLegId = callResponse.body?.data?.dispatch?.providerLegId as string;
+    expect(typeof providerLegId).toBe('string');
+    expect(providerLegId.length).toBeGreaterThan(0);
+
+    const webhookResponse = await request(app)
+      .post('/api/v1/connectshyft/webhooks/inbound')
+      .set(buildHeaders({
+        'x-test-connectshyft-provider-rollout-allowlist': JSON.stringify({
+          telnyx: {
+            tenantOrgUnitPairs: ['tenant-connectshyft-f1::org-connectshyft-f1-east'],
+            tenantIds: [],
+            orgUnitIds: [],
+          },
+        }),
+      }))
+      .send({
+        eventType: 'voice.connected',
+        providerKey: 'telnyx',
+        providerLegId,
+      });
+
+    expect(webhookResponse.status).toBe(200);
+    expect(webhookResponse.body).toMatchObject({
+      ok: false,
+
+import connectShyftRouter from '../connectshyft'
+import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions'
+import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents'
+import { connectShyftNumberMappingServiceAsync } from '../../../../modules/connectshyft/numberMappings'
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings'
+
+const toCanonicalEventType = (rawEventType: string): string => rawEventType
+  .split(/[._-]+/)
+  .map((part) => (part ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : ''))
+  .join('')
+
+const toProviderCorrelation = (payload: unknown) => {
+  const source = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {}
+
+  return {
+    providerLegId: typeof source.providerLegId === 'string' ? source.providerLegId : null,
+    providerMessageId: typeof source.providerMessageId === 'string' ? source.providerMessageId : null,
+    providerEventId: typeof source.providerEventId === 'string' ? source.providerEventId : null,
+    providerNumber: typeof source.providerNumber === 'string'
+      ? source.providerNumber
+      : (typeof source.to === 'string'
+        ? source.to
+        : (typeof source.to_number === 'string' ? source.to_number : null)),
+  }
+}
+
+const sendSmsMock = jest.fn()
+const startOutboundCallMock = jest.fn(async (command: { threadId: string; targetPhone?: string }) => ({
+  providerKey: 'telnyx',
+  channel: 'call' as const,
+  providerLegId: command.targetPhone === '+12605550155'
+    ? `provider-leg-operator-${command.threadId}`
+    : `provider-leg-neighbor-${command.threadId}`,
+  providerMessageId: null,
+  providerRequestId: 'req-call-2001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:05:00.000Z',
+}))
+const startBridgeSessionMock = jest.fn(async (command: {
+  bridgeSessionId: string
+  operatorProviderCallId: string
+  neighborProviderCallId: string
+}) => ({
+  providerKey: 'telnyx',
+  bridgeSessionId: command.bridgeSessionId,
+  bridgeEstablished: true as const,
+  providerRequestId: 'req-bridge-3001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:06:00.000Z',
+}))
+const verifyWebhookMock = jest.fn(
+  (): { ok: true } | {
+    ok: false
+    refusal: {
+      code: 'WEBHOOK_SIGNATURE_NOT_CONFIGURED' | 'WEBHOOK_SIGNATURE_MISSING' | 'WEBHOOK_SIGNATURE_INVALID'
+      message: string
+      refusalType: 'business' | 'client'
+      httpStatus: 401 | 503
+    }
+  } => ({ ok: true as const }),
+)
+const endCallMock = jest.fn(async (command: { providerLegId: string }) => ({
+  providerKey: 'telnyx',
+  providerLegId: command.providerLegId,
+  ended: true as const,
+  providerRequestId: 'req-end-call-4001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-11T12:07:00.000Z',
+}))
+const translateProviderEventMock = jest.fn(({ rawEventType, payload }: { rawEventType: string; payload: unknown }) => ({
+  eventType: toCanonicalEventType(rawEventType),
+  payload: (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>,
+  correlation: toProviderCorrelation(payload),
+  providerNeutral: true as const,
+  providerSpecificFieldsStripped: true as const,
+  providerBranchingInDomain: false as const,
+}))
+
+jest.mock('../../../../../../../infrastructure/communications', () => ({
+  resolveTelephonyProviderAdapter: jest.fn(() => ({
+    providerKey: 'telnyx',
+    adapterInterfaceVersion: 'v1',
+    sendSms: sendSmsMock,
+    startOutboundCall: startOutboundCallMock,
+    startBridgeSession: startBridgeSessionMock,
+    endCall: endCallMock,
+    verifyWebhook: verifyWebhookMock,
+    translateProviderEvent: translateProviderEventMock,
+  })),
+}))
+
+const buildHeaders = (extra: Record<string, string> = {}): Record<string, string> => ({
+  'x-test-connectshyft-tenant-id': 'tenant-connectshyft-f1',
+  'x-test-connectshyft-orgunit-id': 'org-connectshyft-f1-east',
+  'x-test-connectshyft-orgunit-memberships': JSON.stringify(['org-connectshyft-f1-east']),
+  'x-test-connectshyft-role': 'ORGUNIT_MEMBER',
+  'x-test-connectshyft-user-id': 'user-connectshyft-f1-primary-operator',
+  'x-test-connectshyft-enabled-providers': JSON.stringify(['telnyx']),
+  'x-test-connectshyft-flags': JSON.stringify({
+    connectshyft_enabled: true,
+    connectshyft_inbox_enabled: true,
+    connectshyft_escalation_enabled: true,
+    connectshyft_webhooks_enabled: true,
+  }),
+  ...extra,
+})
+
+const invokeRoute = async (input: {
+  method?: 'GET' | 'POST'
+  url: string
+  body?: Record<string, unknown>
+  rawBody?: string | Buffer
+  headers?: Record<string, string>
+}): Promise<{ status: number; body: unknown }> => {
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(input.headers || {}).map(([key, value]) => [key.toLowerCase(), value]),
+  )
+
+  return new Promise((resolve, reject) => {
+    let resolved = false
+    const req = {
+      method: input.method || 'POST',
+      url: input.url,
+      originalUrl: input.url,
+      path: input.url,
+      protocol: 'https',
+      body: input.body || {},
+      rawBody: input.rawBody,
+      headers: normalizedHeaders,
+      params: {},
+      query: {},
+      tenantContext: undefined,
+      tenantId: undefined,
+      orgUnitId: undefined,
+      user: undefined,
+      header(name: string): string | undefined {
+        return normalizedHeaders[name.toLowerCase()]
+      },
+      get(name: string): string | undefined {
+        return normalizedHeaders[name.toLowerCase()]
+      },
+    } as any
+
+    const res = {
+      locals: {},
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code
+        return this
+      },
+      json(payload: unknown) {
+        resolved = true
+        resolve({
+          status: this.statusCode,
+          body: payload,
+        })
+        return this
+      },
+      send(payload: unknown) {
+        resolved = true
+        resolve({
+          status: this.statusCode,
+          body: payload,
+        })
+        return this
+      },
+      setHeader() {
+        return this
+      },
+      getHeader() {
+        return undefined
+      },
+      end(payload?: unknown) {
+        if (!resolved) {
+          resolved = true
+          resolve({
+            status: this.statusCode,
+            body: payload,
+          })
+        }
+        return this
+      },
+    } as any
+
+    ;(connectShyftRouter as any).handle(req, res, (error?: unknown) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      if (!resolved) {
+        resolve({
+          status: res.statusCode,
+          body: null,
+        })
+      }
+    })
+  })
+}
+
+describe('connectshyft bridge webhook flow', () => {
+  const previousNodeEnv = process.env.NODE_ENV
+  const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test'
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true'
+  })
+
+  beforeEach(() => {
+    sendSmsMock.mockClear()
+    startOutboundCallMock.mockClear()
+    startBridgeSessionMock.mockClear()
+    endCallMock.mockClear()
+    verifyWebhookMock.mockClear()
+    translateProviderEventMock.mockClear()
+    resetConnectShyftCanonicalEventsForTests()
+    resetConnectShyftBridgeSessionStateForTests()
+    resetConnectShyftProviderCorrelationStateForTests()
+    jest.spyOn(connectShyftNumberMappingServiceAsync, 'resolveRoutingMappingByNumber').mockImplementation(
+      async (input) => {
+        if (input.tenantId === 'tenant-connectshyft-f1' && input.twilioNumberE164 === '+12605550191') {
+          return {
+            status: 'found' as const,
+            mapping: {
+              mappingId: 'mapping-f1-001',
+              tenantId: 'tenant-connectshyft-f1',
+              orgUnitId: 'org-connectshyft-f1-east',
+              twilioNumberE164: '+12605550191',
+              label: 'Front Desk',
+              isActive: true,
+              createdAtUtc: '2026-03-11T12:00:00.000Z',
+              updatedAtUtc: '2026-03-11T12:00:00.000Z',
+            },
+          }
+        }
+
+        return {
+          status: 'not-found' as const,
+        }
+      },
+    )
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags
+  })
+
+  it('creates a persisted bridge session on call start with operator-first dialing', async () => {
+    const response = await invokeRoute({
+
+=== EXISTING SPECS / TELEPHONY-RELATED ===
+specs/003-telnyx-outbound-adapter
+specs/004-bridge-test-fixture-normalization
+specs/020-connectshyft-sms-handoff
+specs/021-connectshyft-sms-sender-architecture
+specs/022-inbound-sms-identity-resolution-and-raw-body-capture
+
+=== CURRENT TEST RESULTS: TARGETED TELEPHONY SUITE ===
+
+=== CURRENT TEST RESULTS: FULL CONNECTSHYFT API ===
+
+> moneyshyft-monorepo@0.3.6 nx /Users/jeremiahotis/projects/connectshyft
+> node scripts/nx-shim.mjs "run" "connectshyft-api:test"
+
+
+> connectshyft-api@0.3.6 test:integration
+> NODE_ENV=test CONNECTSHYFT_MINIMAL_APP=1 jest --runInBand --config jest.config.js --runTestsByPath ../../tests/integration/connectshyft-api/health.test.ts ../../tests/integration/connectshyft-api/work-intents.test.ts ../../tests/integration/peoplecore/contact-points.test.ts ../../tests/integration/peoplecore/identity-decision.test.ts ../../tests/integration/peoplecore/resolver-reviews.test.ts
+

--- a/specs/slice-16-codex-ready-implementation-brief.md
+++ b/specs/slice-16-codex-ready-implementation-brief.md
@@ -1,0 +1,470 @@
+# Slice 16: ConnectShyft Telephony Stabilization
+
+## Objective
+
+Stabilize the telephony runtime that already exists in `apps/connectshyft-api` so ConnectShyft can move from architecture groundwork into trustworthy real-world operation.
+
+This slice is not a redesign.
+This slice is a runtime stabilization slice.
+
+It must:
+- preserve the current provider-neutral architecture
+- preserve the thin-router direction already established
+- preserve current identity ambiguity behavior from Slices 13 through 15
+- keep ConnectShyft neighbor/person authority boundaries unchanged
+- harden telephony behavior where tests and recon show instability
+- close the currently failing bridge-flow regression before any broader telephony expansion
+
+---
+
+## Repo-Snapped Scope
+
+Primary runtime surface already exists in:
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/inboundSms.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+
+Primary tests already in play:
+
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/numberMappings.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundVoice.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/inboundSms.test.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/__tests__/senderNumberResolver.test.ts`
+
+---
+
+## Locked Recommendation
+
+Implement Slice 16 as **telephony runtime stabilization**, not as telephony expansion.
+
+Best-practice call:
+- fix the failing bridge-flow persistence/read path first
+- then harden runtime seams already present in the router and modules
+- do not introduce new provider features, new transport modes, or major schema redesign in this slice
+- do not move identity ownership again in this slice
+- do not fold telephony logic back into unrelated handler families
+
+Why this is the right move:
+- recon shows the telephony surface already exists and is broad
+- the current targeted failure set is narrow: one bridge-flow test is failing while the rest of the telephony target set is largely green
+- this means the fastest path to a working system is stabilization, not new capability expansion
+
+Counterpoint:
+A tempting path is to jump directly into outbound/provider feature growth because the route already contains a lot of telephony logic. That is the wrong move for this slice. A partially stable call/message stack with one unresolved bridge persistence/read defect is not ready for expansion.
+
+---
+
+## Policy: Telephony Stabilization (LOCKED)
+
+Decision:
+- Slice 16 stabilizes existing telephony runtime behavior only.
+
+Rules:
+- No provider redesign.
+- No new provider abstraction layer.
+- No new identity authority model.
+- No silent fallback that weakens ambiguity handling.
+- No route thickening beyond minimal stabilization changes.
+- No behavioral drift in response shapes unless an explicit checkpoint below requires it.
+
+Enforcement:
+- Existing telephony route contracts remain authoritative.
+- Existing ambiguity behavior remains authoritative.
+- Existing provider-neutral event translation remains authoritative.
+- Every runtime change must be covered by characterization or focused regression tests.
+
+Telemetry:
+- Preserve current canonical event, correlation, and webhook receipt behavior.
+- Do not remove existing replay-safe or side-effect reporting fields.
+
+---
+
+## Non-Negotiable Constraints
+
+- Preserve current response shapes for inbound SMS, inbound voice, outbound dispatch, and provider-webhook flows unless explicitly locked below.
+- Preserve Slice 13 and Slice 14 ambiguity semantics exactly.
+- Preserve router order in `connectshyft.ts`.
+- Keep route-family orchestration in handlers/helpers/modules, not ad hoc inline sprawl.
+- Do not create standalone policy docs.
+- If documentation is updated, policy must be embedded inline in the slice docs already in scope.
+- Do not invent PeopleCore ↔ neighbor reconciliation.
+- Do not add new mapping tables for person ↔ neighbor equivalence.
+- Do not change app-shell, feature-flag, or UI architecture in this slice.
+- Do not expand beyond telephony stabilization just because nearby code is messy.
+
+---
+
+## Recon Snapshot (Authoritative for This Slice)
+
+The attached recon shows:
+- branch is `codex/dev`
+- telephony surface is already concentrated in `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- the route already coordinates provider selection, sender resolution, correlation mapping, inbound SMS handling, bridge sessions, and webhook processing
+- targeted telephony tests are mostly passing
+- the only listed failing target in the provided failures file is:
+  - `src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+  - failing test: `connectshyft bridge webhook flow › loads persisted bridge state from a fresh thread detail read after completion`
+
+This means Slice 16 should treat bridge-flow persistence/read coherence as the entry defect and then harden adjacent seams without redesigning the platform.
+
+---
+
+## Success Criteria
+
+By the end of Slice 16:
+
+- the bridge-flow failing test passes
+- the full telephony target suite passes
+- webhook SMS behavior remains green
+- provider registry dispatch and guardrails remain green
+- outbound dispatch remains green
+- inbound voice and inbound SMS module tests remain green
+- provider correlation and number mapping tests remain green
+- no identity ambiguity regression is introduced
+- no new unresolved route-contract drift is introduced
+- ConnectShyft is measurably closer to real telephony readiness because the runtime path is stabilized instead of merely described
+
+---
+
+# CHECKPOINT 1
+## Lock the Current Telephony Runtime Surface and Reproduce the Bridge Defect
+
+### Purpose
+Before changing production logic, lock the current runtime behavior around the failing bridge-flow readback path and the nearest telephony seams.
+
+### Required work
+Add or refine characterization coverage only where needed to make the bridge persistence/read expectations explicit.
+
+### Files in scope
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts`
+- `apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts`
+
+### Required behavior to lock
+- completed bridge webhook progression must be readable from a fresh thread detail read
+- persisted bridge session state must not disappear after completion
+- correlation mapping and bridge aggregate state must remain deterministic after webhook application
+- no unrelated identity or SMS fallback behavior changes
+
+### Prohibitions
+- no production logic edits in this checkpoint
+- no schema edits
+- no router refactor in this checkpoint
+
+### Validate
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts
+
+pnpm nx run connectshyft-api:test
+```
+
+### Commit
+```bash
+git add apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts \
+  apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts
+
+git commit -m "test(slice-16): lock bridge-flow telephony stabilization behavior"
+```
+
+### Stop condition
+STOP after Checkpoint 1. Report exact failing assertions before changing production code.
+
+---
+
+# CHECKPOINT 2
+## Repair Bridge Completion Persistence and Fresh-Read Coherence
+
+### Purpose
+Fix the specific bridge-flow defect where completed bridge state is not loading correctly from a fresh thread detail read.
+
+### Files in scope
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts`
+- any narrow helper already used by these modules if absolutely required
+
+### Required behavior
+- when a bridge webhook progression completes, persisted bridge state must remain readable on subsequent fresh thread-detail reads
+- bridge aggregate state, domain event output, and correlation mapping must remain internally coherent
+- completion handling must not suppress the persisted state needed by the thread-detail projection
+- replay-safe semantics must remain intact
+
+### Prohibitions
+- no provider redesign
+- no new route families
+- no broad projection rewrite
+- no change to unrelated inbound SMS or outbound message behavior
+
+### Implementation rule
+Prefer the narrowest possible fix:
+- repair persistence/read contract mismatch first
+- repair completion-state projection second only if required
+- do not rewrite bridge session architecture unless the failing test proves it is unavoidable
+
+### Validate
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts
+
+pnpm nx run connectshyft-api:test
+```
+
+### Commit
+```bash
+git add apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts \
+  apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts \
+  apps/connectshyft-api/src/modules/connectshyft/canonicalEvents.ts
+
+git commit -m "fix(slice-16): restore bridge completion persistence and fresh-read coherence"
+```
+
+### Stop condition
+STOP after Checkpoint 2. Confirm the previously failing bridge-flow test now passes.
+
+---
+
+# CHECKPOINT 3
+## Stabilize Inbound Webhook Correlation and Reusable Neighbor Resolution
+
+### Purpose
+Harden the inbound telephony path that reuses explicit or correlated neighbor identity during webhook intake, without changing ambiguity policy.
+
+### Files in scope
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/neighbors.ts`
+
+### Required behavior
+- explicit inbound neighbor reuse remains supported when valid
+- correlated thread neighbor reuse remains supported when valid
+- retryable persistence failures remain explicit
+- ambiguity still blocks creation
+- no-match still allows the existing create-new shell where already characterized
+- PeopleCore-unavailable fallback remains stable where already characterized
+
+### Prohibitions
+- no weakening of Slice 13 ambiguity precedence
+- no new silent winner selection
+- no new crosswalk logic between person and neighbor
+
+### Validate
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts
+
+pnpm nx run connectshyft-api:test
+```
+
+### Commit
+```bash
+git add apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts \
+  apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings.ts \
+  apps/connectshyft-api/src/modules/connectshyft/identityResolver.ts \
+  apps/connectshyft-api/src/modules/connectshyft/neighbors.ts
+
+git commit -m "fix(slice-16): stabilize inbound telephony correlation and neighbor reuse"
+```
+
+### Stop condition
+STOP after Checkpoint 3. Report whether inbound SMS and provider-registry telephony suites are still green.
+
+---
+
+# CHECKPOINT 4
+## Stabilize Outbound Sender Resolution and Bridge Dispatch Guardrails
+
+### Purpose
+Harden the outbound call/message runtime without redesigning provider selection.
+
+### Files in scope
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts`
+
+### Required behavior
+- outbound SMS target ambiguity behavior remains unchanged
+- outbound sender ambiguity behavior remains unchanged
+- bridge transport policy remains enforced for calls
+- provider adapter selection remains deterministic
+- dispatch-side persistence and replay-safe behavior remain intact
+
+### Prohibitions
+- no new transport modes
+- no experimental provider branching in domain modules
+- no response-shape redesign
+
+### Validate
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+  src/modules/connectshyft/__tests__/senderNumberResolver.test.ts \
+  src/modules/connectshyft/__tests__/numberMappings.test.ts \
+  src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts
+
+pnpm nx run connectshyft-api:test
+```
+
+### Commit
+```bash
+git add apps/connectshyft-api/src/routes/api/v1/connectshyft.ts \
+  apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts \
+  apps/connectshyft-api/src/modules/connectshyft/smsPreferenceOverrides.ts \
+  apps/connectshyft-api/src/modules/connectshyft/providerRegistry.ts \
+  apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts
+
+git commit -m "fix(slice-16): harden outbound telephony dispatch and sender resolution"
+```
+
+### Stop condition
+STOP after Checkpoint 4. Confirm outbound dispatch suite remains green.
+
+---
+
+# CHECKPOINT 5
+## Add Telephony Runtime Notes Aligned to Actual Repo Ownership
+
+### Purpose
+Document the stabilized runtime seams so future slices do not re-thicken the router or re-open settled ambiguity behavior.
+
+### Create
+- `docs/architecture/connectshyft-telephony-runtime-notes.md`
+
+### Update
+- `docs/architecture/connectshyft-router-refactor-plan.md`
+
+### Required documentation content
+- what telephony runtime remains in `connectshyft.ts`
+- what is intentionally still owned by domain/infrastructure modules
+- that Slice 16 is stabilization, not expansion
+- that ambiguity rules remain governed by Slices 13 through 15
+- what remains deferred for future telephony audit/launch readiness
+
+### Prohibitions
+- no standalone policy docs
+- no fake future architecture descriptions
+- no claims that PeopleCore already replaces ConnectShyft neighbor runtime
+
+### Validate
+```bash
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+### Commit
+```bash
+git add docs/architecture/connectshyft-telephony-runtime-notes.md \
+  docs/architecture/connectshyft-router-refactor-plan.md
+
+git commit -m "docs(slice-16): lock connectshyft telephony runtime stabilization boundaries"
+```
+
+### Stop condition
+STOP after Checkpoint 5.
+
+---
+
+# CHECKPOINT 6
+## Final Telephony Target Validation and PR Prep
+
+### Purpose
+Run the exact telephony-focused validation set and close the slice only if the runtime is stable.
+
+### Validate
+```bash
+pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath \
+  src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts \
+  src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts \
+  src/modules/connectshyft/__tests__/numberMappings.test.ts \
+  src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts \
+  src/modules/connectshyft/__tests__/inboundVoice.test.ts \
+  src/modules/connectshyft/__tests__/inboundSms.test.ts \
+  src/modules/connectshyft/__tests__/senderNumberResolver.test.ts
+
+pnpm nx run connectshyft-api:test
+pnpm nx run contracts:test
+```
+
+### Commit
+```bash
+git status --short
+```
+
+If clean and green, then:
+
+```bash
+git push -u origin codex/slice-16-telephony-stabilization
+```
+
+### PR
+Title:
+```text
+Slice 16: stabilize ConnectShyft telephony runtime
+```
+
+### PR body must state
+- bridge-flow failing test fixed
+- telephony target suite green
+- no ambiguity-policy regression
+- no provider redesign performed
+- slice stayed within stabilization scope
+
+---
+
+## Codex Execution Rules
+
+- Work checkpoint by checkpoint.
+- Do not skip ahead.
+- Stop after each checkpoint.
+- If validation fails, report:
+  - exact failing tests
+  - exact file/line if available
+  - whether failure is new, pre-existing, or caused by current checkpoint
+  - minimal next fix recommendation
+- Commit all and only the files changed for that checkpoint if validation passes.
+- Do not silently widen scope.
+
+---
+
+## Definition of Done
+
+Slice 16 is done only if:
+- the bridge-flow defect is resolved
+- telephony runtime target suites are green
+- no ambiguity regressions were introduced
+- no new telephony architecture drift was introduced
+- docs accurately describe the stabilized runtime ownership
+


### PR DESCRIPTION
## Summary
- bridge-flow failing test fixed
- telephony target suite green
- no ambiguity-policy regression
- no provider redesign performed
- slice stayed within stabilization scope

## Validation
- pnpm --dir apps/connectshyft-api exec jest --runInBand --config jest.config.js --runTestsByPath src/routes/api/v1/__tests__/connectshyft.bridge-flow.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.dispatch-events.test.ts src/routes/api/v1/__tests__/connectshyft.provider-registry.guardrails.test.ts src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts src/modules/connectshyft/__tests__/numberMappings.test.ts src/modules/connectshyft/__tests__/providerCorrelationMappings.test.ts src/modules/connectshyft/__tests__/inboundVoice.test.ts src/modules/connectshyft/__tests__/inboundSms.test.ts src/modules/connectshyft/__tests__/senderNumberResolver.test.ts
- pnpm nx run connectshyft-api:test
- pnpm nx run contracts:test