### PR TITLE
feat(connectshyft): add activity service and API endpoints

### DIFF
--- a/apps/connectshyft-api/src/migrations/20260324130000_create_people_activities.ts
+++ b/apps/connectshyft-api/src/migrations/20260324130000_create_people_activities.ts
@@ -1,0 +1,4 @@
+export {
+  down,
+  up,
+} from '../../../../shared/database/migrations/20260324130000_create_people_activities';

--- a/apps/connectshyft-api/src/migrations/20260324131000_add_activity_id_to_connectshyft_threads.ts
+++ b/apps/connectshyft-api/src/migrations/20260324131000_add_activity_id_to_connectshyft_threads.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE connectshyft.cs_threads
+      ADD COLUMN IF NOT EXISTS activity_id UUID NULL;
+  `);
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS cs_threads_activity_idx
+    ON connectshyft.cs_threads (tenant_id, org_unit_id, activity_id)
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP INDEX IF EXISTS connectshyft.cs_threads_activity_idx');
+  await knex.raw(`
+    ALTER TABLE connectshyft.cs_threads
+      DROP COLUMN IF EXISTS activity_id
+  `);
+}

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/activities.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/activities.test.ts
@@ -1,0 +1,346 @@
+import type { Person } from '@shyft/contracts';
+import type { Request, Response } from 'express';
+import type { Activity } from '../../peoplecore/activity';
+import type { ConnectShyftThread } from '../threads';
+import {
+  ConnectShyftActivityForbiddenError,
+  ConnectShyftActivityNotFoundError,
+  ConnectShyftActivityPersistenceUnavailableError,
+  ConnectShyftActivityService,
+  ConnectShyftPersonNotFoundError,
+  InMemoryConnectShyftActivityThreadStore,
+  connectShyftActivityServiceAsync,
+} from '../activities';
+import { getActivityThreadsHandler } from '../handlers/getActivityThreadsHandler';
+import { getPersonActivitiesHandler } from '../handlers/getPersonActivitiesHandler';
+import { postPersonActivityHandler } from '../handlers/postPersonActivityHandler';
+
+type MockResponse = Response & {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+type RequestOptions = {
+  activityId?: string;
+  body?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  orgUnitId?: string;
+  personId?: string;
+  role?: string;
+  tenantId?: string;
+  userId?: string;
+};
+
+const BASE_ACTIVITY: Activity = {
+  id: '11111111-1111-4111-8111-111111111111',
+  tenantId: 'tenant-connectshyft-activity',
+  orgUnitId: 'org-connectshyft-activity-east',
+  personId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1',
+  type: 'housing-intake',
+  status: 'ACTIVE',
+  createdAtUtc: '2026-03-23T12:00:00.000Z',
+  updatedAtUtc: '2026-03-23T12:00:00.000Z',
+};
+
+const BASE_PERSON: Person = {
+  id: BASE_ACTIVITY.personId,
+  tenantId: BASE_ACTIVITY.tenantId,
+  orgUnitId: BASE_ACTIVITY.orgUnitId,
+  firstName: 'Activity',
+  lastName: 'Person',
+  preferredName: undefined,
+  status: 'active_confirmed',
+  mergedIntoPersonId: undefined,
+  createdAt: '2026-03-23T11:00:00.000Z',
+  updatedAt: '2026-03-23T11:00:00.000Z',
+};
+
+const BASE_THREAD: ConnectShyftThread = {
+  threadId: '22222222-2222-4222-8222-222222222222',
+  tenantId: BASE_ACTIVITY.tenantId,
+  orgUnitId: BASE_ACTIVITY.orgUnitId,
+  neighborId: 'neighbor-connectshyft-activity-1',
+  personId: BASE_ACTIVITY.personId,
+  activityId: BASE_ACTIVITY.id,
+  source: 'VOICE',
+  state: 'UNCLAIMED',
+  lastInboundCsNumberId: 'cs-inbound-1',
+  preferredOutboundCsNumberId: 'cs-outbound-1',
+  claimedByUserId: null,
+  claimedAtUtc: null,
+  closedByUserId: null,
+  closedAtUtc: null,
+  createdAtUtc: '2026-03-23T13:00:00.000Z',
+  updatedAtUtc: '2026-03-23T13:00:00.000Z',
+  escalation: {
+    stage: 0,
+    nextEvaluationAtUtc: '2026-03-23T13:00:00.000Z',
+  },
+};
+
+const createRequest = (options: RequestOptions = {}): Request => {
+  const tenantId = options.tenantId ?? BASE_ACTIVITY.tenantId;
+  const orgUnitId = options.orgUnitId ?? BASE_ACTIVITY.orgUnitId;
+  const normalizedHeaders = Object.entries({
+    'x-test-connectshyft-flags': JSON.stringify({
+      connectshyft_enabled: true,
+      connectshyft_inbox_enabled: true,
+      connectshyft_escalation_enabled: true,
+      connectshyft_webhooks_enabled: true,
+    }),
+    'x-test-connectshyft-orgunit-memberships': JSON.stringify([orgUnitId]),
+    ...options.headers,
+  }).reduce<Record<string, string>>((acc, [key, value]) => {
+    acc[key.toLowerCase()] = value;
+    return acc;
+  }, {});
+
+  return {
+    body: options.body ?? {},
+    params: {
+      ...(options.personId ? { personId: options.personId } : {}),
+      ...(options.activityId ? { activityId: options.activityId } : {}),
+    },
+    tenantId,
+    orgUnitId,
+    tenantContext: {
+      tenantId,
+      orgUnitId,
+      scopeMode: 'ORG_UNIT',
+      source: 'auth',
+    },
+    user: {
+      userId: options.userId ?? 'user-connectshyft-activity',
+      email: 'activity-handler@example.com',
+      householdId: tenantId,
+      activeTenantId: tenantId,
+      activeOrgUnitId: orgUnitId,
+      role: options.role ?? 'ORGUNIT_MEMBER',
+    },
+    header: (name: string) => normalizedHeaders[name.toLowerCase()] || undefined,
+  } as unknown as Request;
+};
+
+const createMockResponse = (): MockResponse => {
+  const res = {
+    locals: {
+      responseEnvelope: {
+        correlationId: 'corr-connectshyft-activity-tests',
+        tenantId: BASE_ACTIVITY.tenantId,
+      },
+    },
+    status: jest.fn(),
+    json: jest.fn(),
+  } as unknown as MockResponse;
+
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+
+  return res;
+};
+
+describe('connectshyft activity service', () => {
+  let service: ConnectShyftActivityService;
+  let peopleCoreService: {
+    createActivity: jest.Mock;
+    getActivity: jest.Mock;
+    getPerson: jest.Mock;
+    listActivities: jest.Mock;
+  };
+
+  beforeEach(() => {
+    peopleCoreService = {
+      createActivity: jest.fn(),
+      getActivity: jest.fn(),
+      getPerson: jest.fn(),
+      listActivities: jest.fn(),
+    };
+
+    service = new ConnectShyftActivityService(
+      peopleCoreService as any,
+      new InMemoryConnectShyftActivityThreadStore([
+        BASE_THREAD,
+        {
+          ...BASE_THREAD,
+          threadId: '33333333-3333-4333-8333-333333333333',
+          createdAtUtc: '2026-03-23T13:05:00.000Z',
+          updatedAtUtc: '2026-03-23T13:05:00.000Z',
+          activityId: BASE_ACTIVITY.id,
+        },
+        {
+          ...BASE_THREAD,
+          threadId: '44444444-4444-4444-8444-444444444444',
+          activityId: '55555555-5555-4555-8555-555555555555',
+        },
+      ]),
+    );
+  });
+
+  it('creates a person activity when the actor has activity create capability', async () => {
+    peopleCoreService.getPerson.mockResolvedValue(BASE_PERSON);
+    peopleCoreService.createActivity.mockResolvedValue(BASE_ACTIVITY);
+
+    const activity = await service.createPersonActivity({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: BASE_ACTIVITY.tenantId,
+      orgUnitId: BASE_ACTIVITY.orgUnitId,
+      personId: BASE_ACTIVITY.personId,
+      type: BASE_ACTIVITY.type,
+    });
+
+    expect(activity).toEqual(BASE_ACTIVITY);
+    expect(peopleCoreService.createActivity).toHaveBeenCalledWith({
+      tenantId: BASE_ACTIVITY.tenantId,
+      orgUnitId: BASE_ACTIVITY.orgUnitId,
+      personId: BASE_ACTIVITY.personId,
+      type: BASE_ACTIVITY.type,
+      status: undefined,
+    });
+  });
+
+  it('throws CONNECTSHYFT_FORBIDDEN when the actor lacks activity create capability', async () => {
+    await expect(service.createPersonActivity({
+      actorRoles: ['TENANT_VIEWER'],
+      tenantId: BASE_ACTIVITY.tenantId,
+      orgUnitId: BASE_ACTIVITY.orgUnitId,
+      personId: BASE_ACTIVITY.personId,
+      type: BASE_ACTIVITY.type,
+    })).rejects.toBeInstanceOf(ConnectShyftActivityForbiddenError);
+  });
+
+  it('throws CONNECTSHYFT_PERSON_NOT_FOUND when the person is outside the current orgUnit', async () => {
+    peopleCoreService.getPerson.mockResolvedValue({
+      ...BASE_PERSON,
+      orgUnitId: 'org-connectshyft-activity-west',
+    });
+
+    await expect(service.listPersonActivities({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: BASE_ACTIVITY.tenantId,
+      orgUnitId: BASE_ACTIVITY.orgUnitId,
+      personId: BASE_ACTIVITY.personId,
+    })).rejects.toBeInstanceOf(ConnectShyftPersonNotFoundError);
+  });
+
+  it('lists only threads bound to the requested activity', async () => {
+    peopleCoreService.getActivity.mockResolvedValue(BASE_ACTIVITY);
+
+    const threads = await service.listActivityThreads({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: BASE_ACTIVITY.tenantId,
+      orgUnitId: BASE_ACTIVITY.orgUnitId,
+      activityId: BASE_ACTIVITY.id,
+    });
+
+    expect(threads.map((thread) => thread.threadId)).toEqual([
+      '22222222-2222-4222-8222-222222222222',
+      '33333333-3333-4333-8333-333333333333',
+    ]);
+  });
+
+  it('throws CONNECTSHYFT_ACTIVITY_NOT_FOUND when the activity does not exist', async () => {
+    peopleCoreService.getActivity.mockResolvedValue(null);
+
+    await expect(service.listActivityThreads({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: BASE_ACTIVITY.tenantId,
+      orgUnitId: BASE_ACTIVITY.orgUnitId,
+      activityId: BASE_ACTIVITY.id,
+    })).rejects.toBeInstanceOf(ConnectShyftActivityNotFoundError);
+  });
+});
+
+describe('connectshyft activity handlers', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+  });
+
+  it('returns a 201 success envelope when creating a person activity', async () => {
+    jest.spyOn(connectShyftActivityServiceAsync, 'createPersonActivity').mockResolvedValue(BASE_ACTIVITY);
+    const res = createMockResponse();
+
+    await postPersonActivityHandler(createRequest({
+      personId: BASE_ACTIVITY.personId,
+      body: {
+        type: BASE_ACTIVITY.type,
+      },
+    }), res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      ok: true,
+      code: 'CONNECTSHYFT_ACTIVITY_CREATED',
+      data: {
+        activity: BASE_ACTIVITY,
+      },
+    }));
+  });
+
+  it('returns a client refusal when personId is not a UUID', async () => {
+    const createSpy = jest.spyOn(connectShyftActivityServiceAsync, 'createPersonActivity');
+    const res = createMockResponse();
+
+    await postPersonActivityHandler(createRequest({
+      personId: 'not-a-uuid',
+      body: {
+        type: BASE_ACTIVITY.type,
+      },
+    }), res);
+
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      code: 'CONNECTSHYFT_PERSON_ID_INVALID',
+      refusalType: 'client',
+    }));
+  });
+
+  it('maps person not found to a 404 refusal envelope', async () => {
+    jest
+      .spyOn(connectShyftActivityServiceAsync, 'listPersonActivities')
+      .mockRejectedValue(new ConnectShyftPersonNotFoundError());
+    const res = createMockResponse();
+
+    await getPersonActivitiesHandler(createRequest({
+      personId: BASE_ACTIVITY.personId,
+    }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      code: 'CONNECTSHYFT_PERSON_NOT_FOUND',
+    }));
+  });
+
+  it('maps persistence failures to a 503 system envelope', async () => {
+    jest
+      .spyOn(connectShyftActivityServiceAsync, 'listActivityThreads')
+      .mockRejectedValue(new ConnectShyftActivityPersistenceUnavailableError());
+    const res = createMockResponse();
+
+    await getActivityThreadsHandler(createRequest({
+      activityId: BASE_ACTIVITY.id,
+    }), res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      code: 'CONNECTSHYFT_ACTIVITY_PERSISTENCE_UNAVAILABLE',
+      errorType: 'system',
+    }));
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts
@@ -1,6 +1,9 @@
 import knex, { Knex } from 'knex';
 import { up as migrateThreadsUp } from '../../../migrations/20260224170000_create_connectshyft_threads';
+import { up as migratePeopleCoreIdentityFoundationUp } from '../../../migrations/20260321100000_create_peoplecore_identity_foundation';
 import { up as migrateThreadPersonIdentityUp } from '../../../migrations/20260323180000_add_connectshyft_thread_person_identity';
+import { up as migratePeopleActivitiesUp } from '../../../migrations/20260324130000_create_people_activities';
+import { up as migrateThreadActivityIdUp } from '../../../migrations/20260324131000_add_activity_id_to_connectshyft_threads';
 import { AsyncConnectShyftThreadService, KnexConnectShyftThreadStore } from '../threads';
 import { resolveSenderNumber } from '../senderNumberResolver';
 
@@ -15,7 +18,37 @@ async function ensurePerson(db: Knex, personId: string): Promise<void> {
   await db
     .withSchema('people')
     .table('persons')
-    .insert({ id: personId })
+    .insert({
+      id: personId,
+      tenant_id: 'tenant-contract-c1-people',
+      org_unit_id: 'org-contract-c1-people',
+      first_name: 'Contract',
+      last_name: 'Person',
+    })
+    .onConflict('id')
+    .ignore();
+}
+
+async function ensureActivity(input: {
+  db: Knex;
+  activityId: string;
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+  type?: string;
+  status?: 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+}): Promise<void> {
+  await input.db
+    .withSchema('people')
+    .table('activities')
+    .insert({
+      id: input.activityId,
+      tenant_id: input.tenantId,
+      org_unit_id: input.orgUnitId,
+      person_id: input.personId,
+      type: input.type ?? 'housing-intake',
+      status: input.status ?? 'ACTIVE',
+    })
     .onConflict('id')
     .ignore();
 }
@@ -30,8 +63,6 @@ describeIfDb('connectshyft threads (postgres contract)', () => {
     });
 
     await db.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
-    await db.raw('CREATE SCHEMA IF NOT EXISTS people');
-    await db.raw('CREATE TABLE IF NOT EXISTS people.persons (id UUID PRIMARY KEY)');
 
     const hasUsersTable = await db.schema.hasTable('users');
     if (!hasUsersTable) {
@@ -40,14 +71,22 @@ describeIfDb('connectshyft threads (postgres contract)', () => {
       });
     }
 
+    await migratePeopleCoreIdentityFoundationUp(db);
     await migrateThreadsUp(db);
     await migrateThreadPersonIdentityUp(db);
+    await migratePeopleActivitiesUp(db);
+    await migrateThreadActivityIdUp(db);
   });
 
   afterEach(async () => {
     await db
       .withSchema('connectshyft')
       .table('cs_threads')
+      .where('tenant_id', 'like', `${CONTRACT_TENANT_PREFIX}%`)
+      .del();
+    await db
+      .withSchema('people')
+      .table('activities')
       .where('tenant_id', 'like', `${CONTRACT_TENANT_PREFIX}%`)
       .del();
   });
@@ -484,6 +523,173 @@ describeIfDb('connectshyft threads (postgres contract)', () => {
       ok: false,
       code: 'CONNECTSHYFT_THREAD_PERSON_REQUIRED',
       message: 'ConnectShyft thread persistence requires personId.',
+    });
+
+    const persistedRows = await db
+      .withSchema('connectshyft')
+      .table('cs_threads')
+      .where({ tenant_id: tenantId })
+      .count<{ count: string }[]>('* as count');
+
+    expect(Number(persistedRows[0]?.count ?? 0)).toBe(0);
+  });
+
+  it('binds a valid activityId on thread creation and returns it in the DTO', async () => {
+    const tenantId = `${CONTRACT_TENANT_PREFIX}activity-valid`;
+    const orgUnitId = 'org-contract-c1-activity-valid';
+    const neighborId = 'neighbor-contract-c1-activity-valid';
+    const personId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa6';
+    const activityId = '55555555-5555-4555-8555-555555555555';
+    const service = new AsyncConnectShyftThreadService(new KnexConnectShyftThreadStore(db));
+
+    await ensurePerson(db, personId);
+    await ensureActivity({
+      db,
+      activityId,
+      tenantId,
+      orgUnitId,
+      personId,
+      status: 'ACTIVE',
+    });
+
+    const result = await service.ensureThread({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId,
+      orgUnitId,
+      neighborId,
+      personId,
+      activityId,
+      source: 'SMS',
+      lastInboundCsNumberId: 'cs-inbound-activity-valid',
+      preferredOutboundCsNumberId: 'cs-outbound-activity-valid',
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_ENSURED',
+      data: {
+        thread: {
+          personId,
+          activityId,
+        },
+      },
+    });
+
+    const persisted = await db
+      .withSchema('connectshyft')
+      .table('cs_threads')
+      .where({
+        tenant_id: tenantId,
+        org_unit_id: orgUnitId,
+        neighbor_id: neighborId,
+      })
+      .first<{ activity_id: string | null; person_id: string }>('activity_id', 'person_id');
+
+    expect(persisted?.person_id).toBe(personId);
+    expect(persisted?.activity_id).toBe(activityId);
+  });
+
+  it.each([
+    [
+      'missing activity',
+      async () => undefined,
+    ],
+    [
+      'activity owned by a different person',
+      async () => {
+        const tenantId = `${CONTRACT_TENANT_PREFIX}activity-invalid-different-person`;
+        const orgUnitId = 'org-contract-c1-activity-invalid-different-person';
+        const personId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa7';
+        const otherPersonId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa8';
+        const activityId = '66666666-6666-4666-8666-666666666666';
+
+        await ensurePerson(db, personId);
+        await ensurePerson(db, otherPersonId);
+        await ensureActivity({
+          db,
+          activityId,
+          tenantId,
+          orgUnitId,
+          personId: otherPersonId,
+          status: 'ACTIVE',
+        });
+
+        return { tenantId, orgUnitId, personId, activityId };
+      },
+    ],
+  ])('refuses ensureThread for %s activity associations', async (_label, setup) => {
+    const fallbackTenantId = `${CONTRACT_TENANT_PREFIX}activity-invalid-missing`;
+    const fallbackOrgUnitId = 'org-contract-c1-activity-invalid-missing';
+    const fallbackPersonId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa9';
+    const fallbackActivityId = '77777777-7777-4777-8777-777777777777';
+    const service = new AsyncConnectShyftThreadService(new KnexConnectShyftThreadStore(db));
+
+    await ensurePerson(db, fallbackPersonId);
+
+    const seeded = await setup();
+    const tenantId = seeded?.tenantId ?? fallbackTenantId;
+    const orgUnitId = seeded?.orgUnitId ?? fallbackOrgUnitId;
+    const personId = seeded?.personId ?? fallbackPersonId;
+    const activityId = seeded?.activityId ?? fallbackActivityId;
+
+    const result = await service.ensureThread({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId,
+      orgUnitId,
+      neighborId: `neighbor-${tenantId}`,
+      personId,
+      activityId,
+      source: 'SMS',
+      lastInboundCsNumberId: 'cs-inbound-activity-invalid',
+      preferredOutboundCsNumberId: 'cs-outbound-activity-invalid',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ACTIVITY_INVALID',
+    });
+
+    const persistedRows = await db
+      .withSchema('connectshyft')
+      .table('cs_threads')
+      .where({ tenant_id: tenantId })
+      .count<{ count: string }[]>('* as count');
+
+    expect(Number(persistedRows[0]?.count ?? 0)).toBe(0);
+  });
+
+  it('refuses ensureThread when activityId references a non-active activity', async () => {
+    const tenantId = `${CONTRACT_TENANT_PREFIX}activity-not-active`;
+    const orgUnitId = 'org-contract-c1-activity-not-active';
+    const personId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa10';
+    const activityId = '88888888-8888-4888-8888-888888888888';
+    const service = new AsyncConnectShyftThreadService(new KnexConnectShyftThreadStore(db));
+
+    await ensurePerson(db, personId);
+    await ensureActivity({
+      db,
+      activityId,
+      tenantId,
+      orgUnitId,
+      personId,
+      status: 'COMPLETED',
+    });
+
+    const result = await service.ensureThread({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId,
+      orgUnitId,
+      neighborId: 'neighbor-contract-c1-activity-not-active',
+      personId,
+      activityId,
+      source: 'SMS',
+      lastInboundCsNumberId: 'cs-inbound-activity-not-active',
+      preferredOutboundCsNumberId: 'cs-outbound-activity-not-active',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_ACTIVITY_NOT_ACTIVE',
     });
 
     const persistedRows = await db

--- a/apps/connectshyft-api/src/modules/connectshyft/activities.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/activities.ts
@@ -1,0 +1,431 @@
+import type { Person } from '@shyft/contracts';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+import {
+  CAPABILITIES,
+  hasCapability,
+  type Capability,
+} from '../../platform/rbac/capabilities';
+import type { Activity, ActivityStatus } from '../peoplecore/activity';
+import {
+  AsyncPeopleCoreService,
+  PeopleCorePersistenceUnavailableError,
+  peopleCoreServiceAsync,
+} from '../peoplecore/service';
+import { PeopleCoreScopeViolationError } from '../peoplecore/store';
+import type { ConnectShyftThread } from './threads';
+
+const CREATE_ACTIVITY_CAPABILITIES: readonly Capability[] = [
+  CAPABILITIES.ORG_UNIT_NEIGHBOR_EDIT_RELATED,
+  CAPABILITIES.NEIGHBOR_EDIT_ALL,
+  CAPABILITIES.ORG_UNIT_IDENTITY_RESOLVE,
+] as const;
+
+const VIEW_ACTIVITY_CAPABILITIES: readonly Capability[] = [
+  CAPABILITIES.ORG_UNIT_NEIGHBOR_EDIT_RELATED,
+  CAPABILITIES.NEIGHBOR_EDIT_ALL,
+  CAPABILITIES.ORG_UNIT_IDENTITY_RESOLVE,
+  CAPABILITIES.ORG_UNIT_THREAD_VIEW,
+  CAPABILITIES.THREAD_VIEW_ALL,
+  CAPABILITIES.TENANT_READ_ALL,
+] as const;
+
+const isMissingPersistenceError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const candidate = error as { code?: string };
+  return candidate.code === '42P01'
+    || candidate.code === '3F000'
+    || candidate.code === '42703';
+};
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const toIsoUtc = (value: unknown, fallbackIsoUtc: string): string => {
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.valueOf())) {
+      return parsed.toISOString();
+    }
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.valueOf())) {
+    return value.toISOString();
+  }
+
+  return fallbackIsoUtc;
+};
+
+const cloneThread = (thread: ConnectShyftThread): ConnectShyftThread => ({
+  ...thread,
+  escalation: {
+    ...thread.escalation,
+  },
+});
+
+const compareThreads = (left: ConnectShyftThread, right: ConnectShyftThread): number => {
+  const createdAtDelta =
+    new Date(left.createdAtUtc).getTime() - new Date(right.createdAtUtc).getTime();
+  if (createdAtDelta !== 0) {
+    return createdAtDelta;
+  }
+
+  return left.threadId.localeCompare(right.threadId);
+};
+
+type DbThreadRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  neighbor_id: string;
+  person_id: string;
+  activity_id: string | null;
+  source: string;
+  state: ConnectShyftThread['state'];
+  escalation_stage: number;
+  next_evaluation_at_utc: string | Date | null;
+  last_inbound_cs_number_id: string;
+  preferred_outbound_cs_number_id: string;
+  claimed_by_user_id: string | null;
+  claimed_at_utc: string | Date | null;
+  closed_by_user_id: string | null;
+  closed_at_utc: string | Date | null;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+const mapDbThreadRowToThread = (row: DbThreadRow): ConnectShyftThread => {
+  const fallbackIsoUtc = new Date().toISOString();
+
+  return {
+    threadId: row.id,
+    tenantId: row.tenant_id,
+    orgUnitId: row.org_unit_id,
+    neighborId: row.neighbor_id,
+    personId: row.person_id,
+    activityId: row.activity_id,
+    source: row.source,
+    state: row.state,
+    lastInboundCsNumberId: row.last_inbound_cs_number_id,
+    preferredOutboundCsNumberId: row.preferred_outbound_cs_number_id,
+    claimedByUserId: row.claimed_by_user_id,
+    claimedAtUtc: row.claimed_at_utc ? toIsoUtc(row.claimed_at_utc, fallbackIsoUtc) : null,
+    closedByUserId: row.closed_by_user_id,
+    closedAtUtc: row.closed_at_utc ? toIsoUtc(row.closed_at_utc, fallbackIsoUtc) : null,
+    createdAtUtc: toIsoUtc(row.created_at_utc, fallbackIsoUtc),
+    updatedAtUtc: toIsoUtc(row.updated_at_utc, fallbackIsoUtc),
+    escalation: {
+      stage: row.escalation_stage,
+      nextEvaluationAtUtc: row.next_evaluation_at_utc
+        ? toIsoUtc(row.next_evaluation_at_utc, fallbackIsoUtc)
+        : null,
+    },
+  };
+};
+
+const hasAnyCapability = (
+  actorRoles: Array<string | null | undefined>,
+  capabilities: readonly Capability[],
+): boolean => capabilities.some((capability) => hasCapability(actorRoles, capability));
+
+const isPersonInOrgUnit = (person: Person | null, orgUnitId: string): person is Person =>
+  Boolean(person && person.orgUnitId === orgUnitId);
+
+type ActivityThreadStoreInput = {
+  tenantId: string;
+  orgUnitId: string;
+  activityId: string;
+};
+
+type PeopleCoreActivityServiceLike = Pick<
+  AsyncPeopleCoreService,
+  'createActivity' | 'getActivity' | 'getPerson' | 'listActivities'
+>;
+
+export class ConnectShyftActivityServiceError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly httpStatus: number,
+    readonly refusalType: 'business' | 'client' | 'security' = 'business',
+    cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'ConnectShyftActivityServiceError';
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export class ConnectShyftActivityForbiddenError extends ConnectShyftActivityServiceError {
+  constructor() {
+    super(
+      'ConnectShyft activity access requires an authorized ConnectShyft role.',
+      'CONNECTSHYFT_FORBIDDEN',
+      403,
+      'security',
+    );
+    this.name = 'ConnectShyftActivityForbiddenError';
+  }
+}
+
+export class ConnectShyftPersonNotFoundError extends ConnectShyftActivityServiceError {
+  constructor() {
+    super(
+      'Person not found for the active tenant and orgUnit context.',
+      'CONNECTSHYFT_PERSON_NOT_FOUND',
+      404,
+    );
+    this.name = 'ConnectShyftPersonNotFoundError';
+  }
+}
+
+export class ConnectShyftActivityNotFoundError extends ConnectShyftActivityServiceError {
+  constructor() {
+    super(
+      'Activity not found for the active tenant and orgUnit context.',
+      'CONNECTSHYFT_ACTIVITY_NOT_FOUND',
+      404,
+    );
+    this.name = 'ConnectShyftActivityNotFoundError';
+  }
+}
+
+export class ConnectShyftActivityPersistenceUnavailableError extends ConnectShyftActivityServiceError {
+  constructor(cause?: unknown) {
+    super(
+      'ConnectShyft activity persistence is temporarily unavailable.',
+      'CONNECTSHYFT_ACTIVITY_PERSISTENCE_UNAVAILABLE',
+      503,
+      'business',
+      cause,
+    );
+    this.name = 'ConnectShyftActivityPersistenceUnavailableError';
+  }
+}
+
+export interface CreatePersonActivityInput {
+  actorRoles: Array<string | null | undefined>;
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+  type: string;
+  status?: ActivityStatus;
+}
+
+export interface ListPersonActivitiesInput {
+  actorRoles: Array<string | null | undefined>;
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+}
+
+export interface ListActivityThreadsInput {
+  actorRoles: Array<string | null | undefined>;
+  tenantId: string;
+  orgUnitId: string;
+  activityId: string;
+}
+
+export interface AsyncConnectShyftActivityService {
+  createPersonActivity(input: CreatePersonActivityInput): Promise<Activity>;
+  listPersonActivities(input: ListPersonActivitiesInput): Promise<Activity[]>;
+  listActivityThreads(input: ListActivityThreadsInput): Promise<ConnectShyftThread[]>;
+}
+
+export interface ConnectShyftActivityThreadStore {
+  listThreadsByActivity(input: ActivityThreadStoreInput): Promise<ConnectShyftThread[]>;
+}
+
+export class InMemoryConnectShyftActivityThreadStore implements ConnectShyftActivityThreadStore {
+  constructor(private readonly threads: ConnectShyftThread[] = []) {}
+
+  async listThreadsByActivity(input: ActivityThreadStoreInput): Promise<ConnectShyftThread[]> {
+    return this.threads
+      .filter((thread) =>
+        thread.tenantId === input.tenantId
+        && thread.orgUnitId === input.orgUnitId
+        && thread.activityId === input.activityId)
+      .sort(compareThreads)
+      .map(cloneThread);
+  }
+}
+
+export class KnexConnectShyftActivityThreadStore implements ConnectShyftActivityThreadStore {
+  constructor(private readonly knexClient: Knex = db) {}
+
+  async listThreadsByActivity(input: ActivityThreadStoreInput): Promise<ConnectShyftThread[]> {
+    try {
+      const rows = await this.knexClient
+        .withSchema('connectshyft')
+        .table('cs_threads')
+        .where({
+          tenant_id: input.tenantId,
+          org_unit_id: input.orgUnitId,
+          activity_id: input.activityId,
+        })
+        .orderBy('created_at_utc', 'asc')
+        .orderBy('id', 'asc')
+        .select<DbThreadRow[]>([
+          'id',
+          'tenant_id',
+          'org_unit_id',
+          'neighbor_id',
+          'person_id',
+          'activity_id',
+          'source',
+          'state',
+          'escalation_stage',
+          'next_evaluation_at_utc',
+          'last_inbound_cs_number_id',
+          'preferred_outbound_cs_number_id',
+          'claimed_by_user_id',
+          'claimed_at_utc',
+          'closed_by_user_id',
+          'closed_at_utc',
+          'created_at_utc',
+          'updated_at_utc',
+        ]);
+
+      return rows.map(mapDbThreadRowToThread);
+    } catch (error) {
+      if (isMissingPersistenceError(error)) {
+        throw new ConnectShyftActivityPersistenceUnavailableError(error);
+      }
+
+      throw error;
+    }
+  }
+}
+
+export class ConnectShyftActivityService implements AsyncConnectShyftActivityService {
+  constructor(
+    private readonly peopleCoreService: PeopleCoreActivityServiceLike = peopleCoreServiceAsync,
+    private readonly threadStore: ConnectShyftActivityThreadStore =
+      new KnexConnectShyftActivityThreadStore(),
+  ) {}
+
+  private async withPersistenceHandling<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (error instanceof ConnectShyftActivityServiceError) {
+        throw error;
+      }
+
+      if (error instanceof PeopleCorePersistenceUnavailableError) {
+        throw new ConnectShyftActivityPersistenceUnavailableError(error);
+      }
+
+      throw error;
+    }
+  }
+
+  private ensureCreateCapability(actorRoles: Array<string | null | undefined>): void {
+    if (!hasAnyCapability(actorRoles, CREATE_ACTIVITY_CAPABILITIES)) {
+      throw new ConnectShyftActivityForbiddenError();
+    }
+  }
+
+  private ensureViewCapability(actorRoles: Array<string | null | undefined>): void {
+    if (!hasAnyCapability(actorRoles, VIEW_ACTIVITY_CAPABILITIES)) {
+      throw new ConnectShyftActivityForbiddenError();
+    }
+  }
+
+  private async ensurePersonInScope(input: {
+    tenantId: string;
+    orgUnitId: string;
+    personId: string;
+  }): Promise<Person> {
+    const person = await this.peopleCoreService.getPerson({
+      tenantId: input.tenantId,
+      personId: input.personId,
+    });
+
+    if (!isPersonInOrgUnit(person, input.orgUnitId)) {
+      throw new ConnectShyftPersonNotFoundError();
+    }
+
+    return person;
+  }
+
+  async createPersonActivity(input: CreatePersonActivityInput): Promise<Activity> {
+    this.ensureCreateCapability(input.actorRoles);
+
+    return this.withPersistenceHandling(async () => {
+      await this.ensurePersonInScope(input);
+
+      try {
+        return await this.peopleCoreService.createActivity({
+          tenantId: input.tenantId,
+          orgUnitId: input.orgUnitId,
+          personId: input.personId,
+          type: normalizeString(input.type),
+          status: input.status,
+        });
+      } catch (error) {
+        if (error instanceof PeopleCoreScopeViolationError) {
+          throw new ConnectShyftPersonNotFoundError();
+        }
+
+        throw error;
+      }
+    });
+  }
+
+  async listPersonActivities(input: ListPersonActivitiesInput): Promise<Activity[]> {
+    this.ensureViewCapability(input.actorRoles);
+
+    return this.withPersistenceHandling(async () => {
+      await this.ensurePersonInScope(input);
+
+      try {
+        return await this.peopleCoreService.listActivities({
+          tenantId: input.tenantId,
+          orgUnitId: input.orgUnitId,
+          personId: input.personId,
+        });
+      } catch (error) {
+        if (error instanceof PeopleCoreScopeViolationError) {
+          throw new ConnectShyftPersonNotFoundError();
+        }
+
+        throw error;
+      }
+    });
+  }
+
+  async listActivityThreads(input: ListActivityThreadsInput): Promise<ConnectShyftThread[]> {
+    this.ensureViewCapability(input.actorRoles);
+
+    return this.withPersistenceHandling(async () => {
+      const activity = await this.peopleCoreService.getActivity({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        activityId: input.activityId,
+      });
+
+      if (!activity) {
+        throw new ConnectShyftActivityNotFoundError();
+      }
+
+      return this.threadStore.listThreadsByActivity({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        activityId: input.activityId,
+      });
+    });
+  }
+}
+
+export const connectShyftActivityServiceAsync = new ConnectShyftActivityService();

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/getActivityThreadsHandler.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/getActivityThreadsHandler.ts
@@ -1,0 +1,99 @@
+import { Request, Response } from 'express';
+import {
+  error as errorEnvelope,
+  refusal,
+  success,
+} from '../../../platform/envelopes/response';
+import {
+  ConnectShyftActivityServiceError,
+  connectShyftActivityServiceAsync,
+} from '../activities';
+import {
+  enforceConnectShyftCapability,
+  resolveConnectShyftActorRoles,
+  resolveConnectShyftRouteContextDecision,
+  respondWithConnectShyftContextRefusal,
+} from '../http/accessContext';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const respondActivityError = (res: Response, error: ConnectShyftActivityServiceError) => {
+  if (error.httpStatus >= 500) {
+    return errorEnvelope(res, {
+      code: error.code,
+      message: error.message,
+      httpStatus: error.httpStatus,
+    });
+  }
+
+  return refusal(res, {
+    code: error.code,
+    message: error.message,
+    refusalType: error.refusalType,
+    httpStatus: error.httpStatus,
+  });
+};
+
+export const getActivityThreadsHandler = async (req: Request, res: Response) => {
+  if (!await enforceConnectShyftCapability(req, res, 'module')) {
+    return;
+  }
+
+  const activityId = normalizeString(req.params?.activityId);
+  if (!UUID_PATTERN.test(activityId)) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_ACTIVITY_ID_INVALID',
+      message: 'activityId must be a non-empty UUID.',
+      refusalType: 'client',
+      httpStatus: 400,
+      data: {
+        fieldErrors: [
+          {
+            field: 'activityId',
+            reason: 'INVALID',
+            message: 'activityId must be a non-empty UUID.',
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  const contextDecision = await resolveConnectShyftRouteContextDecision(req);
+  if (!contextDecision.ok) {
+    respondWithConnectShyftContextRefusal(res, contextDecision);
+    return;
+  }
+
+  try {
+    const threads = await connectShyftActivityServiceAsync.listActivityThreads({
+      actorRoles: resolveConnectShyftActorRoles(req, contextDecision.context),
+      tenantId: contextDecision.context.tenantId,
+      orgUnitId: contextDecision.context.orgUnitId,
+      activityId,
+    });
+
+    return success(res, {
+      code: 'CONNECTSHYFT_ACTIVITY_THREADS_LISTED',
+      message: 'ConnectShyft activity threads listed',
+      httpStatus: 200,
+      data: {
+        threads,
+      },
+    });
+  } catch (error) {
+    if (!(error instanceof ConnectShyftActivityServiceError)) {
+      throw error;
+    }
+
+    respondActivityError(res, error);
+  }
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/getPersonActivitiesHandler.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/getPersonActivitiesHandler.ts
@@ -1,0 +1,99 @@
+import { Request, Response } from 'express';
+import {
+  error as errorEnvelope,
+  refusal,
+  success,
+} from '../../../platform/envelopes/response';
+import {
+  ConnectShyftActivityServiceError,
+  connectShyftActivityServiceAsync,
+} from '../activities';
+import {
+  enforceConnectShyftCapability,
+  resolveConnectShyftActorRoles,
+  resolveConnectShyftRouteContextDecision,
+  respondWithConnectShyftContextRefusal,
+} from '../http/accessContext';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const respondActivityError = (res: Response, error: ConnectShyftActivityServiceError) => {
+  if (error.httpStatus >= 500) {
+    return errorEnvelope(res, {
+      code: error.code,
+      message: error.message,
+      httpStatus: error.httpStatus,
+    });
+  }
+
+  return refusal(res, {
+    code: error.code,
+    message: error.message,
+    refusalType: error.refusalType,
+    httpStatus: error.httpStatus,
+  });
+};
+
+export const getPersonActivitiesHandler = async (req: Request, res: Response) => {
+  if (!await enforceConnectShyftCapability(req, res, 'module')) {
+    return;
+  }
+
+  const personId = normalizeString(req.params?.personId);
+  if (!UUID_PATTERN.test(personId)) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_PERSON_ID_INVALID',
+      message: 'personId must be a non-empty UUID.',
+      refusalType: 'client',
+      httpStatus: 400,
+      data: {
+        fieldErrors: [
+          {
+            field: 'personId',
+            reason: 'INVALID',
+            message: 'personId must be a non-empty UUID.',
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  const contextDecision = await resolveConnectShyftRouteContextDecision(req);
+  if (!contextDecision.ok) {
+    respondWithConnectShyftContextRefusal(res, contextDecision);
+    return;
+  }
+
+  try {
+    const activities = await connectShyftActivityServiceAsync.listPersonActivities({
+      actorRoles: resolveConnectShyftActorRoles(req, contextDecision.context),
+      tenantId: contextDecision.context.tenantId,
+      orgUnitId: contextDecision.context.orgUnitId,
+      personId,
+    });
+
+    return success(res, {
+      code: 'CONNECTSHYFT_PERSON_ACTIVITIES_LISTED',
+      message: 'ConnectShyft person activities listed',
+      httpStatus: 200,
+      data: {
+        activities,
+      },
+    });
+  } catch (error) {
+    if (!(error instanceof ConnectShyftActivityServiceError)) {
+      throw error;
+    }
+
+    respondActivityError(res, error);
+  }
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postPersonActivityHandler.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postPersonActivityHandler.ts
@@ -1,0 +1,150 @@
+import { Request, Response } from 'express';
+import { ACTIVITY_STATUSES, type ActivityStatus } from '../../peoplecore/activity';
+import {
+  error as errorEnvelope,
+  refusal,
+  success,
+} from '../../../platform/envelopes/response';
+import {
+  ConnectShyftActivityServiceError,
+  connectShyftActivityServiceAsync,
+} from '../activities';
+import {
+  enforceConnectShyftCapability,
+  resolveConnectShyftActorRoles,
+  resolveConnectShyftRouteContextDecision,
+  respondWithConnectShyftContextRefusal,
+} from '../http/accessContext';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const parseStatus = (value: unknown): ActivityStatus | undefined | null => {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return undefined;
+  }
+
+  if (!ACTIVITY_STATUSES.includes(normalized as ActivityStatus)) {
+    return null;
+  }
+
+  return normalized as ActivityStatus;
+};
+
+const respondInvalidField = (
+  res: Response,
+  input: {
+    code: string;
+    field: string;
+    message: string;
+    reason?: string;
+  },
+) => refusal(res, {
+  code: input.code,
+  message: input.message,
+  refusalType: 'client',
+  httpStatus: 400,
+  data: {
+    fieldErrors: [
+      {
+        field: input.field,
+        reason: input.reason ?? 'INVALID',
+        message: input.message,
+      },
+    ],
+  },
+});
+
+const respondActivityError = (res: Response, error: ConnectShyftActivityServiceError) => {
+  if (error.httpStatus >= 500) {
+    return errorEnvelope(res, {
+      code: error.code,
+      message: error.message,
+      httpStatus: error.httpStatus,
+    });
+  }
+
+  return refusal(res, {
+    code: error.code,
+    message: error.message,
+    refusalType: error.refusalType,
+    httpStatus: error.httpStatus,
+  });
+};
+
+export const postPersonActivityHandler = async (req: Request, res: Response) => {
+  if (!await enforceConnectShyftCapability(req, res, 'module')) {
+    return;
+  }
+
+  const personId = normalizeString(req.params?.personId);
+  if (!UUID_PATTERN.test(personId)) {
+    respondInvalidField(res, {
+      code: 'CONNECTSHYFT_PERSON_ID_INVALID',
+      field: 'personId',
+      message: 'personId must be a non-empty UUID.',
+    });
+    return;
+  }
+
+  const activityType = normalizeString(req.body?.type);
+  if (!activityType) {
+    respondInvalidField(res, {
+      code: 'CONNECTSHYFT_ACTIVITY_TYPE_REQUIRED',
+      field: 'type',
+      message: 'type is required.',
+      reason: 'REQUIRED',
+    });
+    return;
+  }
+
+  const status = parseStatus(req.body?.status);
+  if (status === null) {
+    respondInvalidField(res, {
+      code: 'CONNECTSHYFT_ACTIVITY_STATUS_INVALID',
+      field: 'status',
+      message: 'status must be ACTIVE, COMPLETED, or CANCELLED.',
+    });
+    return;
+  }
+
+  const contextDecision = await resolveConnectShyftRouteContextDecision(req);
+  if (!contextDecision.ok) {
+    respondWithConnectShyftContextRefusal(res, contextDecision);
+    return;
+  }
+
+  try {
+    const activity = await connectShyftActivityServiceAsync.createPersonActivity({
+      actorRoles: resolveConnectShyftActorRoles(req, contextDecision.context),
+      tenantId: contextDecision.context.tenantId,
+      orgUnitId: contextDecision.context.orgUnitId,
+      personId,
+      type: activityType,
+      status,
+    });
+
+    return success(res, {
+      code: 'CONNECTSHYFT_ACTIVITY_CREATED',
+      message: 'ConnectShyft activity created',
+      httpStatus: 201,
+      data: {
+        activity,
+      },
+    });
+  } catch (error) {
+    if (!(error instanceof ConnectShyftActivityServiceError)) {
+      throw error;
+    }
+
+    respondActivityError(res, error);
+  }
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/http/index.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/index.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { getActivityThreadsHandler } from '../handlers/getActivityThreadsHandler';
+import { getPersonActivitiesHandler } from '../handlers/getPersonActivitiesHandler';
+import { postPersonActivityHandler } from '../handlers/postPersonActivityHandler';
+
+const router = Router();
+
+router.post('/people/:personId/activities', postPersonActivityHandler);
+router.get('/people/:personId/activities', getPersonActivitiesHandler);
+router.get('/activities/:activityId/threads', getActivityThreadsHandler);
+
+export default router;

--- a/apps/connectshyft-api/src/modules/connectshyft/threads.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/threads.ts
@@ -3,6 +3,10 @@ import type { Knex } from 'knex';
 import db from '../../config/knex';
 import { CAPABILITIES, hasCapability } from '../../platform/rbac/capabilities';
 import { isStrictUtcIsoTimestamp } from '../../platform/time/timezoneService';
+import {
+  AsyncPeopleCoreService,
+  peopleCoreServiceAsync,
+} from '../peoplecore/service';
 
 const CONNECTSHYFT_CANONICAL_THREAD_STATES = ['UNCLAIMED', 'CLAIMED', 'CLOSED'] as const;
 const CONNECTSHYFT_CANONICAL_THREAD_STATE_SET = new Set<string>(CONNECTSHYFT_CANONICAL_THREAD_STATES);
@@ -36,6 +40,7 @@ export type ConnectShyftThread = {
   orgUnitId: string;
   neighborId: string;
   personId: string;
+  activityId: string | null;
   source: string;
   state: ConnectShyftThreadState;
   lastInboundCsNumberId: string;
@@ -62,6 +67,7 @@ type ThreadStoreEnsureInput = {
   orgUnitId: string;
   neighborId: string;
   personId: string;
+  activityId?: string | null;
   source: string;
   state: ConnectShyftThreadState;
   lastInboundCsNumberId: string;
@@ -136,6 +142,8 @@ type ThreadRefusalResult = {
     | 'CONNECTSHYFT_THREAD_VIEW_FORBIDDEN'
     | 'CONNECTSHYFT_THREAD_TRANSITION_FORBIDDEN'
     | 'CONNECTSHYFT_THREAD_PERSON_REQUIRED'
+    | 'CONNECTSHYFT_THREAD_ACTIVITY_INVALID'
+    | 'CONNECTSHYFT_THREAD_ACTIVITY_NOT_ACTIVE'
     | 'CONNECTSHYFT_THREAD_STATE_INVALID'
     | 'CONNECTSHYFT_THREAD_NEXT_EVALUATION_INVALID'
     | 'CONNECTSHYFT_ESCALATION_AS_OF_INVALID'
@@ -154,6 +162,7 @@ export type ConnectShyftEnsureThreadCommand = {
   orgUnitId: string;
   neighborId: string;
   personId: string;
+  activityId?: string;
   source?: string;
   forcedState?: string | null;
   lastInboundCsNumberId: string;
@@ -250,6 +259,7 @@ type DbThreadRow = {
   org_unit_id: string;
   neighbor_id: string;
   person_id: string;
+  activity_id: string | null;
   source: string;
   state: ConnectShyftThreadState;
   escalation_stage: number;
@@ -529,6 +539,7 @@ const mapDbRowToThread = (row: DbThreadRow): ConnectShyftThread => ({
   orgUnitId: row.org_unit_id,
   neighborId: row.neighbor_id,
   personId: row.person_id,
+  activityId: row.activity_id,
   source: row.source,
   state: row.state,
   lastInboundCsNumberId: normalizeThreadSenderAlignmentValue(row.last_inbound_cs_number_id),
@@ -590,6 +601,18 @@ const buildThreadPersonRequiredRefusal = (): ThreadRefusalResult => ({
   ok: false,
   code: 'CONNECTSHYFT_THREAD_PERSON_REQUIRED',
   message: 'ConnectShyft thread persistence requires personId.',
+});
+
+const buildThreadActivityInvalidRefusal = (): ThreadRefusalResult => ({
+  ok: false,
+  code: 'CONNECTSHYFT_THREAD_ACTIVITY_INVALID',
+  message: 'activityId must reference an activity for the same tenant, orgUnit, and person.',
+});
+
+const buildThreadActivityNotActiveRefusal = (): ThreadRefusalResult => ({
+  ok: false,
+  code: 'CONNECTSHYFT_THREAD_ACTIVITY_NOT_ACTIVE',
+  message: 'activityId must reference an ACTIVE activity.',
 });
 
 const buildThreadStateInvalidRefusal = (): ThreadRefusalResult => ({
@@ -736,12 +759,12 @@ export class InMemoryConnectShyftThreadStore {
     if (activeThreadId) {
       const existing = this.threadsById.get(activeThreadId);
       if (existing) {
-      const updated: ConnectShyftThread = {
-        ...existing,
-        personId: input.personId,
-        source: input.source,
-        lastInboundCsNumberId,
-        preferredOutboundCsNumberId,
+        const updated: ConnectShyftThread = {
+          ...existing,
+          personId: input.personId,
+          source: input.source,
+          lastInboundCsNumberId,
+          preferredOutboundCsNumberId,
           updatedAtUtc: now,
           escalation: {
             ...existing.escalation,
@@ -776,6 +799,7 @@ export class InMemoryConnectShyftThreadStore {
       orgUnitId: input.orgUnitId,
       neighborId: input.neighborId,
       personId: input.personId,
+      activityId: input.activityId ?? null,
       source: input.source,
       state: input.state,
       lastInboundCsNumberId,
@@ -940,6 +964,7 @@ export class KnexConnectShyftThreadStore {
       'org_unit_id',
       'neighbor_id',
       'person_id',
+      'activity_id',
       'source',
       'state',
       'escalation_stage',
@@ -1018,6 +1043,7 @@ export class KnexConnectShyftThreadStore {
           org_unit_id: input.orgUnitId,
           neighbor_id: input.neighborId,
           person_id: input.personId,
+          activity_id: input.activityId ?? null,
           source: input.source,
           state: input.state,
           escalation_stage: 0,
@@ -1298,6 +1324,14 @@ export class ConnectShyftThreadService {
       return buildThreadPersonRequiredRefusal();
     }
 
+    const requestedActivityId = normalizeString(input.activityId);
+    const normalizedActivityId = requestedActivityId.length > 0
+      ? normalizeUuid(requestedActivityId)
+      : null;
+    if (requestedActivityId.length > 0 && !normalizedActivityId) {
+      return buildThreadActivityInvalidRefusal();
+    }
+
     const requestedNextEvaluationAtUtc = normalizeString(input.nextEvaluationAtUtc);
     if (
       requestedNextEvaluationAtUtc.length > 0
@@ -1311,6 +1345,7 @@ export class ConnectShyftThreadService {
       orgUnitId: input.orgUnitId,
       neighborId: input.neighborId,
       personId: normalizedPersonId,
+      activityId: normalizedActivityId,
       source: normalizeString(input.source) || DEFAULT_THREAD_SOURCE,
       state,
       lastInboundCsNumberId: normalizeString(input.lastInboundCsNumberId),
@@ -1450,6 +1485,7 @@ export const connectShyftThreadService = new ConnectShyftThreadService(defaultTh
 export class AsyncConnectShyftThreadService {
   constructor(
     private readonly store: KnexConnectShyftThreadStore = defaultKnexThreadStore,
+    private readonly peopleCoreService: Pick<AsyncPeopleCoreService, 'getActivity'> = peopleCoreServiceAsync,
   ) {}
 
   async ensureThread(input: ConnectShyftEnsureThreadCommand): Promise<ConnectShyftEnsureThreadResult> {
@@ -1470,6 +1506,14 @@ export class AsyncConnectShyftThreadService {
       return buildThreadPersonRequiredRefusal();
     }
 
+    const requestedActivityId = normalizeString(input.activityId);
+    const normalizedActivityId = requestedActivityId.length > 0
+      ? normalizeUuid(requestedActivityId)
+      : null;
+    if (requestedActivityId.length > 0 && !normalizedActivityId) {
+      return buildThreadActivityInvalidRefusal();
+    }
+
     const requestedNextEvaluationAtUtc = normalizeString(input.nextEvaluationAtUtc);
     if (
       requestedNextEvaluationAtUtc.length > 0
@@ -1479,11 +1523,28 @@ export class AsyncConnectShyftThreadService {
     }
 
     try {
+      if (normalizedActivityId) {
+        const activity = await this.peopleCoreService.getActivity({
+          tenantId: input.tenantId,
+          orgUnitId: input.orgUnitId,
+          activityId: normalizedActivityId,
+        });
+
+        if (!activity || activity.personId !== normalizedPersonId) {
+          return buildThreadActivityInvalidRefusal();
+        }
+
+        if (activity.status !== 'ACTIVE') {
+          return buildThreadActivityNotActiveRefusal();
+        }
+      }
+
       const persisted = await this.store.ensureActiveThread({
         tenantId: input.tenantId,
         orgUnitId: input.orgUnitId,
         neighborId: input.neighborId,
         personId: normalizedPersonId,
+        activityId: normalizedActivityId,
         source: normalizeString(input.source) || DEFAULT_THREAD_SOURCE,
         state,
         lastInboundCsNumberId: normalizeString(input.lastInboundCsNumberId),

--- a/apps/connectshyft-api/src/modules/peoplecore/__tests__/activity.test.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/__tests__/activity.test.ts
@@ -1,0 +1,358 @@
+import type { Activity } from '../activity';
+import {
+  AsyncPeopleCoreService,
+  PeopleCorePersistenceUnavailableError,
+} from '../service';
+import {
+  KnexPeopleCoreStore,
+  PeopleCoreScopeViolationError,
+} from '../store';
+
+const PERSON_ID = '11111111-1111-4111-8111-111111111111';
+const PERSON_ID_TWO = '22222222-2222-4222-8222-222222222222';
+const ACTIVITY_ID_ONE = '33333333-3333-4333-8333-333333333333';
+const ACTIVITY_ID_TWO = '44444444-4444-4444-8444-444444444444';
+
+type TableFixture = {
+  rows: any[];
+  firstQueue: any[];
+  returningQueue: any[][];
+  inserted: any[];
+  whereCalls: Array<Record<string, unknown>>;
+  orderByCalls: Array<[string, string]>;
+};
+
+const createFixture = (input: Partial<TableFixture> = {}): TableFixture => ({
+  rows: input.rows || [],
+  firstQueue: input.firstQueue ? [...input.firstQueue] : [],
+  returningQueue: input.returningQueue ? [...input.returningQueue] : [],
+  inserted: [],
+  whereCalls: [],
+  orderByCalls: [],
+});
+
+const buildKnexMock = (initial: Record<string, Partial<TableFixture>> = {}) => {
+  const fixtures = new Map<string, TableFixture>(
+    Object.entries(initial).map(([key, value]) => [key, createFixture(value)]),
+  );
+
+  const getFixture = (key: string): TableFixture => {
+    const existing = fixtures.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const created = createFixture();
+    fixtures.set(key, created);
+    return created;
+  };
+
+  const knex: any = {
+    fn: {
+      now: () => 'NOW()',
+    },
+    withSchema: (schema: string) => ({
+      table: (tableName: string) => {
+        const fixture = getFixture(`${schema}.${tableName}`);
+        const builder: any = {
+          where: (clause: Record<string, unknown>) => {
+            fixture.whereCalls.push(clause);
+            return builder;
+          },
+          orderBy: (column: string, direction: string = 'asc') => {
+            fixture.orderByCalls.push([column, direction]);
+            return builder;
+          },
+          select: async () => fixture.rows,
+          first: async () => (
+            fixture.firstQueue.length > 0 ? fixture.firstQueue.shift() || null : null
+          ),
+          insert: (value: Record<string, unknown>) => {
+            fixture.inserted.push(value);
+            return {
+              returning: async () => (
+                fixture.returningQueue.length > 0 ? fixture.returningQueue.shift() || [] : []
+              ),
+            };
+          },
+        };
+
+        return builder;
+      },
+    }),
+  };
+
+  return {
+    knex,
+    getFixture,
+  };
+};
+
+const buildActivityRow = (input: {
+  id: string;
+  personId: string;
+  type: string;
+  status: Activity['status'];
+  createdAtUtc: string;
+  updatedAtUtc?: string;
+}) => ({
+  id: input.id,
+  tenant_id: 'tenant-1',
+  org_unit_id: 'org-1',
+  person_id: input.personId,
+  type: input.type,
+  status: input.status,
+  created_at_utc: input.createdAtUtc,
+  updated_at_utc: input.updatedAtUtc ?? input.createdAtUtc,
+});
+
+describe('PeopleCore activity persistence', () => {
+  it('creates an activity with a default ACTIVE status and returns the normalized DTO', async () => {
+    const createdRow = buildActivityRow({
+      id: ACTIVITY_ID_ONE,
+      personId: PERSON_ID,
+      type: 'housing-intake',
+      status: 'ACTIVE',
+      createdAtUtc: '2026-03-24T13:00:00.000Z',
+    });
+    const { knex, getFixture } = buildKnexMock({
+      'people.persons': {
+        firstQueue: [{ id: PERSON_ID }],
+      },
+      'people.activities': {
+        returningQueue: [[createdRow]],
+      },
+    });
+    const store = new KnexPeopleCoreStore(knex);
+
+    const created = await store.createActivity({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      personId: PERSON_ID,
+      type: 'housing-intake',
+    });
+
+    expect(created).toEqual({
+      id: ACTIVITY_ID_ONE,
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      personId: PERSON_ID,
+      type: 'housing-intake',
+      status: 'ACTIVE',
+      createdAtUtc: '2026-03-24T13:00:00.000Z',
+      updatedAtUtc: '2026-03-24T13:00:00.000Z',
+    });
+    expect(getFixture('people.persons').whereCalls).toEqual([
+      {
+        id: PERSON_ID,
+        tenant_id: 'tenant-1',
+        org_unit_id: 'org-1',
+      },
+    ]);
+    expect(getFixture('people.activities').inserted[0]).toMatchObject({
+      tenant_id: 'tenant-1',
+      org_unit_id: 'org-1',
+      person_id: PERSON_ID,
+      type: 'housing-intake',
+      status: 'ACTIVE',
+      created_at_utc: 'NOW()',
+      updated_at_utc: 'NOW()',
+    });
+  });
+
+  it('gets an activity when it exists and returns null when it does not', async () => {
+    const activityRow = buildActivityRow({
+      id: ACTIVITY_ID_ONE,
+      personId: PERSON_ID,
+      type: 'food-pantry',
+      status: 'COMPLETED',
+      createdAtUtc: '2026-03-24T13:01:00.000Z',
+    });
+    const { knex, getFixture } = buildKnexMock({
+      'people.activities': {
+        firstQueue: [activityRow, null],
+      },
+    });
+    const store = new KnexPeopleCoreStore(knex);
+
+    const found = await store.getActivity({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      activityId: ACTIVITY_ID_ONE,
+    });
+    const missing = await store.getActivity({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      activityId: ACTIVITY_ID_TWO,
+    });
+
+    expect(found).toEqual({
+      id: ACTIVITY_ID_ONE,
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      personId: PERSON_ID,
+      type: 'food-pantry',
+      status: 'COMPLETED',
+      createdAtUtc: '2026-03-24T13:01:00.000Z',
+      updatedAtUtc: '2026-03-24T13:01:00.000Z',
+    });
+    expect(missing).toBeNull();
+    expect(getFixture('people.activities').whereCalls).toEqual([
+      {
+        id: ACTIVITY_ID_ONE,
+        tenant_id: 'tenant-1',
+        org_unit_id: 'org-1',
+      },
+      {
+        id: ACTIVITY_ID_TWO,
+        tenant_id: 'tenant-1',
+        org_unit_id: 'org-1',
+      },
+    ]);
+  });
+
+  it('lists activities in created order for the requested person scope', async () => {
+    const firstActivity = buildActivityRow({
+      id: ACTIVITY_ID_ONE,
+      personId: PERSON_ID,
+      type: 'housing-intake',
+      status: 'ACTIVE',
+      createdAtUtc: '2026-03-24T13:00:00.000Z',
+    });
+    const secondActivity = buildActivityRow({
+      id: ACTIVITY_ID_TWO,
+      personId: PERSON_ID,
+      type: 'job-search',
+      status: 'CANCELLED',
+      createdAtUtc: '2026-03-24T13:05:00.000Z',
+    });
+    const { knex, getFixture } = buildKnexMock({
+      'people.persons': {
+        firstQueue: [{ id: PERSON_ID }],
+      },
+      'people.activities': {
+        rows: [firstActivity, secondActivity],
+      },
+    });
+    const store = new KnexPeopleCoreStore(knex);
+
+    const activities = await store.listActivities({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      personId: PERSON_ID,
+    });
+
+    expect(activities.map((activity) => activity.id)).toEqual([
+      ACTIVITY_ID_ONE,
+      ACTIVITY_ID_TWO,
+    ]);
+    expect(getFixture('people.activities').whereCalls).toEqual([
+      {
+        tenant_id: 'tenant-1',
+        org_unit_id: 'org-1',
+        person_id: PERSON_ID,
+      },
+    ]);
+    expect(getFixture('people.activities').orderByCalls).toEqual([
+      ['created_at_utc', 'asc'],
+      ['id', 'asc'],
+    ]);
+  });
+
+  it('throws PeopleCoreScopeViolationError when creating or listing outside the tenant org scope', async () => {
+    const { knex } = buildKnexMock({
+      'people.persons': {
+        firstQueue: [null, null],
+      },
+    });
+    const store = new KnexPeopleCoreStore(knex);
+
+    await expect(
+      store.createActivity({
+        tenantId: 'tenant-1',
+        orgUnitId: 'org-1',
+        personId: PERSON_ID_TWO,
+        type: 'housing-intake',
+      }),
+    ).rejects.toBeInstanceOf(PeopleCoreScopeViolationError);
+
+    await expect(
+      store.listActivities({
+        tenantId: 'tenant-1',
+        orgUnitId: 'org-1',
+        personId: PERSON_ID_TWO,
+      }),
+    ).rejects.toBeInstanceOf(PeopleCoreScopeViolationError);
+  });
+});
+
+describe('AsyncPeopleCoreService activity methods', () => {
+  const activity: Activity = {
+    id: ACTIVITY_ID_ONE,
+    tenantId: 'tenant-1',
+    orgUnitId: 'org-1',
+    personId: PERSON_ID,
+    type: 'housing-intake',
+    status: 'ACTIVE',
+    createdAtUtc: '2026-03-24T13:00:00.000Z',
+    updatedAtUtc: '2026-03-24T13:00:00.000Z',
+  };
+
+  it('delegates create, get, and list activity operations to the configured store', async () => {
+    const store = {
+      createActivity: jest.fn(async () => activity),
+      getActivity: jest.fn(async () => activity),
+      listActivities: jest.fn(async () => [activity]),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.createActivity({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      personId: PERSON_ID,
+      type: 'housing-intake',
+    })).resolves.toEqual(activity);
+    await expect(service.getActivity({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      activityId: ACTIVITY_ID_ONE,
+    })).resolves.toEqual(activity);
+    await expect(service.listActivities({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      personId: PERSON_ID,
+    })).resolves.toEqual([activity]);
+  });
+
+  it.each([
+    ['createActivity', (service: AsyncPeopleCoreService) => service.createActivity({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      personId: PERSON_ID,
+      type: 'housing-intake',
+    })],
+    ['getActivity', (service: AsyncPeopleCoreService) => service.getActivity({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      activityId: ACTIVITY_ID_ONE,
+    })],
+    ['listActivities', (service: AsyncPeopleCoreService) => service.listActivities({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      personId: PERSON_ID,
+    })],
+  ])('wraps missing persistence for %s', async (_name, invoke) => {
+    const missingTableError = Object.assign(
+      new Error('relation "people.activities" does not exist'),
+      { code: '42P01' },
+    );
+    const store = {
+      [_name]: jest.fn(async () => {
+        throw missingTableError;
+      }),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(invoke(service)).rejects.toBeInstanceOf(PeopleCorePersistenceUnavailableError);
+  });
+});

--- a/apps/connectshyft-api/src/modules/peoplecore/activity.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/activity.ts
@@ -1,0 +1,40 @@
+export const ACTIVITY_STATUSES = ['ACTIVE', 'COMPLETED', 'CANCELLED'] as const;
+
+export type ActivityStatus = (typeof ACTIVITY_STATUSES)[number];
+
+export type Activity = {
+  id: string;
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+  type: string;
+  status: ActivityStatus;
+  createdAtUtc: string;
+  updatedAtUtc: string;
+};
+
+export interface CreateActivityInput {
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+  type: string;
+  status?: ActivityStatus;
+}
+
+export interface GetActivityInput {
+  tenantId: string;
+  orgUnitId: string;
+  activityId: string;
+}
+
+export interface ListActivitiesInput {
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+}
+
+export interface PeopleCoreActivityStore {
+  createActivity(input: CreateActivityInput): Promise<Activity>;
+  getActivity(input: GetActivityInput): Promise<Activity | null>;
+  listActivities(input: ListActivitiesInput): Promise<Activity[]>;
+}

--- a/apps/connectshyft-api/src/modules/peoplecore/index.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/index.ts
@@ -1,2 +1,3 @@
+export * from './activity';
 export * from './store';
 export * from './service';

--- a/apps/connectshyft-api/src/modules/peoplecore/service.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/service.ts
@@ -1,3 +1,8 @@
+import type {
+  CreateActivityInput,
+  GetActivityInput,
+  ListActivitiesInput,
+} from './activity';
 import {
   KnexPeopleCoreStore,
   type AppendContactPointEventInput,
@@ -65,12 +70,24 @@ export class AsyncPeopleCoreService {
     return this.execute(() => this.store.createPerson(input));
   }
 
+  createActivity(input: CreateActivityInput) {
+    return this.execute(() => this.store.createActivity(input));
+  }
+
   getPerson(input: GetPersonInput) {
     return this.execute(() => this.store.getPerson(input));
   }
 
+  getActivity(input: GetActivityInput) {
+    return this.execute(() => this.store.getActivity(input));
+  }
+
   listPersons(input: ListPersonsInput) {
     return this.execute(() => this.store.listPersons(input));
+  }
+
+  listActivities(input: ListActivitiesInput) {
+    return this.execute(() => this.store.listActivities(input));
   }
 
   createHousehold(input: CreateHouseholdInput) {

--- a/apps/connectshyft-api/src/modules/peoplecore/store.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/store.ts
@@ -11,6 +11,13 @@ import type {
 } from '@shyft/contracts';
 import type { Knex } from 'knex';
 import db from '../../config/knex';
+import type {
+  Activity,
+  CreateActivityInput,
+  GetActivityInput,
+  ListActivitiesInput,
+  PeopleCoreActivityStore,
+} from './activity';
 
 const PEOPLE_SCHEMA = 'people';
 const DEFAULT_CONTACT_POINT_EVENT_LIMIT = 50;
@@ -172,7 +179,7 @@ export type ListResolverReviewsInput = {
   orgUnitId?: string;
 };
 
-export interface PeopleCoreStore {
+export interface PeopleCoreStore extends PeopleCoreActivityStore {
   createPerson(input: CreatePersonInput): Promise<Person>;
   getPerson(input: GetPersonInput): Promise<Person | null>;
   listPersons(input: ListPersonsInput): Promise<Person[]>;
@@ -307,6 +314,17 @@ type DbResolverReviewRow = {
   resolution_type: ResolverReview['resolutionType'] | null;
   resolution_reason: string | null;
   resolution_notes: string | null;
+};
+
+type DbActivityRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  person_id: string;
+  type: string;
+  status: Activity['status'];
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
 };
 
 const mapPersonRow = (row: DbPersonRow): Person => {
@@ -457,6 +475,21 @@ const mapResolverReviewRow = (row: DbResolverReviewRow): ResolverReview => {
   };
 };
 
+const mapActivityRow = (row: DbActivityRow): Activity => {
+  const fallbackIsoUtc = new Date().toISOString();
+
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    orgUnitId: row.org_unit_id,
+    personId: row.person_id,
+    type: row.type,
+    status: row.status,
+    createdAtUtc: toIsoUtc(row.created_at_utc, fallbackIsoUtc),
+    updatedAtUtc: toIsoUtc(row.updated_at_utc, fallbackIsoUtc),
+  };
+};
+
 export class KnexPeopleCoreStore implements PeopleCoreStore {
   constructor(private readonly knexClient: Knex = db) {}
 
@@ -586,19 +619,44 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
     ];
   }
 
-  private async assertPersonInTenant(tenantId: string, personId: string): Promise<void> {
+  private activityColumns(): string[] {
+    return [
+      'id',
+      'tenant_id',
+      'org_unit_id',
+      'person_id',
+      'type',
+      'status',
+      'created_at_utc',
+      'updated_at_utc',
+    ];
+  }
+
+  private async assertPersonInTenant(
+    tenantId: string,
+    personId: string,
+    orgUnitId?: string,
+  ): Promise<void> {
+    const whereClause: Record<string, string> = {
+      id: personId,
+      tenant_id: tenantId,
+    };
+
+    if (orgUnitId) {
+      whereClause.org_unit_id = orgUnitId;
+    }
+
     const row = await this.knexClient
       .withSchema(PEOPLE_SCHEMA)
       .table('persons')
-      .where({
-        id: personId,
-        tenant_id: tenantId,
-      })
+      .where(whereClause)
       .first(['id']);
 
     if (!row) {
       throw new PeopleCoreScopeViolationError(
-        `Person ${personId} is not available in tenant ${tenantId}.`,
+        orgUnitId
+          ? `Person ${personId} is not available in tenant ${tenantId} org unit ${orgUnitId}.`
+          : `Person ${personId} is not available in tenant ${tenantId}.`,
       );
     }
   }
@@ -691,6 +749,58 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
       .select<DbPersonRow[]>(this.personColumns());
 
     return rows.map(mapPersonRow);
+  }
+
+  async createActivity(input: CreateActivityInput): Promise<Activity> {
+    await this.assertPersonInTenant(input.tenantId, input.personId, input.orgUnitId);
+
+    const [row] = await this.knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('activities')
+      .insert({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        person_id: input.personId,
+        type: input.type,
+        status: input.status ?? 'ACTIVE',
+        created_at_utc: this.knexClient.fn.now(),
+        updated_at_utc: this.knexClient.fn.now(),
+      })
+      .returning<DbActivityRow[]>(this.activityColumns());
+
+    return mapActivityRow(row);
+  }
+
+  async getActivity(input: GetActivityInput): Promise<Activity | null> {
+    const row = await this.knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('activities')
+      .where({
+        id: input.activityId,
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+      })
+      .first<DbActivityRow>(this.activityColumns());
+
+    return row ? mapActivityRow(row) : null;
+  }
+
+  async listActivities(input: ListActivitiesInput): Promise<Activity[]> {
+    await this.assertPersonInTenant(input.tenantId, input.personId, input.orgUnitId);
+
+    const rows = await this.knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('activities')
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        person_id: input.personId,
+      })
+      .orderBy('created_at_utc', 'asc')
+      .orderBy('id', 'asc')
+      .select<DbActivityRow[]>(this.activityColumns());
+
+    return rows.map(mapActivityRow);
   }
 
   async createHousehold(input: CreateHouseholdInput): Promise<Household> {

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -142,6 +142,7 @@ import {
 import {
   persistConnectShyftThreadIdentityEventAsync,
 } from '../../../modules/connectshyft/threadIdentityEvents';
+import connectShyftActivityHttpRouter from '../../../modules/connectshyft/http';
 import {
   CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
   CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
@@ -4475,6 +4476,9 @@ const parseThreadEnsureBody = (req: Request) => ({
   personId: typeof req.body?.personId === 'string'
     ? req.body.personId.trim()
     : '',
+  activityId: typeof req.body?.activityId === 'string'
+    ? req.body.activityId.trim()
+    : undefined,
   source: typeof req.body?.source === 'string' ? req.body.source : 'VOICE',
   forcedState: typeof req.body?.forcedState === 'string' ? req.body.forcedState : undefined,
   lastInboundCsNumberId: typeof req.body?.lastInboundCsNumberId === 'string'
@@ -4594,6 +4598,7 @@ router.get('/context', getConnectContext);
 router.get('/inbox', getConnectInbox);
 
 router.use('/ops', connectShyftOpsRouter);
+router.use(connectShyftActivityHttpRouter);
 
 router.post('/neighbors', postConnectNeighborCreate);
 
@@ -5116,6 +5121,7 @@ router.post('/threads', async (req: Request, res: Response) => {
     orgUnitId: context.orgUnitId,
     neighborId: payload.neighborId,
     personId: payload.personId,
+    activityId: payload.activityId,
     source: payload.source,
     forcedState: payload.forcedState,
     lastInboundCsNumberId: payload.lastInboundCsNumberId,

--- a/shared/database/migrations/20260324130000_create_people_activities.ts
+++ b/shared/database/migrations/20260324130000_create_people_activities.ts
@@ -1,0 +1,35 @@
+import { Knex } from 'knex';
+
+const PEOPLE_SCHEMA = 'people';
+const ACTIVITIES_TABLE = 'activities';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${PEOPLE_SCHEMA}`);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${PEOPLE_SCHEMA}.${ACTIVITIES_TABLE} (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      person_id UUID NOT NULL REFERENCES ${PEOPLE_SCHEMA}.persons(id) ON DELETE CASCADE,
+      type TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('ACTIVE','COMPLETED','CANCELLED')),
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS activities_tenant_org_person_idx
+    ON ${PEOPLE_SCHEMA}.${ACTIVITIES_TABLE} (tenant_id, org_unit_id, person_id)
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS activities_tenant_id_idx
+    ON ${PEOPLE_SCHEMA}.${ACTIVITIES_TABLE} (tenant_id, id)
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`DROP TABLE IF EXISTS ${PEOPLE_SCHEMA}.${ACTIVITIES_TABLE}`);
+}

--- a/specs/slice-24-codex-ready-implementation-brief.md
+++ b/specs/slice-24-codex-ready-implementation-brief.md
@@ -1,0 +1,517 @@
+# Slice 24 — Activity Model (Structure Lock)
+
+## 1. OBJECTIVE
+
+Introduce an **Activity** domain model that sits between a person and their communication threads. Each activity represents a discrete program, case or engagement (e.g. a housing intake, a food pantry request, a job search effort). Threads may remain person‑level or be optionally bound to an activity. A persistent, queryable activity table must exist in PeopleCore, and ConnectShyft must store an `activityId` on threads. The UI exposes a person’s activities alongside their communications and allows navigation into an activity’s detail and related threads.
+
+## 2. ARCHITECTURAL DECISIONS (LOCKED)
+
+1. **Activity as first‑class object** – An `Activity` belongs to a `Person`. It has its own ID, type and status. Activities live in the PeopleCore database under the `people` schema; all tenants share a common table with tenant and orgUnit scoping.
+2. **Thread dual anchoring** – A thread remains anchored to contact point and orgUnit as per ADR‑006, but now also carries an optional `activityId` referencing the person’s activity. Threads without an `activityId` remain person‑level.
+3. **Immutable references** – Once a thread is created, its `activityId` cannot be changed. Reassigning a thread to a different activity or person requires closing the existing thread and starting a new one.
+4. **Status enumeration** – Activity `status` must be one of `'ACTIVE'`, `'COMPLETED'` or `'CANCELLED'`. Additional statuses (e.g. `'ARCHIVED'`) are reserved for future slices. The `type` field is free text scoped by tenant conventions; no global enum is enforced.
+5. **No cross‑schema FK** – ConnectShyft stores an `activity_id` string on the `cs_threads` table. It does **not** define a foreign key to PeopleCore because PeopleCore and ConnectShyft run in separate Postgres schemas and do not enforce cross‑schema constraints. The application layer validates existence.
+6. **Read–only projection** – The person profile page projects activities and their related communications from separate stores without mutating underlying data. There is no mechanism to bulk update or merge activities in this slice.
+
+## 3. EXECUTION FLOW
+
+### 3.1 Create Activity
+
+1. `POST /api/v1/people/:personId/activities` is called with `{ type: string, status?: 'ACTIVE' }`. Default `status` to `'ACTIVE'` if omitted.
+2. Handler resolves tenant, orgUnit and person scope. It validates that the actor has `create_activity` capability (implementation uses existing RBAC system).
+3. The handler calls `peopleCoreService.createActivity({ tenantId, orgUnitId, personId, type, status })`.
+4. The service delegates to `PeopleCoreStore.createActivity`, which inserts a row into `people.activities` with a new UUID, the provided fields and timestamps. It verifies that the person exists in the tenant.
+5. The created activity is returned to the caller. The API returns HTTP 201 with the activity record.
+
+### 3.2 List Person Activities
+
+1. `GET /api/v1/people/:personId/activities` is called.
+2. Handler resolves tenant, orgUnit and person scope and requires `view_activity` capability.
+3. Calls `peopleCoreService.listActivities({ tenantId, orgUnitId, personId })`.
+4. The service calls `PeopleCoreStore.listActivities` which queries the `people.activities` table by tenant, orgUnit and personId, ordered by `created_at_utc` ascending, and returns normalized activity records.
+5. The API returns HTTP 200 with an array of activities.
+
+### 3.3 Create Thread Bound to Activity
+
+1. Existing thread creation (`ensureThread`) in `threads.ts` is extended to accept an optional `activityId`. The request payload in `ConnectShyftEnsureThreadCommand` includes `activityId?: string`.
+2. Prior to thread creation, the handler validates:
+   - If `activityId` is provided, call `peopleCoreService.getActivity({ tenantId, orgUnitId, activityId })`. If not found or the activity’s `personId` does not match the thread’s personId, return a `CONNECTSHYFT_THREAD_ACTIVITY_INVALID` refusal.
+   - If the activity’s status is not `'ACTIVE'`, return a `CONNECTSHYFT_THREAD_ACTIVITY_NOT_ACTIVE` refusal.
+3. When persisting the thread, the store writes the provided `activityId` (or `null`) into the `cs_threads.activity_id` column. It leaves all other fields unchanged.
+4. The response includes the `activityId` on the thread DTO.
+
+### 3.4 List Threads for an Activity
+
+1. `GET /api/v1/activities/:activityId/threads` is called.
+2. Handler resolves tenant, orgUnit and person context. It validates `view_thread` capability.
+3. Calls `threadService.listByActivity({ tenantId, orgUnitId, activityId })` which queries `cs_threads` by tenant, orgUnit and `activity_id = activityId` and returns thread DTOs ordered by `created_at_utc` ascending.
+4. The API returns HTTP 200 with an array of threads. If the activity has no threads, an empty array is returned.
+
+## 4. STATE MACHINE
+
+### Activity
+
+| State       | Description                                  | Transitions                                              |
+| ----------- | -------------------------------------------- | -------------------------------------------------------- |
+| `ACTIVE`    | Activity is in progress.                     | → `COMPLETED` when finished; → `CANCELLED` when aborted. |
+| `COMPLETED` | Activity has ended successfully.             | No further transitions; remains terminal.                |
+| `CANCELLED` | Activity has been closed without completion. | No further transitions; remains terminal.                |
+
+An activity cannot be returned to `ACTIVE` once completed or cancelled. Threads bound to a non‑active activity cannot be created; existing threads remain valid.
+
+### Thread
+
+Threads retain their existing state machine (`UNCLAIMED`, `CLAIMED`, `CLOSED`) defined in ADR‑006. A thread’s `activityId` is immutable after creation; no new transitions are introduced by this slice.
+
+## 5. DATABASE CONTRACTS
+
+### 5.1 `people.activities`
+
+| Column           | Type        | Constraints                                                     |
+| ---------------- | ----------- | --------------------------------------------------------------- |
+| `id`             | UUID        | Primary key; default `uuid_generate_v4()`                       |
+| `tenant_id`      | TEXT        | NOT NULL; foreign key to `people.persons.tenant_id`             |
+| `org_unit_id`    | TEXT        | NOT NULL; foreign key to `people.persons.org_unit_id`           |
+| `person_id`      | UUID        | NOT NULL; foreign key to `people.persons.id`                    |
+| `type`           | TEXT        | NOT NULL                                                        |
+| `status`         | TEXT        | NOT NULL CHECK (`status` IN ('ACTIVE','COMPLETED','CANCELLED')) |
+| `created_at_utc` | TIMESTAMPTZ | NOT NULL DEFAULT `NOW()`                                        |
+| `updated_at_utc` | TIMESTAMPTZ | NOT NULL DEFAULT `NOW()`                                        |
+
+**Indexes:**
+
+- `activities_tenant_org_person_idx` – `(tenant_id, org_unit_id, person_id)` for listing.
+- `activities_tenant_id_idx` – `(tenant_id, id)` for point lookups.
+
+### 5.2 `connectshyft.cs_threads` (modified)
+
+Adds a nullable column:
+
+| Column        | Type | Constraints     |
+| ------------- | ---- | --------------- |
+| `activity_id` | UUID | NULLABLE; no FK |
+
+**Existing unique index** on `(tenant_id, org_unit_id, neighbor_id)` remains unchanged. An additional index on `(tenant_id, org_unit_id, activity_id)` is added to support list operations.
+
+## 6. SERVICE LAYER (STRICT)
+
+### 6.1 PeopleCore (new file: `apps/connectshyft-api/src/modules/peoplecore/activity.ts`)
+
+```ts
+export interface CreateActivityInput {
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+  type: string;
+  status?: "ACTIVE" | "COMPLETED" | "CANCELLED";
+}
+
+export interface GetActivityInput {
+  tenantId: string;
+  orgUnitId: string;
+  activityId: string;
+}
+
+export interface ListActivitiesInput {
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+}
+
+export interface PeopleCoreActivityStore {
+  createActivity(input: CreateActivityInput): Promise<Activity>;
+  getActivity(input: GetActivityInput): Promise<Activity | null>;
+  listActivities(input: ListActivitiesInput): Promise<Activity[]>;
+}
+```
+
+The PeopleCore activity service implements simple validation (person exists) and delegates to the store. Each method wraps returned rows into the canonical `Activity` DTO:
+
+```ts
+export type Activity = {
+  id: string;
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+  type: string;
+  status: "ACTIVE" | "COMPLETED" | "CANCELLED";
+  createdAtUtc: string;
+  updatedAtUtc: string;
+};
+```
+
+### 6.2 ConnectShyft Threads (modified file: `apps/connectshyft-api/src/modules/connectshyft/threads.ts`)
+
+Add an optional `activityId` property to the following types:
+
+- `ConnectShyftThread` → add `activityId: string | null`.
+- `ConnectShyftEnsureThreadCommand` → add `activityId?: string`.
+
+Modify `ensureThread` implementation to:
+
+1. Validate `activityId` if provided by invoking `peopleCoreService.getActivity` as described in the execution flow.
+2. Persist `activity_id` on insert into `cs_threads`.
+3. Include `activityId` in returned thread DTO.
+
+### 6.3 ConnectShyft Activity Service (new file: `apps/connectshyft-api/src/modules/connectshyft/activities.ts`)
+
+```ts
+export interface CreatePersonActivityInput {
+  actorRoles: (string | null | undefined)[];
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+  type: string;
+  status?: "ACTIVE" | "COMPLETED" | "CANCELLED";
+}
+
+export interface ListPersonActivitiesInput {
+  actorRoles: (string | null | undefined)[];
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+}
+
+export interface ListActivityThreadsInput {
+  actorRoles: (string | null | undefined)[];
+  tenantId: string;
+  orgUnitId: string;
+  activityId: string;
+}
+
+export interface AsyncConnectShyftActivityService {
+  createPersonActivity(input: CreatePersonActivityInput): Promise<Activity>;
+  listPersonActivities(input: ListPersonActivitiesInput): Promise<Activity[]>;
+  listActivityThreads(
+    input: ListActivityThreadsInput,
+  ): Promise<ConnectShyftThread[]>;
+}
+```
+
+The service enforces RBAC using existing `hasCapability` helper. It orchestrates calls to PeopleCore activity store and threads store.
+
+### 6.4 HTTP Handlers
+
+Handlers reside in `apps/connectshyft-api/src/modules/connectshyft/handlers` and follow existing envelope patterns. New handlers include:
+
+- `postPersonActivityHandler(req, res)` → calls `createPersonActivity`; returns a success envelope with the created activity and HTTP 201.
+- `getPersonActivitiesHandler(req, res)` → calls `listPersonActivities`; returns a success envelope with the list.
+- `getActivityThreadsHandler(req, res)` → calls `listActivityThreads`; returns a success envelope with threads.
+
+Corresponding route definitions are added to `apps/connectshyft-api/src/modules/connectshyft/http/index.ts`.
+
+## 7. PROVIDER / INTEGRATION CONTRACTS
+
+No external provider integration is introduced in this slice. All operations occur within PeopleCore and ConnectShyft. The only cross‑service call is from ConnectShyft threads to PeopleCore activity service via direct function invocation.
+
+## 8. EVENT HANDLING
+
+No new domain events are emitted in this slice. Activity creation and thread binding are persistence operations only. Future slices may emit events such as `activity.created` or `activity.completed`.
+
+## 9. IDEMPOTENCY RULES
+
+1. **Create Activity** – Repeatedly creating the same activity with the same type and person is allowed; there is no uniqueness constraint on `(personId, type)`. The caller must decide idempotency at a higher layer if needed.
+2. **List Activities** – Pure read; repeated calls return the same result until activities change.
+3. **Create Thread with Activity** – When `activityId` is provided, validate once and persist. If thread creation fails after persisting the `activityId` (e.g. due to unique constraint on `(tenant_id, org_unit_id, neighbor_id)`), the caller may retry without risk of duplicate `cs_threads` rows because of the existing unique index. Do not attempt to update `activity_id` on conflict.
+
+Guard conditions in thread creation:
+
+```ts
+if (command.activityId) {
+  const activity = await peopleCoreService.getActivity({
+    tenantId,
+    orgUnitId,
+    activityId,
+  });
+  if (!activity || activity.personId !== neighbor.personId)
+    return refusal("CONNECTSHYFT_THREAD_ACTIVITY_INVALID");
+  if (activity.status !== "ACTIVE")
+    return refusal("CONNECTSHYFT_THREAD_ACTIVITY_NOT_ACTIVE");
+}
+```
+
+## 10. FAILURE MODES
+
+1. **Person or Activity Not Found** – Calls to `getActivity` or `getPerson` return `null`; handlers must translate to a 404 envelope (`CONNECTSHYFT_ACTIVITY_NOT_FOUND` or `CONNECTSHYFT_PERSON_NOT_FOUND`).
+2. **Invalid Activity–Person Association** – When `activityId` does not belong to the specified person, return a refusal envelope with code `CONNECTSHYFT_THREAD_ACTIVITY_INVALID` and HTTP 422.
+3. **Inactive Activity** – When `activity.status` is not `'ACTIVE'`, return a refusal envelope with code `CONNECTSHYFT_THREAD_ACTIVITY_NOT_ACTIVE` and HTTP 422.
+4. **Database Unavailable** – All store methods throw `ConnectShyftPersistenceUnavailableError` or `PeopleCorePersistenceUnavailableError` when the database cannot be reached. Handlers return a 503 envelope.
+5. **RBAC Denied** – If the actor lacks required capability for creating or viewing activities, return a 403 envelope (`CONNECTSHYFT_FORBIDDEN`).
+
+## 11. TEST CONTRACT
+
+### 11.1 PeopleCore Unit Tests
+
+Add tests in `apps/connectshyft-api/src/modules/peoplecore/__tests__/activity.test.ts`:
+
+1. **createActivity** – Creating an activity inserts a row into `people.activities` with the correct person/tenant/orgUnit and returns the expected DTO.
+2. **getActivity** – Returns `null` when no activity exists; returns the activity when it does.
+3. **listActivities** – Returns an array of activities ordered by `created_at_utc` ascending; filters by person.
+4. **scope violation** – Creating or listing an activity with mismatched tenant/person throws `PeopleCoreScopeViolationError`.
+
+### 11.2 ConnectShyft Unit Tests
+
+Update `threads.contract.test.ts` to cover:
+
+1. Creating a thread with a valid `activityId` persists the `activity_id` column and returns it in the DTO.
+2. Creating a thread with an invalid `activityId` (non‑existent or belonging to a different person) returns a refusal.
+3. Creating a thread with a non‑active activity (status `'COMPLETED'`) returns a refusal.
+4. `listActivityThreads` returns only threads whose `activity_id` matches the requested activity.
+
+### 11.3 ConnectShyft Integration Tests
+
+Add new tests in `tests/integration/connectshyft-api/activity.integration.test.ts`:
+
+1. `POST /people/:personId/activities` creates an activity and returns HTTP 201 with the activity record.
+2. `GET /people/:personId/activities` lists activities in order.
+3. `POST /threads` with `activityId` binds to the activity and surfaces the `activityId` in the response.
+4. `GET /activities/:activityId/threads` returns only threads bound to that activity.
+
+## 12. CHECKPOINTS
+
+### Checkpoint 1 — Create `people.activities` table and store
+
+**BRANCH**
+
+Create and switch to branch codex/slice-24-activity-model before beginning any work.
+
+**FILES:**
+
+1. `shared/database/migrations/20260324130000_create_people_activities.ts` – new migration creating the `activities` table under `people` schema with fields and constraints described above.
+2. `apps/connectshyft-api/src/modules/peoplecore/activity.ts` – new file defining DTOs, input types and the store interface.
+3. `apps/connectshyft-api/src/modules/peoplecore/store.ts` – update to implement `createActivity`, `getActivity`, `listActivities` in `KnexPeopleCoreStore`.
+4. `apps/connectshyft-api/src/modules/peoplecore/service.ts` – update to expose new methods that call the store.
+5. `apps/connectshyft-api/src/modules/peoplecore/__tests__/activity.test.ts` – new unit tests for PeopleCore activity operations.
+
+**FUNCTION SIGNATURES:**
+
+Add the following methods to `KnexPeopleCoreStore` class:
+
+```ts
+async createActivity(input: CreateActivityInput): Promise<Activity>;
+async getActivity(input: GetActivityInput): Promise<Activity | null>;
+async listActivities(input: ListActivitiesInput): Promise<Activity[]>;
+```
+
+Add corresponding methods to `AsyncPeopleCoreService` interface and its implementation.
+
+**LINE‑LEVEL DIFF EXPECTATIONS:**
+
+Migration file example:
+
+```diff
+*** Begin Migration: shared/database/migrations/20260324130000_create_people_activities.ts
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw('CREATE SCHEMA IF NOT EXISTS people');
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS people.activities (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      person_id UUID NOT NULL REFERENCES people.persons(id) ON DELETE CASCADE,
+      type TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('ACTIVE','COMPLETED','CANCELLED')),
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+  await knex.raw('CREATE INDEX IF NOT EXISTS activities_tenant_org_person_idx ON people.activities (tenant_id, org_unit_id, person_id)');
+  await knex.raw('CREATE INDEX IF NOT EXISTS activities_tenant_id_idx ON people.activities (tenant_id, id)');
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP TABLE IF EXISTS people.activities');
+}
+*** End Migration
+```
+
+In `store.ts`, implement `createActivity`, `getActivity` and `listActivities` using `withSchema('people').table('activities')`, similar to other store methods.
+
+**DATA MUTATIONS:**
+
+Creating an activity inserts a row into `people.activities` with `tenant_id`, `org_unit_id`, `person_id`, `type`, `status`, `created_at_utc`, `updated_at_utc` and a generated UUID. Listing activities reads rows filtered by `tenant_id`, `org_unit_id` and `person_id`.
+
+**GUARDS:**
+
+- `createActivity` must call `assertPersonInTenant` to ensure the person belongs to the tenant.
+- `getActivity` and `listActivities` must filter by tenant and orgUnit. Attempts to access a different tenant/orgUnit result in `PeopleCoreScopeViolationError`.
+
+**STOP CONDITION:**
+
+Run the PeopleCore activity unit tests. All tests should pass, and the migration should create the `people.activities` table. An example check:
+
+```sql
+SELECT COUNT(*) FROM people.activities;
+-- should return 0 on a fresh database
+```
+
+**COMMIT POINT:**
+
+```bash
+git add shared/database/migrations/20260324130000_create_people_activities.ts \
+    apps/connectshyft-api/src/modules/peoplecore/activity.ts \
+    apps/connectshyft-api/src/modules/peoplecore/store.ts \
+    apps/connectshyft-api/src/modules/peoplecore/service.ts \
+    apps/connectshyft-api/src/modules/peoplecore/index.ts \
+    apps/connectshyft-api/src/modules/peoplecore/__tests__/activity.test.ts
+git commit -m "feat(peoplecore): add Activity model and persistence"
+```
+
+### Checkpoint 2 — Add `activity_id` to `cs_threads`
+
+**FILES:**
+
+1. `apps/connectshyft-api/src/migrations/20260324131000_add_activity_id_to_connectshyft_threads.ts` – new migration adding `activity_id` column and index.
+2. `apps/connectshyft-api/src/modules/connectshyft/threads.ts` – update types and persistence logic.
+3. `apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts` – update and add tests covering activity binding.
+
+**FUNCTION SIGNATURES:**
+
+Add `activityId?: string` to `ConnectShyftEnsureThreadCommand`. Add `activityId: string | null` to `ConnectShyftThread` DTO.
+
+**LINE‑LEVEL DIFF EXPECTATIONS:**
+
+Migration file example:
+
+```diff
+*** Begin Migration: apps/connectshyft-api/src/migrations/20260324131000_add_activity_id_to_connectshyft_threads.ts
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE connectshyft.cs_threads
+      ADD COLUMN IF NOT EXISTS activity_id UUID NULL;
+  `);
+  await knex.raw('CREATE INDEX IF NOT EXISTS cs_threads_activity_idx ON connectshyft.cs_threads (tenant_id, org_unit_id, activity_id)');
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`ALTER TABLE connectshyft.cs_threads DROP COLUMN IF EXISTS activity_id`);
+}
+*** End Migration
+```
+
+In `threads.ts`, extend the `ConnectShyftThread` and `ConnectShyftEnsureThreadCommand` types and modify the insertion logic to write `activity_id` if provided. Update the return DTO accordingly.
+
+**REQUIRED CHANGES:**
+
+- Migration adds nullable `activity_id` column and index.
+- Update TypeScript types as shown above.
+- Modify `ensureThread` logic to validate and persist `activityId` via PeopleCore service, and include it in the returned thread.
+
+**DATA MUTATIONS:**
+
+- Adding `activity_id` does not mutate existing rows (they remain `NULL`). Threads created after migration will have `activity_id` set based on input.
+
+**GUARDS:**
+
+- Ensure `activityId` is only persisted on creation; do not update for existing threads.
+- Validate `activityId` belongs to the same person and tenant as the thread as described in execution flow.
+
+**STOP CONDITION:**
+
+The updated tests in `threads.contract.test.ts` should pass, verifying that threads can be created with and without an `activityId` and that invalid activity associations are rejected.
+
+**COMMIT POINT:**
+
+```bash
+git add apps/connectshyft-api/src/migrations/20260324131000_add_activity_id_to_connectshyft_threads.ts \
+    apps/connectshyft-api/src/modules/connectshyft/threads.ts \
+    apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.contract.test.ts
+git commit -m "feat(connectshyft): support optional activityId on threads"
+```
+
+### Checkpoint 3 — Activity Service & HTTP Handlers
+
+**FILES:**
+
+1. `apps/connectshyft-api/src/modules/connectshyft/activities.ts` – new service orchestrating PeopleCore and thread stores.
+2. `apps/connectshyft-api/src/modules/connectshyft/handlers/postPersonActivityHandler.ts` – new handler for creating an activity.
+3. `apps/connectshyft-api/src/modules/connectshyft/handlers/getPersonActivitiesHandler.ts` – new handler for listing activities.
+4. `apps/connectshyft-api/src/modules/connectshyft/handlers/getActivityThreadsHandler.ts` – new handler for listing threads by activity.
+5. `apps/connectshyft-api/src/modules/connectshyft/http/index.ts` – update to register new routes.
+6. `apps/connectshyft-api/src/modules/connectshyft/__tests__/activities.test.ts` – new unit tests for the service and handlers.
+7. `tests/integration/connectshyft-api/activity.integration.test.ts` – new integration tests as described in the test contract.
+
+**FUNCTION SIGNATURES:**
+
+Add to the activity service as shown in section 6.3.
+
+**LINE‑LEVEL DIFF EXPECTATIONS:**
+
+For route registration (simplified example):
+
+```diff
+*** Update File: apps/connectshyft-api/src/modules/connectshyft/http/index.ts
+@@
+ import { postPersonActivityHandler } from './handlers/postPersonActivityHandler';
+ import { getPersonActivitiesHandler } from './handlers/getPersonActivitiesHandler';
+ import { getActivityThreadsHandler } from './handlers/getActivityThreadsHandler';
+@@
+ router.post('/api/v1/people/:personId/activities', postPersonActivityHandler);
+ router.get('/api/v1/people/:personId/activities', getPersonActivitiesHandler);
+ router.get('/api/v1/activities/:activityId/threads', getActivityThreadsHandler);
+*** End Patch
+```
+
+Handlers must follow existing patterns: resolve context, enforce RBAC, call the service, wrap the result in a success envelope, and handle refusals or errors appropriately.
+
+**REQUIRED CHANGES:**
+
+- Implement the activity service to delegate to PeopleCore and threads store.
+- Create handlers and register routes.
+- Write unit and integration tests ensuring the service functions and endpoints behave as specified.
+
+**DATA MUTATIONS:**
+
+- Creating an activity persists a record as in Checkpoint 1.
+- Listing activities and threads does not mutate data.
+
+**GUARDS:**
+
+- All handlers must enforce capabilities (`create_activity` and `view_activity`). Reuse `hasCapability` helper.
+- Validate request parameters (non‑empty `personId`, `activityId` are UUIDs).
+
+**STOP CONDITION:**
+
+Run the new activity unit and integration tests. All tests should pass. A manual call to the endpoints in a development environment should return expected results.
+
+**COMMIT POINT:**
+
+```bash
+git add apps/connectshyft-api/src/modules/connectshyft/activities.ts \
+    apps/connectshyft-api/src/modules/connectshyft/handlers/postPersonActivityHandler.ts \
+    apps/connectshyft-api/src/modules/connectshyft/handlers/getPersonActivitiesHandler.ts \
+    apps/connectshyft-api/src/modules/connectshyft/handlers/getActivityThreadsHandler.ts \
+    apps/connectshyft-api/src/modules/connectshyft/http/index.ts \
+    apps/connectshyft-api/src/modules/connectshyft/__tests__/activities.test.ts \
+    tests/integration/connectshyft-api/activity.integration.test.ts
+git commit -m "feat(connectshyft): add activity service and API endpoints"
+```
+
+## 13. DEFINITION OF DONE
+
+1. The `people.activities` table exists in the database with correct schema and indexes.
+2. PeopleCore store and service expose `createActivity`, `getActivity` and `listActivities` and are covered by unit tests.
+3. The `cs_threads` table includes a nullable `activity_id` column, and the `ConnectShyftThread` DTO and `ensureThread` command accept it.
+4. Thread creation validates and persists the provided `activityId` and refuses invalid or inactive activities.
+5. Activity service and HTTP endpoints allow operators to create activities and list activities and activity‑bound threads.
+6. All new and updated unit and integration tests pass. There are no test regressions elsewhere in the monorepo.
+7. No other modules or files are modified beyond those specified in the checkpoints.
+
+## 14. NON‑GOALS
+
+- This slice does not implement any UI components. Front‑end changes are deferred to the next slice (presentation layer integration).
+- It does not add activity scheduling, due dates, or reminders. Only type and status are tracked.
+- It does not permit updating or deleting activities. Activities remain immutable aside from status transitions, which are out of scope.
+- It does not reassign existing threads to activities. Historical threads remain person‑level unless explicitly created with an `activityId`.
+
+## 15. FUTURE EXTENSION POINTS
+
+1. **Activity workflows** – Introduce due dates, reminders and workflow state transitions (e.g. `'IN_PROGRESS'`, `'ON_HOLD'`, `'COMPLETE'`) with automatic notifications.
+2. **Activity merging and rebinding** – Support merging activities or transferring them between persons or households with full audit trails.
+3. **Activity metrics** – Aggregate activity outcomes and durations for reporting and analytics.
+4. **Activity timeline projection** – Extend the UI timeline to group communications by activity and show high‑level progress.
+5. **Event emission** – Emit `activity.created`, `activity.status.changed` events for integration with external systems (e.g. case management).

--- a/tests/integration/connectshyft-api/activity.integration.test.ts
+++ b/tests/integration/connectshyft-api/activity.integration.test.ts
@@ -1,0 +1,344 @@
+import knex, { Knex } from 'knex';
+import request from 'supertest';
+import { up as migrateThreadsUp } from '../../../apps/connectshyft-api/src/migrations/20260224170000_create_connectshyft_threads';
+import { up as migratePeopleCoreIdentityFoundationUp } from '../../../apps/connectshyft-api/src/migrations/20260321100000_create_peoplecore_identity_foundation';
+import { up as migrateThreadPersonIdentityUp } from '../../../apps/connectshyft-api/src/migrations/20260323180000_add_connectshyft_thread_person_identity';
+import { up as migratePeopleActivitiesUp } from '../../../apps/connectshyft-api/src/migrations/20260324130000_create_people_activities';
+import { up as migrateThreadActivityIdUp } from '../../../apps/connectshyft-api/src/migrations/20260324131000_add_activity_id_to_connectshyft_threads';
+import {
+  buildApp,
+  buildHeaders,
+} from '../../../apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.provider-registry.test.shared';
+
+const DATABASE_URL = process.env.MONEYSHYFT_TEST_DATABASE_URL || process.env.DATABASE_URL;
+const shouldRun = Boolean(DATABASE_URL);
+const describeIfDb = shouldRun ? describe : describe.skip;
+
+const TENANT_PREFIX = 'tenant-connectshyft-activity-';
+
+const seedPerson = async (db: Knex, input: {
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+}): Promise<void> => {
+  await db
+    .withSchema('people')
+    .table('persons')
+    .insert({
+      id: input.personId,
+      tenant_id: input.tenantId,
+      org_unit_id: input.orgUnitId,
+      first_name: 'Integration',
+      last_name: 'Person',
+    })
+    .onConflict('id')
+    .ignore();
+};
+
+const seedActivity = async (db: Knex, input: {
+  activityId: string;
+  createdAtUtc?: string;
+  orgUnitId: string;
+  personId: string;
+  status?: 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+  tenantId: string;
+  type?: string;
+}): Promise<void> => {
+  await db
+    .withSchema('people')
+    .table('activities')
+    .insert({
+      id: input.activityId,
+      tenant_id: input.tenantId,
+      org_unit_id: input.orgUnitId,
+      person_id: input.personId,
+      type: input.type ?? 'housing-intake',
+      status: input.status ?? 'ACTIVE',
+      created_at_utc: input.createdAtUtc ?? '2026-03-23T12:00:00.000Z',
+      updated_at_utc: input.createdAtUtc ?? '2026-03-23T12:00:00.000Z',
+    })
+    .onConflict('id')
+    .ignore();
+};
+
+const seedThread = async (db: Knex, input: {
+  activityId?: string | null;
+  createdAtUtc?: string;
+  neighborId: string;
+  orgUnitId: string;
+  personId: string;
+  tenantId: string;
+  threadId: string;
+}): Promise<void> => {
+  const createdAtUtc = input.createdAtUtc ?? '2026-03-23T13:00:00.000Z';
+
+  await db
+    .withSchema('connectshyft')
+    .table('cs_threads')
+    .insert({
+      id: input.threadId,
+      tenant_id: input.tenantId,
+      org_unit_id: input.orgUnitId,
+      neighbor_id: input.neighborId,
+      person_id: input.personId,
+      activity_id: input.activityId ?? null,
+      source: 'VOICE',
+      state: 'UNCLAIMED',
+      escalation_stage: 0,
+      next_evaluation_at_utc: createdAtUtc,
+      last_inbound_cs_number_id: `cs-inbound-${input.threadId}`,
+      preferred_outbound_cs_number_id: `cs-outbound-${input.threadId}`,
+      created_at_utc: createdAtUtc,
+      updated_at_utc: createdAtUtc,
+    })
+    .onConflict('id')
+    .ignore();
+};
+
+describeIfDb('connectshyft activity integration', () => {
+  let db: Knex;
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+  const previousConnectShyftEnabled = process.env.CONNECTSHYFT_ENABLED;
+  const previousConnectShyftInboxEnabled = process.env.CONNECTSHYFT_INBOX_ENABLED;
+  const previousConnectShyftEscalationEnabled = process.env.CONNECTSHYFT_ESCALATION_ENABLED;
+  const previousConnectShyftWebhooksEnabled = process.env.CONNECTSHYFT_WEBHOOKS_ENABLED;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+    process.env.CONNECTSHYFT_ENABLED = 'true';
+    process.env.CONNECTSHYFT_INBOX_ENABLED = 'true';
+    process.env.CONNECTSHYFT_ESCALATION_ENABLED = 'true';
+    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = 'true';
+
+    db = knex({
+      client: 'pg',
+      connection: DATABASE_URL,
+    });
+
+    await db.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
+
+    const hasUsersTable = await db.schema.hasTable('users');
+    if (!hasUsersTable) {
+      await db.schema.createTable('users', (table) => {
+        table.uuid('id').primary();
+      });
+    }
+
+    await migratePeopleCoreIdentityFoundationUp(db);
+    await migrateThreadsUp(db);
+    await migrateThreadPersonIdentityUp(db);
+    await migratePeopleActivitiesUp(db);
+    await migrateThreadActivityIdUp(db);
+  });
+
+  afterEach(async () => {
+    await db
+      .withSchema('connectshyft')
+      .table('cs_threads')
+      .where('tenant_id', 'like', `${TENANT_PREFIX}%`)
+      .del();
+    await db
+      .withSchema('people')
+      .table('activities')
+      .where('tenant_id', 'like', `${TENANT_PREFIX}%`)
+      .del();
+    await db
+      .withSchema('people')
+      .table('persons')
+      .where('tenant_id', 'like', `${TENANT_PREFIX}%`)
+      .del();
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousOverrideFlag;
+    process.env.CONNECTSHYFT_ENABLED = previousConnectShyftEnabled;
+    process.env.CONNECTSHYFT_INBOX_ENABLED = previousConnectShyftInboxEnabled;
+    process.env.CONNECTSHYFT_ESCALATION_ENABLED = previousConnectShyftEscalationEnabled;
+    process.env.CONNECTSHYFT_WEBHOOKS_ENABLED = previousConnectShyftWebhooksEnabled;
+  });
+
+  it('creates an activity through POST /people/:personId/activities', async () => {
+    const tenantId = `${TENANT_PREFIX}create`;
+    const orgUnitId = 'org-connectshyft-activity-create-east';
+    const personId = '99999999-aaaa-4999-8999-999999999991';
+
+    await seedPerson(db, { tenantId, orgUnitId, personId });
+
+    const response = await (request as any)(buildApp())
+      .post(`/api/v1/connectshyft/people/${personId}/activities`)
+      .set(buildHeaders({
+        'x-test-connectshyft-tenant-id': tenantId,
+        'x-test-connectshyft-orgunit-id': orgUnitId,
+        'x-test-connectshyft-orgunit-memberships': JSON.stringify([orgUnitId]),
+      }))
+      .send({
+        type: 'housing-intake',
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_ACTIVITY_CREATED',
+      data: {
+        activity: {
+          tenantId,
+          orgUnitId,
+          personId,
+          type: 'housing-intake',
+          status: 'ACTIVE',
+        },
+      },
+    });
+  });
+
+  it('lists person activities in created_at_utc order', async () => {
+    const tenantId = `${TENANT_PREFIX}list`;
+    const orgUnitId = 'org-connectshyft-activity-list-east';
+    const personId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1';
+
+    await seedPerson(db, { tenantId, orgUnitId, personId });
+    await seedActivity(db, {
+      tenantId,
+      orgUnitId,
+      personId,
+      activityId: '11111111-aaaa-4111-8111-111111111111',
+      type: 'first-activity',
+      createdAtUtc: '2026-03-23T10:00:00.000Z',
+    });
+    await seedActivity(db, {
+      tenantId,
+      orgUnitId,
+      personId,
+      activityId: '22222222-aaaa-4222-8222-222222222222',
+      type: 'second-activity',
+      createdAtUtc: '2026-03-23T11:00:00.000Z',
+    });
+
+    const response = await (request as any)(buildApp())
+      .get(`/api/v1/connectshyft/people/${personId}/activities`)
+      .set(buildHeaders({
+        'x-test-connectshyft-tenant-id': tenantId,
+        'x-test-connectshyft-orgunit-id': orgUnitId,
+        'x-test-connectshyft-orgunit-memberships': JSON.stringify([orgUnitId]),
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.activities.map((activity: { id: string }) => activity.id)).toEqual([
+      '11111111-aaaa-4111-8111-111111111111',
+      '22222222-aaaa-4222-8222-222222222222',
+    ]);
+  });
+
+  it('binds activityId on POST /threads and returns it in the thread DTO', async () => {
+    const tenantId = `${TENANT_PREFIX}thread-create`;
+    const orgUnitId = 'org-connectshyft-activity-thread-create-east';
+    const personId = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1';
+    const activityId = '33333333-aaaa-4333-8333-333333333333';
+
+    await seedPerson(db, { tenantId, orgUnitId, personId });
+    await seedActivity(db, {
+      tenantId,
+      orgUnitId,
+      personId,
+      activityId,
+    });
+
+    const response = await (request as any)(buildApp())
+      .post('/api/v1/connectshyft/threads')
+      .set(buildHeaders({
+        'x-test-connectshyft-tenant-id': tenantId,
+        'x-test-connectshyft-orgunit-id': orgUnitId,
+        'x-test-connectshyft-orgunit-memberships': JSON.stringify([orgUnitId]),
+      }))
+      .send({
+        neighborId: 'neighbor-activity-integration-thread-create',
+        personId,
+        activityId,
+        source: 'SMS',
+        lastInboundCsNumberId: 'cs-inbound-activity-route',
+        preferredOutboundCsNumberId: 'cs-outbound-activity-route',
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_ENSURED',
+      data: {
+        thread: {
+          tenantId,
+          orgUnitId,
+          personId,
+          activityId,
+        },
+      },
+    });
+  });
+
+  it('returns only threads bound to the requested activity', async () => {
+    const tenantId = `${TENANT_PREFIX}thread-list`;
+    const orgUnitId = 'org-connectshyft-activity-thread-list-east';
+    const personId = 'dddddddd-dddd-4ddd-8ddd-ddddddddddd1';
+    const activityId = '44444444-aaaa-4444-8444-444444444444';
+    const otherActivityId = '55555555-aaaa-4555-8555-555555555555';
+
+    await seedPerson(db, { tenantId, orgUnitId, personId });
+    await seedActivity(db, {
+      tenantId,
+      orgUnitId,
+      personId,
+      activityId,
+    });
+    await seedActivity(db, {
+      tenantId,
+      orgUnitId,
+      personId,
+      activityId: otherActivityId,
+      type: 'other-activity',
+    });
+    await seedThread(db, {
+      tenantId,
+      orgUnitId,
+      personId,
+      threadId: '66666666-6666-4666-8666-666666666666',
+      neighborId: 'neighbor-activity-integration-thread-list-1',
+      activityId,
+      createdAtUtc: '2026-03-23T14:00:00.000Z',
+    });
+    await seedThread(db, {
+      tenantId,
+      orgUnitId,
+      personId,
+      threadId: '77777777-7777-4777-8777-777777777777',
+      neighborId: 'neighbor-activity-integration-thread-list-2',
+      activityId,
+      createdAtUtc: '2026-03-23T14:05:00.000Z',
+    });
+    await seedThread(db, {
+      tenantId,
+      orgUnitId,
+      personId,
+      threadId: '88888888-8888-4888-8888-888888888888',
+      neighborId: 'neighbor-activity-integration-thread-list-3',
+      activityId: otherActivityId,
+      createdAtUtc: '2026-03-23T14:10:00.000Z',
+    });
+
+    const response = await (request as any)(buildApp())
+      .get(`/api/v1/connectshyft/activities/${activityId}/threads`)
+      .set(buildHeaders({
+        'x-test-connectshyft-tenant-id': tenantId,
+        'x-test-connectshyft-orgunit-id': orgUnitId,
+        'x-test-connectshyft-orgunit-memberships': JSON.stringify([orgUnitId]),
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.threads.map((thread: { threadId: string }) => thread.threadId)).toEqual([
+      '66666666-6666-4666-8666-666666666666',
+      '77777777-7777-4777-8777-777777777777',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add the ConnectShyft activity service, handlers, and route registration for person activities and activity thread reads
- add unit and integration coverage for activity create/list flows and activity-bound threads
- wire the mounted ConnectShyft router to forward `activityId` on real thread creation requests

## Validation
- npx jest --runInBand src/modules/connectshyft/__tests__/activities.test.ts
- npx jest --runInBand --runTestsByPath ../../tests/integration/connectshyft-api/activity.integration.test.ts