### PR TITLE
Fix: unblock admin-api production build

### DIFF
--- a/apps/admin-api/tsconfig.build.json
+++ b/apps/admin-api/tsconfig.build.json
@@ -3,6 +3,7 @@
   "exclude": [
     "node_modules",
     "dist",
+    "src/migrations/**",
     "src/**/__tests__/**",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",


### PR DESCRIPTION
## Summary
- exclude admin-api source migrations from the production TypeScript build so migration mirror files outside the app rootDir do not break compilation
- preserve the existing production migration path that packages shared migrations into dist/shared/database/migrations

## Validation
- cd apps/admin-api && npm run build