### PR TITLE
feat(connectshyft): bridge lifecycle and telephony persistence

### DIFF
--- a/apps/connectshyft-api/src/migrations/20260325101000_add_person_id_to_connectshyft_bridge_sessions.ts
+++ b/apps/connectshyft-api/src/migrations/20260325101000_add_person_id_to_connectshyft_bridge_sessions.ts
@@ -1,0 +1,56 @@
+import type { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions';
+const THREADS_TABLE = 'cs_threads';
+const BRIDGE_SESSION_PERSON_INDEX = 'connectshyft_cs_bridge_sessions_scope_person_idx';
+const PERSON_REQUIRED_MESSAGE =
+  'connectshyft.cs_bridge_sessions has NULL person_id rows; backfill person_id before enabling NOT NULL enforcement';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}
+      ADD COLUMN IF NOT EXISTS person_id TEXT NULL
+  `);
+
+  await knex.raw(`
+    UPDATE ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE} AS sessions
+    SET person_id = threads.person_id::text
+    FROM ${CONNECTSHYFT_SCHEMA}.${THREADS_TABLE} AS threads
+    WHERE sessions.thread_id = threads.id::text
+      AND sessions.person_id IS NULL
+      AND threads.person_id IS NOT NULL
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}
+        WHERE person_id IS NULL
+      ) THEN
+        RAISE EXCEPTION '${PERSON_REQUIRED_MESSAGE}';
+      END IF;
+
+      ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}
+        ALTER COLUMN person_id SET NOT NULL;
+    END $$;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${BRIDGE_SESSION_PERSON_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE} (tenant_id, org_unit_id, person_id, created_at_utc DESC, id)
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSION_PERSON_INDEX}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}
+      DROP COLUMN IF EXISTS person_id
+  `);
+}

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/bridgeSessions.test.ts
@@ -71,6 +71,7 @@ const baseInput = {
   tenantId: 'tenant-connectshyft-f1',
   orgUnitId: 'org-connectshyft-f1-east',
   threadId: 'thread-f1-unclaimed-1001',
+  personId: 'person-connectshyft-f1-1001',
   operatorParticipantId: 'user-connectshyft-f1-primary-operator',
   neighborParticipantId: 'neighbor-f1-1001',
   operatorContactPointId: '+12605550155',

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/callLifecycle.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/callLifecycle.test.ts
@@ -1,0 +1,271 @@
+import {
+  buildConnectShyftCallLifecycleService,
+  listConnectShyftLifecycleEventsForTests,
+  resetConnectShyftCallLifecycleStateForTests,
+} from '../callLifecycle';
+import {
+  connectShyftCallServiceAsync,
+  resetConnectShyftCallStateForTests,
+} from '../calls';
+import {
+  loadConnectShyftBridgeAggregateByThreadId,
+  resetConnectShyftBridgeSessionStateForTests,
+} from '../bridgeSessions';
+import { resolveConnectShyftProviderAdapter } from '../providerRegistry';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../providerCorrelationMappings';
+import {
+  connectShyftVoicemailServiceAsync,
+  resetConnectShyftVoicemailStateForTests,
+} from '../voicemails';
+
+const tenantId = 'tenant-connectshyft-f1';
+const orgUnitId = 'org-connectshyft-f1-east';
+const threadId = 'thread-f1-call-lifecycle-1001';
+const personId = 'person-connectshyft-f1-1001';
+const actorUserId = 'user-connectshyft-f1-operator';
+const providerRegistryHeaders = {
+  'x-test-connectshyft-enabled-providers': '["mock-sandbox"]',
+  'x-test-connectshyft-disabled-providers': '[]',
+};
+
+const thread = {
+  threadId,
+  tenantId,
+  orgUnitId,
+  neighborId: 'neighbor-connectshyft-f1-1001',
+  personId,
+  activityId: null,
+  source: 'VOICE',
+  state: 'UNCLAIMED' as const,
+  lastInboundCsNumberId: '+12605550199',
+  preferredOutboundCsNumberId: '+12605550191',
+  claimedByUserId: null,
+  claimedAtUtc: null,
+  closedByUserId: null,
+  closedAtUtc: null,
+  createdAtUtc: '2026-03-23T12:00:00.000Z',
+  updatedAtUtc: '2026-03-23T12:00:00.000Z',
+  escalation: {
+    stage: 0,
+    nextEvaluationAtUtc: null,
+  },
+};
+
+describe('connectshyft callLifecycle', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+  });
+
+  beforeEach(() => {
+    resetConnectShyftCallStateForTests();
+    resetConnectShyftVoicemailStateForTests();
+    resetConnectShyftBridgeSessionStateForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+    resetConnectShyftCallLifecycleStateForTests();
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags;
+  });
+
+  const buildService = () => buildConnectShyftCallLifecycleService({
+    threadService: {
+      findThreadById: jest.fn(async () => thread),
+    },
+    neighborService: {
+      resolveNeighbor: jest.fn(async () => ({
+        ok: true,
+        code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+        httpStatus: 200,
+        data: {
+          neighbor: {
+            neighborId: thread.neighborId,
+            phones: [
+              {
+                phoneId: 'neighbor-phone-1001',
+                label: 'Primary',
+                value: '+12605550111',
+                verificationStatus: 'VERIFIED',
+                isPrimary: true,
+                isShared: false,
+                sortOrder: 0,
+                isActive: true,
+                createdAtUtc: '2026-03-23T10:00:00.000Z',
+                updatedAtUtc: '2026-03-23T10:00:00.000Z',
+                provenance: {},
+              },
+            ],
+          },
+        },
+      })) as any,
+    },
+    resolveOperatorDestinationFn: jest.fn(async () => ({
+      phoneNumber: '+12605550155',
+      source: 'actor_user' as const,
+      userId: actorUserId,
+      orgUnitId,
+    })),
+    resolveSenderNumberFn: jest.fn(async () => ({
+      ok: true,
+      providerNumberE164: '+12605550191',
+      mappingId: 'mapping-connectshyft-f1-1001',
+      routingMetadata: {
+        deterministic: true,
+        channel: 'voice',
+        source: 'thread_alignment',
+        mappingLabel: 'Main line',
+        threadId,
+        tenantId,
+        orgUnitId,
+        preferredOutboundCsNumberId: '+12605550191',
+        lastInboundCsNumberId: '+12605550191',
+        alignedFrom: 'preferred_outbound',
+        candidateProviderNumberE164: '+12605550191',
+      },
+    })) as any,
+    resolveProviderAdapterFn: (input) => resolveConnectShyftProviderAdapter({
+      ...input,
+      req: {
+        ...input.req,
+        header: (name: string) => providerRegistryHeaders[name.toLowerCase() as keyof typeof providerRegistryHeaders],
+        headers: providerRegistryHeaders,
+      },
+    }),
+  });
+
+  const baseStartInput = {
+    tenantId,
+    orgUnitId,
+    threadId,
+    personId,
+    actorRoles: ['ORGUNIT_MEMBER'],
+    actorUserId,
+    requestedProvider: 'mock-sandbox',
+    providerRegistryHeaders,
+  };
+
+  it('starts a call, links it to a bridge session, and emits a call started event', async () => {
+    const service = buildService();
+
+    const call = await service.startCall(baseStartInput);
+    const aggregate = await loadConnectShyftBridgeAggregateByThreadId({
+      tenantId,
+      threadId,
+    });
+
+    expect(call.status).toBe('operator_dialing');
+    expect(call.bridgeSessionId).toBeTruthy();
+    expect(aggregate?.session.id).toBe(call.bridgeSessionId);
+
+    const persistedCalls = await connectShyftCallServiceAsync.listThreadCalls({
+      tenantId,
+      orgUnitId,
+      threadId,
+    });
+    expect(persistedCalls).toHaveLength(1);
+    expect(persistedCalls[0]?.id).toBe(call.id);
+
+    expect(listConnectShyftLifecycleEventsForTests()).toEqual([
+      expect.objectContaining({
+        eventName: 'connectshyft.call.started',
+        entityId: call.id,
+      }),
+    ]);
+  });
+
+  it('returns the existing call when the same idempotency key is replayed', async () => {
+    const service = buildService();
+
+    const initial = await service.startCall({
+      ...baseStartInput,
+      idempotencyKey: 'idem-call-1001',
+    });
+    const replay = await service.startCall({
+      ...baseStartInput,
+      idempotencyKey: 'idem-call-1001',
+    });
+
+    expect(replay.id).toBe(initial.id);
+  });
+
+  it('advances persisted call status from provider events and records voicemail fallback', async () => {
+    const service = buildService();
+
+    const startedCall = await service.startCall(baseStartInput);
+    const startedAggregate = await loadConnectShyftBridgeAggregateByThreadId({
+      tenantId,
+      threadId,
+    });
+    expect(startedAggregate).not.toBeNull();
+
+    await service.handleProviderEvent({
+      tenantId,
+      provider: 'mock-sandbox',
+      event: {
+        type: 'operator_answered',
+        bridgeSessionId: startedAggregate!.session.id,
+        providerCallId: startedAggregate!.operatorLeg.providerCallId!,
+        occurredAt: new Date('2026-03-23T12:01:00.000Z'),
+      },
+      eventJson: {
+        eventType: 'CallAnswered',
+      },
+      providerCallId: startedAggregate!.operatorLeg.providerCallId!,
+      occurredAt: new Date('2026-03-23T12:01:00.000Z'),
+    });
+
+    const afterAnswered = await connectShyftCallServiceAsync.getCallById(startedCall.id, tenantId);
+    expect(afterAnswered?.status).toBe('operator_answered');
+    expect(afterAnswered?.operatorAnsweredAtUtc).toBe('2026-03-23T12:01:00.000Z');
+
+    await connectShyftCallServiceAsync.updateCallStatus({
+      callId: startedCall.id,
+      tenantId,
+      status: 'failed',
+      bridgeSessionId: startedCall.bridgeSessionId,
+      endedAtUtc: '2026-03-23T12:02:00.000Z',
+      failureCode: 'neighbor_failed',
+      failureMessage: 'Neighbor did not answer',
+    });
+
+    const voicemail = await service.handleVoicemail({
+      tenantId,
+      orgUnitId,
+      callId: startedCall.id,
+      threadId,
+      personId,
+      artifactId: 'artifact-call-lifecycle-1001',
+      recordingUrl: 'https://example.test/voicemail-1001.mp3',
+      recordingStatus: 'completed',
+      occurredAt: new Date('2026-03-23T12:03:00.000Z'),
+    });
+
+    const completedCall = await connectShyftCallServiceAsync.getCallById(startedCall.id, tenantId);
+    const callVoicemails = await connectShyftVoicemailServiceAsync.listCallVoicemails({
+      tenantId,
+      callId: startedCall.id,
+    });
+
+    expect(voicemail.recordingStatus).toBe('completed');
+    expect(callVoicemails).toHaveLength(1);
+    expect(completedCall?.status).toBe('voicemail');
+    expect(completedCall?.endedAtUtc).toBe('2026-03-23T12:02:00.000Z');
+    expect(listConnectShyftLifecycleEventsForTests()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventName: 'connectshyft.call.updated',
+          entityId: startedCall.id,
+        }),
+        expect.objectContaining({
+          eventName: 'connectshyft.voicemail.recorded',
+          entityId: voicemail.id,
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts
@@ -1,4 +1,5 @@
 import * as canonicalEventsModule from '../canonicalEvents';
+import * as callsModule from '../calls';
 import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../inboundSms';
 import {
   CONNECTSHYFT_INBOUND_VOICE_VOICEMAIL_EVENT_NAME,
@@ -11,6 +12,7 @@ import {
   mapConnectShyftCanonicalEventToTimelineItem,
   sortConnectShyftThreadTimelineItems,
 } from '../threadTimeline';
+import * as voicemailsModule from '../voicemails';
 
 describe('connectshyft thread timeline projection', () => {
   afterEach(() => {
@@ -329,5 +331,69 @@ describe('connectshyft thread timeline projection', () => {
       type: 'voicemail',
       transcript: 'Leave package at the side door',
     });
+  });
+
+  it('projects persisted calls and persisted voicemails alongside canonical events', async () => {
+    jest.spyOn(canonicalEventsModule, 'listConnectShyftCanonicalEvents').mockResolvedValueOnce([]);
+    jest.spyOn(callsModule.connectShyftCallServiceAsync, 'listThreadCalls').mockResolvedValueOnce([
+      {
+        id: 'call-timeline-1001',
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-timeline-persisted-1001',
+        personId: 'person-connectshyft-f1-1001',
+        bridgeSessionId: 'bridge-timeline-1001',
+        status: 'bridged',
+        failureCode: null,
+        failureMessage: null,
+        startedAtUtc: '2026-03-19T10:00:00.000Z',
+        operatorAnsweredAtUtc: '2026-03-19T10:00:30.000Z',
+        neighborAnsweredAtUtc: '2026-03-19T10:01:00.000Z',
+        bridgedAtUtc: '2026-03-19T10:01:30.000Z',
+        endedAtUtc: null,
+        createdAtUtc: '2026-03-19T10:00:00.000Z',
+        updatedAtUtc: '2026-03-19T10:01:30.000Z',
+      },
+    ]);
+    jest.spyOn(voicemailsModule.connectShyftVoicemailServiceAsync, 'listCallVoicemails').mockResolvedValueOnce([
+      {
+        id: 'voicemail-timeline-1001',
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        callId: 'call-timeline-1001',
+        threadId: 'thread-timeline-persisted-1001',
+        personId: 'person-connectshyft-f1-1001',
+        artifactId: 'artifact-timeline-1001',
+        recordingUrl: 'https://example.test/timeline-vm.mp3',
+        recordingStatus: 'completed',
+        occurredAtUtc: '2026-03-19T10:02:00.000Z',
+        createdAtUtc: '2026-03-19T10:02:00.000Z',
+        updatedAtUtc: '2026-03-19T10:02:00.000Z',
+        transcriptionJson: null,
+      },
+    ]);
+
+    const timeline = await getThreadTimeline({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-timeline-persisted-1001',
+    });
+
+    expect(timeline.items).toEqual([
+      expect.objectContaining({
+        id: 'call-call-timeline-1001',
+        type: 'voice_event',
+        deliveryStatus: 'bridged',
+        providerMetadata: expect.objectContaining({
+          callId: 'call-timeline-1001',
+          status: 'bridged',
+        }),
+      }),
+      expect.objectContaining({
+        id: 'voicemail-voicemail-timeline-1001',
+        type: 'voicemail',
+        recordingUrl: 'https://example.test/timeline-vm.mp3',
+      }),
+    ]);
   });
 });

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts
@@ -333,8 +333,25 @@ describe('connectshyft thread timeline projection', () => {
     });
   });
 
-  it('projects persisted calls and persisted voicemails alongside canonical events', async () => {
-    jest.spyOn(canonicalEventsModule, 'listConnectShyftCanonicalEvents').mockResolvedValueOnce([]);
+  it('projects persisted calls and persisted voicemails alongside canonical events in chronological order', async () => {
+    jest.spyOn(canonicalEventsModule, 'listConnectShyftCanonicalEvents').mockResolvedValueOnce([
+      {
+        eventId: 'event-sms-persisted-1001',
+        aggregateId: 'thread-timeline-persisted-1001',
+        aggregateType: 'Thread',
+        eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+        occurredAtUtc: '2026-03-19T09:59:00.000Z',
+        payload: {
+          direction: 'inbound',
+          channel: 'sms',
+          actor: 'neighbor',
+          eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+          inboundMessageArtifact: {
+            body: 'before the call',
+          },
+        },
+      },
+    ]);
     jest.spyOn(callsModule.connectShyftCallServiceAsync, 'listThreadCalls').mockResolvedValueOnce([
       {
         id: 'call-timeline-1001',
@@ -381,18 +398,53 @@ describe('connectshyft thread timeline projection', () => {
 
     expect(timeline.items).toEqual([
       expect.objectContaining({
+        id: 'event-sms-persisted-1001',
+        type: 'message',
+        body: 'before the call',
+      }),
+      expect.objectContaining({
         id: 'call-call-timeline-1001',
         type: 'voice_event',
+        occurredAtUtc: '2026-03-19T10:00:00.000Z',
         deliveryStatus: 'bridged',
         providerMetadata: expect.objectContaining({
           callId: 'call-timeline-1001',
           status: 'bridged',
+          statusEvents: [
+            {
+              status: 'operator_dialing',
+              occurredAtUtc: '2026-03-19T10:00:00.000Z',
+            },
+            {
+              status: 'operator_answered',
+              occurredAtUtc: '2026-03-19T10:00:30.000Z',
+            },
+            {
+              status: 'neighbor_dialing',
+              occurredAtUtc: '2026-03-19T10:00:30.000Z',
+            },
+            {
+              status: 'neighbor_answered',
+              occurredAtUtc: '2026-03-19T10:01:00.000Z',
+            },
+            {
+              status: 'bridged',
+              occurredAtUtc: '2026-03-19T10:01:30.000Z',
+            },
+          ],
         }),
       }),
       expect.objectContaining({
         id: 'voicemail-voicemail-timeline-1001',
         type: 'voicemail',
+        occurredAtUtc: '2026-03-19T10:02:00.000Z',
+        deliveryStatus: 'completed',
         recordingUrl: 'https://example.test/timeline-vm.mp3',
+        providerMetadata: {
+          callId: 'call-timeline-1001',
+          artifactId: 'artifact-timeline-1001',
+          recordingStatus: 'completed',
+        },
       }),
     ]);
   });

--- a/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../../../domains/communication'
 import { recordConnectShyftBridgeLegProviderIdentifierMapping } from './providerCorrelationMappings'
 import { isConnectShyftTestOverrideEnabled } from './featureFlags'
+import { connectShyftProviderEventServiceAsync } from './providerEvents'
 import type {
   ConnectShyftOutboundCallDispatchPolicy,
   ConnectShyftProviderAdapter,
@@ -74,6 +75,7 @@ type DbBridgeSessionRow = {
   tenant_id: string
   org_unit_id: string
   thread_id: string
+  person_id?: string | null
   operator_participant_id: string
   neighbor_participant_id: string
   operator_contact_point_id: string
@@ -121,6 +123,7 @@ type StartConnectShyftBridgeSessionInput = {
   tenantId: string
   orgUnitId: string
   threadId: string
+  personId: string
   operatorParticipantId: string
   neighborParticipantId: string
   operatorContactPointId: string
@@ -157,6 +160,19 @@ type BridgeMappingResult = {
     message: string
   } | null
 }
+
+type ConnectShyftBridgeSessionRecordWithPersonId = BridgeSessionRecord & {
+  personId?: string | null
+}
+
+export type ConnectShyftBridgeCallStatusHookInput = {
+  aggregate: BridgeSessionAggregate
+  domainEvent: ProviderBridgeEvent | null
+}
+
+type ConnectShyftBridgeCallStatusHook = (
+  input: ConnectShyftBridgeCallStatusHookInput,
+) => Promise<void>
 
 const normalizeString = (value: unknown): string => {
   if (typeof value !== 'string') {
@@ -273,26 +289,31 @@ const isMissingPersistenceError = (error: unknown): boolean => {
     || candidate.code === '42703'
 }
 
-const mapSessionRow = (row: DbBridgeSessionRow): BridgeSessionRecord => ({
-  id: row.id,
-  tenantId: row.tenant_id,
-  orgUnitId: row.org_unit_id,
-  threadId: row.thread_id,
-  operatorParticipantId: row.operator_participant_id,
-  neighborParticipantId: row.neighbor_participant_id,
-  operatorContactPointId: row.operator_contact_point_id,
-  neighborContactPointId: row.neighbor_contact_point_id,
-  selectedOutboundContactPointId: normalizeString(row.selected_outbound_contact_point_id) || null,
-  status: row.bridge_status as BridgeSessionRecord['status'],
-  failureCode: normalizeString(row.failure_code) as BridgeSessionRecord['failureCode'],
-  failureMessage: normalizeString(row.failure_message) || null,
-  endedBy: normalizeString(row.ended_by) || null,
-  idempotencyKey: normalizeString(row.idempotency_key) || null,
-  auditCorrelationId: normalizeString(row.audit_correlation_id) || null,
-  createdAt: new Date(toIsoString(row.created_at_utc) || new Date().toISOString()),
-  updatedAt: new Date(toIsoString(row.updated_at_utc) || new Date().toISOString()),
-  completedAt: toDate(row.completed_at_utc),
-})
+const mapSessionRow = (row: DbBridgeSessionRow): BridgeSessionRecord => {
+  const session: ConnectShyftBridgeSessionRecordWithPersonId = {
+    id: row.id,
+    tenantId: row.tenant_id,
+    orgUnitId: row.org_unit_id,
+    threadId: row.thread_id,
+    personId: normalizeString(row.person_id) || null,
+    operatorParticipantId: row.operator_participant_id,
+    neighborParticipantId: row.neighbor_participant_id,
+    operatorContactPointId: row.operator_contact_point_id,
+    neighborContactPointId: row.neighbor_contact_point_id,
+    selectedOutboundContactPointId: normalizeString(row.selected_outbound_contact_point_id) || null,
+    status: row.bridge_status as BridgeSessionRecord['status'],
+    failureCode: normalizeString(row.failure_code) as BridgeSessionRecord['failureCode'],
+    failureMessage: normalizeString(row.failure_message) || null,
+    endedBy: normalizeString(row.ended_by) || null,
+    idempotencyKey: normalizeString(row.idempotency_key) || null,
+    auditCorrelationId: normalizeString(row.audit_correlation_id) || null,
+    createdAt: new Date(toIsoString(row.created_at_utc) || new Date().toISOString()),
+    updatedAt: new Date(toIsoString(row.updated_at_utc) || new Date().toISOString()),
+    completedAt: toDate(row.completed_at_utc),
+  }
+
+  return session
+}
 
 const mapLegRow = (row: DbBridgeLegRow): BridgeLegRecord => ({
   id: row.id,
@@ -313,26 +334,31 @@ const mapLegRow = (row: DbBridgeLegRow): BridgeLegRecord => ({
   updatedAt: new Date(toIsoString(row.updated_at_utc) || new Date().toISOString()),
 })
 
-const sessionToRow = (session: BridgeSessionRecord) => ({
-  id: session.id,
-  tenant_id: session.tenantId,
-  org_unit_id: session.orgUnitId,
-  thread_id: session.threadId,
-  operator_participant_id: session.operatorParticipantId,
-  neighbor_participant_id: session.neighborParticipantId,
-  operator_contact_point_id: session.operatorContactPointId,
-  neighbor_contact_point_id: session.neighborContactPointId,
-  selected_outbound_contact_point_id: session.selectedOutboundContactPointId ?? null,
-  bridge_status: session.status,
-  failure_code: session.failureCode ?? null,
-  failure_message: session.failureMessage ?? null,
-  ended_by: session.endedBy ?? null,
-  idempotency_key: session.idempotencyKey ?? null,
-  audit_correlation_id: session.auditCorrelationId ?? null,
-  created_at_utc: session.createdAt.toISOString(),
-  updated_at_utc: session.updatedAt.toISOString(),
-  completed_at_utc: session.completedAt ? session.completedAt.toISOString() : null,
-})
+const sessionToRow = (session: BridgeSessionRecord) => {
+  const persistedSession = session as ConnectShyftBridgeSessionRecordWithPersonId
+
+  return {
+    id: session.id,
+    tenant_id: session.tenantId,
+    org_unit_id: session.orgUnitId,
+    thread_id: session.threadId,
+    person_id: normalizeString(persistedSession.personId) || null,
+    operator_participant_id: session.operatorParticipantId,
+    neighbor_participant_id: session.neighborParticipantId,
+    operator_contact_point_id: session.operatorContactPointId,
+    neighbor_contact_point_id: session.neighborContactPointId,
+    selected_outbound_contact_point_id: session.selectedOutboundContactPointId ?? null,
+    bridge_status: session.status,
+    failure_code: session.failureCode ?? null,
+    failure_message: session.failureMessage ?? null,
+    ended_by: session.endedBy ?? null,
+    idempotency_key: session.idempotencyKey ?? null,
+    audit_correlation_id: session.auditCorrelationId ?? null,
+    created_at_utc: session.createdAt.toISOString(),
+    updated_at_utc: session.updatedAt.toISOString(),
+    completed_at_utc: session.completedAt ? session.completedAt.toISOString() : null,
+  }
+}
 
 const legToRow = (leg: BridgeLegRecord) => ({
   id: leg.id,
@@ -354,7 +380,7 @@ const legToRow = (leg: BridgeLegRecord) => ({
 })
 
 class InMemoryConnectShyftBridgeSessionStore implements BridgeSessionRepository {
-  private sessions = new Map<string, BridgeSessionRecord>()
+  private sessions = new Map<string, ConnectShyftBridgeSessionRecordWithPersonId>()
   private legsBySessionId = new Map<string, Map<PersistedConnectShyftBridgeLegRole, BridgeLegRecord>>()
   private sessionIdByProviderCallId = new Map<string, string>()
   private sessionIdByProviderCallControlId = new Map<string, string>()
@@ -911,6 +937,84 @@ class KnexConnectShyftBridgeSessionStore implements BridgeSessionRepository {
 
 const inMemoryBridgeSessionStore = new InMemoryConnectShyftBridgeSessionStore()
 const knexBridgeSessionStore = new KnexConnectShyftBridgeSessionStore()
+let connectShyftBridgeCallStatusHook: ConnectShyftBridgeCallStatusHook = async () => {}
+
+const attachPersonIdToSessionRecord = (
+  session: BridgeSessionRecord,
+  personId: string,
+): BridgeSessionRecord => ({
+  ...(session as ConnectShyftBridgeSessionRecordWithPersonId),
+  personId,
+}) as BridgeSessionRecord
+
+const attachPersonIdToAggregate = (
+  aggregate: BridgeSessionAggregate,
+  personId: string,
+): BridgeSessionAggregate => ({
+  ...aggregate,
+  session: attachPersonIdToSessionRecord(aggregate.session, personId),
+})
+
+const buildStartBridgeSessionRepository = (personId: string): BridgeSessionRepository => ({
+  async createSession(session) {
+    await repositoryProxy.createSession(attachPersonIdToSessionRecord(session, personId))
+  },
+  createLeg(leg) {
+    return repositoryProxy.createLeg(leg)
+  },
+  async saveAggregate(aggregate) {
+    await repositoryProxy.saveAggregate(attachPersonIdToAggregate(aggregate, personId))
+  },
+  getAggregateBySessionId(sessionId) {
+    return repositoryProxy.getAggregateBySessionId(sessionId)
+  },
+  getAggregateByThreadId(input) {
+    return repositoryProxy.getAggregateByThreadId(input)
+  },
+  getAggregateByProviderCallId(input) {
+    return repositoryProxy.getAggregateByProviderCallId(input)
+  },
+})
+
+const recordBridgeProviderEvent = async (input: {
+  tenantId: string
+  provider: string
+  providerCallId: string | null
+  aggregate: BridgeSessionAggregate
+  domainEvent: ProviderBridgeEvent
+  rawEventType: string
+  occurredAt?: Date
+  reason?: string | null
+}): Promise<void> => {
+  await connectShyftProviderEventServiceAsync.recordEvent({
+    tenantId: input.tenantId,
+    provider: input.provider,
+    eventType: input.domainEvent.type,
+    eventJson: {
+      domainEvent: input.domainEvent,
+      rawEventType: input.rawEventType,
+      reason: input.reason ?? null,
+      providerCallId: input.providerCallId,
+      bridgeSessionId: input.aggregate.session.id,
+      occurredAtUtc: input.occurredAt ? input.occurredAt.toISOString() : null,
+    },
+    bridgeSessionId: input.aggregate.session.id,
+    providerCallId: input.providerCallId,
+    occurredAtUtc: input.occurredAt
+      ? input.occurredAt.toISOString()
+      : new Date().toISOString(),
+  })
+}
+
+const invokeBridgeCallStatusHook = async (input: {
+  aggregate: BridgeSessionAggregate
+  domainEvent: ProviderBridgeEvent | null
+}): Promise<void> => {
+  await connectShyftBridgeCallStatusHook({
+    aggregate: input.aggregate,
+    domainEvent: input.domainEvent,
+  })
+}
 
 const callPolicyOrDefault = (
   callPolicy?: ConnectShyftOutboundCallDispatchPolicy,
@@ -1244,6 +1348,13 @@ const repositoryProxy: BridgeSessionRepository = {
 
 export const resetConnectShyftBridgeSessionStateForTests = (): void => {
   inMemoryBridgeSessionStore.reset()
+  connectShyftBridgeCallStatusHook = async () => {}
+}
+
+export const registerConnectShyftBridgeCallStatusHook = (
+  hook: ConnectShyftBridgeCallStatusHook,
+): void => {
+  connectShyftBridgeCallStatusHook = hook
 }
 
 export async function updateConnectShyftBridgeSessionVoicemailFallbackAsync(
@@ -1332,7 +1443,7 @@ export const startConnectShyftBridgeSession = async (
     callPolicy: input.callPolicy,
   })
   const startBridgeSession = buildStartBridgeSession({
-    repository: repositoryProxy,
+    repository: buildStartBridgeSessionRepository(input.personId),
     telephonyProvider,
     idGenerator: randomUUID,
   })
@@ -1349,6 +1460,11 @@ export const startConnectShyftBridgeSession = async (
     idempotencyKey: input.idempotencyKey ?? undefined,
     auditCorrelationId: input.auditCorrelationId ?? undefined,
   } satisfies StartBridgeSessionCommand)
+
+  await invokeBridgeCallStatusHook({
+    aggregate,
+    domainEvent: null,
+  })
 
   return {
     aggregate,
@@ -1427,6 +1543,21 @@ export const handleConnectShyftBridgeWebhookEvent = async (
       correlationMapping: null,
     }
   }
+
+  await recordBridgeProviderEvent({
+    tenantId: input.tenantId,
+    provider: input.providerKey,
+    providerCallId: providerLegId,
+    aggregate,
+    domainEvent,
+    rawEventType: input.eventType,
+    occurredAt: input.occurredAt,
+    reason: input.reason ?? null,
+  })
+  await invokeBridgeCallStatusHook({
+    aggregate,
+    domainEvent,
+  })
 
   return {
     handled: true,

--- a/apps/connectshyft-api/src/modules/connectshyft/callLifecycle.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/callLifecycle.ts
@@ -1,0 +1,1222 @@
+import type { Knex } from 'knex';
+import { executePlatformMutation } from '../../platform/mutations/executePlatformMutation';
+import db from '../../config/knex';
+import type {
+  BridgeSessionAggregate,
+  ProviderBridgeEvent,
+} from '../../../../../domains/communication';
+import {
+  connectShyftCallServiceAsync,
+  ConnectShyftPersistenceUnavailableError,
+  type Call,
+  type CallStatus,
+  type ConnectShyftCallService,
+} from './calls';
+import {
+  connectShyftVoicemailServiceAsync,
+  type ConnectShyftVoicemailService,
+  type Voicemail,
+} from './voicemails';
+import {
+  connectShyftDeliveryAttemptServiceAsync,
+  type ConnectShyftDeliveryAttemptService,
+} from './deliveryAttempts';
+import {
+  connectShyftProviderEventServiceAsync,
+  type ConnectShyftProviderEventService,
+} from './providerEvents';
+import {
+  handleConnectShyftBridgeWebhookEvent,
+  loadConnectShyftBridgeAggregateByProviderCallId,
+  loadConnectShyftBridgeAggregateBySessionId,
+  loadConnectShyftBridgeAggregateByThreadId,
+  registerConnectShyftBridgeCallStatusHook,
+  startConnectShyftBridgeSession,
+} from './bridgeSessions';
+import {
+  connectShyftThreadServiceAsync,
+  type AsyncConnectShyftThreadService,
+  type ConnectShyftThread,
+} from './threads';
+import {
+  connectShyftNeighborServiceAsync,
+  type AsyncConnectShyftNeighborService,
+} from './neighbors';
+import {
+  resolveOperatorDestination,
+  type ConnectShyftOperatorDestinationResolution,
+} from './operatorDestinationResolver';
+import {
+  resolveSenderNumber,
+  type ResolveSenderNumberResult,
+} from './senderNumberResolver';
+import {
+  resolveConnectShyftProviderAdapter,
+  type ConnectShyftOutboundCallDispatchPolicy,
+  type ConnectShyftProviderAdapter,
+  type ConnectShyftProviderResolutionResult,
+} from './providerRegistry';
+import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ACTIVE_CALL_STATUSES = new Set<CallStatus>([
+  'operator_dialing',
+  'operator_answered',
+  'neighbor_dialing',
+  'neighbor_answered',
+  'bridged',
+]);
+const TERMINAL_CALL_STATUSES = new Set<CallStatus>([
+  'voicemail',
+  'completed',
+  'failed',
+  'canceled',
+  'expired',
+]);
+const CALL_STATUS_ORDER: Record<CallStatus, number> = {
+  operator_dialing: 1,
+  operator_answered: 2,
+  neighbor_dialing: 3,
+  neighbor_answered: 4,
+  bridged: 5,
+  voicemail: 6,
+  completed: 7,
+  failed: 7,
+  canceled: 7,
+  expired: 7,
+};
+const DEFAULT_OUTBOUND_CALL_POLICY: ConnectShyftOutboundCallDispatchPolicy = {
+  transport: 'bridge',
+  autoRetry: false,
+  redialPolicy: 'manual_only',
+};
+
+export interface StartCallInput {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  personId: string;
+  idempotencyKey?: string;
+  actorRoles: string[];
+  actorUserId?: string | null;
+  requestedProvider?: string | null;
+  providerRegistryHeaders?: Record<string, string | undefined>;
+}
+
+export interface HandleProviderEventInput {
+  tenantId: string;
+  provider: string;
+  event: ProviderBridgeEvent;
+  eventJson: unknown;
+  providerCallId?: string | null;
+  occurredAt: Date;
+}
+
+export interface HandleVoicemailInput {
+  tenantId: string;
+  orgUnitId: string;
+  callId: string;
+  threadId: string;
+  personId: string;
+  artifactId: string;
+  recordingUrl: string | null;
+  recordingStatus: 'pending' | 'completed' | 'failed';
+  occurredAt: Date;
+  transcriptionJson?: unknown;
+}
+
+export interface ConnectShyftCallLifecycleService {
+  startCall(input: StartCallInput): Promise<Call>;
+  handleProviderEvent(input: HandleProviderEventInput): Promise<void>;
+  handleVoicemail(input: HandleVoicemailInput): Promise<Voicemail>;
+}
+
+export class ConnectShyftCallLifecycleRefusalError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly refusalType: 'business' | 'client' = 'business',
+    readonly httpStatus = 200,
+    readonly data?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'ConnectShyftCallLifecycleRefusalError';
+  }
+}
+
+export type ConnectShyftCallLifecycleEventPublisher = {
+  publishCallStarted(input: {
+    tenantId: string;
+    call: Call;
+    actorUserId?: string | null;
+  }): Promise<void>;
+  publishCallUpdated(input: {
+    tenantId: string;
+    call: Call;
+    actorUserId?: string | null;
+  }): Promise<void>;
+  publishVoicemailRecorded(input: {
+    tenantId: string;
+    voicemail: Voicemail;
+    actorUserId?: string | null;
+  }): Promise<void>;
+};
+
+type CallLifecycleDependencies = {
+  callService?: ConnectShyftCallService;
+  voicemailService?: ConnectShyftVoicemailService;
+  deliveryAttemptService?: ConnectShyftDeliveryAttemptService;
+  providerEventService?: ConnectShyftProviderEventService;
+  threadService?: Pick<AsyncConnectShyftThreadService, 'findThreadById'>;
+  neighborService?: Pick<AsyncConnectShyftNeighborService, 'resolveNeighbor'>;
+  resolveOperatorDestinationFn?: (input: {
+    tenantId: string;
+    orgUnitId: string;
+    actorUserId?: string | null;
+    claimedByUserId?: string | null;
+  }) => Promise<ConnectShyftOperatorDestinationResolution>;
+  resolveSenderNumberFn?: typeof resolveSenderNumber;
+  resolveProviderAdapterFn?: (input: {
+    req: {
+      header: (name: string) => string | undefined;
+      body: Record<string, unknown>;
+      headers: Record<string, string>;
+      originalUrl: string;
+      protocol: string;
+      tenantId?: string | null;
+      orgUnitId?: string | null;
+    };
+    requestedProvider?: string | null;
+    operation: 'call' | 'webhook';
+  }) => ConnectShyftProviderResolutionResult;
+  startBridgeSessionFn?: typeof startConnectShyftBridgeSession;
+  handleBridgeWebhookEventFn?: typeof handleConnectShyftBridgeWebhookEvent;
+  loadBridgeAggregateByThreadIdFn?: typeof loadConnectShyftBridgeAggregateByThreadId;
+  loadBridgeAggregateBySessionIdFn?: typeof loadConnectShyftBridgeAggregateBySessionId;
+  loadBridgeAggregateByProviderCallIdFn?: typeof loadConnectShyftBridgeAggregateByProviderCallId;
+  registerBridgeCallStatusHookFn?: typeof registerConnectShyftBridgeCallStatusHook;
+  eventPublisher?: ConnectShyftCallLifecycleEventPublisher;
+};
+
+type PersistedLifecycleEvent = {
+  id: string;
+  eventName: string;
+  entityId: string;
+  payload: Record<string, unknown>;
+};
+
+const persistedLifecycleEventsForTests: PersistedLifecycleEvent[] = [];
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const toIsoString = (value: string | Date | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = new Date(normalized);
+  if (!Number.isNaN(parsed.valueOf())) {
+    return parsed.toISOString();
+  }
+
+  return normalized;
+};
+
+const isUuid = (value: string | null | undefined): value is string =>
+  typeof value === 'string' && UUID_PATTERN.test(value.trim());
+
+const isTerminalCallStatus = (status: CallStatus): boolean => TERMINAL_CALL_STATUSES.has(status);
+
+const mapBridgeStatusToCallStatus = (status: string): CallStatus | null => {
+  if (
+    status === 'operator_dialing'
+    || status === 'operator_answered'
+    || status === 'neighbor_dialing'
+    || status === 'neighbor_answered'
+    || status === 'bridged'
+    || status === 'completed'
+    || status === 'failed'
+    || status === 'canceled'
+    || status === 'expired'
+  ) {
+    return status;
+  }
+
+  return null;
+};
+
+const resolveCallEndedAtUtc = (
+  aggregate: BridgeSessionAggregate,
+): string | null => {
+  const completedAt = toIsoString(aggregate.session.completedAt);
+  if (completedAt) {
+    return completedAt;
+  }
+
+  return toIsoString(aggregate.neighborLeg.endedAt)
+    || toIsoString(aggregate.operatorLeg.endedAt)
+    || (
+      aggregate.session.status === 'failed'
+      || aggregate.session.status === 'canceled'
+      || aggregate.session.status === 'expired'
+      ? toIsoString(aggregate.session.updatedAt)
+      : null
+    );
+};
+
+const shouldApplyCallUpdate = (
+  existingStatus: CallStatus,
+  nextStatus: CallStatus,
+): boolean => {
+  if (existingStatus === nextStatus) {
+    return true;
+  }
+
+  if (existingStatus === 'failed' && nextStatus === 'voicemail') {
+    return true;
+  }
+
+  if (existingStatus === 'voicemail' && nextStatus === 'completed') {
+    return true;
+  }
+
+  if (isTerminalCallStatus(existingStatus)) {
+    return false;
+  }
+
+  return CALL_STATUS_ORDER[nextStatus] >= CALL_STATUS_ORDER[existingStatus];
+};
+
+const buildCallUpdateFromAggregate = (input: {
+  aggregate: BridgeSessionAggregate;
+  existingCall: Call;
+  domainEvent?: ProviderBridgeEvent | null;
+}): {
+  status: CallStatus;
+  bridgeSessionId: string;
+  operatorAnsweredAtUtc?: string;
+  neighborAnsweredAtUtc?: string;
+  bridgedAtUtc?: string;
+  endedAtUtc?: string;
+  failureCode?: string | null;
+  failureMessage?: string | null;
+} | null => {
+  const statusFromDomainEvent = input.domainEvent?.type === 'operator_answered'
+    ? 'operator_answered'
+    : null;
+  const status = statusFromDomainEvent || mapBridgeStatusToCallStatus(input.aggregate.session.status);
+  if (!status) {
+    return null;
+  }
+
+  if (!shouldApplyCallUpdate(input.existingCall.status, status)) {
+    return null;
+  }
+
+  const patch: {
+    status: CallStatus;
+    bridgeSessionId: string;
+    operatorAnsweredAtUtc?: string;
+    neighborAnsweredAtUtc?: string;
+    bridgedAtUtc?: string;
+    endedAtUtc?: string;
+    failureCode?: string | null;
+    failureMessage?: string | null;
+  } = {
+    status,
+    bridgeSessionId: input.aggregate.session.id,
+  };
+
+  const operatorAnsweredAtUtc = toIsoString(input.aggregate.operatorLeg.answeredAt);
+  if (operatorAnsweredAtUtc) {
+    patch.operatorAnsweredAtUtc = operatorAnsweredAtUtc;
+  }
+
+  const neighborAnsweredAtUtc = toIsoString(input.aggregate.neighborLeg.answeredAt);
+  if (neighborAnsweredAtUtc) {
+    patch.neighborAnsweredAtUtc = neighborAnsweredAtUtc;
+  }
+
+  if (status === 'bridged' || status === 'completed') {
+    patch.bridgedAtUtc = toIsoString(input.aggregate.session.updatedAt) || undefined;
+  }
+
+  const endedAtUtc = resolveCallEndedAtUtc(input.aggregate);
+  if (endedAtUtc) {
+    patch.endedAtUtc = endedAtUtc;
+  }
+
+  if (status === 'failed' || status === 'canceled' || status === 'expired') {
+    patch.failureCode = normalizeString(input.aggregate.session.failureCode) || null;
+    patch.failureMessage = normalizeString(input.aggregate.session.failureMessage) || null;
+  }
+
+  return patch;
+};
+
+const resolveCallStatusEvents = (call: Call): Array<{ status: CallStatus; occurredAtUtc: string }> => {
+  const events: Array<{ status: CallStatus; occurredAtUtc: string }> = [];
+  events.push({
+    status: 'operator_dialing',
+    occurredAtUtc: call.startedAtUtc,
+  });
+
+  if (call.operatorAnsweredAtUtc) {
+    events.push({
+      status: 'operator_answered',
+      occurredAtUtc: call.operatorAnsweredAtUtc,
+    });
+    events.push({
+      status: 'neighbor_dialing',
+      occurredAtUtc: call.operatorAnsweredAtUtc,
+    });
+  }
+
+  if (call.neighborAnsweredAtUtc) {
+    events.push({
+      status: 'neighbor_answered',
+      occurredAtUtc: call.neighborAnsweredAtUtc,
+    });
+  }
+
+  if (call.bridgedAtUtc) {
+    events.push({
+      status: 'bridged',
+      occurredAtUtc: call.bridgedAtUtc,
+    });
+  }
+
+  if (
+    call.status === 'voicemail'
+    || call.status === 'completed'
+    || call.status === 'failed'
+    || call.status === 'canceled'
+    || call.status === 'expired'
+  ) {
+    events.push({
+      status: call.status,
+      occurredAtUtc: call.endedAtUtc || call.updatedAtUtc,
+    });
+  }
+
+  return events;
+};
+
+const buildLifecycleEventPayload = (call: Call): Record<string, unknown> => ({
+  callId: call.id,
+  threadId: call.threadId,
+  personId: call.personId,
+  bridgeSessionId: call.bridgeSessionId,
+  status: call.status,
+  startedAtUtc: call.startedAtUtc,
+  operatorAnsweredAtUtc: call.operatorAnsweredAtUtc,
+  neighborAnsweredAtUtc: call.neighborAnsweredAtUtc,
+  bridgedAtUtc: call.bridgedAtUtc,
+  endedAtUtc: call.endedAtUtc,
+  failureCode: call.failureCode,
+  failureMessage: call.failureMessage,
+  statusEvents: resolveCallStatusEvents(call),
+});
+
+const buildBestEffortLifecycleEventPublisher = (
+  knexClient: Knex = db,
+): ConnectShyftCallLifecycleEventPublisher => {
+  const publish = async (input: {
+    tenantId: string;
+    actorUserId?: string | null;
+    eventName: string;
+    entityId: string;
+    payload: Record<string, unknown>;
+  }): Promise<void> => {
+    if (
+      isConnectShyftTestOverrideEnabled()
+      || !isUuid(input.tenantId)
+      || !isUuid(input.entityId)
+      || (input.actorUserId != null && !isUuid(input.actorUserId))
+    ) {
+      persistedLifecycleEventsForTests.push({
+        id: `${input.eventName}:${input.entityId}:${persistedLifecycleEventsForTests.length + 1}`,
+        eventName: input.eventName,
+        entityId: input.entityId,
+        payload: input.payload,
+      });
+      return;
+    }
+
+    try {
+      await executePlatformMutation({
+        mutation: async () => null,
+        event: {
+          tenantId: input.tenantId,
+          actorId: input.actorUserId ?? null,
+          eventName: input.eventName,
+          entityType: 'connectshyft.call',
+          entityId: input.entityId,
+          payload: input.payload,
+          occurredAtUtc: new Date(),
+        },
+      }, knexClient);
+    } catch (_error) {
+      // Event emission is best-effort in this checkpoint to avoid blocking the call path.
+    }
+  };
+
+  return {
+    publishCallStarted(input) {
+      return publish({
+        tenantId: input.tenantId,
+        actorUserId: input.actorUserId,
+        eventName: 'connectshyft.call.started',
+        entityId: input.call.id,
+        payload: buildLifecycleEventPayload(input.call),
+      });
+    },
+    publishCallUpdated(input) {
+      return publish({
+        tenantId: input.tenantId,
+        actorUserId: input.actorUserId,
+        eventName: 'connectshyft.call.updated',
+        entityId: input.call.id,
+        payload: buildLifecycleEventPayload(input.call),
+      });
+    },
+    publishVoicemailRecorded(input) {
+      return publish({
+        tenantId: input.tenantId,
+        actorUserId: input.actorUserId,
+        eventName: 'connectshyft.voicemail.recorded',
+        entityId: input.voicemail.id,
+        payload: {
+          voicemailId: input.voicemail.id,
+          callId: input.voicemail.callId,
+          threadId: input.voicemail.threadId,
+          personId: input.voicemail.personId,
+          recordingUrl: input.voicemail.recordingUrl,
+          recordingStatus: input.voicemail.recordingStatus,
+          occurredAtUtc: input.voicemail.occurredAtUtc,
+        },
+      });
+    },
+  };
+};
+
+const buildProviderResolutionRequest = (input: {
+  tenantId: string;
+  orgUnitId: string;
+  requestedProvider?: string | null;
+  headers?: Record<string, string | undefined>;
+  operation: 'call' | 'webhook';
+}) => {
+  const normalizedHeaders: Record<string, string> = {};
+
+  Object.entries(input.headers || {}).forEach(([key, value]) => {
+    if (typeof value !== 'string') {
+      return;
+    }
+
+    const normalized = value.trim();
+    if (!normalized) {
+      return;
+    }
+
+    normalizedHeaders[key.toLowerCase()] = normalized;
+  });
+
+  return {
+    req: {
+      body: input.requestedProvider ? { providerKey: input.requestedProvider } : {},
+      headers: normalizedHeaders,
+      originalUrl: input.operation === 'call'
+        ? '/api/v1/connectshyft/thread/call'
+        : '/api/v1/connectshyft/provider-events',
+      protocol: 'https',
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      header(name: string) {
+        return normalizedHeaders[name.toLowerCase()];
+      },
+    },
+    requestedProvider: input.requestedProvider,
+    operation: input.operation,
+  } as const;
+};
+
+const findCallForAggregate = (
+  calls: Call[],
+  aggregate: BridgeSessionAggregate,
+): Call | null => {
+  const byBridgeSession = calls.find((call) => call.bridgeSessionId === aggregate.session.id);
+  if (byBridgeSession) {
+    return byBridgeSession;
+  }
+
+  const personId = normalizeString((aggregate.session as { personId?: string | null }).personId);
+  const unlinkedPending = calls.find((call) => (
+    call.bridgeSessionId === null
+    && call.status === 'operator_dialing'
+    && call.threadId === aggregate.session.threadId
+    && (!personId || call.personId === personId)
+  ));
+
+  return unlinkedPending || null;
+};
+
+export const mapConnectShyftWebhookEventToBridgeEvent = (input: {
+  aggregate: BridgeSessionAggregate;
+  rawEventType: string;
+  providerCallId?: string | null;
+  bridgeSessionId?: string | null;
+  occurredAt?: Date;
+  reason?: string | null;
+}): ProviderBridgeEvent | null => {
+  const normalizedEventType = normalizeString(input.rawEventType).toLowerCase();
+  const providerCallId = normalizeString(input.providerCallId) || null;
+  const legRole = providerCallId === input.aggregate.operatorLeg.providerCallId
+    ? 'operator'
+    : providerCallId === input.aggregate.neighborLeg.providerCallId
+      ? 'neighbor'
+      : null;
+
+  if (normalizedEventType === 'callanswered' || normalizedEventType === 'voiceanswered') {
+    if (legRole === 'operator' && providerCallId) {
+      return {
+        type: 'operator_answered',
+        bridgeSessionId: input.bridgeSessionId || input.aggregate.session.id,
+        providerCallId,
+        occurredAt: input.occurredAt,
+      };
+    }
+
+    if (legRole === 'neighbor' && providerCallId) {
+      return {
+        type: 'neighbor_answered',
+        bridgeSessionId: input.bridgeSessionId || input.aggregate.session.id,
+        providerCallId,
+        occurredAt: input.occurredAt,
+      };
+    }
+  }
+
+  if (normalizedEventType === 'callbridged' || normalizedEventType === 'callconnected') {
+    return {
+      type: 'bridge_connected',
+      bridgeSessionId: input.bridgeSessionId || input.aggregate.session.id,
+      occurredAt: input.occurredAt,
+    };
+  }
+
+  if (
+    normalizedEventType === 'callhangup'
+    || normalizedEventType === 'callcompleted'
+    || normalizedEventType === 'callended'
+  ) {
+    if (input.aggregate.session.status === 'bridged' || input.aggregate.session.status === 'completed') {
+      return {
+        type: 'completed',
+        bridgeSessionId: input.bridgeSessionId || input.aggregate.session.id,
+        providerCallId: providerCallId || undefined,
+        occurredAt: input.occurredAt,
+      };
+    }
+
+    if (legRole === 'operator') {
+      return {
+        type: 'operator_failed',
+        bridgeSessionId: input.bridgeSessionId || input.aggregate.session.id,
+        providerCallId: providerCallId || undefined,
+        reason: input.reason || 'call_hangup',
+        occurredAt: input.occurredAt,
+      };
+    }
+
+    if (legRole === 'neighbor') {
+      return {
+        type: 'neighbor_failed',
+        bridgeSessionId: input.bridgeSessionId || input.aggregate.session.id,
+        providerCallId: providerCallId || undefined,
+        reason: input.reason || 'call_hangup',
+        occurredAt: input.occurredAt,
+      };
+    }
+  }
+
+  if (
+    normalizedEventType === 'callfailed'
+    || normalizedEventType === 'callfailure'
+    || normalizedEventType === 'callrejected'
+  ) {
+    if (legRole === 'operator') {
+      return {
+        type: 'operator_failed',
+        bridgeSessionId: input.bridgeSessionId || input.aggregate.session.id,
+        providerCallId: providerCallId || undefined,
+        reason: input.reason || 'call_failed',
+        occurredAt: input.occurredAt,
+      };
+    }
+
+    if (legRole === 'neighbor') {
+      return {
+        type: 'neighbor_failed',
+        bridgeSessionId: input.bridgeSessionId || input.aggregate.session.id,
+        providerCallId: providerCallId || undefined,
+        reason: input.reason || 'call_failed',
+        occurredAt: input.occurredAt,
+      };
+    }
+  }
+
+  return null;
+};
+
+const resolveBridgeWebhookReplayInput = async (input: {
+  event: ProviderBridgeEvent;
+  providerCallId?: string | null;
+  loadBySessionId: typeof loadConnectShyftBridgeAggregateBySessionId;
+  loadByProviderCallId: typeof loadConnectShyftBridgeAggregateByProviderCallId;
+}): Promise<{
+  aggregate: BridgeSessionAggregate;
+  providerLegId: string;
+  eventType: string;
+  reason?: string | null;
+} | null> => {
+  const bridgeSessionId = 'bridgeSessionId' in input.event
+    ? normalizeString(input.event.bridgeSessionId)
+    : '';
+  const providerCallId = normalizeString(input.providerCallId)
+    || ('providerCallId' in input.event ? normalizeString(input.event.providerCallId) : '');
+
+  const aggregate = bridgeSessionId
+    ? await input.loadBySessionId(bridgeSessionId)
+    : providerCallId
+      ? await input.loadByProviderCallId({
+        tenantId: undefined,
+        providerCallId,
+      })
+      : null;
+  if (!aggregate) {
+    return null;
+  }
+
+  const providerLegId = providerCallId
+    || aggregate.neighborLeg.providerCallId
+    || aggregate.operatorLeg.providerCallId
+    || '';
+  if (!providerLegId) {
+    return null;
+  }
+
+  if (input.event.type === 'operator_answered' || input.event.type === 'neighbor_answered') {
+    return {
+      aggregate,
+      providerLegId,
+      eventType: 'CallAnswered',
+    };
+  }
+
+  if (input.event.type === 'bridge_connected') {
+    return {
+      aggregate,
+      providerLegId,
+      eventType: 'CallBridged',
+    };
+  }
+
+  if (input.event.type === 'completed') {
+    return {
+      aggregate,
+      providerLegId,
+      eventType: 'CallCompleted',
+    };
+  }
+
+  if (
+    input.event.type === 'operator_failed'
+    || input.event.type === 'neighbor_failed'
+    || input.event.type === 'bridge_failed'
+  ) {
+    return {
+      aggregate,
+      providerLegId,
+      eventType: 'CallFailed',
+      reason: 'reason' in input.event ? input.event.reason || null : null,
+    };
+  }
+
+  return null;
+};
+
+export const buildConnectShyftCallLifecycleService = (
+  dependencies: CallLifecycleDependencies = {},
+): ConnectShyftCallLifecycleService => {
+  const callService = dependencies.callService || connectShyftCallServiceAsync;
+  const voicemailService = dependencies.voicemailService || connectShyftVoicemailServiceAsync;
+  const deliveryAttemptService = dependencies.deliveryAttemptService || connectShyftDeliveryAttemptServiceAsync;
+  const providerEventService = dependencies.providerEventService || connectShyftProviderEventServiceAsync;
+  const threadService = dependencies.threadService || connectShyftThreadServiceAsync;
+  const neighborService = dependencies.neighborService || connectShyftNeighborServiceAsync;
+  const resolveOperatorDestinationFn =
+    dependencies.resolveOperatorDestinationFn || resolveOperatorDestination;
+  const resolveSenderNumberFn = dependencies.resolveSenderNumberFn || resolveSenderNumber;
+  const resolveProviderAdapterFn =
+    dependencies.resolveProviderAdapterFn || resolveConnectShyftProviderAdapter;
+  const startBridgeSessionFn =
+    dependencies.startBridgeSessionFn || startConnectShyftBridgeSession;
+  const handleBridgeWebhookEventFn =
+    dependencies.handleBridgeWebhookEventFn || handleConnectShyftBridgeWebhookEvent;
+  const loadBridgeAggregateByThreadIdFn =
+    dependencies.loadBridgeAggregateByThreadIdFn || loadConnectShyftBridgeAggregateByThreadId;
+  const loadBridgeAggregateBySessionIdFn =
+    dependencies.loadBridgeAggregateBySessionIdFn || loadConnectShyftBridgeAggregateBySessionId;
+  const loadBridgeAggregateByProviderCallIdFn =
+    dependencies.loadBridgeAggregateByProviderCallIdFn || loadConnectShyftBridgeAggregateByProviderCallId;
+  const registerBridgeCallStatusHookFn =
+    dependencies.registerBridgeCallStatusHookFn || registerConnectShyftBridgeCallStatusHook;
+  const eventPublisher =
+    dependencies.eventPublisher || buildBestEffortLifecycleEventPublisher();
+
+  const syncCallFromAggregate = async (
+    aggregate: BridgeSessionAggregate,
+    domainEvent?: ProviderBridgeEvent | null,
+  ): Promise<Call | null> => {
+    const personId = normalizeString((aggregate.session as { personId?: string | null }).personId);
+    if (!personId) {
+      return null;
+    }
+
+    const threadCalls = await callService.listThreadCalls({
+      tenantId: aggregate.session.tenantId,
+      orgUnitId: aggregate.session.orgUnitId,
+      threadId: aggregate.session.threadId,
+    });
+    let call = findCallForAggregate(threadCalls, aggregate);
+    let created = false;
+
+    if (!call) {
+      call = await callService.createCall({
+        tenantId: aggregate.session.tenantId,
+        orgUnitId: aggregate.session.orgUnitId,
+        threadId: aggregate.session.threadId,
+        personId,
+      });
+      created = true;
+      await deliveryAttemptService.createAttempt({
+        tenantId: call.tenantId,
+        orgUnitId: call.orgUnitId,
+        threadId: call.threadId,
+        personId: call.personId,
+        callId: call.id,
+        channel: 'voice',
+        status: 'pending',
+      });
+    }
+
+    const patch = buildCallUpdateFromAggregate({
+      aggregate,
+      existingCall: call,
+      domainEvent: domainEvent ?? null,
+    });
+    if (!patch) {
+      return call;
+    }
+
+    await callService.updateCallStatus({
+      callId: call.id,
+      tenantId: call.tenantId,
+      ...patch,
+    });
+    const refreshedCall = await callService.getCallById(call.id, call.tenantId);
+    if (!refreshedCall) {
+      return call;
+    }
+
+    if (created) {
+      await eventPublisher.publishCallStarted({
+        tenantId: refreshedCall.tenantId,
+        call: refreshedCall,
+      });
+    } else if (refreshedCall.status !== call.status) {
+      await eventPublisher.publishCallUpdated({
+        tenantId: refreshedCall.tenantId,
+        call: refreshedCall,
+      });
+    }
+
+    return refreshedCall;
+  };
+
+  const registerBridgeHook = (): void => {
+    registerBridgeCallStatusHookFn(async ({ aggregate, domainEvent }) => {
+      await syncCallFromAggregate(aggregate, domainEvent);
+    });
+  };
+
+  const resolveThreadOrThrow = async (input: {
+    tenantId: string;
+    orgUnitId: string;
+    threadId: string;
+  }): Promise<ConnectShyftThread> => {
+    const thread = await threadService.findThreadById({
+      tenantId: input.tenantId,
+      threadId: input.threadId,
+    });
+    if (!thread || thread.orgUnitId !== input.orgUnitId) {
+      throw new ConnectShyftCallLifecycleRefusalError(
+        'CONNECTSHYFT_THREAD_NOT_FOUND',
+        'Thread not found for this tenant/orgUnit context.',
+        'business',
+        404,
+      );
+    }
+
+    return thread;
+  };
+
+  return {
+    async startCall(input: StartCallInput): Promise<Call> {
+      registerBridgeHook();
+
+      const thread = await resolveThreadOrThrow({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        threadId: input.threadId,
+      });
+
+      const existingCalls = await callService.listThreadCalls({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        threadId: input.threadId,
+      });
+      const existingAggregate = await loadBridgeAggregateByThreadIdFn({
+        tenantId: input.tenantId,
+        threadId: input.threadId,
+      });
+
+      if (
+        input.idempotencyKey
+        && existingAggregate
+        && normalizeString(existingAggregate.session.idempotencyKey) === input.idempotencyKey
+      ) {
+        const existingCall = existingCalls.find(
+          (call) => call.bridgeSessionId === existingAggregate.session.id,
+        );
+        if (existingCall) {
+          return existingCall;
+        }
+      }
+
+      const activeCall = existingCalls.find((call) => ACTIVE_CALL_STATUSES.has(call.status));
+      if (activeCall) {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          'CONNECTSHYFT_CALL_ALREADY_IN_PROGRESS',
+          'A call is already in progress for this thread.',
+        );
+      }
+
+      const operatorDestination = await resolveOperatorDestinationFn({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        actorUserId: input.actorUserId ?? null,
+        claimedByUserId: thread.claimedByUserId || null,
+      });
+      const operatorContactPointId = normalizeString(operatorDestination.phoneNumber) || null;
+      if (!operatorContactPointId && operatorDestination.source === 'none') {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          'CONNECTSHYFT_OPERATOR_DESTINATION_MISSING',
+          'Outbound bridge calls require a resolved operator destination.',
+        );
+      }
+      if (!operatorContactPointId) {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          'CONNECTSHYFT_OPERATOR_INVALID_PHONE',
+          'Outbound bridge calls require a valid operator destination phone.',
+        );
+      }
+
+      const resolvedNeighbor = await neighborService.resolveNeighbor({
+        tenantId: input.tenantId,
+        neighborId: thread.neighborId,
+        actorRoles: input.actorRoles,
+      });
+      if (!resolvedNeighbor.ok) {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+          'Outbound bridge calls require a dialable neighbor phone.',
+        );
+      }
+
+      const neighborContactPointId = resolvedNeighbor.data.neighbor.phones
+        .filter((phone) => phone.isActive !== false)
+        .sort((left, right) => left.sortOrder - right.sortOrder)[0]?.value || null;
+      if (!neighborContactPointId) {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          'CONNECTSHYFT_NEIGHBOR_PHONE_REQUIRED',
+          'Outbound bridge calls require a dialable neighbor phone.',
+        );
+      }
+
+      const senderResolution = await resolveSenderNumberFn({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        threadId: input.threadId,
+        channel: 'voice',
+      }, {
+        loadThread: async () => thread,
+      });
+      if (!senderResolution.ok) {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          senderResolution.reason === 'sender_mapping_ambiguous'
+            ? 'CONNECTSHYFT_CALL_SENDER_AMBIGUOUS'
+            : 'CONNECTSHYFT_CALL_SENDER_REQUIRED',
+          senderResolution.reason === 'sender_mapping_ambiguous'
+            ? 'Resolve the mapped ConnectShyft outbound line so exactly one active scoped mapping remains before starting a call.'
+            : 'Persist one valid mapped ConnectShyft outbound line on the thread before starting a call.',
+        );
+      }
+
+      const providerResolution = resolveProviderAdapterFn(
+        buildProviderResolutionRequest({
+          tenantId: input.tenantId,
+          orgUnitId: input.orgUnitId,
+          requestedProvider: input.requestedProvider,
+          headers: input.providerRegistryHeaders,
+          operation: 'call',
+        }),
+      );
+      if (!providerResolution.ok) {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          providerResolution.refusal.code,
+          providerResolution.refusal.message,
+          providerResolution.refusal.refusalType,
+          providerResolution.refusal.httpStatus,
+          providerResolution.refusal.data,
+        );
+      }
+
+      const call = await callService.createCall({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        threadId: input.threadId,
+        personId: input.personId,
+        idempotencyKey: input.idempotencyKey,
+      });
+
+      await deliveryAttemptService.createAttempt({
+        tenantId: call.tenantId,
+        orgUnitId: call.orgUnitId,
+        threadId: call.threadId,
+        personId: call.personId,
+        callId: call.id,
+        channel: 'voice',
+        status: 'pending',
+      });
+
+      try {
+        const started = await startBridgeSessionFn({
+          tenantId: input.tenantId,
+          orgUnitId: input.orgUnitId,
+          threadId: input.threadId,
+          personId: input.personId,
+          operatorParticipantId: input.actorUserId || 'unknown-operator',
+          neighborParticipantId: thread.neighborId,
+          operatorContactPointId,
+          neighborContactPointId,
+          selectedOutboundContactPointId: senderResolution.providerNumberE164,
+          providerKey: providerResolution.providerResolution.resolvedProvider,
+          providerAdapter: providerResolution.adapter as ConnectShyftProviderAdapter,
+          idempotencyKey: input.idempotencyKey,
+          auditCorrelationId: input.idempotencyKey,
+          callPolicy: DEFAULT_OUTBOUND_CALL_POLICY,
+        });
+
+        await callService.updateCallStatus({
+          callId: call.id,
+          tenantId: call.tenantId,
+          status: 'operator_dialing',
+          bridgeSessionId: started.aggregate.session.id,
+        });
+
+        const refreshed = await callService.getCallById(call.id, call.tenantId);
+        if (!refreshed) {
+          throw new Error(`Failed to reload call ${call.id} after starting bridge session.`);
+        }
+
+        await eventPublisher.publishCallStarted({
+          tenantId: refreshed.tenantId,
+          call: refreshed,
+          actorUserId: input.actorUserId ?? null,
+        });
+
+        return refreshed;
+      } catch (error) {
+        await callService.updateCallStatus({
+          callId: call.id,
+          tenantId: call.tenantId,
+          status: 'failed',
+          endedAtUtc: new Date().toISOString(),
+          failureCode: 'provider_error',
+          failureMessage: error instanceof Error ? error.message : 'provider_error',
+        });
+        const failedCall = await callService.getCallById(call.id, call.tenantId);
+        if (failedCall) {
+          await eventPublisher.publishCallUpdated({
+            tenantId: failedCall.tenantId,
+            call: failedCall,
+            actorUserId: input.actorUserId ?? null,
+          });
+        }
+
+        throw new ConnectShyftCallLifecycleRefusalError(
+          'CONNECTSHYFT_PROVIDER_DISPATCH_FAILED',
+          'Provider dispatch failed before persistence.',
+        );
+      }
+    },
+
+    async handleProviderEvent(input: HandleProviderEventInput): Promise<void> {
+      registerBridgeHook();
+
+      const replayInput = await resolveBridgeWebhookReplayInput({
+        event: input.event,
+        providerCallId: input.providerCallId ?? null,
+        loadBySessionId: loadBridgeAggregateBySessionIdFn,
+        loadByProviderCallId: loadBridgeAggregateByProviderCallIdFn,
+      });
+      if (!replayInput) {
+        return;
+      }
+
+      const currentCalls = await callService.listThreadCalls({
+        tenantId: replayInput.aggregate.session.tenantId,
+        orgUnitId: replayInput.aggregate.session.orgUnitId,
+        threadId: replayInput.aggregate.session.threadId,
+      });
+      const currentCall = currentCalls.find(
+        (call) => call.bridgeSessionId === replayInput.aggregate.session.id,
+      ) || null;
+
+      await providerEventService.recordEvent({
+        tenantId: replayInput.aggregate.session.tenantId,
+        provider: input.provider,
+        eventType: input.event.type,
+        eventJson: input.eventJson,
+        callId: currentCall?.id || null,
+        bridgeSessionId: replayInput.aggregate.session.id,
+        providerCallId: replayInput.providerLegId,
+        occurredAtUtc: input.occurredAt.toISOString(),
+      });
+
+      const providerResolution = resolveProviderAdapterFn(
+        buildProviderResolutionRequest({
+          tenantId: replayInput.aggregate.session.tenantId,
+          orgUnitId: replayInput.aggregate.session.orgUnitId,
+          requestedProvider: input.provider,
+          operation: 'webhook',
+        }),
+      );
+      if (!providerResolution.ok) {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          providerResolution.refusal.code,
+          providerResolution.refusal.message,
+          providerResolution.refusal.refusalType,
+          providerResolution.refusal.httpStatus,
+          providerResolution.refusal.data,
+        );
+      }
+
+      await handleBridgeWebhookEventFn({
+        tenantId: replayInput.aggregate.session.tenantId,
+        orgUnitId: replayInput.aggregate.session.orgUnitId,
+        threadId: replayInput.aggregate.session.threadId,
+        providerKey: providerResolution.providerResolution.resolvedProvider,
+        providerAdapter: providerResolution.adapter as ConnectShyftProviderAdapter,
+        providerLegId: replayInput.providerLegId,
+        eventType: replayInput.eventType,
+        occurredAt: input.occurredAt,
+        reason: replayInput.reason || null,
+        callPolicy: DEFAULT_OUTBOUND_CALL_POLICY,
+      });
+    },
+
+    async handleVoicemail(input: HandleVoicemailInput): Promise<Voicemail> {
+      registerBridgeHook();
+
+      const call = await callService.getCallById(input.callId, input.tenantId);
+      if (!call) {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          'CONNECTSHYFT_CALL_NOT_FOUND',
+          'Call not found for this tenant context.',
+          'business',
+          404,
+        );
+      }
+
+      let voicemailEligible = call.status === 'failed' || call.status === 'voicemail';
+      if (!voicemailEligible && call.bridgeSessionId) {
+        const aggregate = await loadBridgeAggregateBySessionIdFn(call.bridgeSessionId);
+        voicemailEligible = aggregate?.session.failureCode === 'neighbor_failed';
+      }
+
+      if (!voicemailEligible) {
+        throw new ConnectShyftCallLifecycleRefusalError(
+          'CONNECTSHYFT_VOICEMAIL_NOT_ALLOWED',
+          'Voicemail fallback is only allowed after a failed neighbor connection.',
+        );
+      }
+
+      const voicemail = await voicemailService.createVoicemail({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        callId: input.callId,
+        threadId: input.threadId,
+        personId: input.personId,
+        artifactId: input.artifactId,
+        recordingUrl: input.recordingUrl,
+        recordingStatus: input.recordingStatus,
+        occurredAtUtc: input.occurredAt.toISOString(),
+        transcriptionJson: input.transcriptionJson,
+      });
+
+      if (shouldApplyCallUpdate(call.status, 'voicemail')) {
+        await callService.updateCallStatus({
+          callId: call.id,
+          tenantId: call.tenantId,
+          status: 'voicemail',
+          endedAtUtc: call.endedAtUtc || input.occurredAt.toISOString(),
+        });
+      }
+
+      await eventPublisher.publishVoicemailRecorded({
+        tenantId: voicemail.tenantId,
+        voicemail,
+      });
+
+      return voicemail;
+    },
+  };
+};
+
+export const connectShyftCallLifecycleServiceAsync =
+  buildConnectShyftCallLifecycleService();
+
+export const resetConnectShyftCallLifecycleStateForTests = (): void => {
+  persistedLifecycleEventsForTests.splice(0, persistedLifecycleEventsForTests.length);
+};
+
+export const listConnectShyftLifecycleEventsForTests = (): PersistedLifecycleEvent[] =>
+  [...persistedLifecycleEventsForTests];

--- a/apps/connectshyft-api/src/modules/connectshyft/callLifecycle.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/callLifecycle.ts
@@ -1,6 +1,3 @@
-import type { Knex } from 'knex';
-import { executePlatformMutation } from '../../platform/mutations/executePlatformMutation';
-import db from '../../config/knex';
 import type {
   BridgeSessionAggregate,
   ProviderBridgeEvent,
@@ -56,9 +53,13 @@ import {
   type ConnectShyftProviderAdapter,
   type ConnectShyftProviderResolutionResult,
 } from './providerRegistry';
-import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+import {
+  buildConnectShyftLifecycleEventPublisher,
+  listConnectShyftLifecycleEventsForTests as listLifecycleEventsForTests,
+  resetConnectShyftLifecycleEventsForTests as resetLifecycleEventsForTests,
+  type ConnectShyftCallLifecycleEventPublisher,
+} from './events';
 
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const ACTIVE_CALL_STATUSES = new Set<CallStatus>([
   'operator_dialing',
   'operator_answered',
@@ -144,24 +145,6 @@ export class ConnectShyftCallLifecycleRefusalError extends Error {
   }
 }
 
-export type ConnectShyftCallLifecycleEventPublisher = {
-  publishCallStarted(input: {
-    tenantId: string;
-    call: Call;
-    actorUserId?: string | null;
-  }): Promise<void>;
-  publishCallUpdated(input: {
-    tenantId: string;
-    call: Call;
-    actorUserId?: string | null;
-  }): Promise<void>;
-  publishVoicemailRecorded(input: {
-    tenantId: string;
-    voicemail: Voicemail;
-    actorUserId?: string | null;
-  }): Promise<void>;
-};
-
 type CallLifecycleDependencies = {
   callService?: ConnectShyftCallService;
   voicemailService?: ConnectShyftVoicemailService;
@@ -198,15 +181,6 @@ type CallLifecycleDependencies = {
   eventPublisher?: ConnectShyftCallLifecycleEventPublisher;
 };
 
-type PersistedLifecycleEvent = {
-  id: string;
-  eventName: string;
-  entityId: string;
-  payload: Record<string, unknown>;
-};
-
-const persistedLifecycleEventsForTests: PersistedLifecycleEvent[] = [];
-
 const normalizeString = (value: unknown): string => {
   if (typeof value !== 'string') {
     return '';
@@ -236,9 +210,6 @@ const toIsoString = (value: string | Date | null | undefined): string | null => 
 
   return normalized;
 };
-
-const isUuid = (value: string | null | undefined): value is string =>
-  typeof value === 'string' && UUID_PATTERN.test(value.trim());
 
 const isTerminalCallStatus = (status: CallStatus): boolean => TERMINAL_CALL_STATUSES.has(status);
 
@@ -367,152 +338,6 @@ const buildCallUpdateFromAggregate = (input: {
   }
 
   return patch;
-};
-
-const resolveCallStatusEvents = (call: Call): Array<{ status: CallStatus; occurredAtUtc: string }> => {
-  const events: Array<{ status: CallStatus; occurredAtUtc: string }> = [];
-  events.push({
-    status: 'operator_dialing',
-    occurredAtUtc: call.startedAtUtc,
-  });
-
-  if (call.operatorAnsweredAtUtc) {
-    events.push({
-      status: 'operator_answered',
-      occurredAtUtc: call.operatorAnsweredAtUtc,
-    });
-    events.push({
-      status: 'neighbor_dialing',
-      occurredAtUtc: call.operatorAnsweredAtUtc,
-    });
-  }
-
-  if (call.neighborAnsweredAtUtc) {
-    events.push({
-      status: 'neighbor_answered',
-      occurredAtUtc: call.neighborAnsweredAtUtc,
-    });
-  }
-
-  if (call.bridgedAtUtc) {
-    events.push({
-      status: 'bridged',
-      occurredAtUtc: call.bridgedAtUtc,
-    });
-  }
-
-  if (
-    call.status === 'voicemail'
-    || call.status === 'completed'
-    || call.status === 'failed'
-    || call.status === 'canceled'
-    || call.status === 'expired'
-  ) {
-    events.push({
-      status: call.status,
-      occurredAtUtc: call.endedAtUtc || call.updatedAtUtc,
-    });
-  }
-
-  return events;
-};
-
-const buildLifecycleEventPayload = (call: Call): Record<string, unknown> => ({
-  callId: call.id,
-  threadId: call.threadId,
-  personId: call.personId,
-  bridgeSessionId: call.bridgeSessionId,
-  status: call.status,
-  startedAtUtc: call.startedAtUtc,
-  operatorAnsweredAtUtc: call.operatorAnsweredAtUtc,
-  neighborAnsweredAtUtc: call.neighborAnsweredAtUtc,
-  bridgedAtUtc: call.bridgedAtUtc,
-  endedAtUtc: call.endedAtUtc,
-  failureCode: call.failureCode,
-  failureMessage: call.failureMessage,
-  statusEvents: resolveCallStatusEvents(call),
-});
-
-const buildBestEffortLifecycleEventPublisher = (
-  knexClient: Knex = db,
-): ConnectShyftCallLifecycleEventPublisher => {
-  const publish = async (input: {
-    tenantId: string;
-    actorUserId?: string | null;
-    eventName: string;
-    entityId: string;
-    payload: Record<string, unknown>;
-  }): Promise<void> => {
-    if (
-      isConnectShyftTestOverrideEnabled()
-      || !isUuid(input.tenantId)
-      || !isUuid(input.entityId)
-      || (input.actorUserId != null && !isUuid(input.actorUserId))
-    ) {
-      persistedLifecycleEventsForTests.push({
-        id: `${input.eventName}:${input.entityId}:${persistedLifecycleEventsForTests.length + 1}`,
-        eventName: input.eventName,
-        entityId: input.entityId,
-        payload: input.payload,
-      });
-      return;
-    }
-
-    try {
-      await executePlatformMutation({
-        mutation: async () => null,
-        event: {
-          tenantId: input.tenantId,
-          actorId: input.actorUserId ?? null,
-          eventName: input.eventName,
-          entityType: 'connectshyft.call',
-          entityId: input.entityId,
-          payload: input.payload,
-          occurredAtUtc: new Date(),
-        },
-      }, knexClient);
-    } catch (_error) {
-      // Event emission is best-effort in this checkpoint to avoid blocking the call path.
-    }
-  };
-
-  return {
-    publishCallStarted(input) {
-      return publish({
-        tenantId: input.tenantId,
-        actorUserId: input.actorUserId,
-        eventName: 'connectshyft.call.started',
-        entityId: input.call.id,
-        payload: buildLifecycleEventPayload(input.call),
-      });
-    },
-    publishCallUpdated(input) {
-      return publish({
-        tenantId: input.tenantId,
-        actorUserId: input.actorUserId,
-        eventName: 'connectshyft.call.updated',
-        entityId: input.call.id,
-        payload: buildLifecycleEventPayload(input.call),
-      });
-    },
-    publishVoicemailRecorded(input) {
-      return publish({
-        tenantId: input.tenantId,
-        actorUserId: input.actorUserId,
-        eventName: 'connectshyft.voicemail.recorded',
-        entityId: input.voicemail.id,
-        payload: {
-          voicemailId: input.voicemail.id,
-          callId: input.voicemail.callId,
-          threadId: input.voicemail.threadId,
-          personId: input.voicemail.personId,
-          recordingUrl: input.voicemail.recordingUrl,
-          recordingStatus: input.voicemail.recordingStatus,
-          occurredAtUtc: input.voicemail.occurredAtUtc,
-        },
-      });
-    },
-  };
 };
 
 const buildProviderResolutionRequest = (input: {
@@ -788,7 +613,7 @@ export const buildConnectShyftCallLifecycleService = (
   const registerBridgeCallStatusHookFn =
     dependencies.registerBridgeCallStatusHookFn || registerConnectShyftBridgeCallStatusHook;
   const eventPublisher =
-    dependencies.eventPublisher || buildBestEffortLifecycleEventPublisher();
+    dependencies.eventPublisher || buildConnectShyftLifecycleEventPublisher();
 
   const syncCallFromAggregate = async (
     aggregate: BridgeSessionAggregate,
@@ -1215,8 +1040,8 @@ export const connectShyftCallLifecycleServiceAsync =
   buildConnectShyftCallLifecycleService();
 
 export const resetConnectShyftCallLifecycleStateForTests = (): void => {
-  persistedLifecycleEventsForTests.splice(0, persistedLifecycleEventsForTests.length);
+  resetLifecycleEventsForTests();
 };
 
-export const listConnectShyftLifecycleEventsForTests = (): PersistedLifecycleEvent[] =>
-  [...persistedLifecycleEventsForTests];
+export const listConnectShyftLifecycleEventsForTests = () =>
+  listLifecycleEventsForTests();

--- a/apps/connectshyft-api/src/modules/connectshyft/calls.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/calls.ts
@@ -1,0 +1,478 @@
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const CALLS_TABLE = 'cs_calls';
+
+export type CallStatus =
+  | 'operator_dialing'
+  | 'operator_answered'
+  | 'neighbor_dialing'
+  | 'neighbor_answered'
+  | 'bridged'
+  | 'voicemail'
+  | 'completed'
+  | 'failed'
+  | 'canceled'
+  | 'expired';
+
+export type Call = {
+  id: string;
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  personId: string;
+  bridgeSessionId: string | null;
+  status: CallStatus;
+  failureCode: string | null;
+  failureMessage: string | null;
+  startedAtUtc: string;
+  operatorAnsweredAtUtc: string | null;
+  neighborAnsweredAtUtc: string | null;
+  bridgedAtUtc: string | null;
+  endedAtUtc: string | null;
+  createdAtUtc: string;
+  updatedAtUtc: string;
+};
+
+export interface CreateCallInput {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  personId: string;
+  idempotencyKey?: string;
+}
+
+export interface UpdateCallStatusInput {
+  callId: string;
+  tenantId: string;
+  status: CallStatus;
+  bridgeSessionId?: string | null;
+  startedAtUtc?: string;
+  operatorAnsweredAtUtc?: string;
+  neighborAnsweredAtUtc?: string;
+  bridgedAtUtc?: string;
+  endedAtUtc?: string;
+  failureCode?: string | null;
+  failureMessage?: string | null;
+}
+
+export interface ListThreadCallsInput {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+}
+
+export interface ListPersonCallsInput {
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+}
+
+export interface ConnectShyftCallService {
+  createCall(input: CreateCallInput): Promise<Call>;
+  updateCallStatus(input: UpdateCallStatusInput): Promise<void>;
+  listThreadCalls(input: ListThreadCallsInput): Promise<Call[]>;
+  listPersonCalls(input: ListPersonCallsInput): Promise<Call[]>;
+  getCallById(callId: string, tenantId: string): Promise<Call | null>;
+}
+
+type DbCallRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  thread_id: string;
+  person_id: string;
+  bridge_session_id?: string | null;
+  status: string;
+  failure_code?: string | null;
+  failure_message?: string | null;
+  started_at_utc: string | Date;
+  operator_answered_at_utc?: string | Date | null;
+  neighbor_answered_at_utc?: string | Date | null;
+  bridged_at_utc?: string | Date | null;
+  ended_at_utc?: string | Date | null;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const toIsoUtc = (value: string | Date | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = new Date(normalized);
+  if (!Number.isNaN(parsed.valueOf())) {
+    return parsed.toISOString();
+  }
+
+  return normalized;
+};
+
+export const isConnectShyftPersistenceErrorCause = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const candidate = error as { code?: string };
+  const normalizedCode = typeof candidate.code === 'string'
+    ? candidate.code.toUpperCase()
+    : '';
+
+  return normalizedCode === '42P01'
+    || normalizedCode === '3F000'
+    || normalizedCode === '42703'
+    || normalizedCode === '28000'
+    || normalizedCode === '28P01'
+    || normalizedCode.startsWith('08')
+    || normalizedCode === 'ECONNREFUSED'
+    || normalizedCode === 'ENOTFOUND'
+    || normalizedCode === 'ETIMEDOUT';
+};
+
+const mapCallRow = (row: DbCallRow): Call => ({
+  id: row.id,
+  tenantId: row.tenant_id,
+  orgUnitId: row.org_unit_id,
+  threadId: row.thread_id,
+  personId: row.person_id,
+  bridgeSessionId: normalizeString(row.bridge_session_id) || null,
+  status: row.status as CallStatus,
+  failureCode: normalizeString(row.failure_code) || null,
+  failureMessage: normalizeString(row.failure_message) || null,
+  startedAtUtc: toIsoUtc(row.started_at_utc) || new Date().toISOString(),
+  operatorAnsweredAtUtc: toIsoUtc(row.operator_answered_at_utc),
+  neighborAnsweredAtUtc: toIsoUtc(row.neighbor_answered_at_utc),
+  bridgedAtUtc: toIsoUtc(row.bridged_at_utc),
+  endedAtUtc: toIsoUtc(row.ended_at_utc),
+  createdAtUtc: toIsoUtc(row.created_at_utc) || new Date().toISOString(),
+  updatedAtUtc: toIsoUtc(row.updated_at_utc) || new Date().toISOString(),
+});
+
+export class ConnectShyftPersistenceUnavailableError extends Error {
+  readonly code = 'CONNECTSHYFT_PERSISTENCE_UNAVAILABLE';
+
+  constructor(cause?: unknown) {
+    super('ConnectShyft persistence is unavailable.');
+    this.name = 'ConnectShyftPersistenceUnavailableError';
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+class InMemoryConnectShyftCallStore implements ConnectShyftCallService {
+  private readonly records = new Map<string, Call>();
+
+  async createCall(input: CreateCallInput): Promise<Call> {
+    const nowIsoUtc = new Date().toISOString();
+    const call: Call = {
+      id: randomUUID(),
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      threadId: input.threadId,
+      personId: input.personId,
+      bridgeSessionId: null,
+      status: 'operator_dialing',
+      failureCode: null,
+      failureMessage: null,
+      startedAtUtc: nowIsoUtc,
+      operatorAnsweredAtUtc: null,
+      neighborAnsweredAtUtc: null,
+      bridgedAtUtc: null,
+      endedAtUtc: null,
+      createdAtUtc: nowIsoUtc,
+      updatedAtUtc: nowIsoUtc,
+    };
+
+    this.records.set(call.id, call);
+    return call;
+  }
+
+  async updateCallStatus(input: UpdateCallStatusInput): Promise<void> {
+    const existing = this.records.get(input.callId);
+    if (!existing || existing.tenantId !== input.tenantId) {
+      return;
+    }
+
+    this.records.set(input.callId, {
+      ...existing,
+      status: input.status,
+      bridgeSessionId: input.bridgeSessionId === undefined
+        ? existing.bridgeSessionId
+        : input.bridgeSessionId,
+      startedAtUtc: input.startedAtUtc || existing.startedAtUtc,
+      operatorAnsweredAtUtc: input.operatorAnsweredAtUtc ?? existing.operatorAnsweredAtUtc,
+      neighborAnsweredAtUtc: input.neighborAnsweredAtUtc ?? existing.neighborAnsweredAtUtc,
+      bridgedAtUtc: input.bridgedAtUtc ?? existing.bridgedAtUtc,
+      endedAtUtc: input.endedAtUtc ?? existing.endedAtUtc,
+      failureCode: input.failureCode === undefined ? existing.failureCode : input.failureCode,
+      failureMessage: input.failureMessage === undefined
+        ? existing.failureMessage
+        : input.failureMessage,
+      updatedAtUtc: new Date().toISOString(),
+    });
+  }
+
+  async listThreadCalls(input: ListThreadCallsInput): Promise<Call[]> {
+    return [...this.records.values()]
+      .filter((call) => (
+        call.tenantId === input.tenantId
+        && call.orgUnitId === input.orgUnitId
+        && call.threadId === input.threadId
+      ))
+      .sort((left, right) => (
+        new Date(right.createdAtUtc).getTime() - new Date(left.createdAtUtc).getTime()
+      ) || right.id.localeCompare(left.id));
+  }
+
+  async listPersonCalls(input: ListPersonCallsInput): Promise<Call[]> {
+    return [...this.records.values()]
+      .filter((call) => (
+        call.tenantId === input.tenantId
+        && call.orgUnitId === input.orgUnitId
+        && call.personId === input.personId
+      ))
+      .sort((left, right) => (
+        new Date(right.createdAtUtc).getTime() - new Date(left.createdAtUtc).getTime()
+      ) || right.id.localeCompare(left.id));
+  }
+
+  async getCallById(callId: string, tenantId: string): Promise<Call | null> {
+    const record = this.records.get(callId);
+    if (!record || record.tenantId !== tenantId) {
+      return null;
+    }
+
+    return record;
+  }
+
+  reset(): void {
+    this.records.clear();
+  }
+}
+
+class KnexConnectShyftCallStore implements ConnectShyftCallService {
+  constructor(private readonly knexClient: Knex = db) {}
+
+  private table() {
+    return this.knexClient.withSchema(CONNECTSHYFT_SCHEMA).table(CALLS_TABLE);
+  }
+
+  async createCall(input: CreateCallInput): Promise<Call> {
+    const callId = randomUUID();
+    const nowIsoUtc = new Date().toISOString();
+    await this.table().insert({
+      id: callId,
+      tenant_id: input.tenantId,
+      org_unit_id: input.orgUnitId,
+      thread_id: input.threadId,
+      person_id: input.personId,
+      bridge_session_id: null,
+      status: 'operator_dialing',
+      failure_code: null,
+      failure_message: null,
+      started_at_utc: nowIsoUtc,
+      operator_answered_at_utc: null,
+      neighbor_answered_at_utc: null,
+      bridged_at_utc: null,
+      ended_at_utc: null,
+      created_at_utc: nowIsoUtc,
+      updated_at_utc: nowIsoUtc,
+    });
+
+    const row = await this.table()
+      .where({ id: callId, tenant_id: input.tenantId })
+      .first<DbCallRow>();
+
+    if (!row) {
+      throw new Error(`Failed to load ConnectShyft call ${callId} after insert.`);
+    }
+
+    return mapCallRow(row);
+  }
+
+  async updateCallStatus(input: UpdateCallStatusInput): Promise<void> {
+    const patch: Record<string, string | null> = {
+      status: input.status,
+      updated_at_utc: new Date().toISOString(),
+    };
+
+    if (input.bridgeSessionId !== undefined) {
+      patch.bridge_session_id = input.bridgeSessionId;
+    }
+    if (input.startedAtUtc !== undefined) {
+      patch.started_at_utc = input.startedAtUtc;
+    }
+    if (input.operatorAnsweredAtUtc !== undefined) {
+      patch.operator_answered_at_utc = input.operatorAnsweredAtUtc;
+    }
+    if (input.neighborAnsweredAtUtc !== undefined) {
+      patch.neighbor_answered_at_utc = input.neighborAnsweredAtUtc;
+    }
+    if (input.bridgedAtUtc !== undefined) {
+      patch.bridged_at_utc = input.bridgedAtUtc;
+    }
+    if (input.endedAtUtc !== undefined) {
+      patch.ended_at_utc = input.endedAtUtc;
+    }
+    if (input.failureCode !== undefined) {
+      patch.failure_code = input.failureCode;
+    }
+    if (input.failureMessage !== undefined) {
+      patch.failure_message = input.failureMessage;
+    }
+
+    await this.table()
+      .where({
+        id: input.callId,
+        tenant_id: input.tenantId,
+      })
+      .update(patch);
+  }
+
+  async listThreadCalls(input: ListThreadCallsInput): Promise<Call[]> {
+    const rows = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        thread_id: input.threadId,
+      })
+      .orderBy('created_at_utc', 'desc')
+      .orderBy('id', 'desc')
+      .select<DbCallRow[]>();
+
+    return rows.map(mapCallRow);
+  }
+
+  async listPersonCalls(input: ListPersonCallsInput): Promise<Call[]> {
+    const rows = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        person_id: input.personId,
+      })
+      .orderBy('created_at_utc', 'desc')
+      .orderBy('id', 'desc')
+      .select<DbCallRow[]>();
+
+    return rows.map(mapCallRow);
+  }
+
+  async getCallById(callId: string, tenantId: string): Promise<Call | null> {
+    const row = await this.table()
+      .where({
+        id: callId,
+        tenant_id: tenantId,
+      })
+      .first<DbCallRow>();
+
+    return row ? mapCallRow(row) : null;
+  }
+}
+
+const inMemoryConnectShyftCallStore = new InMemoryConnectShyftCallStore();
+const knexConnectShyftCallStore = new KnexConnectShyftCallStore();
+
+class AsyncConnectShyftCallService implements ConnectShyftCallService {
+  async createCall(input: CreateCallInput): Promise<Call> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryConnectShyftCallStore.createCall(input);
+    }
+
+    try {
+      return await knexConnectShyftCallStore.createCall(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+
+  async updateCallStatus(input: UpdateCallStatusInput): Promise<void> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      await inMemoryConnectShyftCallStore.updateCallStatus(input);
+      return;
+    }
+
+    try {
+      await knexConnectShyftCallStore.updateCallStatus(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+
+  async listThreadCalls(input: ListThreadCallsInput): Promise<Call[]> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryConnectShyftCallStore.listThreadCalls(input);
+    }
+
+    try {
+      return await knexConnectShyftCallStore.listThreadCalls(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+
+  async listPersonCalls(input: ListPersonCallsInput): Promise<Call[]> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryConnectShyftCallStore.listPersonCalls(input);
+    }
+
+    try {
+      return await knexConnectShyftCallStore.listPersonCalls(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+
+  async getCallById(callId: string, tenantId: string): Promise<Call | null> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryConnectShyftCallStore.getCallById(callId, tenantId);
+    }
+
+    try {
+      return await knexConnectShyftCallStore.getCallById(callId, tenantId);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+}
+
+export const connectShyftCallServiceAsync: ConnectShyftCallService = new AsyncConnectShyftCallService();
+
+export const resetConnectShyftCallStateForTests = (): void => {
+  inMemoryConnectShyftCallStore.reset();
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/deliveryAttempts.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/deliveryAttempts.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+import {
+  ConnectShyftPersistenceUnavailableError,
+  isConnectShyftPersistenceErrorCause,
+} from './calls';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const DELIVERY_ATTEMPTS_TABLE = 'cs_delivery_attempts';
+
+export interface CreateDeliveryAttemptInput {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  personId: string;
+  callId?: string | null;
+  channel: 'sms' | 'voice';
+  providerEventId?: string | null;
+  status: 'pending' | 'succeeded' | 'failed' | 'canceled';
+  failureCode?: string | null;
+  failureMessage?: string | null;
+}
+
+export interface ConnectShyftDeliveryAttemptService {
+  createAttempt(input: CreateDeliveryAttemptInput): Promise<void>;
+}
+
+class InMemoryConnectShyftDeliveryAttemptStore implements ConnectShyftDeliveryAttemptService {
+  async createAttempt(_input: CreateDeliveryAttemptInput): Promise<void> {}
+}
+
+class KnexConnectShyftDeliveryAttemptStore implements ConnectShyftDeliveryAttemptService {
+  constructor(private readonly knexClient: Knex = db) {}
+
+  async createAttempt(input: CreateDeliveryAttemptInput): Promise<void> {
+    await this.knexClient
+      .withSchema(CONNECTSHYFT_SCHEMA)
+      .table(DELIVERY_ATTEMPTS_TABLE)
+      .insert({
+        id: randomUUID(),
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        thread_id: input.threadId,
+        person_id: input.personId,
+        call_id: input.callId ?? null,
+        channel: input.channel,
+        provider_event_id: input.providerEventId ?? null,
+        status: input.status,
+        failure_code: input.failureCode ?? null,
+        failure_message: input.failureMessage ?? null,
+        created_at_utc: new Date().toISOString(),
+        updated_at_utc: new Date().toISOString(),
+      });
+  }
+}
+
+const inMemoryConnectShyftDeliveryAttemptStore = new InMemoryConnectShyftDeliveryAttemptStore();
+const knexConnectShyftDeliveryAttemptStore = new KnexConnectShyftDeliveryAttemptStore();
+
+class AsyncConnectShyftDeliveryAttemptService implements ConnectShyftDeliveryAttemptService {
+  async createAttempt(input: CreateDeliveryAttemptInput): Promise<void> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      await inMemoryConnectShyftDeliveryAttemptStore.createAttempt(input);
+      return;
+    }
+
+    try {
+      await knexConnectShyftDeliveryAttemptStore.createAttempt(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+}
+
+export const connectShyftDeliveryAttemptServiceAsync: ConnectShyftDeliveryAttemptService =
+  new AsyncConnectShyftDeliveryAttemptService();

--- a/apps/connectshyft-api/src/modules/connectshyft/events.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/events.ts
@@ -1,0 +1,208 @@
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+import { executePlatformMutation } from '../../platform/mutations/executePlatformMutation';
+import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+import type { Call, CallStatus } from './calls';
+import type { Voicemail } from './voicemails';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const CONNECTSHYFT_CALL_STARTED_EVENT_NAME = 'connectshyft.call.started' as const;
+export const CONNECTSHYFT_CALL_UPDATED_EVENT_NAME = 'connectshyft.call.updated' as const;
+export const CONNECTSHYFT_VOICEMAIL_RECORDED_EVENT_NAME = 'connectshyft.voicemail.recorded' as const;
+
+export type ConnectShyftPersistedLifecycleEvent = {
+  id: string;
+  eventName: string;
+  entityType: string;
+  entityId: string;
+  payload: Record<string, unknown>;
+};
+
+export type ConnectShyftCallLifecycleEventPublisher = {
+  publishCallStarted(input: {
+    tenantId: string;
+    call: Call;
+    actorUserId?: string | null;
+  }): Promise<void>;
+  publishCallUpdated(input: {
+    tenantId: string;
+    call: Call;
+    actorUserId?: string | null;
+  }): Promise<void>;
+  publishVoicemailRecorded(input: {
+    tenantId: string;
+    voicemail: Voicemail;
+    actorUserId?: string | null;
+  }): Promise<void>;
+};
+
+const persistedLifecycleEventsForTests: ConnectShyftPersistedLifecycleEvent[] = [];
+
+const isUuid = (value: string | null | undefined): value is string =>
+  typeof value === 'string' && UUID_PATTERN.test(value.trim());
+
+const resolveCallStatusEvents = (call: Call): Array<{ status: CallStatus; occurredAtUtc: string }> => {
+  const events: Array<{ status: CallStatus; occurredAtUtc: string }> = [
+    {
+      status: 'operator_dialing',
+      occurredAtUtc: call.startedAtUtc,
+    },
+  ];
+
+  if (call.operatorAnsweredAtUtc) {
+    events.push({
+      status: 'operator_answered',
+      occurredAtUtc: call.operatorAnsweredAtUtc,
+    });
+    events.push({
+      status: 'neighbor_dialing',
+      occurredAtUtc: call.operatorAnsweredAtUtc,
+    });
+  }
+
+  if (call.neighborAnsweredAtUtc) {
+    events.push({
+      status: 'neighbor_answered',
+      occurredAtUtc: call.neighborAnsweredAtUtc,
+    });
+  }
+
+  if (call.bridgedAtUtc) {
+    events.push({
+      status: 'bridged',
+      occurredAtUtc: call.bridgedAtUtc,
+    });
+  }
+
+  if (
+    call.status === 'voicemail'
+    || call.status === 'completed'
+    || call.status === 'failed'
+    || call.status === 'canceled'
+    || call.status === 'expired'
+  ) {
+    events.push({
+      status: call.status,
+      occurredAtUtc: call.endedAtUtc || call.updatedAtUtc,
+    });
+  }
+
+  return events;
+};
+
+const buildCallLifecycleEventPayload = (call: Call): Record<string, unknown> => ({
+  callId: call.id,
+  threadId: call.threadId,
+  personId: call.personId,
+  bridgeSessionId: call.bridgeSessionId,
+  status: call.status,
+  startedAtUtc: call.startedAtUtc,
+  operatorAnsweredAtUtc: call.operatorAnsweredAtUtc,
+  neighborAnsweredAtUtc: call.neighborAnsweredAtUtc,
+  bridgedAtUtc: call.bridgedAtUtc,
+  endedAtUtc: call.endedAtUtc,
+  failureCode: call.failureCode,
+  failureMessage: call.failureMessage,
+  statusEvents: resolveCallStatusEvents(call),
+});
+
+const buildVoicemailLifecycleEventPayload = (
+  voicemail: Voicemail,
+): Record<string, unknown> => ({
+  voicemailId: voicemail.id,
+  callId: voicemail.callId,
+  threadId: voicemail.threadId,
+  personId: voicemail.personId,
+  recordingUrl: voicemail.recordingUrl,
+  recordingStatus: voicemail.recordingStatus,
+  occurredAtUtc: voicemail.occurredAtUtc,
+});
+
+const publishBestEffortLifecycleEvent = async (input: {
+  tenantId: string;
+  actorUserId?: string | null;
+  eventName: string;
+  entityType: string;
+  entityId: string;
+  payload: Record<string, unknown>;
+  knexClient: Knex;
+}): Promise<void> => {
+  if (
+    isConnectShyftTestOverrideEnabled()
+    || !isUuid(input.tenantId)
+    || !isUuid(input.entityId)
+    || (input.actorUserId != null && !isUuid(input.actorUserId))
+  ) {
+    persistedLifecycleEventsForTests.push({
+      id: `${input.eventName}:${input.entityId}:${persistedLifecycleEventsForTests.length + 1}`,
+      eventName: input.eventName,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      payload: input.payload,
+    });
+    return;
+  }
+
+  try {
+    await executePlatformMutation({
+      mutation: async () => null,
+      event: {
+        tenantId: input.tenantId,
+        actorId: input.actorUserId ?? null,
+        eventName: input.eventName,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        payload: input.payload,
+        occurredAtUtc: new Date(),
+      },
+    }, input.knexClient);
+  } catch (_error) {
+    // Event emission remains best-effort so lifecycle persistence keeps its existing behavior.
+  }
+};
+
+export const buildConnectShyftLifecycleEventPublisher = (
+  knexClient: Knex = db,
+): ConnectShyftCallLifecycleEventPublisher => ({
+  publishCallStarted(input) {
+    return publishBestEffortLifecycleEvent({
+      tenantId: input.tenantId,
+      actorUserId: input.actorUserId,
+      eventName: CONNECTSHYFT_CALL_STARTED_EVENT_NAME,
+      entityType: 'connectshyft.call',
+      entityId: input.call.id,
+      payload: buildCallLifecycleEventPayload(input.call),
+      knexClient,
+    });
+  },
+  publishCallUpdated(input) {
+    return publishBestEffortLifecycleEvent({
+      tenantId: input.tenantId,
+      actorUserId: input.actorUserId,
+      eventName: CONNECTSHYFT_CALL_UPDATED_EVENT_NAME,
+      entityType: 'connectshyft.call',
+      entityId: input.call.id,
+      payload: buildCallLifecycleEventPayload(input.call),
+      knexClient,
+    });
+  },
+  publishVoicemailRecorded(input) {
+    return publishBestEffortLifecycleEvent({
+      tenantId: input.tenantId,
+      actorUserId: input.actorUserId,
+      eventName: CONNECTSHYFT_VOICEMAIL_RECORDED_EVENT_NAME,
+      entityType: 'connectshyft.voicemail',
+      entityId: input.voicemail.id,
+      payload: buildVoicemailLifecycleEventPayload(input.voicemail),
+      knexClient,
+    });
+  },
+});
+
+export const resetConnectShyftLifecycleEventsForTests = (): void => {
+  persistedLifecycleEventsForTests.splice(0, persistedLifecycleEventsForTests.length);
+};
+
+export const listConnectShyftLifecycleEventsForTests = (): ConnectShyftPersistedLifecycleEvent[] =>
+  [...persistedLifecycleEventsForTests];

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/__tests__/postProviderEventHandler.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/__tests__/postProviderEventHandler.test.ts
@@ -1,0 +1,84 @@
+import express from 'express';
+import request from 'supertest';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import { buildPostProviderEventHandler } from '../postProviderEventHandler';
+
+describe('postProviderEventHandler', () => {
+  it('maps a provider event into bridge lifecycle handling and acknowledges success', async () => {
+    const handleProviderEvent = jest.fn(async () => undefined);
+
+    const app = express();
+    app.use(express.json());
+    app.use(responseEnvelope);
+    app.post('/api/v1/connectshyft/provider-events', buildPostProviderEventHandler({
+      resolveWebhookAccessContext: jest.fn(async () => ({
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        threadId: 'thread-connectshyft-f1-1001',
+        eventType: 'CallAnswered',
+        normalizedEventType: 'callanswered',
+        providerSelection: {
+          providerResolution: {
+            requestedProvider: 'mock-sandbox',
+            resolvedProvider: 'mock-sandbox',
+            deterministic: true,
+          },
+        },
+        canonicalTranslation: {
+          eventType: 'CallAnswered',
+        },
+        correlation: {
+          ok: true,
+          source: 'provider_fallback',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          threadId: 'thread-connectshyft-f1-1001',
+          providerLegId: 'provider-leg-operator-1001',
+          providerMessageId: null,
+          providerEventId: null,
+          providerNumberE164: null,
+        },
+      })) as any,
+      loadAggregateByProviderCallId: jest.fn(async () => ({
+        session: {
+          id: 'bridge-session-1001',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          threadId: 'thread-connectshyft-f1-1001',
+          status: 'operator_dialing',
+        },
+        operatorLeg: {
+          providerCallId: 'provider-leg-operator-1001',
+        },
+        neighborLeg: {
+          providerCallId: 'provider-leg-neighbor-1001',
+        },
+      })) as any,
+      callLifecycleService: {
+        handleProviderEvent,
+      } as any,
+    }));
+
+    const response = await (request as any)(app)
+      .post('/api/v1/connectshyft/provider-events')
+      .send({
+        eventType: 'CallAnswered',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_PROVIDER_EVENT_ACCEPTED',
+      data: {
+        handled: true,
+      },
+    });
+    expect(handleProviderEvent).toHaveBeenCalledWith(expect.objectContaining({
+      provider: 'mock-sandbox',
+      providerCallId: 'provider-leg-operator-1001',
+      event: expect.objectContaining({
+        type: 'operator_answered',
+      }),
+    }));
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/__tests__/postThreadCallHandler.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/__tests__/postThreadCallHandler.test.ts
@@ -1,0 +1,75 @@
+import express from 'express';
+import request from 'supertest';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import { buildPostThreadCallHandler } from '../postThreadCallHandler';
+
+describe('postThreadCallHandler', () => {
+  it('starts a call and returns the call dto when readiness passes', async () => {
+    const startCall = jest.fn(async () => ({
+      id: 'call-1001',
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-connectshyft-f1-1001',
+      personId: 'person-connectshyft-f1-1001',
+      bridgeSessionId: 'bridge-session-1001',
+      status: 'operator_dialing' as const,
+      failureCode: null,
+      failureMessage: null,
+      startedAtUtc: '2026-03-23T12:00:00.000Z',
+      operatorAnsweredAtUtc: null,
+      neighborAnsweredAtUtc: null,
+      bridgedAtUtc: null,
+      endedAtUtc: null,
+      createdAtUtc: '2026-03-23T12:00:00.000Z',
+      updatedAtUtc: '2026-03-23T12:00:00.000Z',
+    }));
+
+    const app = express();
+    app.use(express.json());
+    app.use(responseEnvelope);
+    app.post('/api/v1/connectshyft/thread/:threadId/call', buildPostThreadCallHandler({
+      resolveAccessContext: jest.fn(async () => ({
+        context: {
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+        },
+        threadId: 'thread-connectshyft-f1-1001',
+        actorUserId: 'user-connectshyft-f1-operator',
+        actorRoles: ['ORGUNIT_MEMBER'],
+        lifecycleContext: {
+          detail: {
+            personId: 'person-connectshyft-f1-1001',
+          },
+        },
+      })) as any,
+      readinessService: {
+        inspectReadiness: jest.fn(async () => ({
+          bridgeCallRunnable: true,
+        })),
+      } as any,
+      callLifecycleService: {
+        startCall,
+      } as any,
+    }));
+
+    const response = await (request as any)(app)
+      .post('/api/v1/connectshyft/thread/thread-connectshyft-f1-1001/call');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_CALL_STARTED',
+      data: {
+        call: {
+          callId: 'call-1001',
+          bridgeSessionId: 'bridge-session-1001',
+          status: 'operator_dialing',
+        },
+      },
+    });
+    expect(startCall).toHaveBeenCalledWith(expect.objectContaining({
+      threadId: 'thread-connectshyft-f1-1001',
+      personId: 'person-connectshyft-f1-1001',
+    }));
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/__tests__/postVoicemailHandler.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/__tests__/postVoicemailHandler.test.ts
@@ -1,0 +1,78 @@
+import express from 'express';
+import request from 'supertest';
+import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import { buildPostVoicemailHandler } from '../postVoicemailHandler';
+
+describe('postVoicemailHandler', () => {
+  it('creates voicemail records after signature verification succeeds', async () => {
+    const handleVoicemail = jest.fn(async () => ({
+      id: 'voicemail-1001',
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      callId: 'call-1001',
+      threadId: 'thread-connectshyft-f1-1001',
+      personId: 'person-connectshyft-f1-1001',
+      artifactId: 'artifact-1001',
+      recordingUrl: 'https://example.test/vm-1001.mp3',
+      recordingStatus: 'completed' as const,
+      occurredAtUtc: '2026-03-23T12:05:00.000Z',
+      createdAtUtc: '2026-03-23T12:05:00.000Z',
+      updatedAtUtc: '2026-03-23T12:05:00.000Z',
+      transcriptionJson: null,
+    }));
+
+    const app = express();
+    app.use(express.json({
+      verify: (req, _res, buf) => {
+        (req as express.Request & { rawBody?: Buffer }).rawBody = Buffer.from(buf);
+      },
+    }));
+    app.use(responseEnvelope);
+    app.post('/api/v1/connectshyft/voicemails', buildPostVoicemailHandler({
+      enforceCapability: jest.fn(async () => ({} as any)),
+      resolveProviderAdapterFn: jest.fn(() => ({
+        ok: true,
+        adapter: {
+          verifyWebhook: jest.fn(() => ({ ok: true })),
+        },
+        providerResolution: {
+          requestedProvider: 'mock-sandbox',
+          resolvedProvider: 'mock-sandbox',
+          deterministic: true,
+        },
+      })) as any,
+      callLifecycleService: {
+        handleVoicemail,
+      } as any,
+    }));
+
+    const response = await (request as any)(app)
+      .post('/api/v1/connectshyft/voicemails')
+      .send({
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        callId: 'call-1001',
+        threadId: 'thread-connectshyft-f1-1001',
+        personId: 'person-connectshyft-f1-1001',
+        artifactId: 'artifact-1001',
+        recordingStatus: 'completed',
+        recordingUrl: 'https://example.test/vm-1001.mp3',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_VOICEMAIL_ACCEPTED',
+      data: {
+        voicemail: {
+          voicemailId: 'voicemail-1001',
+          artifactId: 'artifact-1001',
+        },
+      },
+    });
+    expect(handleVoicemail).toHaveBeenCalledWith(expect.objectContaining({
+      callId: 'call-1001',
+      artifactId: 'artifact-1001',
+    }));
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postProviderEventHandler.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postProviderEventHandler.ts
@@ -1,0 +1,161 @@
+import type { Request, RequestHandler, Response } from 'express';
+import { error, success } from '../../../platform/envelopes/response';
+import {
+  connectShyftCallLifecycleServiceAsync,
+  mapConnectShyftWebhookEventToBridgeEvent,
+  type ConnectShyftCallLifecycleService,
+} from '../callLifecycle';
+import { ConnectShyftPersistenceUnavailableError } from '../calls';
+import {
+  loadConnectShyftBridgeAggregateByProviderCallId,
+  loadConnectShyftBridgeAggregateBySessionId,
+} from '../bridgeSessions';
+import {
+  resolveConnectShyftInboundWebhookAccessContext,
+  type ConnectShyftInboundWebhookAccessContext,
+} from '../http/inboundWebhookContext';
+
+type PostProviderEventHandlerDependencies = {
+  callLifecycleService?: ConnectShyftCallLifecycleService;
+  resolveWebhookAccessContext?: (
+    req: Request,
+    res: Response,
+  ) => Promise<ConnectShyftInboundWebhookAccessContext | null>;
+  loadAggregateBySessionId?: typeof loadConnectShyftBridgeAggregateBySessionId;
+  loadAggregateByProviderCallId?: typeof loadConnectShyftBridgeAggregateByProviderCallId;
+};
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const resolveOccurredAt = (req: Request): Date => {
+  const candidates = [
+    req.body?.occurredAt,
+    req.body?.occurred_at,
+    req.body?.eventTimestamp,
+    req.body?.event_timestamp,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeString(candidate);
+    if (!normalized) {
+      continue;
+    }
+
+    const parsed = new Date(normalized);
+    if (!Number.isNaN(parsed.valueOf())) {
+      return parsed;
+    }
+  }
+
+  return new Date();
+};
+
+export const buildPostProviderEventHandler = (
+  dependencies: PostProviderEventHandlerDependencies = {},
+): RequestHandler => {
+  const callLifecycleService =
+    dependencies.callLifecycleService || connectShyftCallLifecycleServiceAsync;
+  const resolveWebhookAccessContext =
+    dependencies.resolveWebhookAccessContext
+    || ((req: Request, res: Response) => (
+      resolveConnectShyftInboundWebhookAccessContext(req, res, 'inbound')
+    ));
+  const loadAggregateBySessionId =
+    dependencies.loadAggregateBySessionId || loadConnectShyftBridgeAggregateBySessionId;
+  const loadAggregateByProviderCallId =
+    dependencies.loadAggregateByProviderCallId || loadConnectShyftBridgeAggregateByProviderCallId;
+
+  return async (req, res) => {
+    const accessContext = await resolveWebhookAccessContext(req, res);
+    if (!accessContext) {
+      return;
+    }
+
+    try {
+      const providerCallId = accessContext.correlation.providerLegId;
+      const bridgeSessionId = normalizeString(req.body?.bridgeSessionId);
+      const aggregate = bridgeSessionId
+        ? await loadAggregateBySessionId(bridgeSessionId)
+        : providerCallId
+          ? await loadAggregateByProviderCallId({
+            tenantId: accessContext.tenantId,
+            providerCallId,
+          })
+          : null;
+
+      if (!aggregate) {
+        success(res, {
+          code: 'CONNECTSHYFT_PROVIDER_EVENT_ACCEPTED',
+          message: 'Provider event accepted.',
+          data: {
+            handled: false,
+          },
+        });
+        return;
+      }
+
+      const occurredAt = resolveOccurredAt(req);
+      const event = mapConnectShyftWebhookEventToBridgeEvent({
+        aggregate,
+        rawEventType: normalizeString(req.body?.eventType)
+          || normalizeString(req.body?.event_type)
+          || accessContext.eventType,
+        providerCallId,
+        bridgeSessionId,
+        occurredAt,
+        reason:
+          normalizeString(req.body?.reason)
+          || normalizeString(req.body?.hangupCause)
+          || normalizeString(req.body?.hangup_cause)
+          || null,
+      });
+
+      if (!event) {
+        success(res, {
+          code: 'CONNECTSHYFT_PROVIDER_EVENT_ACCEPTED',
+          message: 'Provider event accepted.',
+          data: {
+            handled: false,
+          },
+        });
+        return;
+      }
+
+      await callLifecycleService.handleProviderEvent({
+        tenantId: accessContext.tenantId,
+        provider: accessContext.providerSelection.providerResolution.resolvedProvider,
+        event,
+        eventJson: req.body,
+        providerCallId,
+        occurredAt,
+      });
+
+      success(res, {
+        code: 'CONNECTSHYFT_PROVIDER_EVENT_ACCEPTED',
+        message: 'Provider event accepted.',
+        data: {
+          handled: true,
+        },
+      });
+    } catch (errorCaught) {
+      if (errorCaught instanceof ConnectShyftPersistenceUnavailableError) {
+        error(res, {
+          code: errorCaught.code,
+          message: errorCaught.message,
+          httpStatus: 503,
+        });
+        return;
+      }
+
+      throw errorCaught;
+    }
+  };
+};
+
+export const postProviderEventHandler = buildPostProviderEventHandler();

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postThreadCallHandler.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postThreadCallHandler.ts
@@ -1,0 +1,151 @@
+import type { Request, RequestHandler, Response } from 'express';
+import { error, refusal, success } from '../../../platform/envelopes/response';
+import { resolveConnectShyftRequestedProviderKey } from '../providerRegistry';
+import {
+  connectShyftTelephonyReadinessServiceAsync,
+  type AsyncConnectShyftTelephonyReadinessService,
+} from '../telephonyReadiness';
+import {
+  connectShyftCallLifecycleServiceAsync,
+  ConnectShyftCallLifecycleRefusalError,
+  type ConnectShyftCallLifecycleService,
+} from '../callLifecycle';
+import { ConnectShyftPersistenceUnavailableError } from '../calls';
+import {
+  resolveConnectShyftThreadOutboundAccessContext,
+  type ConnectShyftThreadOutboundAccessContext,
+} from '../http/threadOutboundContext';
+
+type PostThreadCallHandlerDependencies = {
+  callLifecycleService?: ConnectShyftCallLifecycleService;
+  readinessService?: Pick<AsyncConnectShyftTelephonyReadinessService, 'inspectReadiness'>;
+  resolveAccessContext?: (
+    req: Request,
+    res: Response,
+  ) => Promise<ConnectShyftThreadOutboundAccessContext | null>;
+};
+
+const resolveProviderRegistryHeaders = (
+  req: Request,
+): Record<string, string | undefined> => Object.fromEntries(
+  Object.entries(req.headers).map(([key, value]) => [
+    key,
+    Array.isArray(value)
+      ? value[0]
+      : typeof value === 'string'
+        ? value
+        : undefined,
+  ]),
+);
+
+const mapCallResponse = (call: Awaited<ReturnType<ConnectShyftCallLifecycleService['startCall']>>) => ({
+  callId: call.id,
+  tenantId: call.tenantId,
+  orgUnitId: call.orgUnitId,
+  threadId: call.threadId,
+  personId: call.personId,
+  bridgeSessionId: call.bridgeSessionId,
+  status: call.status,
+  startedAtUtc: call.startedAtUtc,
+  operatorAnsweredAtUtc: call.operatorAnsweredAtUtc,
+  neighborAnsweredAtUtc: call.neighborAnsweredAtUtc,
+  bridgedAtUtc: call.bridgedAtUtc,
+  endedAtUtc: call.endedAtUtc,
+  failureCode: call.failureCode,
+  failureMessage: call.failureMessage,
+});
+
+export const buildPostThreadCallHandler = (
+  dependencies: PostThreadCallHandlerDependencies = {},
+): RequestHandler => {
+  const callLifecycleService =
+    dependencies.callLifecycleService || connectShyftCallLifecycleServiceAsync;
+  const readinessService =
+    dependencies.readinessService || connectShyftTelephonyReadinessServiceAsync;
+  const resolveAccessContext =
+    dependencies.resolveAccessContext
+    || ((req: Request, res: Response) => (
+      resolveConnectShyftThreadOutboundAccessContext(req, res, 'call')
+    ));
+
+  return async (req, res) => {
+    const accessContext = await resolveAccessContext(req, res);
+    if (!accessContext) {
+      return;
+    }
+
+    try {
+      const readiness = await readinessService.inspectReadiness({
+        tenantId: accessContext.context.tenantId,
+        orgUnitId: accessContext.context.orgUnitId,
+        userId: accessContext.actorUserId || '',
+        requestedProvider: resolveConnectShyftRequestedProviderKey(req),
+        providerRegistryHeaders: resolveProviderRegistryHeaders(req),
+      });
+      if (!readiness.bridgeCallRunnable) {
+        refusal(res, {
+          code: 'CONNECTSHYFT_TELEPHONY_NOT_READY',
+          message: 'Outbound bridge calls are unavailable until telephony readiness requirements are satisfied.',
+          refusalType: 'business',
+          httpStatus: 200,
+          data: {
+            context: accessContext.context,
+            threadId: accessContext.threadId,
+            telephonyReadiness: readiness,
+          },
+        });
+        return;
+      }
+
+      const call = await callLifecycleService.startCall({
+        tenantId: accessContext.context.tenantId,
+        orgUnitId: accessContext.context.orgUnitId,
+        threadId: accessContext.threadId,
+        personId: accessContext.lifecycleContext.detail?.personId || '',
+        idempotencyKey: typeof req.header('idempotency-key') === 'string'
+          ? req.header('idempotency-key')!.trim() || undefined
+          : undefined,
+        actorRoles: accessContext.actorRoles,
+        actorUserId: accessContext.actorUserId,
+        requestedProvider: resolveConnectShyftRequestedProviderKey(req),
+        providerRegistryHeaders: resolveProviderRegistryHeaders(req),
+      });
+
+      success(res, {
+        code: 'CONNECTSHYFT_CALL_STARTED',
+        message: 'Call started.',
+        data: {
+          call: mapCallResponse(call),
+          bridgeSession: {
+            bridgeSessionId: call.bridgeSessionId,
+            status: call.status,
+          },
+        },
+      });
+    } catch (errorCaught) {
+      if (errorCaught instanceof ConnectShyftCallLifecycleRefusalError) {
+        refusal(res, {
+          code: errorCaught.code,
+          message: errorCaught.message,
+          refusalType: errorCaught.refusalType,
+          httpStatus: errorCaught.httpStatus,
+          data: errorCaught.data,
+        });
+        return;
+      }
+
+      if (errorCaught instanceof ConnectShyftPersistenceUnavailableError) {
+        error(res, {
+          code: errorCaught.code,
+          message: errorCaught.message,
+          httpStatus: 503,
+        });
+        return;
+      }
+
+      throw errorCaught;
+    }
+  };
+};
+
+export const postThreadCallHandler = buildPostThreadCallHandler();

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/postVoicemailHandler.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/postVoicemailHandler.ts
@@ -1,0 +1,197 @@
+import type { Request, RequestHandler } from 'express';
+import { error, refusal, success } from '../../../platform/envelopes/response';
+import {
+  buildConnectShyftWebhookVerificationInput,
+  mapConnectShyftWebhookVerificationResult,
+  resolveConnectShyftProviderAdapter,
+  resolveConnectShyftRequestedProviderKey,
+} from '../providerRegistry';
+import {
+  connectShyftCallLifecycleServiceAsync,
+  ConnectShyftCallLifecycleRefusalError,
+  type ConnectShyftCallLifecycleService,
+} from '../callLifecycle';
+import { ConnectShyftPersistenceUnavailableError } from '../calls';
+import { enforceConnectShyftCapability } from '../http/accessContext';
+
+type PostVoicemailHandlerDependencies = {
+  callLifecycleService?: ConnectShyftCallLifecycleService;
+  enforceCapability?: typeof enforceConnectShyftCapability;
+  resolveProviderAdapterFn?: typeof resolveConnectShyftProviderAdapter;
+};
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const resolveOccurredAt = (req: Request): Date => {
+  const normalized = normalizeString(req.body?.occurredAt || req.body?.occurred_at);
+  if (!normalized) {
+    return new Date();
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.valueOf()) ? new Date() : parsed;
+};
+
+export const buildPostVoicemailHandler = (
+  dependencies: PostVoicemailHandlerDependencies = {},
+): RequestHandler => {
+  const callLifecycleService =
+    dependencies.callLifecycleService || connectShyftCallLifecycleServiceAsync;
+  const enforceCapability =
+    dependencies.enforceCapability || enforceConnectShyftCapability;
+  const resolveProviderAdapterFn =
+    dependencies.resolveProviderAdapterFn || resolveConnectShyftProviderAdapter;
+
+  return async (req, res) => {
+    if (!await enforceCapability(req, res, 'webhooks')) {
+      return;
+    }
+
+    const tenantId = normalizeString(req.body?.tenantId) || normalizeString(req.tenantId);
+    const orgUnitId = normalizeString(req.body?.orgUnitId) || normalizeString(req.orgUnitId);
+    const callId = normalizeString(req.body?.callId);
+    const threadId = normalizeString(req.body?.threadId);
+    const personId = normalizeString(req.body?.personId);
+    const artifactId = normalizeString(req.body?.artifactId);
+    const recordingStatus = normalizeString(req.body?.recordingStatus) as
+      | 'pending'
+      | 'completed'
+      | 'failed';
+
+    if (!tenantId || !orgUnitId || !callId || !threadId || !personId || !artifactId) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_VOICEMAIL_FIELDS_REQUIRED',
+        message: 'tenantId, orgUnitId, callId, threadId, personId, and artifactId are required.',
+        refusalType: 'client',
+        httpStatus: 400,
+      });
+      return;
+    }
+
+    if (recordingStatus !== 'pending' && recordingStatus !== 'completed' && recordingStatus !== 'failed') {
+      refusal(res, {
+        code: 'CONNECTSHYFT_VOICEMAIL_STATUS_INVALID',
+        message: 'recordingStatus must be one of pending, completed, or failed.',
+        refusalType: 'client',
+        httpStatus: 400,
+      });
+      return;
+    }
+
+    const providerResolution = resolveProviderAdapterFn({
+      req: {
+        header: (name: string) => req.header(name),
+        body: req.body && typeof req.body === 'object'
+          ? req.body as Record<string, unknown>
+          : {},
+        headers: Object.fromEntries(
+          Object.entries(req.headers).map(([key, value]) => [
+            key,
+            Array.isArray(value)
+              ? value[0] || ''
+              : typeof value === 'string'
+                ? value
+                : '',
+          ]),
+        ),
+        originalUrl: req.originalUrl,
+        protocol: req.protocol,
+        rawBody: (req as Request & { rawBody?: Buffer | string }).rawBody,
+        tenantId,
+        orgUnitId,
+      },
+      requestedProvider: resolveConnectShyftRequestedProviderKey(req),
+      operation: 'webhook',
+    });
+    if (!providerResolution.ok) {
+      refusal(res, {
+        code: providerResolution.refusal.code,
+        message: providerResolution.refusal.message,
+        refusalType: providerResolution.refusal.refusalType,
+        httpStatus: providerResolution.refusal.httpStatus,
+        data: providerResolution.refusal.data,
+      });
+      return;
+    }
+
+    const signatureDecision = mapConnectShyftWebhookVerificationResult(
+      providerResolution.adapter.verifyWebhook(
+        buildConnectShyftWebhookVerificationInput({
+          req,
+          providerKey: providerResolution.providerResolution.resolvedProvider,
+        }),
+      ),
+    );
+    if (!signatureDecision.ok) {
+      refusal(res, {
+        code: signatureDecision.refusal.code,
+        message: signatureDecision.refusal.message,
+        refusalType: signatureDecision.refusal.refusalType,
+        httpStatus: signatureDecision.refusal.httpStatus,
+      });
+      return;
+    }
+
+    try {
+      const voicemail = await callLifecycleService.handleVoicemail({
+        tenantId,
+        orgUnitId,
+        callId,
+        threadId,
+        personId,
+        artifactId,
+        recordingUrl: normalizeString(req.body?.recordingUrl) || null,
+        recordingStatus,
+        occurredAt: resolveOccurredAt(req),
+        transcriptionJson: req.body?.transcriptionJson ?? req.body?.transcription_json ?? null,
+      });
+
+      success(res, {
+        code: 'CONNECTSHYFT_VOICEMAIL_ACCEPTED',
+        message: 'Voicemail accepted.',
+        data: {
+          voicemail: {
+            voicemailId: voicemail.id,
+            callId: voicemail.callId,
+            threadId: voicemail.threadId,
+            personId: voicemail.personId,
+            artifactId: voicemail.artifactId,
+            recordingUrl: voicemail.recordingUrl,
+            recordingStatus: voicemail.recordingStatus,
+            occurredAtUtc: voicemail.occurredAtUtc,
+          },
+        },
+      });
+    } catch (errorCaught) {
+      if (errorCaught instanceof ConnectShyftCallLifecycleRefusalError) {
+        refusal(res, {
+          code: errorCaught.code,
+          message: errorCaught.message,
+          refusalType: errorCaught.refusalType,
+          httpStatus: errorCaught.httpStatus,
+          data: errorCaught.data,
+        });
+        return;
+      }
+
+      if (errorCaught instanceof ConnectShyftPersistenceUnavailableError) {
+        error(res, {
+          code: errorCaught.code,
+          message: errorCaught.message,
+          httpStatus: 503,
+        });
+        return;
+      }
+
+      throw errorCaught;
+    }
+  };
+};
+
+export const postVoicemailHandler = buildPostVoicemailHandler();

--- a/apps/connectshyft-api/src/modules/connectshyft/http/index.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/index.ts
@@ -1,12 +1,32 @@
 import { Router } from 'express';
 import { getActivityThreadsHandler } from '../handlers/getActivityThreadsHandler';
 import { getPersonActivitiesHandler } from '../handlers/getPersonActivitiesHandler';
+import { postProviderEventHandler } from '../handlers/postProviderEventHandler';
+import { postThreadCallHandler } from '../handlers/postThreadCallHandler';
 import { postPersonActivityHandler } from '../handlers/postPersonActivityHandler';
+import { postVoicemailHandler } from '../handlers/postVoicemailHandler';
 
-const router = Router();
+type ConnectShyftHttpRouterDependencies = {
+  postThreadCall?: typeof postThreadCallHandler;
+  postProviderEvent?: typeof postProviderEventHandler;
+  postVoicemail?: typeof postVoicemailHandler;
+};
 
-router.post('/people/:personId/activities', postPersonActivityHandler);
-router.get('/people/:personId/activities', getPersonActivitiesHandler);
-router.get('/activities/:activityId/threads', getActivityThreadsHandler);
+export const buildConnectShyftHttpRouter = (
+  dependencies: ConnectShyftHttpRouterDependencies = {},
+) => {
+  const router = Router();
+
+  router.post('/people/:personId/activities', postPersonActivityHandler);
+  router.get('/people/:personId/activities', getPersonActivitiesHandler);
+  router.get('/activities/:activityId/threads', getActivityThreadsHandler);
+  router.post('/thread/:threadId/call', dependencies.postThreadCall || postThreadCallHandler);
+  router.post('/provider-events', dependencies.postProviderEvent || postProviderEventHandler);
+  router.post('/voicemails', dependencies.postVoicemail || postVoicemailHandler);
+
+  return router;
+};
+
+const router = buildConnectShyftHttpRouter();
 
 export default router;

--- a/apps/connectshyft-api/src/modules/connectshyft/providerEvents.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/providerEvents.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+import {
+  ConnectShyftPersistenceUnavailableError,
+  isConnectShyftPersistenceErrorCause,
+} from './calls';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const PROVIDER_EVENTS_TABLE = 'cs_provider_events';
+
+export interface RecordProviderEventInput {
+  tenantId: string;
+  provider: string;
+  eventType: string;
+  eventJson: unknown;
+  callId?: string | null;
+  bridgeSessionId?: string | null;
+  providerCallId?: string | null;
+  occurredAtUtc: string;
+}
+
+export interface ConnectShyftProviderEventService {
+  recordEvent(input: RecordProviderEventInput): Promise<void>;
+}
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const buildProviderEventDedupeKey = (input: RecordProviderEventInput): string => (
+  [
+    input.tenantId,
+    normalizeString(input.provider).toLowerCase(),
+    normalizeString(input.providerCallId).toLowerCase(),
+    normalizeString(input.eventType).toLowerCase(),
+    normalizeString(input.occurredAtUtc),
+  ].join('|')
+);
+
+class InMemoryConnectShyftProviderEventStore implements ConnectShyftProviderEventService {
+  private readonly dedupeKeys = new Set<string>();
+
+  async recordEvent(input: RecordProviderEventInput): Promise<void> {
+    this.dedupeKeys.add(buildProviderEventDedupeKey(input));
+  }
+
+  reset(): void {
+    this.dedupeKeys.clear();
+  }
+}
+
+class KnexConnectShyftProviderEventStore implements ConnectShyftProviderEventService {
+  constructor(private readonly knexClient: Knex = db) {}
+
+  private table() {
+    return this.knexClient.withSchema(CONNECTSHYFT_SCHEMA).table(PROVIDER_EVENTS_TABLE);
+  }
+
+  async recordEvent(input: RecordProviderEventInput): Promise<void> {
+    await this.table()
+      .insert({
+        id: randomUUID(),
+        tenant_id: input.tenantId,
+        provider: normalizeString(input.provider).toLowerCase(),
+        event_type: input.eventType,
+        event_json: input.eventJson ?? {},
+        call_id: input.callId ?? null,
+        bridge_session_id: input.bridgeSessionId ?? null,
+        provider_call_id: input.providerCallId ?? null,
+        occurred_at_utc: input.occurredAtUtc,
+        received_at_utc: new Date().toISOString(),
+      })
+      .onConflict(['tenant_id', 'provider', 'provider_call_id', 'event_type', 'occurred_at_utc'])
+      .ignore();
+  }
+}
+
+const inMemoryConnectShyftProviderEventStore = new InMemoryConnectShyftProviderEventStore();
+const knexConnectShyftProviderEventStore = new KnexConnectShyftProviderEventStore();
+
+class AsyncConnectShyftProviderEventService implements ConnectShyftProviderEventService {
+  async recordEvent(input: RecordProviderEventInput): Promise<void> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      await inMemoryConnectShyftProviderEventStore.recordEvent(input);
+      return;
+    }
+
+    try {
+      await knexConnectShyftProviderEventStore.recordEvent(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+}
+
+export const connectShyftProviderEventServiceAsync: ConnectShyftProviderEventService =
+  new AsyncConnectShyftProviderEventService();
+
+export const resetConnectShyftProviderEventStateForTests = (): void => {
+  inMemoryConnectShyftProviderEventStore.reset();
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
@@ -3,6 +3,10 @@ import {
   type SubjectContext,
   validateSubjectContext,
 } from '../../../../../libs/contracts/src/subject-context';
+import {
+  connectShyftCallServiceAsync,
+  ConnectShyftPersistenceUnavailableError,
+} from './calls';
 import { peopleCoreServiceAsync } from '../peoplecore/service';
 
 export type ConnectShyftInboxBucket = 'inbox' | 'mine';
@@ -21,6 +25,13 @@ export type ConnectShyftThreadDisplayRecord = {
   conferenceContext: string;
   claimContext: string;
   voicemailLabel: string;
+};
+
+export type ConnectShyftThreadTelephonyRecord = {
+  callIndicator: boolean;
+  callLabel: string | null;
+  voicemailIndicator: boolean;
+  voicemailLabel: string | null;
 };
 
 export type ConnectShyftThreadSummaryRecord = {
@@ -53,6 +64,8 @@ export type ConnectShyftThreadSummaryRecord = {
     cs_number_id: string;
     label: string;
   };
+  callIndicator?: boolean;
+  callLabel?: string | null;
   voicemailIndicator: boolean;
   voicemailLabel: string | null;
   summary: string;
@@ -67,6 +80,7 @@ export type ConnectShyftThreadDetailRecord = ConnectShyftThreadSummaryRecord & {
   lifecycle: {
     reopenedByInbound: boolean;
   };
+  telephony?: ConnectShyftThreadTelephonyRecord;
 };
 
 export type ConnectShyftThreadTimelineMetadata = {
@@ -91,6 +105,7 @@ type ConnectShyftThreadSeed = {
   lastInboundCsNumberId: string;
   preferredOutboundCsNumberId: string;
   preferredOutboundLabel: string;
+  callIndicator?: boolean;
   voicemailIndicator: boolean;
   summary: string;
 };
@@ -846,6 +861,24 @@ const resolveVoicemailLabel = (input: {
   return 'Voicemail';
 };
 
+const resolveCallLabel = (input: {
+  callIndicator: boolean;
+}): string | null => {
+  return input.callIndicator ? 'Call activity' : null;
+};
+
+const buildThreadTelephonyRecord = (input: {
+  callIndicator: boolean;
+  callLabel: string | null;
+  voicemailIndicator: boolean;
+  voicemailLabel: string | null;
+}): ConnectShyftThreadTelephonyRecord => ({
+  callIndicator: input.callIndicator,
+  callLabel: input.callLabel,
+  voicemailIndicator: input.voicemailIndicator,
+  voicemailLabel: input.voicemailLabel,
+});
+
 const resolveThreadStateLabel = (state: ConnectShyftThreadState): string => {
   if (state === 'UNCLAIMED') {
     return 'Unclaimed';
@@ -989,6 +1022,10 @@ const toSummaryRecord = (
   });
 
   const urgencyLabel = resolveConnectShyftUrgencyLabel(seed.escalationStage);
+  const callIndicator = seed.callIndicator === true;
+  const callLabel = resolveCallLabel({
+    callIndicator,
+  });
   const voicemailLabel = resolveVoicemailLabel({
     voicemailIndicator: seed.voicemailIndicator,
     state: seed.state,
@@ -1029,6 +1066,8 @@ const toSummaryRecord = (
       cs_number_id: preferredOutboundCsNumberId,
       label: seed.preferredOutboundLabel,
     },
+    callIndicator,
+    callLabel,
     voicemailIndicator: seed.voicemailIndicator,
     voicemailLabel,
     summary: seed.summary,
@@ -1131,6 +1170,12 @@ export const resolveConnectShyftThreadDetailContract = (input: {
     lifecycle: {
       reopenedByInbound: false,
     },
+    telephony: buildThreadTelephonyRecord({
+      callIndicator: summary.callIndicator === true,
+      callLabel: summary.callLabel || null,
+      voicemailIndicator: summary.voicemailIndicator,
+      voicemailLabel: summary.voicemailLabel,
+    }),
   };
 };
 
@@ -1373,6 +1418,10 @@ const mapDbRowToSummary = (
     voicemailIndicator,
     state,
   });
+  const callIndicator = false;
+  const callLabel = resolveCallLabel({
+    callIndicator,
+  });
 
   return {
     threadId,
@@ -1404,6 +1453,8 @@ const mapDbRowToSummary = (
       cs_number_id: normalizedPreferredOutboundCsNumberId,
       label: preferredOutboundLabel,
     },
+    callIndicator,
+    callLabel,
     voicemailIndicator,
     voicemailLabel,
     summary: normalizeString(row.summary ?? row.preview ?? row.last_message_preview),
@@ -1417,6 +1468,33 @@ const mapDbRowToSummary = (
       voicemailLabel,
     }),
   };
+};
+
+const enrichSummaryWithCallIndicators = async (
+  summary: ConnectShyftThreadSummaryRecord,
+): Promise<ConnectShyftThreadSummaryRecord> => {
+  try {
+    const calls = await connectShyftCallServiceAsync.listThreadCalls({
+      tenantId: summary.tenantId,
+      orgUnitId: summary.orgUnitId,
+      threadId: summary.threadId,
+    });
+    const callIndicator = calls.length > 0;
+
+    return {
+      ...summary,
+      callIndicator,
+      callLabel: resolveCallLabel({
+        callIndicator,
+      }),
+    };
+  } catch (error) {
+    if (error instanceof ConnectShyftPersistenceUnavailableError) {
+      return summary;
+    }
+
+    throw error;
+  }
 };
 
 const filterRowsForBucket = (
@@ -1504,7 +1582,13 @@ export const resolveConnectShyftInboxContractAsync = async (scope: {
     ))
     .filter((row): row is ConnectShyftThreadSummaryRecord => row !== null);
 
-  return sortConnectShyftThreadSummaries(mapped.filter((row) => row.neighborDeleted !== true));
+  const enriched = await Promise.all(
+    mapped
+      .filter((row) => row.neighborDeleted !== true)
+      .map((row) => enrichSummaryWithCallIndicators(row)),
+  );
+
+  return sortConnectShyftThreadSummaries(enriched);
 };
 
 const resolveBucketFromDbRow = (
@@ -1586,17 +1670,19 @@ export const resolveConnectShyftThreadDetailContractAsync = async (input: {
       [normalizeOptionalString(row.neighbor_id)].filter((neighborId): neighborId is string => Boolean(neighborId)),
     )),
   });
-  const summary = mapDbRowToSummary(
+  const baseSummary = mapDbRowToSummary(
     row,
     resolveBucketFromDbRow(row, input.actorUserId),
     neighborLifecycle?.get(normalizeOptionalString(row.neighbor_id) || '') || null,
   );
-  if (!summary) {
+  if (!baseSummary) {
     return null;
   }
-  if (summary.neighborDeleted && input.includeDeleted !== true) {
+  if (baseSummary.neighborDeleted && input.includeDeleted !== true) {
     return null;
   }
+
+  const summary = await enrichSummaryWithCallIndicators(baseSummary);
 
   let threadPersonStatus: string | null = null;
   const threadPersonId = normalizeOptionalString(row.person_id);
@@ -1624,5 +1710,11 @@ export const resolveConnectShyftThreadDetailContractAsync = async (input: {
     lifecycle: {
       reopenedByInbound: false,
     },
+    telephony: buildThreadTelephonyRecord({
+      callIndicator: summary.callIndicator === true,
+      callLabel: summary.callLabel || null,
+      voicemailIndicator: summary.voicemailIndicator,
+      voicemailLabel: summary.voicemailLabel,
+    }),
   };
 };

--- a/apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts
@@ -4,6 +4,11 @@ import {
   type ConnectShyftCanonicalEventRecord,
 } from './canonicalEvents';
 import { loadConnectShyftBridgeAggregateByThreadId } from './bridgeSessions';
+import {
+  connectShyftCallServiceAsync,
+  ConnectShyftPersistenceUnavailableError,
+  type Call,
+} from './calls';
 import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from './inboundSms';
 import {
   CONNECTSHYFT_INBOUND_VOICE_FALLBACK_EVENT_NAME,
@@ -11,6 +16,10 @@ import {
   CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_ATTACHED_EVENT_NAME,
   CONNECTSHYFT_VOICEMAIL_TRANSCRIPTION_REQUESTED_EVENT_NAME,
 } from './inboundVoice';
+import {
+  connectShyftVoicemailServiceAsync,
+  type Voicemail,
+} from './voicemails';
 
 export const CONNECTSHYFT_THREAD_TIMELINE_DEFAULT_LIMIT = 200;
 export const CONNECTSHYFT_THREAD_TIMELINE_MAX_LIMIT = 200;
@@ -361,6 +370,89 @@ const buildBridgeSessionVoicemailTimelineItem = (input: {
   transcript: null,
 });
 
+const buildCallStatusEvents = (call: Call): Array<{ status: string; occurredAtUtc: string }> => {
+  const events: Array<{ status: string; occurredAtUtc: string }> = [
+    {
+      status: 'operator_dialing',
+      occurredAtUtc: call.startedAtUtc,
+    },
+  ];
+
+  if (call.operatorAnsweredAtUtc) {
+    events.push({
+      status: 'operator_answered',
+      occurredAtUtc: call.operatorAnsweredAtUtc,
+    });
+    events.push({
+      status: 'neighbor_dialing',
+      occurredAtUtc: call.operatorAnsweredAtUtc,
+    });
+  }
+
+  if (call.neighborAnsweredAtUtc) {
+    events.push({
+      status: 'neighbor_answered',
+      occurredAtUtc: call.neighborAnsweredAtUtc,
+    });
+  }
+
+  if (call.bridgedAtUtc) {
+    events.push({
+      status: 'bridged',
+      occurredAtUtc: call.bridgedAtUtc,
+    });
+  }
+
+  if (call.status === 'voicemail' || call.status === 'completed' || call.status === 'failed' || call.status === 'canceled' || call.status === 'expired') {
+    events.push({
+      status: call.status,
+      occurredAtUtc: call.endedAtUtc || call.updatedAtUtc,
+    });
+  }
+
+  return events;
+};
+
+const buildCallTimelineItem = (call: Call): ConnectShyftVoiceEventTimelineItem => ({
+  id: `call-${call.id}`,
+  threadId: call.threadId,
+  type: 'voice_event',
+  direction: 'outbound',
+  channel: 'voice',
+  body: null,
+  occurredAtUtc: call.startedAtUtc,
+  actor: 'user',
+  providerMetadata: {
+    callId: call.id,
+    bridgeSessionId: call.bridgeSessionId,
+    status: call.status,
+    failureCode: call.failureCode,
+    failureMessage: call.failureMessage,
+    statusEvents: buildCallStatusEvents(call),
+  },
+  deliveryStatus: call.status,
+});
+
+const buildVoicemailTimelineItem = (voicemail: Voicemail): ConnectShyftVoicemailTimelineItem => ({
+  id: `voicemail-${voicemail.id}`,
+  threadId: voicemail.threadId,
+  type: 'voicemail',
+  direction: 'outbound',
+  channel: 'voicemail',
+  body: null,
+  occurredAtUtc: voicemail.occurredAtUtc,
+  actor: 'system',
+  providerMetadata: {
+    callId: voicemail.callId,
+    artifactId: voicemail.artifactId,
+    recordingStatus: voicemail.recordingStatus,
+  },
+  deliveryStatus: voicemail.recordingStatus,
+  recordingUrl: voicemail.recordingUrl,
+  durationSeconds: null,
+  transcript: null,
+});
+
 const CONNECTSHYFT_TIMELINE_MAPPERS = new Map<string, TimelineEventMapper>([
   [CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME, mapInboundSmsTimelineEvent],
   [CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME, mapOutboundSmsTimelineEvent],
@@ -468,11 +560,43 @@ export const getThreadTimeline = async (
     tenantId: input.tenantId,
     threadId,
   });
+  let persistedCalls: Call[] = [];
+  try {
+    persistedCalls = await connectShyftCallServiceAsync.listThreadCalls({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      threadId,
+    });
+  } catch (error) {
+    if (!(error instanceof ConnectShyftPersistenceUnavailableError)) {
+      throw error;
+    }
+  }
   const voicemailProjection = resolveBridgeSessionVoicemailProjection(activeBridgeSession);
 
   const items = events
     .map((event) => mapConnectShyftCanonicalEventToTimelineItem(event))
     .filter((item): item is ConnectShyftThreadTimelineItem => item !== null);
+
+  persistedCalls.forEach((call) => {
+    items.push(buildCallTimelineItem(call));
+  });
+
+  try {
+    const persistedVoicemails = await Promise.all(
+      persistedCalls.map((call) => connectShyftVoicemailServiceAsync.listCallVoicemails({
+        tenantId: input.tenantId,
+        callId: call.id,
+      })),
+    );
+    persistedVoicemails.flat().forEach((voicemail) => {
+      items.push(buildVoicemailTimelineItem(voicemail));
+    });
+  } catch (error) {
+    if (!(error instanceof ConnectShyftPersistenceUnavailableError)) {
+      throw error;
+    }
+  }
 
   if (
     voicemailProjection

--- a/apps/connectshyft-api/src/modules/connectshyft/voicemails.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/voicemails.ts
@@ -1,0 +1,271 @@
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+import {
+  ConnectShyftPersistenceUnavailableError,
+  isConnectShyftPersistenceErrorCause,
+} from './calls';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const VOICEMAILS_TABLE = 'cs_voicemails';
+
+export interface CreateVoicemailInput {
+  tenantId: string;
+  orgUnitId: string;
+  callId: string;
+  threadId: string;
+  personId: string;
+  artifactId: string;
+  recordingUrl: string | null;
+  recordingStatus: 'pending' | 'completed' | 'failed';
+  occurredAtUtc: string;
+  transcriptionJson?: unknown;
+}
+
+export interface ListCallVoicemailsInput {
+  tenantId: string;
+  callId: string;
+}
+
+export type Voicemail = {
+  id: string;
+  tenantId: string;
+  orgUnitId: string;
+  callId: string;
+  threadId: string;
+  personId: string;
+  artifactId: string;
+  recordingUrl: string | null;
+  recordingStatus: 'pending' | 'completed' | 'failed';
+  occurredAtUtc: string;
+  createdAtUtc: string;
+  updatedAtUtc: string;
+  transcriptionJson: unknown | null;
+};
+
+export interface ConnectShyftVoicemailService {
+  createVoicemail(input: CreateVoicemailInput): Promise<Voicemail>;
+  listCallVoicemails(input: ListCallVoicemailsInput): Promise<Voicemail[]>;
+}
+
+type DbVoicemailRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  call_id: string;
+  thread_id: string;
+  person_id: string;
+  artifact_id: string;
+  recording_url?: string | null;
+  transcription_json?: unknown;
+  recording_status: 'pending' | 'completed' | 'failed';
+  occurred_at_utc: string | Date;
+  created_at_utc: string | Date;
+  updated_at_utc: string | Date;
+};
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const toIsoUtc = (value: string | Date | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = new Date(normalized);
+  if (!Number.isNaN(parsed.valueOf())) {
+    return parsed.toISOString();
+  }
+
+  return normalized;
+};
+
+const mapVoicemailRow = (row: DbVoicemailRow): Voicemail => ({
+  id: row.id,
+  tenantId: row.tenant_id,
+  orgUnitId: row.org_unit_id,
+  callId: row.call_id,
+  threadId: row.thread_id,
+  personId: row.person_id,
+  artifactId: row.artifact_id,
+  recordingUrl: normalizeString(row.recording_url) || null,
+  recordingStatus: row.recording_status,
+  occurredAtUtc: toIsoUtc(row.occurred_at_utc) || new Date().toISOString(),
+  createdAtUtc: toIsoUtc(row.created_at_utc) || new Date().toISOString(),
+  updatedAtUtc: toIsoUtc(row.updated_at_utc) || new Date().toISOString(),
+  transcriptionJson: row.transcription_json ?? null,
+});
+
+class InMemoryConnectShyftVoicemailStore implements ConnectShyftVoicemailService {
+  private readonly records = new Map<string, Voicemail>();
+  private readonly recordIdByArtifactKey = new Map<string, string>();
+
+  async createVoicemail(input: CreateVoicemailInput): Promise<Voicemail> {
+    const artifactKey = `${input.tenantId}|${input.artifactId}`;
+    const existingId = this.recordIdByArtifactKey.get(artifactKey);
+    if (existingId) {
+      const existing = this.records.get(existingId);
+      if (existing) {
+        return existing;
+      }
+    }
+
+    const nowIsoUtc = new Date().toISOString();
+    const voicemail: Voicemail = {
+      id: randomUUID(),
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      callId: input.callId,
+      threadId: input.threadId,
+      personId: input.personId,
+      artifactId: input.artifactId,
+      recordingUrl: input.recordingUrl,
+      recordingStatus: input.recordingStatus,
+      occurredAtUtc: input.occurredAtUtc,
+      createdAtUtc: nowIsoUtc,
+      updatedAtUtc: nowIsoUtc,
+      transcriptionJson: input.transcriptionJson ?? null,
+    };
+
+    this.records.set(voicemail.id, voicemail);
+    this.recordIdByArtifactKey.set(artifactKey, voicemail.id);
+    return voicemail;
+  }
+
+  async listCallVoicemails(input: ListCallVoicemailsInput): Promise<Voicemail[]> {
+    return [...this.records.values()]
+      .filter((voicemail) => (
+        voicemail.tenantId === input.tenantId
+        && voicemail.callId === input.callId
+      ))
+      .sort((left, right) => (
+        new Date(right.occurredAtUtc).getTime() - new Date(left.occurredAtUtc).getTime()
+      ) || right.id.localeCompare(left.id));
+  }
+
+  reset(): void {
+    this.records.clear();
+    this.recordIdByArtifactKey.clear();
+  }
+}
+
+class KnexConnectShyftVoicemailStore implements ConnectShyftVoicemailService {
+  constructor(private readonly knexClient: Knex = db) {}
+
+  private table() {
+    return this.knexClient.withSchema(CONNECTSHYFT_SCHEMA).table(VOICEMAILS_TABLE);
+  }
+
+  async createVoicemail(input: CreateVoicemailInput): Promise<Voicemail> {
+    const existing = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        artifact_id: input.artifactId,
+      })
+      .first<DbVoicemailRow>();
+    if (existing) {
+      return mapVoicemailRow(existing);
+    }
+
+    const voicemailId = randomUUID();
+    const nowIsoUtc = new Date().toISOString();
+    await this.table().insert({
+      id: voicemailId,
+      tenant_id: input.tenantId,
+      org_unit_id: input.orgUnitId,
+      call_id: input.callId,
+      thread_id: input.threadId,
+      person_id: input.personId,
+      artifact_id: input.artifactId,
+      recording_url: input.recordingUrl,
+      transcription_json: input.transcriptionJson ?? null,
+      recording_status: input.recordingStatus,
+      occurred_at_utc: input.occurredAtUtc,
+      created_at_utc: nowIsoUtc,
+      updated_at_utc: nowIsoUtc,
+    }).onConflict(['tenant_id', 'artifact_id']).ignore();
+
+    const row = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        artifact_id: input.artifactId,
+      })
+      .first<DbVoicemailRow>();
+
+    if (!row) {
+      throw new Error(`Failed to load ConnectShyft voicemail for artifact ${input.artifactId}.`);
+    }
+
+    return mapVoicemailRow(row);
+  }
+
+  async listCallVoicemails(input: ListCallVoicemailsInput): Promise<Voicemail[]> {
+    const rows = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        call_id: input.callId,
+      })
+      .orderBy('occurred_at_utc', 'desc')
+      .orderBy('id', 'desc')
+      .select<DbVoicemailRow[]>();
+
+    return rows.map(mapVoicemailRow);
+  }
+}
+
+const inMemoryConnectShyftVoicemailStore = new InMemoryConnectShyftVoicemailStore();
+const knexConnectShyftVoicemailStore = new KnexConnectShyftVoicemailStore();
+
+class AsyncConnectShyftVoicemailService implements ConnectShyftVoicemailService {
+  async createVoicemail(input: CreateVoicemailInput): Promise<Voicemail> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryConnectShyftVoicemailStore.createVoicemail(input);
+    }
+
+    try {
+      return await knexConnectShyftVoicemailStore.createVoicemail(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+
+  async listCallVoicemails(input: ListCallVoicemailsInput): Promise<Voicemail[]> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryConnectShyftVoicemailStore.listCallVoicemails(input);
+    }
+
+    try {
+      return await knexConnectShyftVoicemailStore.listCallVoicemails(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+}
+
+export const connectShyftVoicemailServiceAsync: ConnectShyftVoicemailService =
+  new AsyncConnectShyftVoicemailService();
+
+export const resetConnectShyftVoicemailStateForTests = (): void => {
+  inMemoryConnectShyftVoicemailStore.reset();
+};

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-voice.characterization.test.ts
@@ -174,6 +174,7 @@ const seedOutboundVoicemailBridgeSession = async (input?: {
     tenantId: 'tenant-connectshyft-f1',
     orgUnitId: 'org-connectshyft-f1-east',
     threadId,
+    personId: 'person-connectshyft-f1-1001',
     operatorParticipantId: 'user-connectshyft-f1-primary-operator',
     neighborParticipantId: 'neighbor-connectshyft-f1-1001',
     operatorContactPointId: '+12605550155',

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -6038,6 +6038,7 @@ const performOutboundAction = async ({
           tenantId: context.tenantId,
           orgUnitId: context.orgUnitId,
           threadId,
+          personId: thread.personId,
           operatorParticipantId: actorUserId || 'unknown-operator',
           neighborParticipantId: thread.neighborId,
           operatorContactPointId: operatorContactPointId || '',

--- a/apps/migration-runner/package.json
+++ b/apps/migration-runner/package.json
@@ -5,9 +5,9 @@
   "description": "Dedicated one-shot shared-authority migration runner",
   "scripts": {
     "migrations:package": "node ./scripts/packageSharedMigrations.js",
-    "migrate:latest": "NODE_ENV=production node ./scripts/packageSharedMigrations.js && NODE_ENV=production node ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env production migrate:latest",
+    "migrate:latest": "NODE_ENV=production node ./scripts/packageSharedMigrations.js && NODE_ENV=production node ./scripts/runMigrations.js",
     "migrate:latest:prod": "npm run migrate:latest",
-    "migrate:rollback:prod": "NODE_ENV=production node ./scripts/packageSharedMigrations.js && NODE_ENV=production node ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env production migrate:rollback",
+    "migrate:rollback:prod": "NODE_ENV=production node ./scripts/packageSharedMigrations.js && NODE_ENV=production node ./scripts/runMigrations.js migrate:rollback",
     "seed:run:prod": "NODE_ENV=production node ./scripts/packageSharedMigrations.js && NODE_ENV=production node ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env production seed:run"
   },
   "dependencies": {

--- a/apps/migration-runner/project.json
+++ b/apps/migration-runner/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "migration-runner",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/migration-runner",
+  "tags": ["lane:connectshyft", "type:app", "runtime:node"],
+  "targets": {
+    "run": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/migration-runner",
+        "command": "npm run migrate:latest"
+      }
+    }
+  }
+}

--- a/apps/migration-runner/scripts/runMigrations.js
+++ b/apps/migration-runner/scripts/runMigrations.js
@@ -1,0 +1,38 @@
+/**
+ * This helper executes knex migrations after loading the migration-runner
+ * local env file. It preserves strict production behaviour by requiring
+ * DATABASE_URL while still letting local development provide it via
+ * apps/migration-runner/.env.
+ */
+const { execSync } = require('child_process');
+const path = require('path');
+
+require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
+
+const action = typeof process.argv[2] === 'string' && process.argv[2].trim()
+  ? process.argv[2].trim()
+  : 'migrate:latest';
+
+const commandByAction = {
+  'migrate:latest': 'node ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env production migrate:latest',
+  'migrate:rollback': 'node ./node_modules/knex/bin/cli.js --knexfile knexfile.js --env production migrate:rollback',
+};
+
+if (!commandByAction[action]) {
+  throw new Error(`migration-runner: unsupported action "${action}"`);
+}
+
+const databaseUrl = process.env.DATABASE_URL && process.env.DATABASE_URL.trim();
+if (!databaseUrl) {
+  throw new Error(
+    'migration-runner: DATABASE_URL must be set via environment or apps/migration-runner/.env',
+  );
+}
+
+execSync(commandByAction[action], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+  },
+});

--- a/scripts/nx-shim.mjs
+++ b/scripts/nx-shim.mjs
@@ -52,9 +52,9 @@ function loadProjects() {
 }
 
 function runShellCommand(command, cwd) {
-  const child = spawn(command, {
+  const shellPath = process.env.SHELL || '/bin/bash';
+  const child = spawn(shellPath, ['-lc', command], {
     cwd,
-    shell: true,
     stdio: 'inherit',
     env: process.env,
   });
@@ -87,8 +87,7 @@ function delegateToNx() {
   });
 }
 
-if (argv[0] === 'run' && typeof argv[1] === 'string' && argv[1].includes(':')) {
-  const [projectName, targetName] = argv[1].split(':');
+function tryRunProjectTarget(projectName, targetName) {
   const projects = loadProjects();
   const project = projects.get(projectName);
   const target = project?.config?.targets?.[targetName];
@@ -98,7 +97,20 @@ if (argv[0] === 'run' && typeof argv[1] === 'string' && argv[1].includes(':')) {
       ? path.resolve(workspaceRoot, target.options.cwd)
       : workspaceRoot;
     runShellCommand(target.options.command, cwd);
-  } else {
+    return true;
+  }
+
+  return false;
+}
+
+if (argv[0] === 'run' && typeof argv[1] === 'string' && argv[1].includes(':')) {
+  const [projectName, targetName] = argv[1].split(':');
+
+  if (!tryRunProjectTarget(projectName, targetName)) {
+    delegateToNx();
+  }
+} else if (argv[0] === 'run' && typeof argv[1] === 'string') {
+  if (!tryRunProjectTarget(argv[1], 'run')) {
     delegateToNx();
   }
 } else {

--- a/shared/database/migrations/20260325100000_create_connectshyft_calls_and_voicemail.ts
+++ b/shared/database/migrations/20260325100000_create_connectshyft_calls_and_voicemail.ts
@@ -1,0 +1,168 @@
+import type { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const CALLS_TABLE = 'cs_calls';
+const VOICEMAILS_TABLE = 'cs_voicemails';
+const DELIVERY_ATTEMPTS_TABLE = 'cs_delivery_attempts';
+const PROVIDER_EVENTS_TABLE = 'cs_provider_events';
+const BRIDGE_SESSIONS_TABLE = 'cs_bridge_sessions';
+const THREADS_TABLE = 'cs_threads';
+const BRIDGE_SESSION_PERSON_INDEX = 'connectshyft_cs_bridge_sessions_scope_person_idx';
+const PERSON_REQUIRED_MESSAGE =
+  'connectshyft.cs_bridge_sessions has NULL person_id rows; backfill person_id before enabling NOT NULL enforcement';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}`);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${CALLS_TABLE} (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      person_id TEXT NOT NULL,
+      bridge_session_id TEXT NULL REFERENCES ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}(id) ON DELETE SET NULL,
+      status TEXT NOT NULL CHECK (status IN (
+        'operator_dialing',
+        'operator_answered',
+        'neighbor_dialing',
+        'neighbor_answered',
+        'bridged',
+        'voicemail',
+        'completed',
+        'failed',
+        'canceled',
+        'expired'
+      )),
+      failure_code TEXT NULL,
+      failure_message TEXT NULL,
+      started_at_utc TIMESTAMPTZ NOT NULL,
+      operator_answered_at_utc TIMESTAMPTZ NULL,
+      neighbor_answered_at_utc TIMESTAMPTZ NULL,
+      bridged_at_utc TIMESTAMPTZ NULL,
+      ended_at_utc TIMESTAMPTZ NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS connectshyft_cs_calls_scope_idx
+    ON ${CONNECTSHYFT_SCHEMA}.${CALLS_TABLE} (tenant_id, org_unit_id, person_id, created_at_utc DESC, id)
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS connectshyft_cs_calls_thread_idx
+    ON ${CONNECTSHYFT_SCHEMA}.${CALLS_TABLE} (tenant_id, org_unit_id, thread_id, created_at_utc DESC, id)
+  `);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${VOICEMAILS_TABLE} (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      call_id TEXT NOT NULL REFERENCES ${CONNECTSHYFT_SCHEMA}.${CALLS_TABLE}(id) ON DELETE CASCADE,
+      thread_id TEXT NOT NULL,
+      person_id TEXT NOT NULL,
+      artifact_id TEXT NOT NULL,
+      recording_url TEXT NULL,
+      transcription_json JSONB NULL,
+      recording_status TEXT NOT NULL CHECK (recording_status IN ('pending', 'completed', 'failed')),
+      occurred_at_utc TIMESTAMPTZ NOT NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT cs_voicemails_artifact_uq UNIQUE (tenant_id, artifact_id)
+    )
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS connectshyft_cs_voicemails_scope_idx
+    ON ${CONNECTSHYFT_SCHEMA}.${VOICEMAILS_TABLE} (tenant_id, org_unit_id, person_id, occurred_at_utc DESC, id)
+  `);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${DELIVERY_ATTEMPTS_TABLE} (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      person_id TEXT NOT NULL,
+      call_id TEXT NULL REFERENCES ${CONNECTSHYFT_SCHEMA}.${CALLS_TABLE}(id) ON DELETE SET NULL,
+      channel TEXT NOT NULL CHECK (channel IN ('sms', 'voice')),
+      provider_event_id TEXT NULL,
+      status TEXT NOT NULL CHECK (status IN ('pending', 'succeeded', 'failed', 'canceled')),
+      failure_code TEXT NULL,
+      failure_message TEXT NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${PROVIDER_EVENTS_TABLE} (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      event_json JSONB NOT NULL,
+      call_id TEXT NULL,
+      bridge_session_id TEXT NULL,
+      provider_call_id TEXT NULL,
+      occurred_at_utc TIMESTAMPTZ NOT NULL,
+      received_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT cs_provider_events_dedup_uq
+        UNIQUE (tenant_id, provider, provider_call_id, event_type, occurred_at_utc)
+    )
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}
+      ADD COLUMN IF NOT EXISTS person_id TEXT NULL
+  `);
+
+  await knex.raw(`
+    UPDATE ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE} AS sessions
+    SET person_id = threads.person_id::text
+    FROM ${CONNECTSHYFT_SCHEMA}.${THREADS_TABLE} AS threads
+    WHERE sessions.thread_id = threads.id::text
+      AND sessions.person_id IS NULL
+      AND threads.person_id IS NOT NULL
+  `);
+
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}
+        WHERE person_id IS NULL
+      ) THEN
+        RAISE EXCEPTION '${PERSON_REQUIRED_MESSAGE}';
+      END IF;
+
+      ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}
+        ALTER COLUMN person_id SET NOT NULL;
+    END $$;
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${BRIDGE_SESSION_PERSON_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE} (tenant_id, org_unit_id, person_id, created_at_utc DESC, id)
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSION_PERSON_INDEX}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${BRIDGE_SESSIONS_TABLE}
+      DROP COLUMN IF EXISTS person_id
+  `);
+
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(PROVIDER_EVENTS_TABLE);
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(DELIVERY_ATTEMPTS_TABLE);
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(VOICEMAILS_TABLE);
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(CALLS_TABLE);
+}

--- a/specs/slice-25-codex-ready-implementation-brief.md
+++ b/specs/slice-25-codex-ready-implementation-brief.md
@@ -1,0 +1,725 @@
+# Slice 25 — Bridge Lifecycle + Telephony (Codex‑Ready Implementation Brief)
+
+## 1. OBJECTIVE
+
+Implement a complete **telephony call lifecycle** built upon the existing bridge‑session domain.  Calls must progress deterministically from operator dialing through bridging to completion, failure or voicemail fallback.  Telephony artifacts (call, voicemail, delivery attempt and provider event) must be persisted in ConnectShyft’s database with person‑scoped keys so that telephony remains **person‑bound** and rebind‑safe.  The UI needs a unified timeline that includes SMS, calls and voicemail; dispatch APIs must enforce the lifecycle state machine and surface meaningful error codes when calling is not possible.  Slice 25 does **not** redesign the provider adapter surface or call control; it layers persistence, state orchestration and timeline projection over the existing bridge domain.
+
+## 2. ARCHITECTURAL DECISIONS (LOCKED)
+
+1. **Person‑bound calls** – Each call is anchored to a person via `personId` (derived from the thread’s subject).  Calls must survive rebinding; persisting calls keyed only by `threadId` is insufficient because threads can migrate between persons.  The `cs_calls` and `cs_voicemails` tables include `person_id` in addition to `thread_id`.
+2. **Bridge session remains the orchestrator** – The existing bridge session domain (`domains/communication/bridge`) remains the authoritative engine for dialing, answering and bridging.  ConnectShyft telephony simply persists call and voicemail artifacts and wires provider events into the domain functions.  There is **no redesign** of the bridge state machine or provider adapters.
+3. **Separate persistence for calls and voicemail** – New tables capture call and voicemail metadata.  A call record reflects the lifecycle of a bridge session; a voicemail record is created only when a voicemail fallback occurs.  The `cs_delivery_attempts` and `cs_provider_events` tables capture low‑level retry attempts and idempotent provider events respectively.
+4. **Idempotent provider event ingestion** – Provider webhooks may deliver duplicate or out‑of‑order events.  Ingested events are persisted in `cs_provider_events` keyed by `(tenant_id, provider_event_id)` and deduplicated.  Application handlers should be idempotent and replay‑safe.
+5. **Thread timeline projection** – The telephony timeline is a read‑only projection that composes SMS, call and voicemail events without rewriting underlying artifacts.  Projection logic lives in `threadTimeline.ts` and uses call/voicemail records plus bridge session state to build timeline items.  It is safe to regenerate the projection on demand.
+6. **No UI implementation here** – This slice exposes data and service surfaces required by the future UI.  Actual UI components and interactions are deferred to front‑end slices.
+
+## 3. EXECUTION FLOW
+
+### 3.1 Start Call / Bridge Session
+
+1. **Initiate** – `POST /api/v1/connectshyft/thread/:threadId/call` is called with no body.  The handler resolves tenant, orgUnit, thread and person context, verifies telephony readiness (Slice 23), and checks that no active bridge session exists for the thread.
+2. **Persist call** – The handler creates a `cs_calls` row with a new `callId`, `tenant_id`, `org_unit_id`, `thread_id`, `person_id`, `status: 'operator_dialing'`, `started_at_utc: now`, and `bridge_session_id: null`.  This call record is updated as the session progresses.
+3. **Start bridge session** – The handler delegates to `bridgeSessions.startBridgeSession` (existing function) to create a new bridge session aggregate.  The domain returns a `bridgeSessionId` and initial leg state.  Persist the `bridge_session_id` onto the call record.
+4. **Return** – The API returns a success envelope with the call DTO (`callId`, `status`, `startedAtUtc`, etc.) and the bridge session status (`operator_dialing`).
+
+### 3.2 Provider Events → State Advancement
+
+1. **Receive webhook** – Provider webhooks are sent to `/api/v1/connectshyft/provider-events`.  The handler resolves `bridgeSessionId` using provider call IDs or correlation mappings.  It records the event in `cs_provider_events` if `(tenant_id, provider_event_id)` is not already persisted.
+2. **Apply domain transition** – The handler calls `handleProviderBridgeEvent` from the bridge domain, passing the `BridgeSessionAggregate` and the provider event.  This returns a new aggregate with advanced session/leg statuses.
+3. **Persist aggregate** – Save the aggregate using `bridgeSessionRepository.saveAggregate`.  In parallel update the corresponding call record’s `status`, `answered_at_utc`, `ended_at_utc` or `failure_code/message` based on the new session state:
+   * `operator_answered` → set `operator_answered_at_utc` on the call and status `operator_answered`.
+   * `neighbor_answered` → set `neighbor_answered_at_utc` and status `neighbor_answered`.
+   * `bridged` → set `bridged_at_utc` and status `bridged`.
+   * `completed` → set `completed_at_utc` and status `completed`.
+   * `failed` / `canceled` / `expired` → set `ended_at_utc` and `failure_code/message` and status accordingly.
+4. **Return** – Acknowledge the provider.  Idempotent replays do not re‑advance the session or duplicate call updates.
+
+### 3.3 Voicemail Fallback
+
+1. **Trigger fallback** – If the neighbor leg does not answer within the provider’s configured timeout, the bridge domain moves to `neighbor_failed` and triggers voicemail fallback logic (already in `bridgeSessions.ts`).  The provider sends a voicemail recording URL and artifact ID once recording completes.
+2. **Persist voicemail** – The voicemail webhook handler creates a row in `cs_voicemails` with `voicemailId`, `callId`, `threadId`, `personId`, `artifactId`, `recordingUrl`, `recordingStatus` and `occurredAtUtc`.  It updates the call’s status to `'voicemail'` and sets `ended_at_utc` if not already set.
+3. **Return** – The API returns a success envelope acknowledging the voicemail.  Duplicate voicemails are deduplicated by `artifactId`.
+
+### 3.4 Endpoints
+
+* **POST /api/v1/connectshyft/thread/:threadId/call** – Start a new call as described above.
+* **GET /api/v1/connectshyft/call/:callId** – Return the call DTO with status, timestamps, bridge session status and voicemail info if applicable.
+* **GET /api/v1/connectshyft/thread/:threadId/call-history** – Return all call DTOs for a thread ordered by `startedAtUtc` descending.  This is used by the timeline projection.
+* **GET /api/v1/connectshyft/person/:personId/call-history** – Return all call DTOs across threads for the person.
+
+## 4. STATE MACHINES
+
+### 4.1 Call State
+
+| Call Status            | Description                                                  | Next States                         |
+|------------------------|--------------------------------------------------------------|-------------------------------------|
+| `operator_dialing`     | Operator leg is dialing the operator’s phone.               | `operator_answered`, `failed`       |
+| `operator_answered`    | Operator answered; neighbor leg is dialing.                 | `neighbor_dialing`, `failed`        |
+| `neighbor_dialing`     | Neighbor leg is dialing the neighbor’s phone.               | `neighbor_answered`, `failed`       |
+| `neighbor_answered`    | Neighbor answered; bridging about to occur.                 | `bridged`, `failed`                 |
+| `bridged`              | Both legs connected; conversation in progress.              | `completed`, `failed`, `canceled`   |
+| `voicemail`            | Bridging failed; voicemail fallback recorded.               | `completed`                         |
+| `completed`            | Call completed normally (hangup by either party).           | —                                   |
+| `failed`               | Call failed due to provider error or no answer.             | —                                   |
+| `canceled` / `expired` | Call cancelled by operator or expired in queue.             | —                                   |
+
+The call status mirrors the underlying `bridgeSession.status` but separates `voicemail` as a distinct call state.  Once a call is in `completed`, `failed` or `voicemail`, it is terminal.
+
+### 4.2 Bridge Session & Leg State
+
+The bridge domain’s state machine (`bridgeStateMachine.ts`) remains unchanged.  It defines session states (`created`, `operator_dialing`, `operator_answered`, `neighbor_dialing`, `neighbor_answered`, `bridged`, `completed`, `failed`, `canceled`, `expired`) and leg statuses (`created`, `dialing`, `ringing`, `answered`, `completed`, `failed`, `canceled`).
+
+### 4.3 Voicemail State
+
+| Voicemail Status | Description                     | Next States  |
+|------------------|---------------------------------|--------------|
+| `pending`        | Recording in progress.           | `completed`, `failed` |
+| `completed`      | Recording finished successfully. | —            |
+| `failed`         | Recording failed.                | —            |
+
+## 5. DATABASE CONTRACTS
+
+### 5.1 `connectshyft.cs_calls` (new)
+
+| Column               | Type        | Constraints                                                                        |
+|----------------------|-------------|------------------------------------------------------------------------------------|
+| `id`                 | TEXT        | Primary key (callId); generated via `randomUUID()`                                 |
+| `tenant_id`          | TEXT        | NOT NULL; scope for multitenancy                                                   |
+| `org_unit_id`        | TEXT        | NOT NULL; orgUnit scope                                                            |
+| `thread_id`          | TEXT        | NOT NULL; thread context                                                           |
+| `person_id`          | TEXT        | NOT NULL; person the call is bound to                                             |
+| `bridge_session_id`  | TEXT        | NULLABLE; references `cs_bridge_sessions.id`; set when session created             |
+| `status`             | TEXT        | NOT NULL; CHECK (`status` IN ('operator_dialing','operator_answered','neighbor_dialing','neighbor_answered','bridged','voicemail','completed','failed','canceled','expired')) |
+| `failure_code`       | TEXT        | NULLABLE; enumeration aligned with `BridgeFailureCode`                              |
+| `failure_message`    | TEXT        | NULLABLE                                                                           |
+| `started_at_utc`     | TIMESTAMPTZ | NOT NULL; call initiation time                                                     |
+| `operator_answered_at_utc` | TIMESTAMPTZ | NULLABLE; when operator answered                           |
+| `neighbor_answered_at_utc` | TIMESTAMPTZ | NULLABLE; when neighbor answered                          |
+| `bridged_at_utc`     | TIMESTAMPTZ | NULLABLE; when bridging occurred                                                  |
+| `ended_at_utc`       | TIMESTAMPTZ | NULLABLE; when call ended or failed                                               |
+| `created_at_utc`     | TIMESTAMPTZ | NOT NULL DEFAULT NOW()                                                            |
+| `updated_at_utc`     | TIMESTAMPTZ | NOT NULL DEFAULT NOW()                                                            |
+
+**Indexes:**
+
+* `cs_calls_scope_idx` – `(tenant_id, org_unit_id, person_id, created_at_utc DESC, id)` to list calls by person.
+* `cs_calls_thread_idx` – `(tenant_id, org_unit_id, thread_id, created_at_utc DESC, id)` to list calls by thread.
+
+### 5.2 `connectshyft.cs_voicemails` (new)
+
+| Column                  | Type        | Constraints                                         |
+|-------------------------|-------------|-----------------------------------------------------|
+| `id`                    | TEXT        | Primary key (voicemailId)                          |
+| `tenant_id`             | TEXT        | NOT NULL                                           |
+| `org_unit_id`           | TEXT        | NOT NULL                                           |
+| `call_id`               | TEXT        | NOT NULL; references `cs_calls.id`                 |
+| `thread_id`             | TEXT        | NOT NULL                                           |
+| `person_id`             | TEXT        | NOT NULL                                           |
+| `artifact_id`           | TEXT        | NOT NULL; unique across all voicemails             |
+| `recording_url`         | TEXT        | NULLABLE                                           |
+| `transcription_json`    | JSONB       | NULLABLE; provider transcription results           |
+| `recording_status`      | TEXT        | NOT NULL CHECK (`recording_status` IN ('pending','completed','failed')) |
+| `occurred_at_utc`       | TIMESTAMPTZ | NOT NULL                                           |
+| `created_at_utc`        | TIMESTAMPTZ | NOT NULL DEFAULT NOW()                             |
+| `updated_at_utc`        | TIMESTAMPTZ | NOT NULL DEFAULT NOW()                             |
+
+**Indexes:**
+
+* `cs_voicemails_scope_idx` – `(tenant_id, org_unit_id, person_id, occurred_at_utc DESC, id)`.
+* `cs_voicemails_artifact_idx` – UNIQUE `(tenant_id, artifact_id)` to deduplicate.
+
+### 5.3 `connectshyft.cs_delivery_attempts` (new)
+
+A record of each outbound dispatch (SMS or voice).  For Slice 25 we create the table but only populate it for voice calls.  Future slices will extend SMS delivery tracking.
+
+| Column               | Type        | Constraints                                         |
+|----------------------|-------------|-----------------------------------------------------|
+| `id`                 | TEXT        | Primary key (deliveryAttemptId)                    |
+| `tenant_id`          | TEXT        | NOT NULL                                           |
+| `org_unit_id`        | TEXT        | NOT NULL                                           |
+| `thread_id`          | TEXT        | NOT NULL                                           |
+| `person_id`          | TEXT        | NOT NULL                                           |
+| `call_id`            | TEXT        | NULLABLE; present for voice attempts               |
+| `channel`            | TEXT        | NOT NULL CHECK (`channel` IN ('sms','voice'))      |
+| `provider_event_id`  | TEXT        | NULLABLE; links to `cs_provider_events.id`         |
+| `status`             | TEXT        | NOT NULL CHECK (`status` IN ('pending','succeeded','failed','canceled')) |
+| `failure_code`       | TEXT        | NULLABLE                                           |
+| `failure_message`    | TEXT        | NULLABLE                                           |
+| `created_at_utc`     | TIMESTAMPTZ | NOT NULL DEFAULT NOW()                             |
+| `updated_at_utc`     | TIMESTAMPTZ | NOT NULL DEFAULT NOW()                             |
+
+### 5.4 `connectshyft.cs_provider_events` (new)
+
+Stores raw provider events to enable idempotent processing and debugging.
+
+| Column               | Type        | Constraints                                         |
+|----------------------|-------------|-----------------------------------------------------|
+| `id`                 | TEXT        | Primary key (providerEventId)                      |
+| `tenant_id`          | TEXT        | NOT NULL                                           |
+| `provider`           | TEXT        | NOT NULL                                           |
+| `event_type`         | TEXT        | NOT NULL                                           |
+| `event_json`         | JSONB       | NOT NULL; full payload                             |
+| `call_id`            | TEXT        | NULLABLE                                           |
+| `bridge_session_id`  | TEXT        | NULLABLE                                           |
+| `provider_call_id`   | TEXT        | NULLABLE                                           |
+| `occurred_at_utc`    | TIMESTAMPTZ | NOT NULL                                           |
+| `received_at_utc`    | TIMESTAMPTZ | NOT NULL DEFAULT NOW()                             |
+
+**Unique constraint** – `(tenant_id, provider, event_type, provider_call_id, occurred_at_utc)` to deduplicate.
+
+## 6. SERVICE LAYER (STRICT)
+
+### 6.1 Call Store & Service (new modules)
+
+**File:** `apps/connectshyft-api/src/modules/connectshyft/calls.ts`
+
+The call service encapsulates call creation and updates and persists to the new tables.  It has the following interface:
+
+```ts
+export interface CreateCallInput {
+  tenantId: string
+  orgUnitId: string
+  threadId: string
+  personId: string
+}
+
+export interface UpdateCallStatusInput {
+  callId: string
+  tenantId: string
+  status: CallStatus
+  operatorAnsweredAtUtc?: string
+  neighborAnsweredAtUtc?: string
+  bridgedAtUtc?: string
+  endedAtUtc?: string
+  failureCode?: string | null
+  failureMessage?: string | null
+}
+
+export interface ListThreadCallsInput {
+  tenantId: string
+  orgUnitId: string
+  threadId: string
+}
+
+export interface ListPersonCallsInput {
+  tenantId: string
+  orgUnitId: string
+  personId: string
+}
+
+export interface ConnectShyftCallService {
+  createCall(input: CreateCallInput): Promise<Call>
+  updateCallStatus(input: UpdateCallStatusInput): Promise<void>
+  listThreadCalls(input: ListThreadCallsInput): Promise<Call[]>
+  listPersonCalls(input: ListPersonCallsInput): Promise<Call[]>
+  getCallById(callId: string, tenantId: string): Promise<Call | null>
+}
+
+export type Call = {
+  id: string
+  tenantId: string
+  orgUnitId: string
+  threadId: string
+  personId: string
+  bridgeSessionId: string | null
+  status: CallStatus
+  failureCode: string | null
+  failureMessage: string | null
+  startedAtUtc: string
+  operatorAnsweredAtUtc: string | null
+  neighborAnsweredAtUtc: string | null
+  bridgedAtUtc: string | null
+  endedAtUtc: string | null
+  createdAtUtc: string
+  updatedAtUtc: string
+}
+
+export type CallStatus =
+  | 'operator_dialing'
+  | 'operator_answered'
+  | 'neighbor_dialing'
+  | 'neighbor_answered'
+  | 'bridged'
+  | 'voicemail'
+  | 'completed'
+  | 'failed'
+  | 'canceled'
+  | 'expired'
+```
+
+The implementation uses `Knex` to insert, update and query the `cs_calls` table.  It does **not** implement business logic; it simply persists state.  The service must throw `ConnectShyftPersistenceUnavailableError` when the database cannot be reached.
+
+### 6.2 Voicemail Store & Service (new modules)
+
+**File:** `apps/connectshyft-api/src/modules/connectshyft/voicemails.ts`
+
+Defines `ConnectShyftVoicemailService` with methods:
+
+```ts
+export interface CreateVoicemailInput {
+  tenantId: string
+  orgUnitId: string
+  callId: string
+  threadId: string
+  personId: string
+  artifactId: string
+  recordingUrl: string | null
+  recordingStatus: 'pending' | 'completed' | 'failed'
+  occurredAtUtc: string
+  transcriptionJson?: unknown
+}
+
+export interface ListCallVoicemailsInput {
+  tenantId: string
+  callId: string
+}
+
+export interface ConnectShyftVoicemailService {
+  createVoicemail(input: CreateVoicemailInput): Promise<Voicemail>
+  listCallVoicemails(input: ListCallVoicemailsInput): Promise<Voicemail[]>
+}
+
+export type Voicemail = {
+  id: string
+  tenantId: string
+  orgUnitId: string
+  callId: string
+  threadId: string
+  personId: string
+  artifactId: string
+  recordingUrl: string | null
+  recordingStatus: 'pending' | 'completed' | 'failed'
+  occurredAtUtc: string
+  createdAtUtc: string
+  updatedAtUtc: string
+  transcriptionJson: any | null
+}
+```
+
+### 6.3 Provider Event Store (new module)
+
+**File:** `apps/connectshyft-api/src/modules/connectshyft/providerEvents.ts`
+
+Defines `ConnectShyftProviderEventService` with methods to record and fetch provider events.  It should expose:
+
+```ts
+export interface RecordProviderEventInput {
+  tenantId: string
+  provider: string
+  eventType: string
+  eventJson: unknown
+  callId?: string | null
+  bridgeSessionId?: string | null
+  providerCallId?: string | null
+  occurredAtUtc: string
+}
+
+export interface ConnectShyftProviderEventService {
+  recordEvent(input: RecordProviderEventInput): Promise<void>
+}
+```
+
+### 6.4 Delivery Attempt Service (stub)
+
+Define a basic `ConnectShyftDeliveryAttemptService` to insert records into `cs_delivery_attempts`.  It accepts channel and callId; future slices will add SMS tracking.
+
+### 6.5 Bridge Session Extensions (existing file: `bridgeSessions.ts`)
+
+**Enhancements:**
+
+1. **personId injection** – When creating a bridge session, accept and persist `personId` in the session record.  Add a new column `person_id TEXT NOT NULL` to `cs_bridge_sessions` via migration.  The `StartConnectShyftBridgeSessionInput` should include `personId` (passed from the API).  This ensures sessions remain person‑bound for rebind safety.
+2. **Call update hook** – Introduce an internal callback in `bridgeSessions.ts` that fires on every session transition.  The callback receives the new aggregate and uses `connectShyftCallService.updateCallStatus` to synchronize the call status and timestamps.  The callback must run outside of domain state transitions (i.e. after persistence) and be idempotent.
+3. **Provider event persistence** – In `handleProviderBridgeEvent`, after computing the updated aggregate, call `providerEventService.recordEvent` with the provider payload and correlation data.
+
+### 6.6 Thread Timeline (modified file: `threadTimeline.ts`)
+
+Extend `resolveBridgeSessionVoicemailProjection` and other helpers to incorporate call and voicemail records.  The timeline builder should fetch calls and voicemails using the call/voicemail services and merge them with existing SMS events into a chronologically sorted list.  Each call appears as a `voice_event` item with subevents (dialing, answered, bridged, voicemail) and associated timestamps.  Each voicemail appears as a `voicemail` item.
+
+### 6.7 HTTP Handlers
+
+Add new handlers under `apps/connectshyft-api/src/modules/connectshyft/handlers`:
+
+* `postThreadCallHandler` – start a call on a thread.
+* `getCallHandler` – return a single call.
+* `getThreadCallHistoryHandler` – list calls for a thread.
+* `getPersonCallHistoryHandler` – list calls for a person.
+* `postProviderEventHandler` – ingest provider webhooks, deduplicate and advance the bridge session.  This handler must validate provider signatures and route events using existing `providerRegistry` logic.
+* `postVoicemailHandler` – handle voicemail recording events; create voicemail record and update call.
+
+Register these routes in `http/index.ts` with appropriate method and path patterns.  Use existing envelope response helpers for success and failure.
+
+## 7. PROVIDER / INTEGRATION CONTRACTS
+
+The provider registry and adapter interface remain unchanged.  Each provider must implement `startOutboundCall`, `startBridgeSession` and emit provider events defined in `ProviderBridgeEvent`.  New endpoints accept provider webhooks carrying `provider_call_id`, `event_type`, `event_timestamp`, `event_payload`, etc.  A signature verification step is required (already implemented by `resolveConnectShyftProviderAdapter` in Slice 23).  The event service deduplicates events using the unique combination `(tenant_id, provider, provider_call_id, event_type, occurred_at_utc)`.
+
+## 8. EVENT HANDLING
+
+This slice introduces new domain events produced by ConnectShyft.  They are emitted via the existing outbound event system:
+
+* `connectshyft.call.started` – emitted after a call is created and bridge session initiated; payload includes `callId`, `threadId`, `personId`, `occurredAtUtc`.
+* `connectshyft.call.updated` – emitted when a call status changes (e.g. answered, bridged, completed, failed).  Includes the new status and timestamps.
+* `connectshyft.voicemail.recorded` – emitted after a voicemail is created; includes `voicemailId`, `callId`, `threadId`, `personId`, `recordingUrl`.
+
+Domain events are delivered via the platform’s outbox mechanism and are idempotent; duplicates are suppressed by event IDs.
+
+## 9. IDEMPOTENCY RULES
+
+1. **Call initiation** – Starting a call with the same idempotency key and thread while a call is in progress should return the existing call record and not create a new bridge session.  The `createCall` method must accept an optional `idempotencyKey` and enforce uniqueness per `(tenant_id, thread_id, idempotencyKey)`.
+2. **Provider event ingestion** – Events with the same `(tenant_id, provider, provider_call_id, event_type, occurred_at_utc)` are dropped after the first processing.  Duplicate processing does not advance the session or update call status.
+3. **Voicemail creation** – If a voicemail with the same `(tenant_id, artifact_id)` already exists, ignore the duplicate webhook.
+4. **Call updates** – Updating a call status must be safe to repeat; if the call is already in a later state, ignore older updates.
+
+## 10. FAILURE MODES
+
+1. **Telephony not ready** – If `telephonyReadiness.inspectReadiness` (Slice 23) reports `NOT_READY` or `bridgeCallRunnable = false`, the call start handler must refuse the call with code `CONNECTSHYFT_TELEPHONY_NOT_READY`.  The client should surface the blocking reasons.
+2. **Existing active call** – If there is a non‑terminal call on the thread, return a refusal `CONNECTSHYFT_CALL_ALREADY_IN_PROGRESS`.
+3. **Provider error** – If provider adapters throw errors when starting a call or bridging, update the call to `failed` with `failureCode = 'provider_error'` and emit a call updated event.
+4. **Database unavailable** – All store methods throw `ConnectShyftPersistenceUnavailableError` when the database is unreachable.  Handlers translate this to a 503 envelope.
+5. **Webhook verification failed** – If signature verification fails, respond with HTTP 401 and do not persist the provider event.
+6. **Invalid thread or person** – If the thread or person cannot be resolved, return a 404 envelope.  Do not create or update any records.
+
+## 11. TEST CONTRACT
+
+### 11.1 Domain Tests (bridge layer)
+
+* Add tests in `domains/communication/bridge/__tests__/callLifecycle.test.ts` verifying that:
+  * Starting a call triggers `startBridgeSession` and produces a new call record with status `operator_dialing`.
+  * Applying provider events transitions call statuses correctly and idempotently (operator answered, neighbor answered, bridged, completed, failed).
+  * Voicemail fallback results in a call with status `voicemail` and a voicemail record.
+
+### 11.2 Service & Store Tests
+
+* `calls.test.ts` – Test `createCall`, `updateCallStatus`, `listThreadCalls`, `listPersonCalls` for correct persistence, idempotency and scope filtering.
+* `voicemails.test.ts` – Test voicemail creation and listing, including duplicate artifact handling.
+* `providerEvents.test.ts` – Test event deduplication and persistence.
+
+### 11.3 API Integration Tests
+
+Add new integration tests in `tests/integration/connectshyft-api/calls.integration.test.ts`:
+
+1. **Start call** – Sending `POST /api/v1/connectshyft/thread/:threadId/call` starts a call when readiness is true and no call exists.  Response includes `callId` and status `operator_dialing`.
+2. **Idempotent start** – Starting a call again with the same idempotency key returns the existing call.
+3. **Advance lifecycle** – Simulate provider events to move through `operator_answered → neighbor_answered → bridged → completed` and assert call status updates and timeline projection.
+4. **Failure** – Simulate provider failure and verify call status `failed`, failure code and message persisted.
+5. **Voicemail** – Simulate voicemail fallback and verify voicemail record creation and call status `voicemail`.
+6. **Listing calls** – List calls by thread and by person and ensure ordering and filtering.
+
+## 12. CHECKPOINTS
+
+### Checkpoint 1 — Persist Telephony Artifacts
+
+**FILES:**
+
+1. `shared/database/migrations/20260325100000_create_connectshyft_calls_and_voicemail.ts` – migration creating `cs_calls`, `cs_voicemails`, `cs_delivery_attempts` and `cs_provider_events` tables as specified in §5.  Also add `person_id` column to `cs_bridge_sessions` and appropriate index.
+2. `apps/connectshyft-api/src/modules/connectshyft/calls.ts` – new call service and store implementation using Knex.
+3. `apps/connectshyft-api/src/modules/connectshyft/voicemails.ts` – new voicemail service and store implementation.
+4. `apps/connectshyft-api/src/modules/connectshyft/providerEvents.ts` – new provider event service implementation.
+5. `apps/connectshyft-api/src/modules/connectshyft/deliveryAttempts.ts` – new delivery attempt service stub.
+6. `apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts` – modify session creation to accept `personId` and persist it; introduce call update hook and provider event recording as described in §6.5.
+7. `apps/connectshyft-api/src/migrations/20260325101000_add_person_id_to_connectshyft_bridge_sessions.ts` – migration adding `person_id` column to `cs_bridge_sessions` with NOT NULL default using thread’s person.
+
+**FUNCTION SIGNATURES:**
+
+* Extend `StartConnectShyftBridgeSessionInput` in `bridgeSessions.ts` to include `personId: string`.
+* Add `idempotencyKey?: string` to call creation inputs.
+* Add call update callback signature to `startBridgeSession` invocation (internal only).
+
+**LINE‑LEVEL DIFF EXPECTATIONS:**
+
+Migration example:
+
+```diff
+*** Begin Migration: shared/database/migrations/20260325100000_create_connectshyft_calls_and_voicemail.ts
+import { Knex } from 'knex'
+
+const CONNECTSHYFT = 'connectshyft'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`CREATE SCHEMA IF NOT EXISTS ${CONNECTSHYFT}`)
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT}.cs_calls (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      person_id TEXT NOT NULL,
+      bridge_session_id TEXT NULL REFERENCES ${CONNECTSHYFT}.cs_bridge_sessions(id) ON DELETE SET NULL,
+      status TEXT NOT NULL CHECK (status IN (
+        'operator_dialing','operator_answered','neighbor_dialing','neighbor_answered','bridged','voicemail','completed','failed','canceled','expired'
+      )),
+      failure_code TEXT NULL,
+      failure_message TEXT NULL,
+      started_at_utc TIMESTAMPTZ NOT NULL,
+      operator_answered_at_utc TIMESTAMPTZ NULL,
+      neighbor_answered_at_utc TIMESTAMPTZ NULL,
+      bridged_at_utc TIMESTAMPTZ NULL,
+      ended_at_utc TIMESTAMPTZ NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+
+  await knex.raw(`CREATE INDEX IF NOT EXISTS connectshyft_cs_calls_scope_idx ON ${CONNECTSHYFT}.cs_calls (tenant_id, org_unit_id, person_id, created_at_utc DESC, id)`)
+  await knex.raw(`CREATE INDEX IF NOT EXISTS connectshyft_cs_calls_thread_idx ON ${CONNECTSHYFT}.cs_calls (tenant_id, org_unit_id, thread_id, created_at_utc DESC, id)`)
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT}.cs_voicemails (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      call_id TEXT NOT NULL REFERENCES ${CONNECTSHYFT}.cs_calls(id) ON DELETE CASCADE,
+      thread_id TEXT NOT NULL,
+      person_id TEXT NOT NULL,
+      artifact_id TEXT NOT NULL,
+      recording_url TEXT NULL,
+      transcription_json JSONB NULL,
+      recording_status TEXT NOT NULL CHECK (recording_status IN ('pending','completed','failed')),
+      occurred_at_utc TIMESTAMPTZ NOT NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT cs_voicemails_artifact_uq UNIQUE (tenant_id, artifact_id)
+    )
+  `)
+
+  await knex.raw(`CREATE INDEX IF NOT EXISTS connectshyft_cs_voicemails_scope_idx ON ${CONNECTSHYFT}.cs_voicemails (tenant_id, org_unit_id, person_id, occurred_at_utc DESC, id)`)
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT}.cs_delivery_attempts (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      person_id TEXT NOT NULL,
+      call_id TEXT NULL REFERENCES ${CONNECTSHYFT}.cs_calls(id) ON DELETE SET NULL,
+      channel TEXT NOT NULL CHECK (channel IN ('sms','voice')),
+      provider_event_id TEXT NULL,
+      status TEXT NOT NULL CHECK (status IN ('pending','succeeded','failed','canceled')),
+      failure_code TEXT NULL,
+      failure_message TEXT NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT}.cs_provider_events (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      provider TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      event_json JSONB NOT NULL,
+      call_id TEXT NULL,
+      bridge_session_id TEXT NULL,
+      provider_call_id TEXT NULL,
+      occurred_at_utc TIMESTAMPTZ NOT NULL,
+      received_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      CONSTRAINT cs_provider_events_dedup_uq UNIQUE (tenant_id, provider, provider_call_id, event_type, occurred_at_utc)
+    )
+  `)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.withSchema(CONNECTSHYFT).dropTableIfExists('cs_provider_events')
+  await knex.schema.withSchema(CONNECTSHYFT).dropTableIfExists('cs_delivery_attempts')
+  await knex.schema.withSchema(CONNECTSHYFT).dropTableIfExists('cs_voicemails')
+  await knex.schema.withSchema(CONNECTSHYFT).dropTableIfExists('cs_calls')
+}
+*** End Migration
+```
+
+Modify `bridgeSessions.ts` to accept `personId` and persist it in `cs_bridge_sessions`.  Introduce a call update hook at the end of `startBridgeSession` and `handleProviderBridgeEvent`:
+
+```diff
+@@ function startBridgeSession(
+   const sessionId = randomUUID()
+   const session: BridgeSessionRecord = {
+     id: sessionId,
+     tenantId: input.tenantId,
+     orgUnitId: input.orgUnitId,
+     threadId: input.threadId,
+     operatorParticipantId: input.operatorParticipantId,
+     neighborParticipantId: input.neighborParticipantId,
+     operatorContactPointId: input.operatorContactPointId,
+     neighborContactPointId: input.neighborContactPointId,
+     selectedOutboundContactPointId: input.selectedOutboundContactPointId ?? null,
+     status: 'created',
+     failureCode: null,
+     failureMessage: null,
+     endedBy: null,
+     idempotencyKey: input.idempotencyKey ?? null,
+     auditCorrelationId: input.auditCorrelationId ?? null,
+     createdAt: new Date(),
+     updatedAt: new Date(),
+     completedAt: null,
+     personId: input.personId, // new field
+   }
+@@
+   await repository.createSession(session)
+   await repository.createLeg(operatorLeg)
+   await repository.createLeg(neighborLeg)
+
+   // NEW: update call status after session creation
+   await callService.updateCallStatus({
+     callId: input.callId!,
+     tenantId: input.tenantId,
+     status: 'operator_dialing',
+     startedAtUtc: new Date().toISOString(),
+   })
+
+***
+```
+
+Similar diff applies to `handleProviderBridgeEvent`: after persisting the updated aggregate, call `callService.updateCallStatus` with the new status and timestamps.
+
+**DATA MUTATIONS:**
+
+* Adding new tables and columns will not mutate existing records.  Existing bridge sessions gain a `person_id` column; migration populates it by joining threads to persons via existing foreign keys.
+
+**GUARDS:**
+
+* The migration must populate `person_id` on existing `cs_bridge_sessions` by joining `cs_threads.thread_id` to `cs_threads.person_id` (threads now carry `personId`).  If any sessions cannot resolve a person, abort migration.
+
+**STOP CONDITION:**
+
+Run the new migrations with `pnpm nx run migration-runner` and verify that tables `cs_calls`, `cs_voicemails`, `cs_delivery_attempts` and `cs_provider_events` exist and that `cs_bridge_sessions` has a non‑null `person_id` column.  PeopleCore and ConnectShyft tests should compile with the new service interfaces.
+
+**COMMIT POINT:**
+
+```bash
+git add shared/database/migrations/20260325100000_create_connectshyft_calls_and_voicemail.ts \
+        apps/connectshyft-api/src/modules/connectshyft/calls.ts \
+        apps/connectshyft-api/src/modules/connectshyft/voicemails.ts \
+        apps/connectshyft-api/src/modules/connectshyft/providerEvents.ts \
+        apps/connectshyft-api/src/modules/connectshyft/deliveryAttempts.ts \
+        apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts \
+        apps/connectshyft-api/src/migrations/20260325101000_add_person_id_to_connectshyft_bridge_sessions.ts
+git commit -m "feat(connectshyft): persist telephony artifacts and person id on bridge sessions"
+```
+
+### Checkpoint 2 — Call Lifecycle Service & Provider Event Processing
+
+**FILES:**
+
+1. `apps/connectshyft-api/src/modules/connectshyft/callLifecycle.ts` – new service that orchestrates call creation, session start, provider event handling, call status updates, voicemail creation and event emission.  It composes the call service, voicemail service, delivery attempt service, provider event service and bridge session domain.
+2. `apps/connectshyft-api/src/modules/connectshyft/handlers/postThreadCallHandler.ts` – start call endpoint.
+3. `apps/connectshyft-api/src/modules/connectshyft/handlers/postProviderEventHandler.ts` – provider webhook endpoint.
+4. `apps/connectshyft-api/src/modules/connectshyft/handlers/postVoicemailHandler.ts` – voicemail webhook endpoint.
+5. `apps/connectshyft-api/src/modules/connectshyft/http/index.ts` – route registration.
+6. `apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts` – update timeline projection logic to include call and voicemail records.
+7. Test files: `callLifecycle.test.ts`, `postThreadCallHandler.test.ts`, `postProviderEventHandler.test.ts`, `postVoicemailHandler.test.ts`.
+
+**FUNCTION SIGNATURES:**
+
+* `async startCall(input: { tenantId: string; orgUnitId: string; threadId: string; personId: string; idempotencyKey?: string; actorRoles: string[]; }): Promise<Call>`
+* `async handleProviderEvent(input: { tenantId: string; provider: string; event: ProviderBridgeEvent; eventJson: unknown; providerCallId?: string | null; occurredAt: Date; }): Promise<void>`
+* `async handleVoicemail(input: { tenantId: string; orgUnitId: string; callId: string; threadId: string; personId: string; artifactId: string; recordingUrl: string | null; recordingStatus: 'pending' | 'completed' | 'failed'; occurredAt: Date; transcriptionJson?: unknown; }): Promise<void>`
+
+**LINE‑LEVEL DIFF EXPECTATIONS:**
+
+Handler registration example:
+
+```diff
+*** Update File: apps/connectshyft-api/src/modules/connectshyft/http/index.ts
+@@
+ import { postThreadCallHandler } from '../handlers/postThreadCallHandler'
+ import { postProviderEventHandler } from '../handlers/postProviderEventHandler'
+ import { postVoicemailHandler } from '../handlers/postVoicemailHandler'
+@@
+ router.post('/api/v1/connectshyft/thread/:threadId/call', postThreadCallHandler)
+ router.post('/api/v1/connectshyft/provider-events', postProviderEventHandler)
+ router.post('/api/v1/connectshyft/voicemails', postVoicemailHandler)
+*** End Patch
+```
+
+**REQUIRED CHANGES:**
+
+* Implement call lifecycle service to orchestrate call start and provider event processing.  This service must call the bridge domain, persist call/voicemail, update statuses and emit domain events via the platform outbox.  It must enforce idempotency by checking existing calls with the same idempotency key and existing provider events.
+* Update thread timeline builder to include call and voicemail items.  Use call service to list calls by thread and include them as `voice_event` with nested status events; include voicemails as `voicemail` items with recording URL.
+
+**DATA MUTATIONS:**
+
+* Starting a call inserts into `cs_calls` and updates `cs_bridge_sessions.person_id` (if not already set).  Provider events update `cs_calls` and insert into `cs_provider_events`.  Voicemail events insert into `cs_voicemails` and update `cs_calls`.
+
+**GUARDS:**
+
+* The call start handler must verify telephony readiness and no active call on the thread.  Use call service to check for non‑terminal calls with status not in (`completed`,`failed`,`canceled`,`expired`,`voicemail`).
+* Provider events must be verified using the provider registry and signature check (Slice 23).  Invalid signatures return 401.
+* Voicemail handler must ensure the call exists and is in a state eligible for voicemail (status `failed` or `neighbor_failed`).
+
+**STOP CONDITION:**
+
+* Unit tests for call lifecycle service, provider event handler and voicemail handler should pass.
+* Integration tests should demonstrate end‑to‑end call lifecycle transitions through the API with simulated provider events.
+
+**COMMIT POINT:**
+
+```bash
+git add apps/connectshyft-api/src/modules/connectshyft/callLifecycle.ts \
+        apps/connectshyft-api/src/modules/connectshyft/handlers/postThreadCallHandler.ts \
+        apps/connectshyft-api/src/modules/connectshyft/handlers/postProviderEventHandler.ts \
+        apps/connectshyft-api/src/modules/connectshyft/handlers/postVoicemailHandler.ts \
+        apps/connectshyft-api/src/modules/connectshyft/http/index.ts \
+        apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts \
+        apps/connectshyft-api/src/modules/connectshyft/__tests__/callLifecycle.test.ts \
+        apps/connectshyft-api/src/modules/connectshyft/handlers/__tests__/postThreadCallHandler.test.ts \
+        apps/connectshyft-api/src/modules/connectshyft/handlers/__tests__/postProviderEventHandler.test.ts \
+        apps/connectshyft-api/src/modules/connectshyft/handlers/__tests__/postVoicemailHandler.test.ts \
+        tests/integration/connectshyft-api/calls.integration.test.ts
+git commit -m "feat(connectshyft): implement call lifecycle service and provider event handling"
+```
+
+### Checkpoint 3 — Timeline Projection & Domain Events
+
+**FILES:**
+
+1. `apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts` – finalize timeline projection logic to merge call and voicemail records with existing SMS timeline items.
+2. `apps/connectshyft-api/src/modules/connectshyft/events.ts` – implement domain event emission for `call.started`, `call.updated` and `voicemail.recorded` using the platform outbox pattern.
+3. Integration tests verifying that timeline projection correctly orders SMS, call and voicemail events.
+4. Update `readContracts.ts` to include new fields (`callIndicator`, `voicemailIndicator`, `callLabel`, etc.) on thread summary responses.
+
+**REQUIRED CHANGES:**
+
+* Extend thread read contract to indicate whether there are unread calls or voicemails and to include a call/voicemail section on the detail view.  The contract must not leak provider identifiers.
+* Emit domain events at appropriate points in call lifecycle service (start, update, voicemail).  Domain events are written to the platform’s outbox table via existing event publisher functions.
+
+**STOP CONDITION:**
+
+* Integration tests demonstrate that thread timeline returns call and voicemail events in correct order with expected fields.  Event logs show domain events being emitted when calls start, update and voicemail are recorded.
+
+**COMMIT POINT:**
+
+```bash
+git add apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts \
+        apps/connectshyft-api/src/modules/connectshyft/events.ts \
+        apps/connectshyft-api/src/modules/connectshyft/readContracts.ts \
+        apps/connectshyft-api/src/modules/connectshyft/__tests__/threadTimeline.test.ts \
+        tests/integration/connectshyft-api/calls.timeline.integration.test.ts
+git commit -m "feat(connectshyft): unify thread timeline with calls and voicemail and emit call events"
+```
+
+## 13. DEFINITION OF DONE
+
+1. New tables `cs_calls`, `cs_voicemails`, `cs_delivery_attempts`, `cs_provider_events` exist and store telephony artifacts.  `cs_bridge_sessions` includes `person_id`.
+2. Call lifecycle service can start a call, advance its status via provider events, record voicemail and emit domain events.
+3. Provider event ingestion is idempotent and deduplicated.  Voicemail events create `cs_voicemails` rows and update call status.
+4. Thread timeline returns call and voicemail items in chronological order alongside SMS events; read contracts include call/voicemail indicators.
+5. Telephony remains person‑bound and rebind‑safe: all call and voicemail records carry `personId` and are unaffected by thread rebinding.
+6. All new unit and integration tests pass.  No regressions in existing bridge or telephony tests.
+7. The implementation adheres to the locked architecture: no redesign of provider adapters or bridge state machine; no UI changes; minimal surgical edits to existing files.
+
+## 14. NON‑GOALS
+
+* Implementing front‑end UI for telephony; that is deferred to a subsequent slice.  This slice only exposes data for the UI to consume.
+* Designing new provider features or multi‑provider call routing; provider logic remains unchanged.
+* Handling SMS delivery attempts; `cs_delivery_attempts` is created but SMS tracking is deferred to later slices.
+* Merging call logs across threads or persons; call history remains scoped to a thread or person separately.
+* Redesigning the domain bridge state machine; the existing state machine is reused.
+
+## 15. FUTURE EXTENSION POINTS
+
+1. **SMS delivery tracking** – Populate `cs_delivery_attempts` for SMS sends and unify SMS events into the communication timeline.
+2. **Call recordings** – Store call recordings and transcription beyond voicemail, including two‑party conversations when both parties consent.
+3. **Real‑time call control** – Implement APIs for pausing, transferring or ending calls mid‑session and surface call control to operators.
+4. **Analytics** – Build dashboards and reports summarizing call durations, answer rates, voicemail rates and failure codes across tenants and orgUnits.
+5. **Provider abstraction** – Support multiple telephony providers with dynamic selection and fail‑over; unify provider event mapping for multiple vendors.

--- a/tests/integration/connectshyft-api/calls.integration.test.ts
+++ b/tests/integration/connectshyft-api/calls.integration.test.ts
@@ -1,0 +1,225 @@
+import express from 'express';
+import request from 'supertest';
+import { responseEnvelope } from '../../../apps/connectshyft-api/src/platform/middleware/responseEnvelope';
+import { buildPostProviderEventHandler } from '../../../apps/connectshyft-api/src/modules/connectshyft/handlers/postProviderEventHandler';
+import { buildPostThreadCallHandler } from '../../../apps/connectshyft-api/src/modules/connectshyft/handlers/postThreadCallHandler';
+import { buildPostVoicemailHandler } from '../../../apps/connectshyft-api/src/modules/connectshyft/handlers/postVoicemailHandler';
+import { buildConnectShyftHttpRouter } from '../../../apps/connectshyft-api/src/modules/connectshyft/http';
+
+describe('connectshyft calls integration', () => {
+  it('runs the checkpoint 2 call lifecycle across the mounted api routes', async () => {
+    const state = {
+      call: null as null | {
+        id: string;
+        bridgeSessionId: string | null;
+        status: string;
+      },
+      voicemails: [] as Array<{ id: string; artifactId: string }>,
+    };
+
+    const lifecycleService = {
+      startCall: jest.fn(async () => {
+        state.call = {
+          id: 'call-integration-1001',
+          bridgeSessionId: 'bridge-integration-1001',
+          status: 'operator_dialing',
+        };
+
+        return {
+          id: 'call-integration-1001',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          threadId: 'thread-connectshyft-f1-1001',
+          personId: 'person-connectshyft-f1-1001',
+          bridgeSessionId: 'bridge-integration-1001',
+          status: 'operator_dialing' as const,
+          failureCode: null,
+          failureMessage: null,
+          startedAtUtc: '2026-03-23T12:00:00.000Z',
+          operatorAnsweredAtUtc: null,
+          neighborAnsweredAtUtc: null,
+          bridgedAtUtc: null,
+          endedAtUtc: null,
+          createdAtUtc: '2026-03-23T12:00:00.000Z',
+          updatedAtUtc: '2026-03-23T12:00:00.000Z',
+        };
+      }),
+      handleProviderEvent: jest.fn(async (input: { event: { type: string } }) => {
+        if (state.call) {
+          state.call.status = input.event.type;
+        }
+      }),
+      handleVoicemail: jest.fn(async () => {
+        const voicemail = {
+          id: 'voicemail-integration-1001',
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          callId: 'call-integration-1001',
+          threadId: 'thread-connectshyft-f1-1001',
+          personId: 'person-connectshyft-f1-1001',
+          artifactId: 'artifact-integration-1001',
+          recordingUrl: 'https://example.test/integration-vm.mp3',
+          recordingStatus: 'completed' as const,
+          occurredAtUtc: '2026-03-23T12:05:00.000Z',
+          createdAtUtc: '2026-03-23T12:05:00.000Z',
+          updatedAtUtc: '2026-03-23T12:05:00.000Z',
+          transcriptionJson: null,
+        };
+        state.voicemails.push({
+          id: voicemail.id,
+          artifactId: voicemail.artifactId,
+        });
+        if (state.call) {
+          state.call.status = 'voicemail';
+        }
+        return voicemail;
+      }),
+    };
+
+    const app = express();
+    app.use(express.json({
+      verify: (req, _res, buf) => {
+        (req as express.Request & { rawBody?: Buffer }).rawBody = Buffer.from(buf);
+      },
+    }));
+    app.use(responseEnvelope);
+    app.use('/api/v1/connectshyft', buildConnectShyftHttpRouter({
+      postThreadCall: buildPostThreadCallHandler({
+        resolveAccessContext: jest.fn(async () => ({
+          context: {
+            tenantId: 'tenant-connectshyft-f1',
+            orgUnitId: 'org-connectshyft-f1-east',
+          },
+          threadId: 'thread-connectshyft-f1-1001',
+          actorUserId: 'user-connectshyft-f1-operator',
+          actorRoles: ['ORGUNIT_MEMBER'],
+          lifecycleContext: {
+            detail: {
+              personId: 'person-connectshyft-f1-1001',
+            },
+          },
+        })) as any,
+        readinessService: {
+          inspectReadiness: jest.fn(async () => ({
+            bridgeCallRunnable: true,
+          })),
+        } as any,
+        callLifecycleService: lifecycleService as any,
+      }),
+      postProviderEvent: buildPostProviderEventHandler({
+        resolveWebhookAccessContext: jest.fn(async () => ({
+          tenantId: 'tenant-connectshyft-f1',
+          orgUnitId: 'org-connectshyft-f1-east',
+          threadId: 'thread-connectshyft-f1-1001',
+          eventType: 'CallAnswered',
+          normalizedEventType: 'callanswered',
+          providerSelection: {
+            providerResolution: {
+              requestedProvider: 'mock-sandbox',
+              resolvedProvider: 'mock-sandbox',
+              deterministic: true,
+            },
+          },
+          canonicalTranslation: {
+            eventType: 'CallAnswered',
+          },
+          correlation: {
+            ok: true,
+            source: 'provider_fallback',
+            tenantId: 'tenant-connectshyft-f1',
+            orgUnitId: 'org-connectshyft-f1-east',
+            threadId: 'thread-connectshyft-f1-1001',
+            providerLegId: 'provider-leg-operator-1001',
+            providerMessageId: null,
+            providerEventId: null,
+            providerNumberE164: null,
+          },
+        })) as any,
+        loadAggregateByProviderCallId: jest.fn(async () => ({
+          session: {
+            id: 'bridge-integration-1001',
+            tenantId: 'tenant-connectshyft-f1',
+            orgUnitId: 'org-connectshyft-f1-east',
+            threadId: 'thread-connectshyft-f1-1001',
+            status: 'operator_dialing',
+          },
+          operatorLeg: {
+            providerCallId: 'provider-leg-operator-1001',
+          },
+          neighborLeg: {
+            providerCallId: 'provider-leg-neighbor-1001',
+          },
+        })) as any,
+        callLifecycleService: lifecycleService as any,
+      }),
+      postVoicemail: buildPostVoicemailHandler({
+        enforceCapability: jest.fn(async () => ({} as any)),
+        resolveProviderAdapterFn: jest.fn(() => ({
+          ok: true,
+          adapter: {
+            verifyWebhook: jest.fn(() => ({ ok: true })),
+          },
+          providerResolution: {
+            requestedProvider: 'mock-sandbox',
+            resolvedProvider: 'mock-sandbox',
+            deterministic: true,
+          },
+        })) as any,
+        callLifecycleService: lifecycleService as any,
+      }),
+    }));
+
+    const startResponse = await (request as any)(app)
+      .post('/api/v1/connectshyft/thread/thread-connectshyft-f1-1001/call');
+    const providerResponse = await (request as any)(app)
+      .post('/api/v1/connectshyft/provider-events')
+      .send({
+        eventType: 'CallAnswered',
+      });
+    const voicemailResponse = await (request as any)(app)
+      .post('/api/v1/connectshyft/voicemails')
+      .send({
+        tenantId: 'tenant-connectshyft-f1',
+        orgUnitId: 'org-connectshyft-f1-east',
+        callId: 'call-integration-1001',
+        threadId: 'thread-connectshyft-f1-1001',
+        personId: 'person-connectshyft-f1-1001',
+        artifactId: 'artifact-integration-1001',
+        recordingStatus: 'completed',
+      });
+
+    expect(startResponse.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_CALL_STARTED',
+      data: {
+        call: {
+          callId: 'call-integration-1001',
+          status: 'operator_dialing',
+        },
+      },
+    });
+    expect(providerResponse.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_PROVIDER_EVENT_ACCEPTED',
+      data: {
+        handled: true,
+      },
+    });
+    expect(voicemailResponse.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_VOICEMAIL_ACCEPTED',
+      data: {
+        voicemail: {
+          voicemailId: 'voicemail-integration-1001',
+        },
+      },
+    });
+    expect(state.call?.status).toBe('voicemail');
+    expect(state.voicemails).toEqual([
+      {
+        id: 'voicemail-integration-1001',
+        artifactId: 'artifact-integration-1001',
+      },
+    ]);
+  });
+});

--- a/tests/integration/connectshyft-api/calls.timeline.integration.test.ts
+++ b/tests/integration/connectshyft-api/calls.timeline.integration.test.ts
@@ -1,0 +1,275 @@
+import {
+  recordConnectShyftCanonicalEvent,
+  resetConnectShyftCanonicalEventsForTests,
+} from '../../../apps/connectshyft-api/src/modules/connectshyft/canonicalEvents';
+import {
+  buildConnectShyftCallLifecycleService,
+} from '../../../apps/connectshyft-api/src/modules/connectshyft/callLifecycle';
+import {
+  connectShyftCallServiceAsync,
+  resetConnectShyftCallStateForTests,
+} from '../../../apps/connectshyft-api/src/modules/connectshyft/calls';
+import {
+  listConnectShyftLifecycleEventsForTests,
+  resetConnectShyftLifecycleEventsForTests,
+} from '../../../apps/connectshyft-api/src/modules/connectshyft/events';
+import {
+  loadConnectShyftBridgeAggregateByThreadId,
+  resetConnectShyftBridgeSessionStateForTests,
+} from '../../../apps/connectshyft-api/src/modules/connectshyft/bridgeSessions';
+import { CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME } from '../../../apps/connectshyft-api/src/modules/connectshyft/inboundSms';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../apps/connectshyft-api/src/modules/connectshyft/providerCorrelationMappings';
+import { resolveConnectShyftProviderAdapter } from '../../../apps/connectshyft-api/src/modules/connectshyft/providerRegistry';
+import { getThreadTimeline } from '../../../apps/connectshyft-api/src/modules/connectshyft/threadTimeline';
+import { resetConnectShyftVoicemailStateForTests } from '../../../apps/connectshyft-api/src/modules/connectshyft/voicemails';
+
+const tenantId = 'tenant-connectshyft-f1';
+const orgUnitId = 'org-connectshyft-f1-east';
+const threadId = 'thread-f1-call-timeline-1001';
+const personId = 'person-connectshyft-f1-1001';
+const actorUserId = 'user-connectshyft-f1-operator';
+const providerRegistryHeaders = {
+  'x-test-connectshyft-enabled-providers': '["mock-sandbox"]',
+  'x-test-connectshyft-disabled-providers': '[]',
+};
+
+const thread = {
+  threadId,
+  tenantId,
+  orgUnitId,
+  neighborId: 'neighbor-connectshyft-f1-1001',
+  personId,
+  activityId: null,
+  source: 'VOICE',
+  state: 'UNCLAIMED' as const,
+  lastInboundCsNumberId: '+12605550199',
+  preferredOutboundCsNumberId: '+12605550191',
+  claimedByUserId: null,
+  claimedAtUtc: null,
+  closedByUserId: null,
+  closedAtUtc: null,
+  createdAtUtc: '2026-03-24T12:00:00.000Z',
+  updatedAtUtc: '2026-03-24T12:00:00.000Z',
+  escalation: {
+    stage: 0,
+    nextEvaluationAtUtc: null,
+  },
+};
+
+describe('connectshyft call timeline integration', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+  });
+
+  beforeEach(() => {
+    resetConnectShyftCallStateForTests();
+    resetConnectShyftVoicemailStateForTests();
+    resetConnectShyftBridgeSessionStateForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+    resetConnectShyftCanonicalEventsForTests();
+    resetConnectShyftLifecycleEventsForTests();
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags;
+  });
+
+  const buildService = () => buildConnectShyftCallLifecycleService({
+    threadService: {
+      findThreadById: jest.fn(async () => thread),
+    },
+    neighborService: {
+      resolveNeighbor: jest.fn(async () => ({
+        ok: true,
+        code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
+        httpStatus: 200,
+        data: {
+          neighbor: {
+            neighborId: thread.neighborId,
+            phones: [
+              {
+                phoneId: 'neighbor-phone-1001',
+                label: 'Primary',
+                value: '+12605550111',
+                verificationStatus: 'VERIFIED',
+                isPrimary: true,
+                isShared: false,
+                sortOrder: 0,
+                isActive: true,
+                createdAtUtc: '2026-03-24T10:00:00.000Z',
+                updatedAtUtc: '2026-03-24T10:00:00.000Z',
+                provenance: {},
+              },
+            ],
+          },
+        },
+      })) as any,
+    },
+    resolveOperatorDestinationFn: jest.fn(async () => ({
+      phoneNumber: '+12605550155',
+      source: 'actor_user' as const,
+      userId: actorUserId,
+      orgUnitId,
+    })),
+    resolveSenderNumberFn: jest.fn(async () => ({
+      ok: true,
+      providerNumberE164: '+12605550191',
+      mappingId: 'mapping-connectshyft-f1-1001',
+      routingMetadata: {
+        deterministic: true,
+        channel: 'voice',
+        source: 'thread_alignment',
+        mappingLabel: 'Main line',
+        threadId,
+        tenantId,
+        orgUnitId,
+        preferredOutboundCsNumberId: '+12605550191',
+        lastInboundCsNumberId: '+12605550191',
+        alignedFrom: 'preferred_outbound',
+        candidateProviderNumberE164: '+12605550191',
+      },
+    })) as any,
+    resolveProviderAdapterFn: (input) => resolveConnectShyftProviderAdapter({
+      ...input,
+      req: {
+        ...input.req,
+        header: (name: string) => providerRegistryHeaders[name.toLowerCase() as keyof typeof providerRegistryHeaders],
+        headers: providerRegistryHeaders,
+      },
+    }),
+  });
+
+  it('returns sms, call, and voicemail timeline items in order and records lifecycle events', async () => {
+    const service = buildService();
+
+    const call = await service.startCall({
+      tenantId,
+      orgUnitId,
+      threadId,
+      personId,
+      actorRoles: ['ORGUNIT_MEMBER'],
+      actorUserId,
+      requestedProvider: 'mock-sandbox',
+      providerRegistryHeaders,
+    });
+    const startedAtMs = new Date(call.startedAtUtc).getTime();
+    const smsOccurredAtUtc = new Date(startedAtMs - 60_000).toISOString();
+    const operatorAnsweredAt = new Date(startedAtMs + 30_000);
+    const failedAtUtc = new Date(startedAtMs + 60_000).toISOString();
+    const voicemailOccurredAt = new Date(startedAtMs + 90_000);
+
+    await recordConnectShyftCanonicalEvent({
+      tenantId,
+      orgUnitId,
+      aggregateId: threadId,
+      aggregateType: 'Thread',
+      eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+      occurredAtUtc: smsOccurredAtUtc,
+      payload: {
+        direction: 'inbound',
+        channel: 'sms',
+        actor: 'neighbor',
+        eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+        inboundMessageArtifact: {
+          body: 'Need help before the call',
+        },
+      },
+    });
+
+    const aggregate = await loadConnectShyftBridgeAggregateByThreadId({
+      tenantId,
+      threadId,
+    });
+    expect(aggregate).not.toBeNull();
+
+    await service.handleProviderEvent({
+      tenantId,
+      provider: 'mock-sandbox',
+      event: {
+        type: 'operator_answered',
+        bridgeSessionId: aggregate!.session.id,
+        providerCallId: aggregate!.operatorLeg.providerCallId!,
+        occurredAt: operatorAnsweredAt,
+      },
+      eventJson: {
+        eventType: 'CallAnswered',
+      },
+      providerCallId: aggregate!.operatorLeg.providerCallId!,
+      occurredAt: operatorAnsweredAt,
+    });
+
+    await connectShyftCallServiceAsync.updateCallStatus({
+      callId: call.id,
+      tenantId,
+      status: 'failed',
+      bridgeSessionId: call.bridgeSessionId,
+      endedAtUtc: failedAtUtc,
+      failureCode: 'neighbor_unavailable',
+      failureMessage: 'Neighbor did not answer.',
+    });
+
+    await service.handleVoicemail({
+      tenantId,
+      orgUnitId,
+      callId: call.id,
+      threadId,
+      personId,
+      artifactId: 'artifact-call-timeline-1001',
+      recordingUrl: 'https://example.test/call-timeline-vm.mp3',
+      recordingStatus: 'completed',
+      occurredAt: voicemailOccurredAt,
+      transcriptionJson: {
+        text: 'Please call me back',
+      },
+    });
+
+    const timeline = await getThreadTimeline({
+      tenantId,
+      orgUnitId,
+      threadId,
+    });
+
+    expect(timeline.items.map((item) => item.type)).toEqual([
+      'message',
+      'voice_event',
+      'voicemail',
+    ]);
+    expect(timeline.items[0]).toMatchObject({
+      channel: 'sms',
+      body: 'Need help before the call',
+      occurredAtUtc: smsOccurredAtUtc,
+    });
+    expect(timeline.items[1]).toMatchObject({
+      id: `call-${call.id}`,
+      channel: 'voice',
+      deliveryStatus: 'voicemail',
+      providerMetadata: expect.objectContaining({
+        callId: call.id,
+        status: 'voicemail',
+        statusEvents: expect.arrayContaining([
+          expect.objectContaining({ status: 'operator_dialing' }),
+          expect.objectContaining({ status: 'operator_answered' }),
+          expect.objectContaining({ status: 'voicemail' }),
+        ]),
+      }),
+    });
+    expect(timeline.items[2]).toMatchObject({
+      channel: 'voicemail',
+      recordingUrl: 'https://example.test/call-timeline-vm.mp3',
+      deliveryStatus: 'completed',
+    });
+
+    expect(listConnectShyftLifecycleEventsForTests().map((event) => event.eventName)).toEqual(
+      expect.arrayContaining([
+        'connectshyft.call.started',
+        'connectshyft.call.updated',
+        'connectshyft.voicemail.recorded',
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- persist slice 25 telephony artifacts and person-bound bridge-session data\n- implement call lifecycle handling, provider event ingestion, voicemail persistence, and timeline projection\n- add lifecycle event publishing, read-contract telephony indicators, and timeline integration coverage\n\n## Validation\n- pnpm --filter migration-runner run migrate:latest\n- ./node_modules/.bin/jest src/modules/connectshyft/__tests__/callLifecycle.test.ts src/modules/connectshyft/handlers/__tests__/postThreadCallHandler.test.ts src/modules/connectshyft/handlers/__tests__/postProviderEventHandler.test.ts src/modules/connectshyft/handlers/__tests__/postVoicemailHandler.test.ts src/modules/connectshyft/__tests__/threadTimeline.test.ts --runInBand\n- ./node_modules/.bin/jest src/modules/connectshyft/__tests__/callLifecycle.test.ts src/modules/connectshyft/__tests__/threadTimeline.test.ts src/modules/connectshyft/__tests__/readContracts.test.ts --runInBand\n- ./node_modules/.bin/jest --runTestsByPath ../../tests/integration/connectshyft-api/calls.integration.test.ts --runInBand\n- ./node_modules/.bin/jest --runTestsByPath ../../tests/integration/connectshyft-api/calls.timeline.integration.test.ts --runInBand