### PR TITLE
feat(slice-26): implement resolver rebinding

### DIFF
--- a/apps/connectshyft-api/src/app.ts
+++ b/apps/connectshyft-api/src/app.ts
@@ -85,6 +85,9 @@ const csrfProtection = useMinimalAppShell
 const connectShyftRouter = useMinimalAppShell
   ? express.Router()
   : require('./routes/api/v1/connectshyft').default;
+const postMergePerson = useMinimalAppShell
+  ? null
+  : require('./modules/peoplecore/handlers/postMergePerson').postMergePerson;
 
 app.use(cors({
   origin: process.env.FRONTEND_URL || 'http://localhost:5173',
@@ -203,6 +206,9 @@ app.post('/people/resolver-reviews', (req: any, res: any) => {
 });
 
 app.use(csrfProtection);
+if (postMergePerson) {
+  app.post('/api/v1/peoplecore/persons/merge', postMergePerson);
+}
 app.use('/api/v1/connectshyft', connectShyftRouter);
 
 app.use((req: any, res: any) => {

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/personRebind.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/personRebind.test.ts
@@ -1,0 +1,447 @@
+import * as canonicalEventsModule from '../canonicalEvents';
+import {
+  loadConnectShyftBridgeAggregateBySessionId,
+  resetConnectShyftBridgeSessionStateForTests,
+  startConnectShyftBridgeSession,
+} from '../bridgeSessions';
+import {
+  connectShyftCallServiceAsync,
+  resetConnectShyftCallStateForTests,
+} from '../calls';
+import {
+  connectShyftDeliveryAttemptServiceAsync,
+  resetConnectShyftDeliveryAttemptStateForTests,
+} from '../deliveryAttempts';
+import {
+  personRebindServiceAsync,
+  resetConnectShyftPersonRebindStateForTests,
+} from '../personRebind';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../providerCorrelationMappings';
+import type { ConnectShyftProviderAdapter } from '../providerRegistry';
+import {
+  connectShyftThreadService,
+  resetConnectShyftThreadStateForTests,
+  type ConnectShyftThread,
+} from '../threads';
+import {
+  connectShyftVoicemailServiceAsync,
+  resetConnectShyftVoicemailStateForTests,
+} from '../voicemails';
+import { peopleCoreServiceAsync } from '../../peoplecore/service';
+
+const tenantId = 'tenant-connectshyft-rebind-f1';
+const orgUnitId = 'org-connectshyft-rebind-f1-east';
+const provisionalPersonId = 'person-connectshyft-rebind-provisional-1001';
+const canonicalPersonId = 'person-connectshyft-rebind-canonical-1001';
+const performedByUserId = 'user-connectshyft-rebind-operator-1001';
+
+const sendSmsMock = jest.fn();
+const startOutboundCallMock = jest.fn();
+const startBridgeOutboundCallMock = jest.fn(async (input: { legRole: string; threadId: string }) => ({
+  providerKey: 'provider-a',
+  channel: 'call' as const,
+  providerLegId: `${input.legRole}-provider-leg-${input.threadId}`,
+  providerMessageId: null,
+  providerRequestId: `req-${input.legRole}-${input.threadId}`,
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-24T12:00:00.000Z',
+}));
+const startBridgeSessionMock = jest.fn(async (input: { bridgeSessionId: string }) => ({
+  providerKey: 'provider-a',
+  bridgeSessionId: input.bridgeSessionId,
+  bridgeEstablished: true as const,
+  providerRequestId: 'req-bridge-session-1001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-24T12:01:00.000Z',
+}));
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const endCallMock = jest.fn(async (input: { providerLegId: string }) => ({
+  providerKey: 'provider-a',
+  providerLegId: input.providerLegId,
+  ended: true as const,
+  providerRequestId: 'req-end-call-1001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-24T12:02:00.000Z',
+}));
+const translateProviderEventMock = jest.fn(() => ({
+  eventType: 'CallAnswered',
+  payload: {},
+  correlation: {
+    providerLegId: null,
+    providerMessageId: null,
+    providerEventId: null,
+    providerNumber: null,
+  },
+  providerNeutral: true as const,
+  providerSpecificFieldsStripped: true as const,
+  providerBranchingInDomain: false as const,
+}));
+
+const providerAdapter: ConnectShyftProviderAdapter = {
+  providerKey: 'provider-a',
+  adapterInterfaceVersion: 'v1',
+  sendSms: sendSmsMock,
+  startOutboundCall: startOutboundCallMock,
+  startBridgeOutboundCall: startBridgeOutboundCallMock,
+  verifyWebhook: verifyWebhookMock,
+  translateProviderEvent: translateProviderEventMock,
+  startBridgeSession: startBridgeSessionMock,
+  endCall: endCallMock,
+};
+
+const buildThread = (input: {
+  threadId: string;
+  neighborId: string;
+  personId: string;
+  source?: string;
+}): ConnectShyftThread => {
+  const result = connectShyftThreadService.ensureThread({
+    actorRoles: ['ORGUNIT_MEMBER'],
+    tenantId,
+    orgUnitId,
+    neighborId: input.neighborId,
+    personId: input.personId,
+    source: input.source ?? 'VOICE',
+    threadId: input.threadId,
+    lastInboundCsNumberId: `${input.threadId}-inbound-number`,
+    preferredOutboundCsNumberId: `${input.threadId}-outbound-number`,
+  });
+
+  if (!result.ok) {
+    throw new Error(`Expected ensureThread to succeed for ${input.threadId}.`);
+  }
+
+  return result.data.thread;
+};
+
+const buildPerson = (input: {
+  id: string;
+  status: 'active_confirmed' | 'active_provisional' | 'merged';
+  mergedIntoPersonId?: string;
+}) => ({
+  id: input.id,
+  tenantId,
+  orgUnitId,
+  firstName: 'Pat',
+  lastName: 'Shyft',
+  status: input.status,
+  mergedIntoPersonId: input.mergedIntoPersonId,
+  createdAt: '2026-03-24T08:00:00.000Z',
+  updatedAt: '2026-03-24T08:00:00.000Z',
+});
+
+describe('connectshyft person rebinding', () => {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = 'true';
+  });
+
+  beforeEach(() => {
+    sendSmsMock.mockReset();
+    startOutboundCallMock.mockReset();
+    startBridgeOutboundCallMock.mockClear();
+    startBridgeSessionMock.mockClear();
+    verifyWebhookMock.mockClear();
+    endCallMock.mockClear();
+    translateProviderEventMock.mockClear();
+    resetConnectShyftThreadStateForTests();
+    resetConnectShyftCallStateForTests();
+    resetConnectShyftVoicemailStateForTests();
+    resetConnectShyftDeliveryAttemptStateForTests();
+    resetConnectShyftBridgeSessionStateForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+    resetConnectShyftPersonRebindStateForTests();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = previousNodeEnv;
+    process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS = previousEnableFlags;
+  });
+
+  it('updates thread personId, sets originPersonId, and leaves the remaining thread fields untouched', async () => {
+    const initialThread = buildThread({
+      threadId: 'thread-rebind-1001',
+      neighborId: 'neighbor-rebind-1001',
+      personId: provisionalPersonId,
+    });
+
+    await personRebindServiceAsync.rebindPersonThreads({
+      tenantId,
+      orgUnitId,
+      provisionalPersonId,
+      canonicalPersonId,
+      performedByUserId,
+    });
+
+    const reboundThread = connectShyftThreadService.findThreadById({
+      tenantId,
+      threadId: initialThread.threadId,
+    });
+
+    expect(reboundThread).toMatchObject({
+      threadId: initialThread.threadId,
+      tenantId: initialThread.tenantId,
+      orgUnitId: initialThread.orgUnitId,
+      neighborId: initialThread.neighborId,
+      personId: canonicalPersonId,
+      originPersonId: provisionalPersonId,
+      activityId: initialThread.activityId,
+      source: initialThread.source,
+      state: initialThread.state,
+      lastInboundCsNumberId: initialThread.lastInboundCsNumberId,
+      preferredOutboundCsNumberId: initialThread.preferredOutboundCsNumberId,
+      claimedByUserId: initialThread.claimedByUserId,
+      claimedAtUtc: initialThread.claimedAtUtc,
+      closedByUserId: initialThread.closedByUserId,
+      closedAtUtc: initialThread.closedAtUtc,
+      createdAtUtc: initialThread.createdAtUtc,
+      updatedAtUtc: initialThread.updatedAtUtc,
+      escalation: initialThread.escalation,
+    });
+  });
+
+  it('updates person_id on calls, voicemails, delivery attempts, and bridge sessions', async () => {
+    const thread = buildThread({
+      threadId: 'thread-rebind-telephony-1001',
+      neighborId: 'neighbor-rebind-telephony-1001',
+      personId: provisionalPersonId,
+    });
+    const call = await connectShyftCallServiceAsync.createCall({
+      tenantId,
+      orgUnitId,
+      threadId: thread.threadId,
+      personId: provisionalPersonId,
+    });
+    await connectShyftVoicemailServiceAsync.createVoicemail({
+      tenantId,
+      orgUnitId,
+      callId: call.id,
+      threadId: thread.threadId,
+      personId: provisionalPersonId,
+      artifactId: 'artifact-telephony-1001',
+      recordingUrl: 'https://example.test/recording.mp3',
+      recordingStatus: 'completed',
+      occurredAtUtc: '2026-03-24T11:00:00.000Z',
+    });
+    await connectShyftDeliveryAttemptServiceAsync.createAttempt({
+      tenantId,
+      orgUnitId,
+      threadId: thread.threadId,
+      personId: provisionalPersonId,
+      callId: call.id,
+      channel: 'voice',
+      status: 'succeeded',
+    });
+    const bridgeSession = await startConnectShyftBridgeSession({
+      tenantId,
+      orgUnitId,
+      threadId: thread.threadId,
+      personId: provisionalPersonId,
+      operatorParticipantId: 'operator-rebind-1001',
+      neighborParticipantId: thread.neighborId,
+      operatorContactPointId: '+12605550155',
+      neighborContactPointId: '+12605550111',
+      selectedOutboundContactPointId: '+12605550191',
+      providerKey: 'provider-a',
+      providerAdapter,
+    });
+
+    await personRebindServiceAsync.rebindPersonThreads({
+      tenantId,
+      orgUnitId,
+      provisionalPersonId,
+      canonicalPersonId,
+      performedByUserId,
+    });
+
+    const reboundCall = await connectShyftCallServiceAsync.getCallById(call.id, tenantId);
+    const reboundVoicemail = await connectShyftVoicemailServiceAsync.listCallVoicemails({
+      tenantId,
+      callId: call.id,
+    });
+    const canonicalAttempts = await connectShyftDeliveryAttemptServiceAsync.listPersonAttempts({
+      tenantId,
+      orgUnitId,
+      personId: canonicalPersonId,
+    });
+    const provisionalAttempts = await connectShyftDeliveryAttemptServiceAsync.listPersonAttempts({
+      tenantId,
+      orgUnitId,
+      personId: provisionalPersonId,
+    });
+    const reboundBridgeAggregate = await loadConnectShyftBridgeAggregateBySessionId(
+      bridgeSession.aggregate.session.id,
+    );
+
+    expect(reboundCall?.personId).toBe(canonicalPersonId);
+    expect(reboundVoicemail[0]?.personId).toBe(canonicalPersonId);
+    expect(canonicalAttempts).toHaveLength(1);
+    expect(canonicalAttempts[0]?.personId).toBe(canonicalPersonId);
+    expect(provisionalAttempts).toEqual([]);
+    expect(
+      (reboundBridgeAggregate?.session as { personId?: string | null } | undefined)?.personId,
+    ).toBe(canonicalPersonId);
+  });
+
+  it('is idempotent when the same provisional and canonical pair is rebound twice', async () => {
+    const thread = buildThread({
+      threadId: 'thread-rebind-idempotent-1001',
+      neighborId: 'neighbor-rebind-idempotent-1001',
+      personId: provisionalPersonId,
+    });
+    const call = await connectShyftCallServiceAsync.createCall({
+      tenantId,
+      orgUnitId,
+      threadId: thread.threadId,
+      personId: provisionalPersonId,
+    });
+
+    const input = {
+      tenantId,
+      orgUnitId,
+      provisionalPersonId,
+      canonicalPersonId,
+      performedByUserId,
+    };
+
+    await personRebindServiceAsync.rebindPersonThreads(input);
+
+    const firstThreadState = connectShyftThreadService.findThreadById({
+      tenantId,
+      threadId: thread.threadId,
+    });
+    const firstCallState = await connectShyftCallServiceAsync.getCallById(call.id, tenantId);
+
+    await personRebindServiceAsync.rebindPersonThreads(input);
+
+    const secondThreadState = connectShyftThreadService.findThreadById({
+      tenantId,
+      threadId: thread.threadId,
+    });
+    const secondCallState = await connectShyftCallServiceAsync.getCallById(call.id, tenantId);
+
+    expect(secondThreadState).toEqual(firstThreadState);
+    expect(secondCallState).toEqual(firstCallState);
+  });
+
+  it('returns a unified, ordered timeline spanning canonical and merged person history with origin context', async () => {
+    const canonicalThread = buildThread({
+      threadId: 'thread-unified-canonical-1001',
+      neighborId: 'neighbor-unified-canonical-1001',
+      personId: canonicalPersonId,
+      source: 'SMS',
+    });
+    const mergedThread = buildThread({
+      threadId: 'thread-unified-merged-1001',
+      neighborId: 'neighbor-unified-merged-1001',
+      personId: provisionalPersonId,
+      source: 'SMS',
+    });
+
+    await personRebindServiceAsync.rebindPersonThreads({
+      tenantId,
+      orgUnitId,
+      provisionalPersonId,
+      canonicalPersonId,
+      performedByUserId,
+    });
+
+    jest.spyOn(peopleCoreServiceAsync, 'getPerson').mockResolvedValue(
+      buildPerson({
+        id: canonicalPersonId,
+        status: 'active_confirmed',
+      }),
+    );
+    jest.spyOn(peopleCoreServiceAsync, 'listPersons').mockResolvedValue([
+      buildPerson({
+        id: canonicalPersonId,
+        status: 'active_confirmed',
+      }),
+      buildPerson({
+        id: provisionalPersonId,
+        status: 'merged',
+        mergedIntoPersonId: canonicalPersonId,
+      }),
+    ]);
+    jest.spyOn(canonicalEventsModule, 'listConnectShyftCanonicalEvents').mockImplementation(
+      async (input) => {
+        if (input.aggregateId === mergedThread.threadId) {
+          return [
+            {
+              eventId: 'event-merged-1001',
+              aggregateId: mergedThread.threadId,
+              aggregateType: 'Thread',
+              eventType: 'connectshyft.thread.outbound_message_dispatched',
+              occurredAtUtc: '2026-03-24T09:59:00.000Z',
+              payload: {
+                direction: 'outbound',
+                channel: 'sms',
+                actor: 'user',
+                eventName: 'connectshyft.thread.outbound_message_dispatched',
+                outboundMessageArtifact: {
+                  body: 'Merged person timeline item',
+                },
+              },
+            },
+          ];
+        }
+
+        if (input.aggregateId === canonicalThread.threadId) {
+          return [
+            {
+              eventId: 'event-canonical-1001',
+              aggregateId: canonicalThread.threadId,
+              aggregateType: 'Thread',
+              eventType: 'connectshyft.inbound.sms_appended',
+              occurredAtUtc: '2026-03-24T10:00:00.000Z',
+              payload: {
+                direction: 'inbound',
+                channel: 'sms',
+                actor: 'neighbor',
+                eventName: 'connectshyft.inbound.sms_appended',
+                inboundMessageArtifact: {
+                  body: 'Canonical person timeline item',
+                },
+              },
+            },
+          ];
+        }
+
+        return [];
+      },
+    );
+
+    const timeline = await personRebindServiceAsync.projectUnifiedTimeline({
+      tenantId,
+      personId: canonicalPersonId,
+    });
+
+    expect(timeline.personId).toBe(canonicalPersonId);
+    expect(timeline.mergedPersonIds).toEqual([provisionalPersonId]);
+    expect(timeline.items.map((item) => item.id)).toEqual([
+      'event-merged-1001',
+      'event-canonical-1001',
+    ]);
+    expect(timeline.items[0]).toMatchObject({
+      threadId: mergedThread.threadId,
+      personContext: {
+        personId: canonicalPersonId,
+        originPersonId: provisionalPersonId,
+      },
+    });
+    expect(timeline.items[1]).toMatchObject({
+      threadId: canonicalThread.threadId,
+      personContext: {
+        personId: canonicalPersonId,
+        originPersonId: null,
+      },
+    });
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/bridgeSessions.ts
@@ -51,6 +51,13 @@ export interface ConnectShyftBridgeLegProviderControlUpdateInput {
   providerCallControlId: string
 }
 
+export interface RebindConnectShyftBridgeSessionPersonInput {
+  tenantId: string
+  orgUnitId: string
+  provisionalPersonId: string
+  canonicalPersonId: string
+}
+
 type PersistedConnectShyftBridgeLegRole = ConnectShyftBridgeLegRole
 
 type ConnectShyftBridgeSessionScope = {
@@ -612,6 +619,23 @@ class InMemoryConnectShyftBridgeSessionStore implements BridgeSessionRepository 
     })
   }
 
+  async rebindPerson(input: RebindConnectShyftBridgeSessionPersonInput): Promise<void> {
+    this.sessions.forEach((session, sessionId) => {
+      if (
+        session.tenantId !== input.tenantId
+        || session.orgUnitId !== input.orgUnitId
+        || normalizeString(session.personId) !== input.provisionalPersonId
+      ) {
+        return
+      }
+
+      this.sessions.set(sessionId, {
+        ...session,
+        personId: input.canonicalPersonId,
+      })
+    })
+  }
+
   reset(): void {
     this.sessions.clear()
     this.legsBySessionId.clear()
@@ -621,7 +645,7 @@ class InMemoryConnectShyftBridgeSessionStore implements BridgeSessionRepository 
   }
 }
 
-class KnexConnectShyftBridgeSessionStore implements BridgeSessionRepository {
+export class KnexConnectShyftBridgeSessionStore implements BridgeSessionRepository {
   constructor(private readonly knexClient: Knex = db) {}
 
   async createSession(session: BridgeSessionRecord): Promise<void> {
@@ -932,6 +956,20 @@ class KnexConnectShyftBridgeSessionStore implements BridgeSessionRepository {
     }
 
     return this.getAggregateBySessionId(sessionId)
+  }
+
+  async rebindPerson(input: RebindConnectShyftBridgeSessionPersonInput): Promise<void> {
+    await this.knexClient
+      .withSchema('connectshyft')
+      .table(BRIDGE_SESSIONS_TABLE)
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        person_id: input.provisionalPersonId,
+      })
+      .update({
+        person_id: input.canonicalPersonId,
+      })
   }
 }
 
@@ -1426,6 +1464,29 @@ export const loadConnectShyftBridgeAggregateByProviderCallId = async (input: {
   tenantId?: string | null
   providerCallId: string
 }): Promise<BridgeSessionAggregate | null> => repositoryProxy.getAggregateByProviderCallId(input)
+
+export async function rebindConnectShyftBridgeSessionPersonsAsync(
+  input: RebindConnectShyftBridgeSessionPersonInput,
+  knexClient?: Knex,
+): Promise<void> {
+  if (isConnectShyftTestOverrideEnabled() && !knexClient) {
+    await inMemoryBridgeSessionStore.rebindPerson(input)
+    return
+  }
+
+  try {
+    const store = knexClient
+      ? new KnexConnectShyftBridgeSessionStore(knexClient)
+      : knexBridgeSessionStore
+    await store.rebindPerson(input)
+  } catch (error) {
+    if (!isMissingPersistenceError(error)) {
+      throw error
+    }
+
+    await inMemoryBridgeSessionStore.rebindPerson(input)
+  }
+}
 
 export const startConnectShyftBridgeSession = async (
   input: StartConnectShyftBridgeSessionInput,

--- a/apps/connectshyft-api/src/modules/connectshyft/calls.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/calls.ts
@@ -71,12 +71,20 @@ export interface ListPersonCallsInput {
   personId: string;
 }
 
+export interface RebindCallPersonInput {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+}
+
 export interface ConnectShyftCallService {
   createCall(input: CreateCallInput): Promise<Call>;
   updateCallStatus(input: UpdateCallStatusInput): Promise<void>;
   listThreadCalls(input: ListThreadCallsInput): Promise<Call[]>;
   listPersonCalls(input: ListPersonCallsInput): Promise<Call[]>;
   getCallById(callId: string, tenantId: string): Promise<Call | null>;
+  rebindPersonCalls(input: RebindCallPersonInput): Promise<void>;
 }
 
 type DbCallRow = {
@@ -266,12 +274,29 @@ class InMemoryConnectShyftCallStore implements ConnectShyftCallService {
     return record;
   }
 
+  async rebindPersonCalls(input: RebindCallPersonInput): Promise<void> {
+    this.records.forEach((call, callId) => {
+      if (
+        call.tenantId !== input.tenantId
+        || call.orgUnitId !== input.orgUnitId
+        || call.personId !== input.provisionalPersonId
+      ) {
+        return;
+      }
+
+      this.records.set(callId, {
+        ...call,
+        personId: input.canonicalPersonId,
+      });
+    });
+  }
+
   reset(): void {
     this.records.clear();
   }
 }
 
-class KnexConnectShyftCallStore implements ConnectShyftCallService {
+export class KnexConnectShyftCallStore implements ConnectShyftCallService {
   constructor(private readonly knexClient: Knex = db) {}
 
   private table() {
@@ -388,6 +413,18 @@ class KnexConnectShyftCallStore implements ConnectShyftCallService {
 
     return row ? mapCallRow(row) : null;
   }
+
+  async rebindPersonCalls(input: RebindCallPersonInput): Promise<void> {
+    await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        person_id: input.provisionalPersonId,
+      })
+      .update({
+        person_id: input.canonicalPersonId,
+      });
+  }
 }
 
 const inMemoryConnectShyftCallStore = new InMemoryConnectShyftCallStore();
@@ -462,6 +499,22 @@ class AsyncConnectShyftCallService implements ConnectShyftCallService {
 
     try {
       return await knexConnectShyftCallStore.getCallById(callId, tenantId);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+
+  async rebindPersonCalls(input: RebindCallPersonInput): Promise<void> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      await inMemoryConnectShyftCallStore.rebindPersonCalls(input);
+      return;
+    }
+
+    try {
+      await knexConnectShyftCallStore.rebindPersonCalls(input);
     } catch (error) {
       if (isConnectShyftPersistenceErrorCause(error)) {
         throw new ConnectShyftPersistenceUnavailableError(error);

--- a/apps/connectshyft-api/src/modules/connectshyft/deliveryAttempts.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/deliveryAttempts.ts
@@ -23,15 +23,100 @@ export interface CreateDeliveryAttemptInput {
   failureMessage?: string | null;
 }
 
+export type DeliveryAttempt = {
+  id: string;
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  personId: string;
+  callId: string | null;
+  channel: 'sms' | 'voice';
+  providerEventId: string | null;
+  status: 'pending' | 'succeeded' | 'failed' | 'canceled';
+  failureCode: string | null;
+  failureMessage: string | null;
+  createdAtUtc: string;
+  updatedAtUtc: string;
+};
+
+export interface ListPersonDeliveryAttemptsInput {
+  tenantId: string;
+  orgUnitId: string;
+  personId: string;
+}
+
+export interface RebindDeliveryAttemptPersonInput {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+}
+
 export interface ConnectShyftDeliveryAttemptService {
   createAttempt(input: CreateDeliveryAttemptInput): Promise<void>;
+  listPersonAttempts(input: ListPersonDeliveryAttemptsInput): Promise<DeliveryAttempt[]>;
+  rebindPersonAttempts(input: RebindDeliveryAttemptPersonInput): Promise<void>;
 }
 
 class InMemoryConnectShyftDeliveryAttemptStore implements ConnectShyftDeliveryAttemptService {
-  async createAttempt(_input: CreateDeliveryAttemptInput): Promise<void> {}
+  private readonly records = new Map<string, DeliveryAttempt>();
+
+  async createAttempt(input: CreateDeliveryAttemptInput): Promise<void> {
+    const nowIsoUtc = new Date().toISOString();
+    const attempt: DeliveryAttempt = {
+      id: randomUUID(),
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      threadId: input.threadId,
+      personId: input.personId,
+      callId: input.callId ?? null,
+      channel: input.channel,
+      providerEventId: input.providerEventId ?? null,
+      status: input.status,
+      failureCode: input.failureCode ?? null,
+      failureMessage: input.failureMessage ?? null,
+      createdAtUtc: nowIsoUtc,
+      updatedAtUtc: nowIsoUtc,
+    };
+
+    this.records.set(attempt.id, attempt);
+  }
+
+  async listPersonAttempts(input: ListPersonDeliveryAttemptsInput): Promise<DeliveryAttempt[]> {
+    return [...this.records.values()]
+      .filter((attempt) => (
+        attempt.tenantId === input.tenantId
+        && attempt.orgUnitId === input.orgUnitId
+        && attempt.personId === input.personId
+      ))
+      .sort((left, right) => (
+        new Date(right.createdAtUtc).getTime() - new Date(left.createdAtUtc).getTime()
+      ) || right.id.localeCompare(left.id));
+  }
+
+  async rebindPersonAttempts(input: RebindDeliveryAttemptPersonInput): Promise<void> {
+    this.records.forEach((attempt, attemptId) => {
+      if (
+        attempt.tenantId !== input.tenantId
+        || attempt.orgUnitId !== input.orgUnitId
+        || attempt.personId !== input.provisionalPersonId
+      ) {
+        return;
+      }
+
+      this.records.set(attemptId, {
+        ...attempt,
+        personId: input.canonicalPersonId,
+      });
+    });
+  }
+
+  reset(): void {
+    this.records.clear();
+  }
 }
 
-class KnexConnectShyftDeliveryAttemptStore implements ConnectShyftDeliveryAttemptService {
+export class KnexConnectShyftDeliveryAttemptStore implements ConnectShyftDeliveryAttemptService {
   constructor(private readonly knexClient: Knex = db) {}
 
   async createAttempt(input: CreateDeliveryAttemptInput): Promise<void> {
@@ -52,6 +137,68 @@ class KnexConnectShyftDeliveryAttemptStore implements ConnectShyftDeliveryAttemp
         failure_message: input.failureMessage ?? null,
         created_at_utc: new Date().toISOString(),
         updated_at_utc: new Date().toISOString(),
+      });
+  }
+
+  async listPersonAttempts(input: ListPersonDeliveryAttemptsInput): Promise<DeliveryAttempt[]> {
+    const rows = await this.knexClient
+      .withSchema(CONNECTSHYFT_SCHEMA)
+      .table(DELIVERY_ATTEMPTS_TABLE)
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        person_id: input.personId,
+      })
+      .orderBy('created_at_utc', 'desc')
+      .orderBy('id', 'desc')
+      .select<Array<{
+        id: string;
+        tenant_id: string;
+        org_unit_id: string;
+        thread_id: string;
+        person_id: string;
+        call_id: string | null;
+        channel: 'sms' | 'voice';
+        provider_event_id: string | null;
+        status: 'pending' | 'succeeded' | 'failed' | 'canceled';
+        failure_code: string | null;
+        failure_message: string | null;
+        created_at_utc: string | Date;
+        updated_at_utc: string | Date;
+      }>>();
+
+    return rows.map((row) => ({
+      id: row.id,
+      tenantId: row.tenant_id,
+      orgUnitId: row.org_unit_id,
+      threadId: row.thread_id,
+      personId: row.person_id,
+      callId: row.call_id,
+      channel: row.channel,
+      providerEventId: row.provider_event_id,
+      status: row.status,
+      failureCode: row.failure_code,
+      failureMessage: row.failure_message,
+      createdAtUtc: row.created_at_utc instanceof Date
+        ? row.created_at_utc.toISOString()
+        : row.created_at_utc,
+      updatedAtUtc: row.updated_at_utc instanceof Date
+        ? row.updated_at_utc.toISOString()
+        : row.updated_at_utc,
+    }));
+  }
+
+  async rebindPersonAttempts(input: RebindDeliveryAttemptPersonInput): Promise<void> {
+    await this.knexClient
+      .withSchema(CONNECTSHYFT_SCHEMA)
+      .table(DELIVERY_ATTEMPTS_TABLE)
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        person_id: input.provisionalPersonId,
+      })
+      .update({
+        person_id: input.canonicalPersonId,
       });
   }
 }
@@ -75,7 +222,42 @@ class AsyncConnectShyftDeliveryAttemptService implements ConnectShyftDeliveryAtt
       throw error;
     }
   }
+
+  async listPersonAttempts(input: ListPersonDeliveryAttemptsInput): Promise<DeliveryAttempt[]> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      return inMemoryConnectShyftDeliveryAttemptStore.listPersonAttempts(input);
+    }
+
+    try {
+      return await knexConnectShyftDeliveryAttemptStore.listPersonAttempts(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+
+  async rebindPersonAttempts(input: RebindDeliveryAttemptPersonInput): Promise<void> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      await inMemoryConnectShyftDeliveryAttemptStore.rebindPersonAttempts(input);
+      return;
+    }
+
+    try {
+      await knexConnectShyftDeliveryAttemptStore.rebindPersonAttempts(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
 }
 
 export const connectShyftDeliveryAttemptServiceAsync: ConnectShyftDeliveryAttemptService =
   new AsyncConnectShyftDeliveryAttemptService();
+
+export const resetConnectShyftDeliveryAttemptStateForTests = (): void => {
+  inMemoryConnectShyftDeliveryAttemptStore.reset();
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/events.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/events.ts
@@ -1,7 +1,12 @@
 import type { Knex } from 'knex';
 import db from '../../config/knex';
 import { executePlatformMutation } from '../../platform/mutations/executePlatformMutation';
+import {
+  PEOPLECORE_PERSON_MERGED_EVENT_NAME,
+  type PeopleCorePersonMergedEvent,
+} from '../peoplecore/events';
 import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+import { personRebindServiceAsync, type PersonRebindService } from './personRebind';
 import type { Call, CallStatus } from './calls';
 import type { Voicemail } from './voicemails';
 
@@ -35,6 +40,10 @@ export type ConnectShyftCallLifecycleEventPublisher = {
     voicemail: Voicemail;
     actorUserId?: string | null;
   }): Promise<void>;
+};
+
+export type ConnectShyftPersonRebindEventSubscriber = {
+  handlePeopleCorePersonMerged(event: PeopleCorePersonMergedEvent): Promise<void>;
 };
 
 const persistedLifecycleEventsForTests: ConnectShyftPersistedLifecycleEvent[] = [];
@@ -196,6 +205,28 @@ export const buildConnectShyftLifecycleEventPublisher = (
       entityId: input.voicemail.id,
       payload: buildVoicemailLifecycleEventPayload(input.voicemail),
       knexClient,
+    });
+  },
+});
+
+export const buildConnectShyftPersonRebindEventSubscriber = (
+  personRebindService: Pick<PersonRebindService, 'rebindPersonThreads'> = personRebindServiceAsync,
+): ConnectShyftPersonRebindEventSubscriber => ({
+  async handlePeopleCorePersonMerged(event) {
+    if (event.type !== PEOPLECORE_PERSON_MERGED_EVENT_NAME) {
+      return;
+    }
+
+    if (event.payload.reviewContactPointLinkIds.length > 0) {
+      return;
+    }
+
+    await personRebindService.rebindPersonThreads({
+      tenantId: event.tenantId,
+      orgUnitId: event.orgUnitId,
+      provisionalPersonId: event.payload.provisionalPersonId,
+      canonicalPersonId: event.payload.canonicalPersonId,
+      performedByUserId: event.payload.performedByUserId,
     });
   },
 });

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/getUnifiedTimeline.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/getUnifiedTimeline.ts
@@ -1,0 +1,150 @@
+import { Request, Response } from 'express';
+import {
+  error as errorEnvelope,
+  refusal,
+  success,
+} from '../../../platform/envelopes/response';
+import { PeopleCorePersistenceUnavailableError } from '../../peoplecore/service';
+import {
+  enforceConnectShyftCapability,
+  resolveConnectShyftRouteContextDecision,
+  respondWithConnectShyftContextRefusal,
+} from '../http/accessContext';
+import {
+  personRebindServiceAsync,
+  type UnifiedPersonTimeline,
+  type UnifiedPersonTimelineItem,
+} from '../personRebind';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type UnifiedPersonTimelineItemDto = {
+  id: string;
+  thread_id: string;
+  type: 'message' | 'voice_event' | 'voicemail';
+  direction: 'inbound' | 'outbound';
+  channel: 'sms' | 'voice' | 'voicemail';
+  body: string | null;
+  occurred_at_utc: string;
+  actor: 'system' | 'user' | 'neighbor';
+  provider_metadata: Record<string, unknown> | null;
+  delivery_status: string | null;
+  person_context: {
+    person_id: string;
+    origin_person_id: string | null;
+  };
+  recording_url?: string | null;
+  duration_seconds?: number | null;
+  transcript?: string | null;
+};
+
+type UnifiedPersonTimelineDto = {
+  person_id: string;
+  merged_person_ids: string[];
+  items: UnifiedPersonTimelineItemDto[];
+};
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const serializeUnifiedTimelineItem = (
+  item: UnifiedPersonTimelineItem,
+): UnifiedPersonTimelineItemDto => {
+  const base = {
+    id: item.id,
+    thread_id: item.threadId,
+    type: item.type,
+    direction: item.direction,
+    channel: item.channel,
+    body: item.body,
+    occurred_at_utc: item.occurredAtUtc,
+    actor: item.actor,
+    provider_metadata: item.providerMetadata,
+    delivery_status: item.deliveryStatus,
+    person_context: {
+      person_id: item.personContext.personId,
+      origin_person_id: item.personContext.originPersonId,
+    },
+  } satisfies UnifiedPersonTimelineItemDto;
+
+  if (item.type !== 'voicemail') {
+    return base;
+  }
+
+  return {
+    ...base,
+    recording_url: item.recordingUrl,
+    duration_seconds: item.durationSeconds,
+    transcript: item.transcript,
+  };
+};
+
+const serializeUnifiedTimeline = (
+  timeline: UnifiedPersonTimeline,
+): UnifiedPersonTimelineDto => ({
+  person_id: timeline.personId,
+  merged_person_ids: [...timeline.mergedPersonIds],
+  items: timeline.items.map(serializeUnifiedTimelineItem),
+});
+
+export const getUnifiedTimeline = async (req: Request, res: Response) => {
+  if (!await enforceConnectShyftCapability(req, res, 'module')) {
+    return;
+  }
+
+  const personId = normalizeString(req.params?.personId);
+  if (!UUID_PATTERN.test(personId)) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_PERSON_ID_INVALID',
+      message: 'personId must be a non-empty UUID.',
+      refusalType: 'client',
+      httpStatus: 400,
+      data: {
+        fieldErrors: [
+          {
+            field: 'personId',
+            reason: 'INVALID',
+            message: 'personId must be a non-empty UUID.',
+          },
+        ],
+      },
+    });
+    return;
+  }
+
+  const contextDecision = await resolveConnectShyftRouteContextDecision(req);
+  if (!contextDecision.ok) {
+    respondWithConnectShyftContextRefusal(res, contextDecision);
+    return;
+  }
+
+  try {
+    const timeline = await personRebindServiceAsync.projectUnifiedTimeline({
+      tenantId: contextDecision.context.tenantId,
+      personId,
+    });
+
+    return success(res, {
+      code: 'CONNECTSHYFT_UNIFIED_TIMELINE_LOADED',
+      message: 'ConnectShyft unified timeline loaded',
+      httpStatus: 200,
+      data: serializeUnifiedTimeline(timeline),
+    });
+  } catch (error) {
+    if (error instanceof PeopleCorePersistenceUnavailableError) {
+      errorEnvelope(res, {
+        code: error.code,
+        message: error.message,
+        httpStatus: 503,
+      });
+      return;
+    }
+
+    throw error;
+  }
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/personRebind.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/personRebind.ts
@@ -1,0 +1,309 @@
+import { randomUUID } from 'node:crypto';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+import { peopleCoreServiceAsync } from '../peoplecore/service';
+import {
+  connectShyftCallServiceAsync,
+  KnexConnectShyftCallStore,
+  type RebindCallPersonInput,
+} from './calls';
+import {
+  rebindConnectShyftBridgeSessionPersonsAsync,
+  type RebindConnectShyftBridgeSessionPersonInput,
+} from './bridgeSessions';
+import {
+  connectShyftDeliveryAttemptServiceAsync,
+  KnexConnectShyftDeliveryAttemptStore,
+  type RebindDeliveryAttemptPersonInput,
+} from './deliveryAttempts';
+import { isConnectShyftTestOverrideEnabled } from './featureFlags';
+import {
+  getThreadTimeline,
+  type ConnectShyftThreadTimelineItem,
+} from './threadTimeline';
+import {
+  connectShyftThreadService,
+  connectShyftThreadServiceAsync,
+  KnexConnectShyftThreadStore,
+  type ConnectShyftRebindThreadPersonInput,
+  type ConnectShyftThread,
+} from './threads';
+import {
+  connectShyftVoicemailServiceAsync,
+  KnexConnectShyftVoicemailStore,
+  type RebindVoicemailPersonInput,
+} from './voicemails';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const PERSON_REBIND_HISTORY_TABLE = 'person_rebind_history';
+const PERSON_REBIND_HISTORY_UNIQUE_INDEX = [
+  'tenant_id',
+  'org_unit_id',
+  'provisional_person_id',
+  'canonical_person_id',
+  'rebind_class',
+];
+
+export type RebindPersonThreadsInput = {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+  performedByUserId: string;
+};
+
+export type UnifiedPersonTimelineItem = ConnectShyftThreadTimelineItem & {
+  personContext: {
+    personId: string;
+    originPersonId: string | null;
+  };
+};
+
+export type UnifiedPersonTimeline = {
+  tenantId: string;
+  personId: string;
+  mergedPersonIds: string[];
+  items: UnifiedPersonTimelineItem[];
+};
+
+export type PersonRebindService = {
+  rebindPersonThreads(input: RebindPersonThreadsInput): Promise<void>;
+  projectUnifiedTimeline(input: {
+    tenantId: string;
+    personId: string;
+  }): Promise<UnifiedPersonTimeline>;
+};
+
+type PersistedPersonRebindHistoryRecord = {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+  performedByUserId: string;
+};
+
+const persistedPersonRebindHistoryForTests: PersistedPersonRebindHistoryRecord[] = [];
+
+const buildPersonRebindHistoryKey = (input: {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+}): string => (
+  `${input.tenantId}:${input.orgUnitId}:${input.provisionalPersonId}:${input.canonicalPersonId}`
+);
+
+const compareUnifiedTimelineItems = (
+  left: UnifiedPersonTimelineItem,
+  right: UnifiedPersonTimelineItem,
+): number => {
+  const occurredAtDelta = (
+    new Date(left.occurredAtUtc).getTime()
+    - new Date(right.occurredAtUtc).getTime()
+  );
+  if (occurredAtDelta !== 0) {
+    return occurredAtDelta;
+  }
+
+  return left.id.localeCompare(right.id);
+};
+
+const mapThreadTimelineToUnifiedItems = (
+  thread: ConnectShyftThread,
+  items: readonly ConnectShyftThreadTimelineItem[],
+): UnifiedPersonTimelineItem[] => (
+  items.map((item) => ({
+    ...item,
+    personContext: {
+      personId: thread.personId,
+      originPersonId: thread.originPersonId ?? null,
+    },
+  }))
+);
+
+const buildRebindInputs = (
+  input: RebindPersonThreadsInput,
+): {
+  threads: ConnectShyftRebindThreadPersonInput;
+  calls: RebindCallPersonInput;
+  voicemails: RebindVoicemailPersonInput;
+  deliveryAttempts: RebindDeliveryAttemptPersonInput;
+  bridgeSessions: RebindConnectShyftBridgeSessionPersonInput;
+} => ({
+  threads: {
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    provisionalPersonId: input.provisionalPersonId,
+    canonicalPersonId: input.canonicalPersonId,
+  },
+  calls: {
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    provisionalPersonId: input.provisionalPersonId,
+    canonicalPersonId: input.canonicalPersonId,
+  },
+  voicemails: {
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    provisionalPersonId: input.provisionalPersonId,
+    canonicalPersonId: input.canonicalPersonId,
+  },
+  deliveryAttempts: {
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    provisionalPersonId: input.provisionalPersonId,
+    canonicalPersonId: input.canonicalPersonId,
+  },
+  bridgeSessions: {
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    provisionalPersonId: input.provisionalPersonId,
+    canonicalPersonId: input.canonicalPersonId,
+  },
+});
+
+const hasPersistedRebindHistoryForTests = (input: RebindPersonThreadsInput): boolean => {
+  const rebindKey = buildPersonRebindHistoryKey(input);
+
+  return persistedPersonRebindHistoryForTests.some((record) => (
+    buildPersonRebindHistoryKey(record) === rebindKey
+  ));
+};
+
+const appendPersistedRebindHistoryForTests = (input: RebindPersonThreadsInput): void => {
+  if (hasPersistedRebindHistoryForTests(input)) {
+    return;
+  }
+
+  persistedPersonRebindHistoryForTests.push({
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    provisionalPersonId: input.provisionalPersonId,
+    canonicalPersonId: input.canonicalPersonId,
+    performedByUserId: input.performedByUserId,
+  });
+};
+
+const resolveUnifiedTimelinePersonIds = async (input: {
+  tenantId: string;
+  personId: string;
+}): Promise<{
+  personId: string;
+  mergedPersonIds: string[];
+  relevantPersonIds: string[];
+}> => {
+  const person = await peopleCoreServiceAsync.getPerson({
+    tenantId: input.tenantId,
+    personId: input.personId,
+  });
+  const canonicalPersonId = person?.mergedIntoPersonId || input.personId;
+  const persons = await peopleCoreServiceAsync.listPersons({
+    tenantId: input.tenantId,
+    ...(person?.orgUnitId ? { orgUnitId: person.orgUnitId } : {}),
+  });
+
+  const mergedPersonIds = persons
+    .filter((candidate) => candidate.mergedIntoPersonId === canonicalPersonId)
+    .map((candidate) => candidate.id);
+
+  return {
+    personId: canonicalPersonId,
+    mergedPersonIds,
+    relevantPersonIds: Array.from(new Set([canonicalPersonId, ...mergedPersonIds])),
+  };
+};
+
+const buildPersonRebindService = (
+  knexClient: Knex = db,
+): PersonRebindService => ({
+  async rebindPersonThreads(input) {
+    if (isConnectShyftTestOverrideEnabled()) {
+      if (hasPersistedRebindHistoryForTests(input)) {
+        return;
+      }
+
+      const rebindInputs = buildRebindInputs(input);
+      connectShyftThreadService.rebindPersonThreads(rebindInputs.threads);
+      await connectShyftCallServiceAsync.rebindPersonCalls(rebindInputs.calls);
+      await connectShyftVoicemailServiceAsync.rebindPersonVoicemails(rebindInputs.voicemails);
+      await connectShyftDeliveryAttemptServiceAsync.rebindPersonAttempts(
+        rebindInputs.deliveryAttempts,
+      );
+      await rebindConnectShyftBridgeSessionPersonsAsync(rebindInputs.bridgeSessions);
+      appendPersistedRebindHistoryForTests(input);
+      return;
+    }
+
+    const rebindInputs = buildRebindInputs(input);
+
+    await knexClient.transaction(async (trx) => {
+      const threadStore = new KnexConnectShyftThreadStore(trx);
+      const callStore = new KnexConnectShyftCallStore(trx);
+      const voicemailStore = new KnexConnectShyftVoicemailStore(trx);
+      const deliveryAttemptStore = new KnexConnectShyftDeliveryAttemptStore(trx);
+
+      await threadStore.rebindPersonThreads(rebindInputs.threads);
+      await callStore.rebindPersonCalls(rebindInputs.calls);
+      await voicemailStore.rebindPersonVoicemails(rebindInputs.voicemails);
+      await deliveryAttemptStore.rebindPersonAttempts(rebindInputs.deliveryAttempts);
+      await rebindConnectShyftBridgeSessionPersonsAsync(rebindInputs.bridgeSessions, trx);
+
+      await trx
+        .withSchema(CONNECTSHYFT_SCHEMA)
+        .table(PERSON_REBIND_HISTORY_TABLE)
+        .insert({
+          id: randomUUID(),
+          tenant_id: input.tenantId,
+          org_unit_id: input.orgUnitId,
+          provisional_person_id: input.provisionalPersonId,
+          canonical_person_id: input.canonicalPersonId,
+          rebind_class: 'auto',
+          performed_by_user_id: input.performedByUserId,
+          notes: null,
+        })
+        .onConflict(PERSON_REBIND_HISTORY_UNIQUE_INDEX)
+        .ignore();
+    });
+  },
+
+  async projectUnifiedTimeline(input) {
+    const resolved = await resolveUnifiedTimelinePersonIds(input);
+    const threads = isConnectShyftTestOverrideEnabled()
+      ? connectShyftThreadService.listThreadsByPersonIds({
+        tenantId: input.tenantId,
+        personIds: resolved.relevantPersonIds,
+      })
+      : await connectShyftThreadServiceAsync.listThreadsByPersonIds({
+        tenantId: input.tenantId,
+        personIds: resolved.relevantPersonIds,
+      });
+    const uniqueThreads = Array.from(
+      threads.reduce((accumulator, thread) => accumulator.set(thread.threadId, thread), new Map<string, ConnectShyftThread>()).values(),
+    );
+
+    const timelines = await Promise.all(
+      uniqueThreads.map(async (thread) => {
+        const timeline = await getThreadTimeline({
+          tenantId: input.tenantId,
+          orgUnitId: thread.orgUnitId,
+          threadId: thread.threadId,
+        });
+
+        return mapThreadTimelineToUnifiedItems(thread, timeline.items);
+      }),
+    );
+
+    return {
+      tenantId: input.tenantId,
+      personId: resolved.personId,
+      mergedPersonIds: resolved.mergedPersonIds,
+      items: timelines.flat().sort(compareUnifiedTimelineItems),
+    };
+  },
+});
+
+export const personRebindServiceAsync = buildPersonRebindService();
+
+export const resetConnectShyftPersonRebindStateForTests = (): void => {
+  persistedPersonRebindHistoryForTests.splice(0, persistedPersonRebindHistoryForTests.length);
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/threads.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/threads.ts
@@ -40,6 +40,7 @@ export type ConnectShyftThread = {
   orgUnitId: string;
   neighborId: string;
   personId: string;
+  originPersonId?: string | null;
   activityId: string | null;
   source: string;
   state: ConnectShyftThreadState;
@@ -102,6 +103,18 @@ type ThreadStoreTransitionInput = {
 type ThreadStoreFindByIdInput = {
   tenantId: string;
   threadId: string;
+};
+
+type ThreadStoreListByPersonIdsInput = {
+  tenantId: string;
+  personIds: string[];
+};
+
+type ThreadStoreRebindInput = {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
 };
 
 export type ConnectShyftEscalationTransition = {
@@ -253,12 +266,25 @@ export type ConnectShyftEvaluateEscalationsResult =
   }
   | ThreadRefusalResult;
 
+export type ConnectShyftListThreadsByPersonIdsInput = {
+  tenantId: string;
+  personIds: string[];
+};
+
+export type ConnectShyftRebindThreadPersonInput = {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+};
+
 type DbThreadRow = {
   id: string;
   tenant_id: string;
   org_unit_id: string;
   neighbor_id: string;
   person_id: string;
+  origin_person_id: string | null;
   activity_id: string | null;
   source: string;
   state: ConnectShyftThreadState;
@@ -539,6 +565,7 @@ const mapDbRowToThread = (row: DbThreadRow): ConnectShyftThread => ({
   orgUnitId: row.org_unit_id,
   neighborId: row.neighbor_id,
   personId: row.person_id,
+  originPersonId: normalizeString(row.origin_person_id) || null,
   activityId: row.activity_id,
   source: row.source,
   state: row.state,
@@ -799,6 +826,7 @@ export class InMemoryConnectShyftThreadStore {
       orgUnitId: input.orgUnitId,
       neighborId: input.neighborId,
       personId: input.personId,
+      originPersonId: null,
       activityId: input.activityId ?? null,
       source: input.source,
       state: input.state,
@@ -952,6 +980,61 @@ export class InMemoryConnectShyftThreadStore {
 
     return cloneThread(thread);
   }
+
+  listThreadsByPersonIds(input: ThreadStoreListByPersonIdsInput): ConnectShyftThread[] {
+    const personIds = new Set(
+      input.personIds
+        .map((personId) => normalizeString(personId))
+        .filter((personId) => personId.length > 0),
+    );
+    if (personIds.size === 0) {
+      return [];
+    }
+
+    return Array.from(this.threadsById.values())
+      .filter((thread) => (
+        thread.tenantId === input.tenantId
+        && (
+          personIds.has(thread.personId)
+          || personIds.has(normalizeString(thread.originPersonId))
+        )
+      ))
+      .sort((left, right) => (
+        new Date(left.createdAtUtc).getTime() - new Date(right.createdAtUtc).getTime()
+      ) || left.threadId.localeCompare(right.threadId))
+      .map(cloneThread);
+  }
+
+  rebindPersonThreads(input: ThreadStoreRebindInput): ConnectShyftThread[] {
+    const updatedThreads: ConnectShyftThread[] = [];
+
+    this.threadsById.forEach((thread, threadId) => {
+      if (
+        thread.tenantId !== input.tenantId
+        || thread.orgUnitId !== input.orgUnitId
+        || thread.personId !== input.provisionalPersonId
+      ) {
+        return;
+      }
+
+      const rebound: ConnectShyftThread = {
+        ...thread,
+        personId: input.canonicalPersonId,
+        originPersonId: normalizeString(thread.originPersonId) || thread.personId,
+      };
+      this.threadsById.set(threadId, rebound);
+      updatedThreads.push(cloneThread(rebound));
+    });
+
+    return updatedThreads.sort((left, right) => (
+      new Date(left.createdAtUtc).getTime() - new Date(right.createdAtUtc).getTime()
+    ) || left.threadId.localeCompare(right.threadId));
+  }
+
+  reset(): void {
+    this.threadsById.clear();
+    this.activeThreadIdByScope.clear();
+  }
 }
 
 export class KnexConnectShyftThreadStore {
@@ -964,6 +1047,7 @@ export class KnexConnectShyftThreadStore {
       'org_unit_id',
       'neighbor_id',
       'person_id',
+      'origin_person_id',
       'activity_id',
       'source',
       'state',
@@ -1043,6 +1127,7 @@ export class KnexConnectShyftThreadStore {
           org_unit_id: input.orgUnitId,
           neighbor_id: input.neighborId,
           person_id: input.personId,
+          origin_person_id: null,
           activity_id: input.activityId ?? null,
           source: input.source,
           state: input.state,
@@ -1299,6 +1384,48 @@ export class KnexConnectShyftThreadStore {
 
     return row ? mapDbRowToThread(row) : null;
   }
+
+  async listThreadsByPersonIds(input: ThreadStoreListByPersonIdsInput): Promise<ConnectShyftThread[]> {
+    const personIds = input.personIds
+      .map((personId) => normalizeString(personId))
+      .filter((personId) => personId.length > 0);
+    if (personIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.knexClient
+      .withSchema('connectshyft')
+      .table('cs_threads')
+      .where({
+        tenant_id: input.tenantId,
+      })
+      .andWhere((queryBuilder) => {
+        queryBuilder.whereIn('person_id', personIds).orWhereIn('origin_person_id', personIds);
+      })
+      .orderBy('created_at_utc', 'asc')
+      .orderBy('id', 'asc')
+      .select<DbThreadRow[]>(this.threadColumns());
+
+    return rows.map(mapDbRowToThread);
+  }
+
+  async rebindPersonThreads(input: ThreadStoreRebindInput): Promise<ConnectShyftThread[]> {
+    const rows = await this.knexClient
+      .withSchema('connectshyft')
+      .table('cs_threads')
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        person_id: input.provisionalPersonId,
+      })
+      .update({
+        origin_person_id: this.knexClient.raw('COALESCE(origin_person_id, person_id)'),
+        person_id: input.canonicalPersonId,
+      })
+      .returning<DbThreadRow[]>(this.threadColumns());
+
+    return rows.map(mapDbRowToThread);
+  }
 }
 
 export class ConnectShyftThreadService {
@@ -1474,6 +1601,14 @@ export class ConnectShyftThreadService {
 
   findThreadById(input: { tenantId: string; threadId: string }): ConnectShyftThread | null {
     return this.store.findThreadById(input);
+  }
+
+  listThreadsByPersonIds(input: ConnectShyftListThreadsByPersonIdsInput): ConnectShyftThread[] {
+    return this.store.listThreadsByPersonIds(input);
+  }
+
+  rebindPersonThreads(input: ConnectShyftRebindThreadPersonInput): ConnectShyftThread[] {
+    return this.store.rebindPersonThreads(input);
   }
 }
 
@@ -1718,6 +1853,38 @@ export class AsyncConnectShyftThreadService {
       return null;
     }
   }
+
+  async listThreadsByPersonIds(
+    input: ConnectShyftListThreadsByPersonIdsInput,
+  ): Promise<ConnectShyftThread[]> {
+    try {
+      return await this.store.listThreadsByPersonIds(input);
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error;
+      }
+
+      return [];
+    }
+  }
+
+  async rebindPersonThreads(
+    input: ConnectShyftRebindThreadPersonInput,
+  ): Promise<ConnectShyftThread[]> {
+    try {
+      return await this.store.rebindPersonThreads(input);
+    } catch (error) {
+      if (!isMissingPersistenceError(error)) {
+        throw error;
+      }
+
+      return [];
+    }
+  }
 }
 
 export const connectShyftThreadServiceAsync = new AsyncConnectShyftThreadService();
+
+export const resetConnectShyftThreadStateForTests = (): void => {
+  defaultThreadStore.reset();
+};

--- a/apps/connectshyft-api/src/modules/connectshyft/voicemails.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/voicemails.ts
@@ -28,6 +28,13 @@ export interface ListCallVoicemailsInput {
   callId: string;
 }
 
+export interface RebindVoicemailPersonInput {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+}
+
 export type Voicemail = {
   id: string;
   tenantId: string;
@@ -47,6 +54,7 @@ export type Voicemail = {
 export interface ConnectShyftVoicemailService {
   createVoicemail(input: CreateVoicemailInput): Promise<Voicemail>;
   listCallVoicemails(input: ListCallVoicemailsInput): Promise<Voicemail[]>;
+  rebindPersonVoicemails(input: RebindVoicemailPersonInput): Promise<void>;
 }
 
 type DbVoicemailRow = {
@@ -158,13 +166,30 @@ class InMemoryConnectShyftVoicemailStore implements ConnectShyftVoicemailService
       ) || right.id.localeCompare(left.id));
   }
 
+  async rebindPersonVoicemails(input: RebindVoicemailPersonInput): Promise<void> {
+    this.records.forEach((voicemail, voicemailId) => {
+      if (
+        voicemail.tenantId !== input.tenantId
+        || voicemail.orgUnitId !== input.orgUnitId
+        || voicemail.personId !== input.provisionalPersonId
+      ) {
+        return;
+      }
+
+      this.records.set(voicemailId, {
+        ...voicemail,
+        personId: input.canonicalPersonId,
+      });
+    });
+  }
+
   reset(): void {
     this.records.clear();
     this.recordIdByArtifactKey.clear();
   }
 }
 
-class KnexConnectShyftVoicemailStore implements ConnectShyftVoicemailService {
+export class KnexConnectShyftVoicemailStore implements ConnectShyftVoicemailService {
   constructor(private readonly knexClient: Knex = db) {}
 
   private table() {
@@ -226,6 +251,18 @@ class KnexConnectShyftVoicemailStore implements ConnectShyftVoicemailService {
 
     return rows.map(mapVoicemailRow);
   }
+
+  async rebindPersonVoicemails(input: RebindVoicemailPersonInput): Promise<void> {
+    await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        person_id: input.provisionalPersonId,
+      })
+      .update({
+        person_id: input.canonicalPersonId,
+      });
+  }
 }
 
 const inMemoryConnectShyftVoicemailStore = new InMemoryConnectShyftVoicemailStore();
@@ -254,6 +291,22 @@ class AsyncConnectShyftVoicemailService implements ConnectShyftVoicemailService 
 
     try {
       return await knexConnectShyftVoicemailStore.listCallVoicemails(input);
+    } catch (error) {
+      if (isConnectShyftPersistenceErrorCause(error)) {
+        throw new ConnectShyftPersistenceUnavailableError(error);
+      }
+      throw error;
+    }
+  }
+
+  async rebindPersonVoicemails(input: RebindVoicemailPersonInput): Promise<void> {
+    if (isConnectShyftTestOverrideEnabled()) {
+      await inMemoryConnectShyftVoicemailStore.rebindPersonVoicemails(input);
+      return;
+    }
+
+    try {
+      await knexConnectShyftVoicemailStore.rebindPersonVoicemails(input);
     } catch (error) {
       if (isConnectShyftPersistenceErrorCause(error)) {
         throw new ConnectShyftPersistenceUnavailableError(error);

--- a/apps/connectshyft-api/src/modules/peoplecore/__tests__/mergePerson.test.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/__tests__/mergePerson.test.ts
@@ -1,0 +1,587 @@
+import { AsyncPeopleCoreService } from '../service';
+import { KnexPeopleCoreStore } from '../store';
+
+const FIXED_NOW = '2026-03-24T15:30:00.000Z';
+const TENANT_ID = '11111111-1111-4111-8111-111111111111';
+const ORG_UNIT_ID = '22222222-2222-4222-8222-222222222222';
+const PROVISIONAL_PERSON_ID = '33333333-3333-4333-8333-333333333333';
+const CANONICAL_PERSON_ID = '44444444-4444-4444-8444-444444444444';
+const OTHER_HOUSEHOLD_ID = '55555555-5555-4555-8555-555555555555';
+const PROVISIONAL_HOUSEHOLD_ID = '66666666-6666-4666-8666-666666666666';
+const CONTACT_POINT_ID = '77777777-7777-4777-8777-777777777777';
+const PROVISIONAL_LINK_ID = '88888888-8888-4888-8888-888888888888';
+const CANONICAL_LINK_ID = '99999999-9999-4999-8999-999999999999';
+const MERGE_USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+type QueryRow = Record<string, any>;
+type QueryTables = Record<string, QueryRow[]>;
+
+const deepClone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const normalizeColumn = (column: string): string => column.split('.').pop() || column;
+
+const projectRow = <T extends QueryRow>(row: T, columns?: readonly string[]): T => {
+  if (!columns || columns.length === 0) {
+    return deepClone(row);
+  }
+
+  return columns.reduce((projected, column) => {
+    projected[normalizeColumn(column)] = row[normalizeColumn(column)];
+    return projected;
+  }, {} as QueryRow) as T;
+};
+
+const buildInsertedRow = (tableKey: string, input: QueryRow, nextId: () => string): QueryRow => {
+  switch (tableKey) {
+    case 'people.persons':
+      return {
+        id: input.id ?? nextId(),
+        tenant_id: input.tenant_id,
+        org_unit_id: input.org_unit_id,
+        first_name: input.first_name ?? '',
+        last_name: input.last_name ?? '',
+        preferred_name: input.preferred_name ?? null,
+        status: input.status ?? 'active_provisional',
+        merged_into_person_id: input.merged_into_person_id ?? null,
+        created_at_utc: input.created_at_utc ?? FIXED_NOW,
+        updated_at_utc: input.updated_at_utc ?? FIXED_NOW,
+      };
+    case 'people.contact_point_links':
+      return {
+        id: input.id ?? nextId(),
+        contact_point_id: input.contact_point_id,
+        subject_type: input.subject_type,
+        subject_id: input.subject_id,
+        link_type: input.link_type,
+        confidence_band: input.confidence_band,
+        is_current: input.is_current,
+        is_primary: input.is_primary,
+        manually_confirmed: input.manually_confirmed,
+        confirmation_source: input.confirmation_source ?? null,
+        first_linked_at_utc: input.first_linked_at_utc,
+        last_confirmed_at_utc: input.last_confirmed_at_utc ?? null,
+        last_used_at_utc: input.last_used_at_utc ?? null,
+        linked_by: input.linked_by,
+        linked_by_user_id: input.linked_by_user_id ?? null,
+        unlink_reason: input.unlink_reason ?? null,
+        unlinked_at_utc: input.unlinked_at_utc ?? null,
+        merged_into_subject_id: input.merged_into_subject_id ?? null,
+        merged_at_utc: input.merged_at_utc ?? null,
+        merged_by_user_id: input.merged_by_user_id ?? null,
+        merge_class: input.merge_class ?? 'auto',
+        merge_reason: input.merge_reason ?? null,
+        created_at_utc: input.created_at_utc ?? FIXED_NOW,
+        updated_at_utc: input.updated_at_utc ?? FIXED_NOW,
+      };
+    case 'people.resolver_reviews':
+      return {
+        id: input.id ?? nextId(),
+        tenant_id: input.tenant_id,
+        org_unit_id: input.org_unit_id,
+        review_type: input.review_type,
+        review_status: input.review_status,
+        priority: input.priority,
+        trigger_source_type: input.trigger_source_type,
+        trigger_source_id: input.trigger_source_id,
+        conversation_id: input.conversation_id ?? null,
+        provisional_person_id: input.provisional_person_id ?? null,
+        candidate_person_ids: typeof input.candidate_person_ids === 'string'
+          ? JSON.parse(input.candidate_person_ids)
+          : (input.candidate_person_ids ?? []),
+        contact_point_id: input.contact_point_id ?? null,
+        confidence_band: input.confidence_band,
+        confidence_reasons: typeof input.confidence_reasons === 'string'
+          ? JSON.parse(input.confidence_reasons)
+          : (input.confidence_reasons ?? []),
+        risk_flags: typeof input.risk_flags === 'string'
+          ? JSON.parse(input.risk_flags)
+          : (input.risk_flags ?? []),
+        requested_by_user_id: input.requested_by_user_id,
+        assigned_resolver_user_id: input.assigned_resolver_user_id ?? null,
+        requested_at_utc: input.requested_at_utc ?? FIXED_NOW,
+        started_at_utc: input.started_at_utc ?? null,
+        resolved_at_utc: input.resolved_at_utc ?? null,
+        resolution_type: input.resolution_type ?? null,
+        resolution_reason: input.resolution_reason ?? null,
+        resolution_notes: input.resolution_notes ?? null,
+      };
+    default:
+      return {
+        id: input.id ?? nextId(),
+        ...input,
+      };
+  }
+};
+
+const createStatefulKnexMock = (initialTables: QueryTables) => {
+  const tables: QueryTables = Object.fromEntries(
+    Object.entries(initialTables).map(([key, rows]) => [key, deepClone(rows)]),
+  );
+  const idCounters = new Map<string, number>();
+
+  const nextIdForTable = (tableKey: string): string => {
+    const next = (idCounters.get(tableKey) ?? 0) + 1;
+    idCounters.set(tableKey, next);
+    return `${tableKey.replace(/[.]/g, '_')}_${next}`;
+  };
+
+  const getRows = (tableKey: string): QueryRow[] => {
+    if (!tables[tableKey]) {
+      tables[tableKey] = [];
+    }
+
+    return tables[tableKey];
+  };
+
+  const knex: any = {
+    fn: {
+      now: () => FIXED_NOW,
+    },
+    transaction: async (callback: (trx: any) => Promise<unknown>) => callback(knex),
+    withSchema: (schema: string) => ({
+      table: (tableName: string) => {
+        const tableKey = `${schema}.${tableName}`;
+        const filters: Array<(row: QueryRow) => boolean> = [];
+        const orderings: Array<{ column: string; direction: 'asc' | 'desc' }> = [];
+
+        const applyFilters = (): QueryRow[] => {
+          const filtered = getRows(tableKey).filter((row) => filters.every((filter) => filter(row)));
+
+          return [...filtered].sort((left, right) => {
+            for (const ordering of orderings) {
+              const column = normalizeColumn(ordering.column);
+              const leftValue = left[column];
+              const rightValue = right[column];
+              if (leftValue === rightValue) {
+                continue;
+              }
+
+              if (leftValue == null) {
+                return ordering.direction === 'asc' ? -1 : 1;
+              }
+
+              if (rightValue == null) {
+                return ordering.direction === 'asc' ? 1 : -1;
+              }
+
+              if (leftValue < rightValue) {
+                return ordering.direction === 'asc' ? -1 : 1;
+              }
+
+              if (leftValue > rightValue) {
+                return ordering.direction === 'asc' ? 1 : -1;
+              }
+            }
+
+            return 0;
+          });
+        };
+
+        const builder: any = {
+          where: (clause: QueryRow) => {
+            filters.push((row) =>
+              Object.entries(clause).every(([column, value]) => row[normalizeColumn(column)] === value));
+            return builder;
+          },
+          whereIn: (column: string, values: readonly unknown[]) => {
+            const normalizedColumn = normalizeColumn(column);
+            filters.push((row) => values.includes(row[normalizedColumn]));
+            return builder;
+          },
+          orderBy: (column: string, direction: 'asc' | 'desc' = 'asc') => {
+            orderings.push({ column, direction });
+            return builder;
+          },
+          first: async (columns?: readonly string[]) => {
+            const row = applyFilters()[0];
+            return row ? projectRow(row, columns) : null;
+          },
+          select: async (columns?: readonly string[]) => applyFilters().map((row) => projectRow(row, columns)),
+          insert: (value: QueryRow | QueryRow[]) => {
+            const inputs = Array.isArray(value) ? value : [value];
+            const insertedRows = inputs.map((row) =>
+              buildInsertedRow(tableKey, row, () => nextIdForTable(tableKey)));
+            getRows(tableKey).push(...insertedRows);
+
+            return {
+              returning: async (columns?: readonly string[]) =>
+                insertedRows.map((row) => projectRow(row, columns)),
+            };
+          },
+          update: async (patch: QueryRow) => {
+            const rows = applyFilters();
+            rows.forEach((row) => {
+              Object.assign(row, patch);
+            });
+            return rows.length;
+          },
+        };
+
+        return builder;
+      },
+    }),
+  };
+
+  return {
+    knex,
+    tables,
+  };
+};
+
+const basePersonRow = (input: {
+  id: string;
+  status: string;
+  mergedIntoPersonId?: string | null;
+}): QueryRow => ({
+  id: input.id,
+  tenant_id: TENANT_ID,
+  org_unit_id: ORG_UNIT_ID,
+  first_name: input.id === PROVISIONAL_PERSON_ID ? 'Provisional' : 'Canonical',
+  last_name: 'Person',
+  preferred_name: null,
+  status: input.status,
+  merged_into_person_id: input.mergedIntoPersonId ?? null,
+  created_at_utc: '2026-03-24T10:00:00.000Z',
+  updated_at_utc: '2026-03-24T10:00:00.000Z',
+});
+
+const baseContactPointRow = (): QueryRow => ({
+  id: CONTACT_POINT_ID,
+  tenant_id: TENANT_ID,
+  type: 'phone',
+  normalized_value: '+12605551212',
+  raw_value: '(260) 555-1212',
+  status: 'active_personal',
+  first_seen_at_utc: '2026-03-24T10:05:00.000Z',
+  last_seen_at_utc: '2026-03-24T10:05:00.000Z',
+  last_inbound_at_utc: null,
+  last_outbound_at_utc: null,
+  suspected_shared: false,
+  confirmed_shared: false,
+  reassignment_suspected: false,
+  created_at_utc: '2026-03-24T10:05:00.000Z',
+  updated_at_utc: '2026-03-24T10:05:00.000Z',
+});
+
+const baseContactPointLinkRow = (input: {
+  id: string;
+  subjectId: string;
+  isPrimary?: boolean;
+  isCurrent?: boolean;
+}): QueryRow => ({
+  id: input.id,
+  contact_point_id: CONTACT_POINT_ID,
+  subject_type: 'person',
+  subject_id: input.subjectId,
+  link_type: 'primary',
+  confidence_band: 'high',
+  is_current: input.isCurrent ?? true,
+  is_primary: input.isPrimary ?? true,
+  manually_confirmed: false,
+  confirmation_source: null,
+  first_linked_at_utc: '2026-03-24T10:10:00.000Z',
+  last_confirmed_at_utc: null,
+  last_used_at_utc: null,
+  linked_by: 'system',
+  linked_by_user_id: null,
+  unlink_reason: null,
+  unlinked_at_utc: null,
+  merged_into_subject_id: null,
+  merged_at_utc: null,
+  merged_by_user_id: null,
+  merge_class: 'auto',
+  merge_reason: null,
+  created_at_utc: '2026-03-24T10:10:00.000Z',
+  updated_at_utc: '2026-03-24T10:10:00.000Z',
+});
+
+const buildService = (initialTables: QueryTables) => {
+  const { knex, tables } = createStatefulKnexMock(initialTables);
+  const publisher = {
+    publishPersonMerged: jest.fn(async () => undefined),
+  };
+  const store = new KnexPeopleCoreStore(knex);
+  const service = new AsyncPeopleCoreService(store, publisher);
+
+  return {
+    service,
+    store,
+    publisher,
+    tables,
+  };
+};
+
+describe('PeopleCore mergePerson', () => {
+  it('marks the provisional person merged, preserves the canonical person, and copies auto-merged links', async () => {
+    const { service, store, publisher, tables } = buildService({
+      'people.persons': [
+        basePersonRow({ id: PROVISIONAL_PERSON_ID, status: 'active_provisional' }),
+        basePersonRow({ id: CANONICAL_PERSON_ID, status: 'active_confirmed' }),
+      ],
+      'people.contact_points': [baseContactPointRow()],
+      'people.contact_point_links': [
+        baseContactPointLinkRow({ id: PROVISIONAL_LINK_ID, subjectId: PROVISIONAL_PERSON_ID }),
+      ],
+      'people.household_memberships': [],
+      'people.households': [],
+      'people.resolver_reviews': [],
+    });
+
+    await expect(service.getPersonMergeStatus({
+      tenantId: TENANT_ID,
+      personId: PROVISIONAL_PERSON_ID,
+    })).resolves.toBe('provisional');
+
+    const result = await service.mergePerson({
+      tenantId: TENANT_ID,
+      orgUnitId: ORG_UNIT_ID,
+      provisionalPersonId: PROVISIONAL_PERSON_ID,
+      canonicalPersonId: CANONICAL_PERSON_ID,
+      performedByUserId: MERGE_USER_ID,
+      mergeReason: 'resolver duplicate cleanup',
+    });
+
+    expect(result).toMatchObject({
+      mergedProvisionalPersonId: PROVISIONAL_PERSON_ID,
+      canonicalPersonId: CANONICAL_PERSON_ID,
+      autoMergedContactPointLinkIds: [PROVISIONAL_LINK_ID],
+      reviewContactPointLinkIds: [],
+      resolverReviewId: undefined,
+      didPersistMerge: true,
+    });
+
+    const provisionalPerson = await store.getPerson({
+      tenantId: TENANT_ID,
+      personId: PROVISIONAL_PERSON_ID,
+    });
+    const canonicalPerson = await store.getPerson({
+      tenantId: TENANT_ID,
+      personId: CANONICAL_PERSON_ID,
+    });
+
+    expect(provisionalPerson).toMatchObject({
+      id: PROVISIONAL_PERSON_ID,
+      status: 'merged',
+      mergedIntoPersonId: CANONICAL_PERSON_ID,
+    });
+    expect(canonicalPerson).toMatchObject({
+      id: CANONICAL_PERSON_ID,
+      status: 'active_confirmed',
+      mergedIntoPersonId: undefined,
+    });
+    await expect(service.getPersonMergeStatus({
+      tenantId: TENANT_ID,
+      personId: PROVISIONAL_PERSON_ID,
+    })).resolves.toBe('merged');
+    await expect(service.getPersonMergeStatus({
+      tenantId: TENANT_ID,
+      personId: CANONICAL_PERSON_ID,
+    })).resolves.toBe('canonical');
+
+    const updatedProvisionalLink = tables['people.contact_point_links']
+      .find((row) => row.id === PROVISIONAL_LINK_ID);
+    const insertedCanonicalLinks = tables['people.contact_point_links']
+      .filter((row) => row.subject_id === CANONICAL_PERSON_ID);
+
+    expect(updatedProvisionalLink).toMatchObject({
+      id: PROVISIONAL_LINK_ID,
+      is_current: false,
+      merged_into_subject_id: CANONICAL_PERSON_ID,
+      merged_by_user_id: MERGE_USER_ID,
+      merge_class: 'auto',
+      merge_reason: 'resolver duplicate cleanup',
+    });
+    expect(insertedCanonicalLinks).toHaveLength(1);
+    expect(insertedCanonicalLinks[0]).toMatchObject({
+      contact_point_id: CONTACT_POINT_ID,
+      subject_id: CANONICAL_PERSON_ID,
+      is_current: true,
+      is_primary: true,
+      first_linked_at_utc: '2026-03-24T10:10:00.000Z',
+      merge_class: 'auto',
+    });
+
+    expect(publisher.publishPersonMerged).toHaveBeenCalledTimes(1);
+    expect(publisher.publishPersonMerged).toHaveBeenCalledWith(expect.objectContaining({
+      provisionalPersonId: PROVISIONAL_PERSON_ID,
+      canonicalPersonId: CANONICAL_PERSON_ID,
+      autoMergedContactPointLinkIds: [PROVISIONAL_LINK_ID],
+      reviewContactPointLinkIds: [],
+      mergeReason: 'resolver duplicate cleanup',
+    }));
+  });
+
+  it('returns review items and creates a merge review when the same contact point has competing primaries', async () => {
+    const { service, publisher, tables } = buildService({
+      'people.persons': [
+        basePersonRow({ id: PROVISIONAL_PERSON_ID, status: 'active_provisional' }),
+        basePersonRow({ id: CANONICAL_PERSON_ID, status: 'active_confirmed' }),
+      ],
+      'people.contact_points': [baseContactPointRow()],
+      'people.contact_point_links': [
+        baseContactPointLinkRow({ id: PROVISIONAL_LINK_ID, subjectId: PROVISIONAL_PERSON_ID }),
+        baseContactPointLinkRow({ id: CANONICAL_LINK_ID, subjectId: CANONICAL_PERSON_ID }),
+      ],
+      'people.household_memberships': [],
+      'people.households': [],
+      'people.resolver_reviews': [],
+    });
+
+    const result = await service.mergePerson({
+      tenantId: TENANT_ID,
+      orgUnitId: ORG_UNIT_ID,
+      provisionalPersonId: PROVISIONAL_PERSON_ID,
+      canonicalPersonId: CANONICAL_PERSON_ID,
+      performedByUserId: MERGE_USER_ID,
+    });
+
+    expect(result.autoMergedContactPointLinkIds).toEqual([]);
+    expect(result.reviewContactPointLinkIds).toEqual([PROVISIONAL_LINK_ID]);
+    expect(result.resolverReviewId).toBeDefined();
+
+    const provisionalLink = tables['people.contact_point_links']
+      .find((row) => row.id === PROVISIONAL_LINK_ID);
+    expect(provisionalLink).toMatchObject({
+      id: PROVISIONAL_LINK_ID,
+      is_current: true,
+      merged_into_subject_id: null,
+      merged_at_utc: null,
+    });
+
+    expect(tables['people.contact_point_links']
+      .filter((row) => row.subject_id === CANONICAL_PERSON_ID)).toHaveLength(1);
+
+    expect(tables['people.resolver_reviews']).toHaveLength(1);
+    expect(tables['people.resolver_reviews'][0]).toMatchObject({
+      id: result.resolverReviewId,
+      review_type: 'merge_review',
+      trigger_source_type: 'person_merge',
+      contact_point_id: CONTACT_POINT_ID,
+      provisional_person_id: PROVISIONAL_PERSON_ID,
+    });
+
+    expect(publisher.publishPersonMerged).toHaveBeenCalledTimes(1);
+    expect(publisher.publishPersonMerged).toHaveBeenCalledWith(expect.objectContaining({
+      reviewContactPointLinkIds: [PROVISIONAL_LINK_ID],
+      resolverReviewId: result.resolverReviewId,
+    }));
+  });
+
+  it('creates a merge review for household ambiguity while still auto-merging non-conflicting contact links', async () => {
+    const { service, tables } = buildService({
+      'people.persons': [
+        basePersonRow({ id: PROVISIONAL_PERSON_ID, status: 'active_provisional' }),
+        basePersonRow({ id: CANONICAL_PERSON_ID, status: 'active_confirmed' }),
+      ],
+      'people.contact_points': [baseContactPointRow()],
+      'people.contact_point_links': [
+        baseContactPointLinkRow({ id: PROVISIONAL_LINK_ID, subjectId: PROVISIONAL_PERSON_ID }),
+      ],
+      'people.households': [
+        {
+          id: PROVISIONAL_HOUSEHOLD_ID,
+          tenant_id: TENANT_ID,
+          org_unit_id: ORG_UNIT_ID,
+          name: 'Provisional household',
+          status: 'active',
+          created_at_utc: FIXED_NOW,
+          updated_at_utc: FIXED_NOW,
+        },
+        {
+          id: OTHER_HOUSEHOLD_ID,
+          tenant_id: TENANT_ID,
+          org_unit_id: ORG_UNIT_ID,
+          name: 'Canonical household',
+          status: 'active',
+          created_at_utc: FIXED_NOW,
+          updated_at_utc: FIXED_NOW,
+        },
+      ],
+      'people.household_memberships': [
+        {
+          id: 'membership_provisional',
+          household_id: PROVISIONAL_HOUSEHOLD_ID,
+          person_id: PROVISIONAL_PERSON_ID,
+          role: 'member',
+          is_current: true,
+          start_at_utc: FIXED_NOW,
+          end_at_utc: null,
+          created_at_utc: FIXED_NOW,
+          updated_at_utc: FIXED_NOW,
+        },
+        {
+          id: 'membership_canonical',
+          household_id: OTHER_HOUSEHOLD_ID,
+          person_id: CANONICAL_PERSON_ID,
+          role: 'member',
+          is_current: true,
+          start_at_utc: FIXED_NOW,
+          end_at_utc: null,
+          created_at_utc: FIXED_NOW,
+          updated_at_utc: FIXED_NOW,
+        },
+      ],
+      'people.resolver_reviews': [],
+    });
+
+    const result = await service.mergePerson({
+      tenantId: TENANT_ID,
+      orgUnitId: ORG_UNIT_ID,
+      provisionalPersonId: PROVISIONAL_PERSON_ID,
+      canonicalPersonId: CANONICAL_PERSON_ID,
+      performedByUserId: MERGE_USER_ID,
+    });
+
+    expect(result.autoMergedContactPointLinkIds).toEqual([PROVISIONAL_LINK_ID]);
+    expect(result.reviewContactPointLinkIds).toEqual([]);
+    expect(result.resolverReviewId).toBeDefined();
+    expect(tables['people.resolver_reviews']).toHaveLength(1);
+    expect(tables['people.resolver_reviews'][0].confidence_reasons).toEqual(expect.arrayContaining([
+      'Manual review required because the people have ambiguous current household memberships.',
+    ]));
+  });
+
+  it('is idempotent for the same provisional and canonical pair', async () => {
+    const { service, publisher, tables } = buildService({
+      'people.persons': [
+        basePersonRow({ id: PROVISIONAL_PERSON_ID, status: 'active_provisional' }),
+        basePersonRow({ id: CANONICAL_PERSON_ID, status: 'active_confirmed' }),
+      ],
+      'people.contact_points': [baseContactPointRow()],
+      'people.contact_point_links': [
+        baseContactPointLinkRow({ id: PROVISIONAL_LINK_ID, subjectId: PROVISIONAL_PERSON_ID }),
+      ],
+      'people.household_memberships': [],
+      'people.households': [],
+      'people.resolver_reviews': [],
+    });
+
+    const firstResult = await service.mergePerson({
+      tenantId: TENANT_ID,
+      orgUnitId: ORG_UNIT_ID,
+      provisionalPersonId: PROVISIONAL_PERSON_ID,
+      canonicalPersonId: CANONICAL_PERSON_ID,
+      performedByUserId: MERGE_USER_ID,
+    });
+    const linkCountAfterFirstMerge = tables['people.contact_point_links'].length;
+
+    const secondResult = await service.mergePerson({
+      tenantId: TENANT_ID,
+      orgUnitId: ORG_UNIT_ID,
+      provisionalPersonId: PROVISIONAL_PERSON_ID,
+      canonicalPersonId: CANONICAL_PERSON_ID,
+      performedByUserId: MERGE_USER_ID,
+    });
+
+    expect(firstResult.autoMergedContactPointLinkIds).toEqual([PROVISIONAL_LINK_ID]);
+    expect(secondResult).toMatchObject({
+      mergedProvisionalPersonId: PROVISIONAL_PERSON_ID,
+      canonicalPersonId: CANONICAL_PERSON_ID,
+      autoMergedContactPointLinkIds: [PROVISIONAL_LINK_ID],
+      reviewContactPointLinkIds: [],
+      didPersistMerge: false,
+    });
+    expect(tables['people.contact_point_links']).toHaveLength(linkCountAfterFirstMerge);
+    expect(publisher.publishPersonMerged).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/connectshyft-api/src/modules/peoplecore/events.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/events.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from 'node:crypto';
+import type { EventEnvelope, SubjectContext } from '@shyft/contracts';
+import type { Knex } from 'knex';
+import db from '../../config/knex';
+import { executePlatformMutation } from '../../platform/mutations/executePlatformMutation';
+
+export const PEOPLECORE_PERSON_MERGED_EVENT_NAME = 'peoplecore.person.merged' as const;
+
+export type PeopleCorePersonMergedPayload = {
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+  autoMergedContactPointLinkIds: string[];
+  reviewContactPointLinkIds: string[];
+  resolverReviewId?: string;
+  performedByUserId: string;
+  mergeReason?: string;
+};
+
+export type PeopleCorePersonMergedEvent = EventEnvelope<PeopleCorePersonMergedPayload> & {
+  type: typeof PEOPLECORE_PERSON_MERGED_EVENT_NAME;
+};
+
+export type PublishPeopleCorePersonMergedInput = {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+  autoMergedContactPointLinkIds: string[];
+  reviewContactPointLinkIds: string[];
+  resolverReviewId?: string;
+  performedByUserId: string;
+  mergeReason?: string;
+};
+
+export type PeopleCoreMergeEventPublisher = {
+  publishPersonMerged(input: PublishPeopleCorePersonMergedInput): Promise<void>;
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const persistedMergeEventsForTests: PeopleCorePersonMergedEvent[] = [];
+
+const isUuid = (value: string | null | undefined): value is string =>
+  typeof value === 'string' && UUID_PATTERN.test(value.trim());
+
+const buildPersonMergeSubject = (input: {
+  orgUnitId: string;
+  canonicalPersonId: string;
+}): SubjectContext => ({
+  orgUnitId: input.orgUnitId,
+  personId: input.canonicalPersonId,
+});
+
+export const buildPeopleCorePersonMergedEvent = (
+  input: PublishPeopleCorePersonMergedInput,
+): PeopleCorePersonMergedEvent => ({
+  id: randomUUID(),
+  type: PEOPLECORE_PERSON_MERGED_EVENT_NAME,
+  source: 'peoplecore.merge_person',
+  tenantId: input.tenantId,
+  orgUnitId: input.orgUnitId,
+  subject: buildPersonMergeSubject({
+    orgUnitId: input.orgUnitId,
+    canonicalPersonId: input.canonicalPersonId,
+  }),
+  createdAt: new Date().toISOString(),
+  payload: {
+    provisionalPersonId: input.provisionalPersonId,
+    canonicalPersonId: input.canonicalPersonId,
+    autoMergedContactPointLinkIds: [...input.autoMergedContactPointLinkIds],
+    reviewContactPointLinkIds: [...input.reviewContactPointLinkIds],
+    resolverReviewId: input.resolverReviewId,
+    performedByUserId: input.performedByUserId,
+    mergeReason: input.mergeReason,
+  },
+});
+
+export const buildPeopleCoreMergeEventPublisher = (
+  knexClient: Knex = db,
+): PeopleCoreMergeEventPublisher => ({
+  async publishPersonMerged(input) {
+    const envelope = buildPeopleCorePersonMergedEvent(input);
+
+    if (
+      !isUuid(input.tenantId)
+      || !isUuid(input.canonicalPersonId)
+      || !isUuid(input.performedByUserId)
+    ) {
+      persistedMergeEventsForTests.push(envelope);
+      return;
+    }
+
+    try {
+      await executePlatformMutation({
+        mutation: async () => null,
+        event: {
+          tenantId: input.tenantId,
+          actorId: input.performedByUserId,
+          eventName: envelope.type,
+          entityType: 'people.person',
+          entityId: input.canonicalPersonId,
+          payload: envelope as unknown as Record<string, unknown>,
+          occurredAtUtc: envelope.createdAt,
+        },
+      }, knexClient);
+    } catch (_error) {
+      persistedMergeEventsForTests.push(envelope);
+    }
+  },
+});
+
+export const resetPeopleCoreMergeEventsForTests = (): void => {
+  persistedMergeEventsForTests.splice(0, persistedMergeEventsForTests.length);
+};
+
+export const listPeopleCoreMergeEventsForTests = (): PeopleCorePersonMergedEvent[] =>
+  [...persistedMergeEventsForTests];

--- a/apps/connectshyft-api/src/modules/peoplecore/handlers/postMergePerson.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/handlers/postMergePerson.ts
@@ -1,0 +1,149 @@
+import { Request, Response } from 'express';
+import {
+  error as errorEnvelope,
+  refusal,
+  success,
+} from '../../../platform/envelopes/response';
+import {
+  enforceConnectShyftCapability,
+  resolveConnectShyftRequestedActorUserId,
+  resolveConnectShyftRouteContextDecision,
+  respondWithConnectShyftContextRefusal,
+} from '../../connectshyft/http/accessContext';
+import { PeopleCorePersistenceUnavailableError, peopleCoreServiceAsync } from '../service';
+import {
+  PeopleCoreMergeScopeViolationError,
+  PeopleCorePersonAlreadyMergedError,
+} from '../store';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const respondInvalidField = (
+  res: Response,
+  input: {
+    code: string;
+    field: string;
+    message: string;
+    reason?: string;
+  },
+) => refusal(res, {
+  code: input.code,
+  message: input.message,
+  refusalType: 'client',
+  httpStatus: 400,
+  data: {
+    fieldErrors: [
+      {
+        field: input.field,
+        reason: input.reason ?? 'INVALID',
+        message: input.message,
+      },
+    ],
+  },
+});
+
+export const postMergePerson = async (req: Request, res: Response) => {
+  if (!await enforceConnectShyftCapability(req, res, 'module')) {
+    return;
+  }
+
+  const provisionalPersonId = normalizeString(req.body?.provisionalPersonId);
+  if (!UUID_PATTERN.test(provisionalPersonId)) {
+    respondInvalidField(res, {
+      code: 'PEOPLECORE_PROVISIONAL_PERSON_ID_INVALID',
+      field: 'provisionalPersonId',
+      message: 'provisionalPersonId must be a non-empty UUID.',
+    });
+    return;
+  }
+
+  const canonicalPersonId = normalizeString(req.body?.canonicalPersonId);
+  if (!UUID_PATTERN.test(canonicalPersonId)) {
+    respondInvalidField(res, {
+      code: 'PEOPLECORE_CANONICAL_PERSON_ID_INVALID',
+      field: 'canonicalPersonId',
+      message: 'canonicalPersonId must be a non-empty UUID.',
+    });
+    return;
+  }
+
+  const actorUserId = normalizeString(resolveConnectShyftRequestedActorUserId(req));
+  if (!actorUserId) {
+    respondInvalidField(res, {
+      code: 'PEOPLECORE_MERGE_ACTOR_REQUIRED',
+      field: 'actorUserId',
+      message: 'Authenticated actor attribution is required.',
+      reason: 'REQUIRED',
+    });
+    return;
+  }
+
+  const contextDecision = await resolveConnectShyftRouteContextDecision(req);
+  if (!contextDecision.ok) {
+    respondWithConnectShyftContextRefusal(res, contextDecision);
+    return;
+  }
+
+  try {
+    const merged = await peopleCoreServiceAsync.mergePerson({
+      tenantId: contextDecision.context.tenantId,
+      orgUnitId: contextDecision.context.orgUnitId,
+      provisionalPersonId,
+      canonicalPersonId,
+      performedByUserId: actorUserId,
+      mergeReason: normalizeString(req.body?.mergeReason) || undefined,
+    });
+
+    return success(res, {
+      code: 'PEOPLECORE_PERSON_MERGED',
+      message: 'PeopleCore person merge complete',
+      httpStatus: 200,
+      data: {
+        mergedProvisionalPersonId: merged.mergedProvisionalPersonId,
+        canonicalPersonId: merged.canonicalPersonId,
+        autoMergedContactPointLinkIds: merged.autoMergedContactPointLinkIds,
+        reviewContactPointLinkIds: merged.reviewContactPointLinkIds,
+        resolverReviewId: merged.resolverReviewId,
+      },
+    });
+  } catch (error) {
+    if (error instanceof PeopleCoreMergeScopeViolationError) {
+      refusal(res, {
+        code: error.code,
+        message: error.message,
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    if (error instanceof PeopleCorePersonAlreadyMergedError) {
+      refusal(res, {
+        code: error.code,
+        message: error.message,
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    if (error instanceof PeopleCorePersistenceUnavailableError) {
+      errorEnvelope(res, {
+        code: error.code,
+        message: error.message,
+        httpStatus: 503,
+      });
+      return;
+    }
+
+    throw error;
+  }
+};

--- a/apps/connectshyft-api/src/modules/peoplecore/index.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/index.ts
@@ -1,3 +1,4 @@
 export * from './activity';
+export * from './events';
 export * from './store';
 export * from './service';

--- a/apps/connectshyft-api/src/modules/peoplecore/service.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/service.ts
@@ -4,6 +4,10 @@ import type {
   ListActivitiesInput,
 } from './activity';
 import {
+  buildPeopleCoreMergeEventPublisher,
+  type PeopleCoreMergeEventPublisher,
+} from './events';
+import {
   KnexPeopleCoreStore,
   type AppendContactPointEventInput,
   type CreateContactPointInput,
@@ -14,6 +18,9 @@ import {
   type CreateResolverReviewInput,
   type GetContactPointInput,
   type GetHouseholdInput,
+  type MergePersonInput,
+  type PeopleCoreMergeResult,
+  type PersonMergeStatus,
   type GetPersonInput,
   type ListContactPointLinksInput,
   type GetResolverReviewInput,
@@ -52,6 +59,8 @@ export class PeopleCorePersistenceUnavailableError extends Error {
 export class AsyncPeopleCoreService {
   constructor(
     private readonly store: PeopleCoreStore = new KnexPeopleCoreStore(),
+    private readonly mergeEventPublisher: PeopleCoreMergeEventPublisher =
+      buildPeopleCoreMergeEventPublisher(),
   ) {}
 
   private async execute<T>(operation: () => Promise<T>): Promise<T> {
@@ -84,6 +93,30 @@ export class AsyncPeopleCoreService {
 
   listPersons(input: ListPersonsInput) {
     return this.execute(() => this.store.listPersons(input));
+  }
+
+  async mergePerson(input: MergePersonInput): Promise<PeopleCoreMergeResult> {
+    const result = await this.execute(() => this.store.mergePerson(input));
+
+    if (result.didPersistMerge) {
+      await this.mergeEventPublisher.publishPersonMerged({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        provisionalPersonId: result.mergedProvisionalPersonId,
+        canonicalPersonId: result.canonicalPersonId,
+        performedByUserId: input.performedByUserId,
+        mergeReason: input.mergeReason,
+        autoMergedContactPointLinkIds: result.autoMergedContactPointLinkIds,
+        reviewContactPointLinkIds: result.reviewContactPointLinkIds,
+        resolverReviewId: result.resolverReviewId,
+      });
+    }
+
+    return result;
+  }
+
+  getPersonMergeStatus(input: GetPersonInput): Promise<PersonMergeStatus> {
+    return this.execute(() => this.store.getPersonMergeStatus(input));
   }
 
   listActivities(input: ListActivitiesInput) {

--- a/apps/connectshyft-api/src/modules/peoplecore/store.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/store.ts
@@ -2,6 +2,7 @@ import type {
   ContactPoint,
   ContactPointEvent,
   ContactPointLink,
+  ResolverReviewStatus,
   ContactPointLinkSubjectType,
   ContactPointType,
   Household,
@@ -70,12 +71,67 @@ const normalizeEventLimit = (value: unknown): number => {
   return Math.min(normalized, MAX_CONTACT_POINT_EVENT_LIMIT);
 };
 
+const PENDING_RESOLVER_REVIEW_STATUSES = new Set<ResolverReviewStatus>([
+  'pending',
+  'queued',
+  'in_review',
+  'waiting_for_more_info',
+]);
+
+const normalizePersonMergeStatus = (person: Pick<Person, 'status' | 'mergedIntoPersonId'>): PersonMergeStatus => {
+  if (person.status === 'merged' || normalizeOptionalString(person.mergedIntoPersonId)) {
+    return 'merged';
+  }
+
+  return person.status === 'active_provisional' ? 'provisional' : 'canonical';
+};
+
+const uniqueStrings = (values: Iterable<string>): string[] =>
+  Array.from(new Set(Array.from(values).filter((value) => value.length > 0)));
+
+const normalizeOptionalUtc = (value: unknown): string | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+
+  return toIsoUtc(value, new Date(0).toISOString());
+};
+
+const buildMergeReviewTriggerSourceId = (input: {
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+}): string => `${input.provisionalPersonId}:${input.canonicalPersonId}`;
+
 export class PeopleCoreScopeViolationError extends Error {
   readonly code = 'PEOPLECORE_SCOPE_VIOLATION';
 
   constructor(message: string, cause?: unknown) {
     super(message);
     this.name = 'PeopleCoreScopeViolationError';
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export class PeopleCoreMergeScopeViolationError extends Error {
+  readonly code = 'PEOPLECORE_MERGE_SCOPE_VIOLATION';
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'PeopleCoreMergeScopeViolationError';
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export class PeopleCorePersonAlreadyMergedError extends Error {
+  readonly code = 'PEOPLECORE_PERSON_ALREADY_MERGED';
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'PeopleCorePersonAlreadyMergedError';
     if (cause !== undefined) {
       (this as Error & { cause?: unknown }).cause = cause;
     }
@@ -141,6 +197,11 @@ export type CreateContactPointLinkInput = Omit<
 > & {
   linkId?: string;
   tenantId: string;
+  mergedIntoSubjectId?: string;
+  mergedAt?: string;
+  mergedByUserId?: string;
+  mergeClass?: PeopleCoreMergeClass;
+  mergeReason?: string;
 };
 
 export type ListCurrentContactPointLinksInput = {
@@ -179,10 +240,34 @@ export type ListResolverReviewsInput = {
   orgUnitId?: string;
 };
 
+export type PeopleCoreMergeClass = 'auto' | 'review';
+
+export type MergePersonInput = {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+  performedByUserId: string;
+  mergeReason?: string;
+};
+
+export type PersonMergeStatus = 'provisional' | 'canonical' | 'merged';
+
+export type PeopleCoreMergeResult = {
+  mergedProvisionalPersonId: string;
+  canonicalPersonId: string;
+  autoMergedContactPointLinkIds: string[];
+  reviewContactPointLinkIds: string[];
+  resolverReviewId?: string;
+  didPersistMerge?: boolean;
+};
+
 export interface PeopleCoreStore extends PeopleCoreActivityStore {
   createPerson(input: CreatePersonInput): Promise<Person>;
   getPerson(input: GetPersonInput): Promise<Person | null>;
   listPersons(input: ListPersonsInput): Promise<Person[]>;
+  mergePerson(input: MergePersonInput): Promise<PeopleCoreMergeResult>;
+  getPersonMergeStatus(input: GetPersonInput): Promise<PersonMergeStatus>;
   createHousehold(input: CreateHouseholdInput): Promise<Household>;
   getHousehold(input: GetHouseholdInput): Promise<Household | null>;
   createHouseholdMembership(input: CreateHouseholdMembershipInput): Promise<HouseholdMembership>;
@@ -275,6 +360,11 @@ type DbContactPointLinkRow = {
   linked_by_user_id: string | null;
   unlink_reason: string | null;
   unlinked_at_utc: string | Date | null;
+  merged_into_subject_id: string | null;
+  merged_at_utc: string | Date | null;
+  merged_by_user_id: string | null;
+  merge_class: PeopleCoreMergeClass;
+  merge_reason: string | null;
   created_at_utc: string | Date;
   updated_at_utc: string | Date;
 };
@@ -403,7 +493,7 @@ const mapContactPointRow = (row: DbContactPointRow): ContactPoint => {
 const mapContactPointLinkRow = (row: DbContactPointLinkRow): ContactPointLink => {
   const fallbackIsoUtc = new Date().toISOString();
 
-  return {
+  const mappedLink = {
     id: row.id,
     contactPointId: row.contact_point_id,
     subjectType: row.subject_type,
@@ -425,9 +515,16 @@ const mapContactPointLinkRow = (row: DbContactPointLinkRow): ContactPointLink =>
     linkedByUserId: normalizeOptionalString(row.linked_by_user_id),
     unlinkReason: normalizeOptionalString(row.unlink_reason),
     unlinkedAt: row.unlinked_at_utc ? toIsoUtc(row.unlinked_at_utc, fallbackIsoUtc) : undefined,
+    mergedIntoSubjectId: normalizeOptionalString(row.merged_into_subject_id),
+    mergedAt: row.merged_at_utc ? toIsoUtc(row.merged_at_utc, fallbackIsoUtc) : undefined,
+    mergedByUserId: normalizeOptionalString(row.merged_by_user_id),
+    mergeClass: row.merge_class,
+    mergeReason: normalizeOptionalString(row.merge_reason),
     createdAt: toIsoUtc(row.created_at_utc, fallbackIsoUtc),
     updatedAt: toIsoUtc(row.updated_at_utc, fallbackIsoUtc),
   };
+
+  return mappedLink;
 };
 
 const mapContactPointEventRow = (row: DbContactPointEventRow): ContactPointEvent => {
@@ -573,6 +670,11 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
       'linked_by_user_id',
       'unlink_reason',
       'unlinked_at_utc',
+      'merged_into_subject_id',
+      'merged_at_utc',
+      'merged_by_user_id',
+      'merge_class',
+      'merge_reason',
       'created_at_utc',
       'updated_at_utc',
     ];
@@ -695,6 +797,249 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
     }
   }
 
+  private async getScopedPersonRow(
+    knexClient: Knex,
+    input: {
+      tenantId: string;
+      orgUnitId: string;
+      personId: string;
+    },
+  ): Promise<DbPersonRow | null> {
+    const row = await knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('persons')
+      .where({
+        id: input.personId,
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+      })
+      .first<DbPersonRow>(this.personColumns());
+
+    return row ?? null;
+  }
+
+  private async listPersonContactPointLinksForTenant(
+    knexClient: Knex,
+    input: {
+      tenantId: string;
+      personId: string;
+    },
+  ): Promise<DbContactPointLinkRow[]> {
+    const linkRows = await knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('contact_point_links')
+      .where({
+        subject_type: 'person',
+        subject_id: input.personId,
+      })
+      .orderBy('created_at_utc', 'asc')
+      .orderBy('id', 'asc')
+      .select<DbContactPointLinkRow[]>(this.contactPointLinkColumns());
+
+    if (linkRows.length === 0) {
+      return [];
+    }
+
+    const scopedContactPointRows = await knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('contact_points')
+      .where({
+        tenant_id: input.tenantId,
+      })
+      .whereIn('id', uniqueStrings(linkRows.map((row) => row.contact_point_id)))
+      .select<Array<{ id: string }>>(['id']);
+
+    const scopedContactPointIds = new Set(scopedContactPointRows.map((row) => row.id));
+    return linkRows.filter((row) => scopedContactPointIds.has(row.contact_point_id));
+  }
+
+  private async listCurrentHouseholdMembershipsForTenant(
+    knexClient: Knex,
+    input: {
+      tenantId: string;
+      personId: string;
+    },
+  ): Promise<DbHouseholdMembershipRow[]> {
+    const membershipRows = await knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('household_memberships')
+      .where({
+        person_id: input.personId,
+        is_current: true,
+      })
+      .orderBy('created_at_utc', 'asc')
+      .orderBy('id', 'asc')
+      .select<DbHouseholdMembershipRow[]>(this.householdMembershipColumns());
+
+    if (membershipRows.length === 0) {
+      return [];
+    }
+
+    const scopedHouseholdRows = await knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('households')
+      .where({
+        tenant_id: input.tenantId,
+      })
+      .whereIn('id', uniqueStrings(membershipRows.map((row) => row.household_id)))
+      .select<Array<{ id: string }>>(['id']);
+
+    const scopedHouseholdIds = new Set(scopedHouseholdRows.map((row) => row.id));
+    return membershipRows.filter((row) => scopedHouseholdIds.has(row.household_id));
+  }
+
+  private hasPrimaryContactConflict(
+    provisionalLink: DbContactPointLinkRow,
+    canonicalLinks: DbContactPointLinkRow[],
+  ): boolean {
+    if (!provisionalLink.is_current || !provisionalLink.is_primary) {
+      return false;
+    }
+
+    return canonicalLinks.some((candidate) => candidate.is_current && candidate.is_primary);
+  }
+
+  private hasEquivalentCanonicalLink(
+    canonicalLinks: DbContactPointLinkRow[],
+    provisionalLink: DbContactPointLinkRow,
+  ): boolean {
+    return canonicalLinks.some((candidate) =>
+      candidate.contact_point_id === provisionalLink.contact_point_id
+      && candidate.link_type === provisionalLink.link_type
+      && candidate.confidence_band === provisionalLink.confidence_band
+      && candidate.is_current === provisionalLink.is_current
+      && candidate.is_primary === provisionalLink.is_primary
+      && candidate.manually_confirmed === provisionalLink.manually_confirmed
+      && candidate.confirmation_source === provisionalLink.confirmation_source
+      && candidate.linked_by === provisionalLink.linked_by
+      && candidate.linked_by_user_id === provisionalLink.linked_by_user_id
+      && candidate.unlink_reason === provisionalLink.unlink_reason
+      && normalizeOptionalUtc(candidate.first_linked_at_utc)
+        === normalizeOptionalUtc(provisionalLink.first_linked_at_utc)
+      && normalizeOptionalUtc(candidate.last_confirmed_at_utc)
+        === normalizeOptionalUtc(provisionalLink.last_confirmed_at_utc)
+      && normalizeOptionalUtc(candidate.last_used_at_utc)
+        === normalizeOptionalUtc(provisionalLink.last_used_at_utc)
+      && normalizeOptionalUtc(candidate.unlinked_at_utc)
+        === normalizeOptionalUtc(provisionalLink.unlinked_at_utc));
+  }
+
+  private async markContactPointLinkMerged(
+    knexClient: Knex,
+    input: {
+      linkId: string;
+      canonicalPersonId: string;
+      mergedAtUtc: string;
+      mergedByUserId: string;
+      mergeClass: PeopleCoreMergeClass;
+      mergeReason?: string;
+    },
+  ): Promise<void> {
+    await knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('contact_point_links')
+      .where({
+        id: input.linkId,
+      })
+      .update({
+        is_current: false,
+        merged_into_subject_id: input.canonicalPersonId,
+        merged_at_utc: input.mergedAtUtc,
+        merged_by_user_id: input.mergedByUserId,
+        merge_class: input.mergeClass,
+        merge_reason: input.mergeReason ?? null,
+        updated_at_utc: input.mergedAtUtc,
+      });
+  }
+
+  private async findExistingMergeReview(
+    knexClient: Knex,
+    input: {
+      tenantId: string;
+      orgUnitId: string;
+      provisionalPersonId: string;
+      canonicalPersonId: string;
+    },
+  ): Promise<ResolverReview | null> {
+    const rows = await knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('resolver_reviews')
+      .where({
+        tenant_id: input.tenantId,
+        org_unit_id: input.orgUnitId,
+        trigger_source_type: 'person_merge',
+        trigger_source_id: buildMergeReviewTriggerSourceId(input),
+      })
+      .orderBy('requested_at_utc', 'asc')
+      .orderBy('id', 'asc')
+      .select<DbResolverReviewRow[]>(this.resolverReviewColumns());
+
+    const existing = rows
+      .map(mapResolverReviewRow)
+      .find((review) =>
+        review.provisionalPersonId === input.provisionalPersonId
+        && review.candidatePersonIds.includes(input.canonicalPersonId)
+        && PENDING_RESOLVER_REVIEW_STATUSES.has(review.reviewStatus));
+
+    return existing ?? null;
+  }
+
+  private async buildExistingMergeResult(
+    knexClient: Knex,
+    input: MergePersonInput,
+  ): Promise<PeopleCoreMergeResult> {
+    const provisionalLinks = await this.listPersonContactPointLinksForTenant(knexClient, {
+      tenantId: input.tenantId,
+      personId: input.provisionalPersonId,
+    });
+    const canonicalLinks = await this.listPersonContactPointLinksForTenant(knexClient, {
+      tenantId: input.tenantId,
+      personId: input.canonicalPersonId,
+    });
+    const provisionalHouseholds = await this.listCurrentHouseholdMembershipsForTenant(knexClient, {
+      tenantId: input.tenantId,
+      personId: input.provisionalPersonId,
+    });
+    const canonicalHouseholds = await this.listCurrentHouseholdMembershipsForTenant(knexClient, {
+      tenantId: input.tenantId,
+      personId: input.canonicalPersonId,
+    });
+
+    const canonicalLinksByContactPointId = new Map<string, DbContactPointLinkRow[]>();
+    canonicalLinks.forEach((link) => {
+      const existing = canonicalLinksByContactPointId.get(link.contact_point_id) ?? [];
+      existing.push(link);
+      canonicalLinksByContactPointId.set(link.contact_point_id, existing);
+    });
+
+    const autoMergedContactPointLinkIds = provisionalLinks
+      .filter((link) => normalizeOptionalString(link.merged_into_subject_id) === input.canonicalPersonId)
+      .map((link) => link.id);
+    const reviewContactPointLinkIds = provisionalLinks
+      .filter((link) => !normalizeOptionalString(link.merged_into_subject_id))
+      .filter((link) =>
+        this.hasPrimaryContactConflict(
+          link,
+          canonicalLinksByContactPointId.get(link.contact_point_id) ?? [],
+        ))
+      .map((link) => link.id);
+
+    const householdAmbiguity = provisionalHouseholds.some((membership) =>
+      canonicalHouseholds.some((candidate) => candidate.household_id !== membership.household_id));
+    const existingReview = await this.findExistingMergeReview(knexClient, input);
+
+    return {
+      mergedProvisionalPersonId: input.provisionalPersonId,
+      canonicalPersonId: input.canonicalPersonId,
+      autoMergedContactPointLinkIds,
+      reviewContactPointLinkIds,
+      resolverReviewId: householdAmbiguity || reviewContactPointLinkIds.length > 0
+        ? existingReview?.id
+        : undefined,
+      didPersistMerge: false,
+    };
+  }
+
   async createPerson(input: CreatePersonInput): Promise<Person> {
     const [row] = await this.knexClient
       .withSchema(PEOPLE_SCHEMA)
@@ -749,6 +1094,233 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
       .select<DbPersonRow[]>(this.personColumns());
 
     return rows.map(mapPersonRow);
+  }
+
+  async mergePerson(input: MergePersonInput): Promise<PeopleCoreMergeResult> {
+    return this.knexClient.transaction(async (trx) => {
+      const provisionalRow = await this.getScopedPersonRow(trx, {
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        personId: input.provisionalPersonId,
+      });
+      const canonicalRow = await this.getScopedPersonRow(trx, {
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        personId: input.canonicalPersonId,
+      });
+
+      if (!provisionalRow || !canonicalRow) {
+        throw new PeopleCoreMergeScopeViolationError(
+          `PeopleCore merge requires both persons to exist in tenant ${input.tenantId} org unit ${input.orgUnitId}.`,
+        );
+      }
+
+      if (input.provisionalPersonId === input.canonicalPersonId) {
+        throw new PeopleCoreMergeScopeViolationError(
+          'PeopleCore merge requires distinct provisional and canonical person ids.',
+        );
+      }
+
+      if (normalizeOptionalString(provisionalRow.merged_into_person_id)) {
+        if (provisionalRow.merged_into_person_id === input.canonicalPersonId) {
+          return this.buildExistingMergeResult(trx, input);
+        }
+
+        throw new PeopleCorePersonAlreadyMergedError(
+          `Person ${input.provisionalPersonId} is already merged into ${provisionalRow.merged_into_person_id}.`,
+        );
+      }
+
+      if (provisionalRow.status !== 'active_provisional') {
+        throw new PeopleCoreMergeScopeViolationError(
+          `Person ${input.provisionalPersonId} must be active_provisional before merge.`,
+        );
+      }
+
+      if (canonicalRow.status !== 'active_confirmed') {
+        throw new PeopleCoreMergeScopeViolationError(
+          `Person ${input.canonicalPersonId} must be active_confirmed before merge.`,
+        );
+      }
+
+      const provisionalLinks = await this.listPersonContactPointLinksForTenant(trx, {
+        tenantId: input.tenantId,
+        personId: input.provisionalPersonId,
+      });
+      const canonicalLinks = await this.listPersonContactPointLinksForTenant(trx, {
+        tenantId: input.tenantId,
+        personId: input.canonicalPersonId,
+      });
+      const provisionalHouseholds = await this.listCurrentHouseholdMembershipsForTenant(trx, {
+        tenantId: input.tenantId,
+        personId: input.provisionalPersonId,
+      });
+      const canonicalHouseholds = await this.listCurrentHouseholdMembershipsForTenant(trx, {
+        tenantId: input.tenantId,
+        personId: input.canonicalPersonId,
+      });
+      const canonicalLinksByContactPointId = new Map<string, DbContactPointLinkRow[]>();
+
+      canonicalLinks.forEach((link) => {
+        const existing = canonicalLinksByContactPointId.get(link.contact_point_id) ?? [];
+        existing.push(link);
+        canonicalLinksByContactPointId.set(link.contact_point_id, existing);
+      });
+
+      const autoMergedContactPointLinkIds: string[] = [];
+      const reviewContactPointLinkIds: string[] = [];
+      const mergedAtUtc = new Date().toISOString();
+      const transactionalStore = new KnexPeopleCoreStore(trx as unknown as Knex);
+
+      for (const link of provisionalLinks) {
+        const canonicalLinksForContactPoint = canonicalLinksByContactPointId.get(link.contact_point_id) ?? [];
+        if (this.hasPrimaryContactConflict(link, canonicalLinksForContactPoint)) {
+          reviewContactPointLinkIds.push(link.id);
+          continue;
+        }
+
+        await this.markContactPointLinkMerged(trx, {
+          linkId: link.id,
+          canonicalPersonId: input.canonicalPersonId,
+          mergedAtUtc,
+          mergedByUserId: input.performedByUserId,
+          mergeClass: 'auto',
+          mergeReason: input.mergeReason,
+        });
+        autoMergedContactPointLinkIds.push(link.id);
+
+        if (this.hasEquivalentCanonicalLink(canonicalLinksForContactPoint, link)) {
+          continue;
+        }
+
+        const createdLink = await transactionalStore.createContactPointLink({
+          tenantId: input.tenantId,
+          contactPointId: link.contact_point_id,
+          subjectType: 'person',
+          subjectId: input.canonicalPersonId,
+          linkType: link.link_type,
+          confidenceBand: link.confidence_band,
+          isCurrent: link.is_current,
+          isPrimary: link.is_primary,
+          manuallyConfirmed: link.manually_confirmed,
+          confirmationSource: link.confirmation_source ?? undefined,
+          firstLinkedAt: toIsoUtc(link.first_linked_at_utc, mergedAtUtc),
+          lastConfirmedAt: link.last_confirmed_at_utc
+            ? toIsoUtc(link.last_confirmed_at_utc, mergedAtUtc)
+            : undefined,
+          lastUsedAt: link.last_used_at_utc
+            ? toIsoUtc(link.last_used_at_utc, mergedAtUtc)
+            : undefined,
+          linkedBy: link.linked_by,
+          linkedByUserId: normalizeOptionalString(link.linked_by_user_id),
+          unlinkReason: normalizeOptionalString(link.unlink_reason),
+          unlinkedAt: link.unlinked_at_utc ? toIsoUtc(link.unlinked_at_utc, mergedAtUtc) : undefined,
+          mergeClass: 'auto',
+        });
+        const existing = canonicalLinksByContactPointId.get(link.contact_point_id) ?? [];
+        existing.push({
+          id: createdLink.id,
+          contact_point_id: createdLink.contactPointId,
+          subject_type: createdLink.subjectType,
+          subject_id: createdLink.subjectId,
+          link_type: createdLink.linkType,
+          confidence_band: createdLink.confidenceBand,
+          is_current: createdLink.isCurrent,
+          is_primary: createdLink.isPrimary,
+          manually_confirmed: createdLink.manuallyConfirmed,
+          confirmation_source: createdLink.confirmationSource ?? null,
+          first_linked_at_utc: createdLink.firstLinkedAt,
+          last_confirmed_at_utc: createdLink.lastConfirmedAt ?? null,
+          last_used_at_utc: createdLink.lastUsedAt ?? null,
+          linked_by: createdLink.linkedBy,
+          linked_by_user_id: createdLink.linkedByUserId ?? null,
+          unlink_reason: createdLink.unlinkReason ?? null,
+          unlinked_at_utc: createdLink.unlinkedAt ?? null,
+          merged_into_subject_id: null,
+          merged_at_utc: null,
+          merged_by_user_id: null,
+          merge_class: 'auto',
+          merge_reason: null,
+          created_at_utc: createdLink.createdAt,
+          updated_at_utc: createdLink.updatedAt,
+        });
+        canonicalLinksByContactPointId.set(link.contact_point_id, existing);
+      }
+
+      const householdAmbiguity = provisionalHouseholds.some((membership) =>
+        canonicalHouseholds.some((candidate) => candidate.household_id !== membership.household_id));
+
+      let resolverReviewId: string | undefined;
+      if (reviewContactPointLinkIds.length > 0 || householdAmbiguity) {
+        const existingReview = await this.findExistingMergeReview(trx, input);
+        if (existingReview) {
+          resolverReviewId = existingReview.id;
+        } else {
+          const reasons = reviewContactPointLinkIds.length > 0
+            ? ['Manual review required because both people own current primary contact links.']
+            : [];
+          if (householdAmbiguity) {
+            reasons.push('Manual review required because the people have ambiguous current household memberships.');
+          }
+
+          const review = await transactionalStore.createResolverReview({
+            tenantId: input.tenantId,
+            orgUnitId: input.orgUnitId,
+            reviewType: 'merge_review',
+            reviewStatus: 'pending',
+            priority: 'normal',
+            triggerSourceType: 'person_merge',
+            triggerSourceId: buildMergeReviewTriggerSourceId(input),
+            provisionalPersonId: input.provisionalPersonId,
+            candidatePersonIds: [input.canonicalPersonId],
+            contactPointId: provisionalLinks.find((link) =>
+              reviewContactPointLinkIds.includes(link.id))?.contact_point_id,
+            confidenceBand: 'medium',
+            confidenceReasons: reasons.length > 0
+              ? reasons
+              : ['Manual review required before finalizing this person merge.'],
+            riskFlags: [],
+            requestedByUserId: input.performedByUserId,
+            requestedAt: mergedAtUtc,
+          });
+          resolverReviewId = review.id;
+        }
+      }
+
+      await trx
+        .withSchema(PEOPLE_SCHEMA)
+        .table('persons')
+        .where({
+          id: input.provisionalPersonId,
+          tenant_id: input.tenantId,
+          org_unit_id: input.orgUnitId,
+        })
+        .update({
+          status: 'merged',
+          merged_into_person_id: input.canonicalPersonId,
+          updated_at_utc: mergedAtUtc,
+        });
+
+      return {
+        mergedProvisionalPersonId: input.provisionalPersonId,
+        canonicalPersonId: input.canonicalPersonId,
+        autoMergedContactPointLinkIds,
+        reviewContactPointLinkIds,
+        resolverReviewId,
+        didPersistMerge: true,
+      };
+    });
+  }
+
+  async getPersonMergeStatus(input: GetPersonInput): Promise<PersonMergeStatus> {
+    const person = await this.getPerson(input);
+    if (!person) {
+      throw new PeopleCoreScopeViolationError(
+        `Person ${input.personId} is not available in tenant ${input.tenantId}.`,
+      );
+    }
+
+    return normalizePersonMergeStatus(person);
   }
 
   async createActivity(input: CreateActivityInput): Promise<Activity> {
@@ -975,6 +1547,11 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
         linked_by_user_id: input.linkedByUserId ?? null,
         unlink_reason: input.unlinkReason ?? null,
         unlinked_at_utc: input.unlinkedAt ?? null,
+        merged_into_subject_id: input.mergedIntoSubjectId ?? null,
+        merged_at_utc: input.mergedAt ?? null,
+        merged_by_user_id: input.mergedByUserId ?? null,
+        merge_class: input.mergeClass ?? 'auto',
+        merge_reason: input.mergeReason ?? null,
         created_at_utc: this.knexClient.fn.now(),
         updated_at_utc: this.knexClient.fn.now(),
       })

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.person-merge-unified-timeline.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.person-merge-unified-timeline.test.ts
@@ -1,0 +1,466 @@
+// @ts-nocheck
+import request from 'supertest';
+import {
+  loadConnectShyftBridgeAggregateBySessionId,
+  resetConnectShyftBridgeSessionStateForTests,
+  startConnectShyftBridgeSession,
+} from '../../../../modules/connectshyft/bridgeSessions';
+import {
+  recordConnectShyftCanonicalEvent,
+  resetConnectShyftCanonicalEventsForTests,
+} from '../../../../modules/connectshyft/canonicalEvents';
+import {
+  connectShyftCallServiceAsync,
+  resetConnectShyftCallStateForTests,
+} from '../../../../modules/connectshyft/calls';
+import {
+  connectShyftDeliveryAttemptServiceAsync,
+  resetConnectShyftDeliveryAttemptStateForTests,
+} from '../../../../modules/connectshyft/deliveryAttempts';
+import { buildConnectShyftPersonRebindEventSubscriber } from '../../../../modules/connectshyft/events';
+import {
+  CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+} from '../../../../modules/connectshyft/inboundSms';
+import { resetConnectShyftPersonRebindStateForTests } from '../../../../modules/connectshyft/personRebind';
+import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import type { ConnectShyftProviderAdapter } from '../../../../modules/connectshyft/providerRegistry';
+import {
+  connectShyftThreadService,
+  resetConnectShyftThreadStateForTests,
+  type ConnectShyftThread,
+} from '../../../../modules/connectshyft/threads';
+import {
+  CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+} from '../../../../modules/connectshyft/threadTimeline';
+import {
+  connectShyftVoicemailServiceAsync,
+  resetConnectShyftVoicemailStateForTests,
+} from '../../../../modules/connectshyft/voicemails';
+import {
+  buildPeopleCoreMergeEventPublisher,
+  listPeopleCoreMergeEventsForTests,
+  resetPeopleCoreMergeEventsForTests,
+} from '../../../../modules/peoplecore/events';
+import { postMergePerson } from '../../../../modules/peoplecore/handlers/postMergePerson';
+import { peopleCoreServiceAsync } from '../../../../modules/peoplecore/service';
+import {
+  buildApp,
+  buildHeaders,
+  registerProviderRegistryRouteIntegrationHooks,
+} from './connectshyft.provider-registry.test.shared';
+
+const TEST_TENANT_ID = 'tenant-connectshyft-f1';
+const TEST_ORG_UNIT_ID = 'org-connectshyft-f1-east';
+const PROVISIONAL_PERSON_ID = '11111111-1111-4111-8111-111111111111';
+const CANONICAL_PERSON_ID = '22222222-2222-4222-8222-222222222222';
+const MERGE_REASON = 'resolver-confirmed-duplicate';
+
+const sendSmsMock = jest.fn();
+const startOutboundCallMock = jest.fn();
+const startBridgeOutboundCallMock = jest.fn(async (input: { legRole: string; threadId: string }) => ({
+  providerKey: 'provider-a',
+  channel: 'call' as const,
+  providerLegId: `${input.legRole}-provider-leg-${input.threadId}`,
+  providerMessageId: null,
+  providerRequestId: `req-${input.legRole}-${input.threadId}`,
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-24T12:00:00.000Z',
+}));
+const startBridgeSessionMock = jest.fn(async (input: { bridgeSessionId: string }) => ({
+  providerKey: 'provider-a',
+  bridgeSessionId: input.bridgeSessionId,
+  bridgeEstablished: true as const,
+  providerRequestId: 'req-bridge-session-1001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-24T12:01:00.000Z',
+}));
+const verifyWebhookMock = jest.fn(() => ({ ok: true as const }));
+const endCallMock = jest.fn(async (input: { providerLegId: string }) => ({
+  providerKey: 'provider-a',
+  providerLegId: input.providerLegId,
+  ended: true as const,
+  providerRequestId: 'req-end-call-1001',
+  adapterInvoked: true as const,
+  providerBranchingInDomain: false as const,
+  requestedAt: '2026-03-24T12:02:00.000Z',
+}));
+const translateProviderEventMock = jest.fn(() => ({
+  eventType: 'CallAnswered',
+  payload: {},
+  correlation: {
+    providerLegId: null,
+    providerMessageId: null,
+    providerEventId: null,
+    providerNumber: null,
+  },
+  providerNeutral: true as const,
+  providerSpecificFieldsStripped: true as const,
+  providerBranchingInDomain: false as const,
+}));
+
+const providerAdapter: ConnectShyftProviderAdapter = {
+  providerKey: 'provider-a',
+  adapterInterfaceVersion: 'v1',
+  sendSms: sendSmsMock,
+  startOutboundCall: startOutboundCallMock,
+  startBridgeOutboundCall: startBridgeOutboundCallMock,
+  verifyWebhook: verifyWebhookMock,
+  translateProviderEvent: translateProviderEventMock,
+  startBridgeSession: startBridgeSessionMock,
+  endCall: endCallMock,
+};
+
+const buildMergeTimelineApp = () => {
+  const app = buildApp();
+  app.post('/api/v1/peoplecore/persons/merge', postMergePerson);
+  return app;
+};
+
+const buildThread = (input: {
+  threadId: string;
+  neighborId: string;
+  personId: string;
+  source?: string;
+}): ConnectShyftThread => {
+  const result = connectShyftThreadService.ensureThread({
+    actorRoles: ['ORGUNIT_MEMBER'],
+    tenantId: TEST_TENANT_ID,
+    orgUnitId: TEST_ORG_UNIT_ID,
+    neighborId: input.neighborId,
+    personId: input.personId,
+    source: input.source ?? 'VOICE',
+    threadId: input.threadId,
+    lastInboundCsNumberId: `${input.threadId}-inbound-number`,
+    preferredOutboundCsNumberId: `${input.threadId}-outbound-number`,
+  });
+
+  if (!result.ok) {
+    throw new Error(`Expected ensureThread to succeed for ${input.threadId}.`);
+  }
+
+  return result.data.thread;
+};
+
+const buildPerson = (input: {
+  id: string;
+  status: 'active_confirmed' | 'active_provisional' | 'merged';
+  mergedIntoPersonId?: string;
+}) => ({
+  id: input.id,
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  firstName: 'Pat',
+  lastName: 'Shyft',
+  status: input.status,
+  mergedIntoPersonId: input.mergedIntoPersonId,
+  createdAt: '2026-03-24T08:00:00.000Z',
+  updatedAt: '2026-03-24T08:00:00.000Z',
+});
+
+const recordTimelineEvent = async (input: {
+  threadId: string;
+  eventType: string;
+  occurredAtUtc: string;
+  payload: Record<string, unknown>;
+}) => recordConnectShyftCanonicalEvent({
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  aggregateId: input.threadId,
+  aggregateType: 'Thread',
+  eventType: input.eventType,
+  occurredAtUtc: input.occurredAtUtc,
+  payload: input.payload,
+});
+
+describe('peoplecore merge and connectshyft unified timeline routes', () => {
+  registerProviderRegistryRouteIntegrationHooks();
+
+  beforeEach(() => {
+    sendSmsMock.mockReset();
+    startOutboundCallMock.mockReset();
+    startBridgeOutboundCallMock.mockClear();
+    startBridgeSessionMock.mockClear();
+    verifyWebhookMock.mockClear();
+    endCallMock.mockClear();
+    translateProviderEventMock.mockClear();
+    resetConnectShyftThreadStateForTests();
+    resetConnectShyftCallStateForTests();
+    resetConnectShyftVoicemailStateForTests();
+    resetConnectShyftDeliveryAttemptStateForTests();
+    resetConnectShyftBridgeSessionStateForTests();
+    resetConnectShyftProviderCorrelationStateForTests();
+    resetConnectShyftPersonRebindStateForTests();
+    resetConnectShyftCanonicalEventsForTests();
+    resetPeopleCoreMergeEventsForTests();
+  });
+
+  afterEach(() => {
+    resetConnectShyftCanonicalEventsForTests();
+    resetPeopleCoreMergeEventsForTests();
+  });
+
+  it('merges a person, rebinds thread and telephony artifacts, and returns a unified timeline projection', async () => {
+    const mergedThread = buildThread({
+      threadId: 'thread-person-merge-1001',
+      neighborId: 'neighbor-person-merge-1001',
+      personId: PROVISIONAL_PERSON_ID,
+    });
+    const canonicalThread = buildThread({
+      threadId: 'thread-person-merge-1002',
+      neighborId: 'neighbor-person-merge-1002',
+      personId: CANONICAL_PERSON_ID,
+    });
+    const call = await connectShyftCallServiceAsync.createCall({
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      threadId: mergedThread.threadId,
+      personId: PROVISIONAL_PERSON_ID,
+    });
+    await connectShyftVoicemailServiceAsync.createVoicemail({
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      callId: call.id,
+      threadId: mergedThread.threadId,
+      personId: PROVISIONAL_PERSON_ID,
+      artifactId: 'artifact-person-merge-1001',
+      recordingUrl: 'https://connectshyft.test/person-merge-voicemail-1001.mp3',
+      recordingStatus: 'completed',
+      occurredAtUtc: '2026-03-24T10:05:00.000Z',
+    });
+    await connectShyftDeliveryAttemptServiceAsync.createAttempt({
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      threadId: mergedThread.threadId,
+      personId: PROVISIONAL_PERSON_ID,
+      callId: call.id,
+      channel: 'voice',
+      status: 'succeeded',
+    });
+    const bridgeSession = await startConnectShyftBridgeSession({
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      threadId: mergedThread.threadId,
+      personId: PROVISIONAL_PERSON_ID,
+      operatorParticipantId: 'operator-person-merge-1001',
+      neighborParticipantId: mergedThread.neighborId,
+      operatorContactPointId: '+12605550155',
+      neighborContactPointId: '+12605550111',
+      selectedOutboundContactPointId: '+12605550191',
+      providerKey: 'provider-a',
+      providerAdapter,
+    });
+    await recordTimelineEvent({
+      threadId: mergedThread.threadId,
+      eventType: 'MessageQueued',
+      occurredAtUtc: '2026-03-24T09:59:00.000Z',
+      payload: {
+        direction: 'outbound',
+        channel: 'sms',
+        actor: 'user',
+        eventName: CONNECTSHYFT_OUTBOUND_SMS_APPENDED_EVENT_NAME,
+        outboundMessageArtifact: {
+          body: 'Merged person timeline item',
+        },
+      },
+    });
+    await recordTimelineEvent({
+      threadId: canonicalThread.threadId,
+      eventType: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+      occurredAtUtc: '2026-03-24T10:00:00.000Z',
+      payload: {
+        direction: 'inbound',
+        channel: 'sms',
+        actor: 'neighbor',
+        eventName: CONNECTSHYFT_INBOUND_SMS_APPENDED_EVENT_NAME,
+        inboundMessageArtifact: {
+          body: 'Canonical person timeline item',
+        },
+      },
+    });
+
+    const mergePersonSpy = jest.spyOn(peopleCoreServiceAsync, 'mergePerson').mockImplementation(
+      async (input) => {
+        await buildPeopleCoreMergeEventPublisher().publishPersonMerged({
+          tenantId: input.tenantId,
+          orgUnitId: input.orgUnitId,
+          provisionalPersonId: input.provisionalPersonId,
+          canonicalPersonId: input.canonicalPersonId,
+          performedByUserId: input.performedByUserId,
+          mergeReason: input.mergeReason,
+          autoMergedContactPointLinkIds: ['contact-link-auto-1001'],
+          reviewContactPointLinkIds: [],
+        });
+
+        return {
+          mergedProvisionalPersonId: input.provisionalPersonId,
+          canonicalPersonId: input.canonicalPersonId,
+          autoMergedContactPointLinkIds: ['contact-link-auto-1001'],
+          reviewContactPointLinkIds: [],
+          didPersistMerge: true,
+        };
+      },
+    );
+    const getPersonSpy = jest.spyOn(peopleCoreServiceAsync, 'getPerson').mockResolvedValue(
+      buildPerson({
+        id: CANONICAL_PERSON_ID,
+        status: 'active_confirmed',
+      }) as any,
+    );
+    const listPersonsSpy = jest.spyOn(peopleCoreServiceAsync, 'listPersons').mockResolvedValue([
+      buildPerson({
+        id: PROVISIONAL_PERSON_ID,
+        status: 'merged',
+        mergedIntoPersonId: CANONICAL_PERSON_ID,
+      }) as any,
+      buildPerson({
+        id: CANONICAL_PERSON_ID,
+        status: 'active_confirmed',
+      }) as any,
+    ]);
+
+    try {
+      const app = buildMergeTimelineApp();
+      const mergeResponse = await request(app)
+        .post('/api/v1/peoplecore/persons/merge')
+        .set(buildHeaders())
+        .send({
+          provisionalPersonId: PROVISIONAL_PERSON_ID,
+          canonicalPersonId: CANONICAL_PERSON_ID,
+          mergeReason: MERGE_REASON,
+        });
+
+      expect(mergeResponse.status).toBe(200);
+      expect(mergeResponse.body).toMatchObject({
+        ok: true,
+        code: 'PEOPLECORE_PERSON_MERGED',
+        message: 'PeopleCore person merge complete',
+        data: {
+          mergedProvisionalPersonId: PROVISIONAL_PERSON_ID,
+          canonicalPersonId: CANONICAL_PERSON_ID,
+          autoMergedContactPointLinkIds: ['contact-link-auto-1001'],
+          reviewContactPointLinkIds: [],
+        },
+      });
+      expect(mergeResponse.body.data).not.toHaveProperty('resolverReviewId');
+
+      const [mergeEvent] = listPeopleCoreMergeEventsForTests();
+      expect(mergeEvent).toBeDefined();
+
+      await buildConnectShyftPersonRebindEventSubscriber().handlePeopleCorePersonMerged(mergeEvent!);
+
+      expect(
+        connectShyftThreadService.findThreadById({
+          tenantId: TEST_TENANT_ID,
+          threadId: mergedThread.threadId,
+        }),
+      ).toMatchObject({
+        threadId: mergedThread.threadId,
+        personId: CANONICAL_PERSON_ID,
+        originPersonId: PROVISIONAL_PERSON_ID,
+      });
+
+      expect(
+        await connectShyftCallServiceAsync.listPersonCalls({
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          personId: PROVISIONAL_PERSON_ID,
+        }),
+      ).toEqual([]);
+      expect(
+        await connectShyftCallServiceAsync.listPersonCalls({
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          personId: CANONICAL_PERSON_ID,
+        }),
+      ).toEqual([
+        expect.objectContaining({
+          id: call.id,
+          threadId: mergedThread.threadId,
+          personId: CANONICAL_PERSON_ID,
+        }),
+      ]);
+      expect(
+        await connectShyftVoicemailServiceAsync.listCallVoicemails({
+          tenantId: TEST_TENANT_ID,
+          callId: call.id,
+        }),
+      ).toEqual([
+        expect.objectContaining({
+          callId: call.id,
+          threadId: mergedThread.threadId,
+          personId: CANONICAL_PERSON_ID,
+        }),
+      ]);
+      expect(
+        await connectShyftDeliveryAttemptServiceAsync.listPersonAttempts({
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          personId: CANONICAL_PERSON_ID,
+        }),
+      ).toEqual([
+        expect.objectContaining({
+          threadId: mergedThread.threadId,
+          personId: CANONICAL_PERSON_ID,
+          callId: call.id,
+        }),
+      ]);
+      expect(
+        await loadConnectShyftBridgeAggregateBySessionId(bridgeSession.aggregate.session.id),
+      ).toMatchObject({
+        session: expect.objectContaining({
+          id: bridgeSession.aggregate.session.id,
+          personId: CANONICAL_PERSON_ID,
+        }),
+      });
+
+      const timelineResponse = await request(app)
+        .get(`/api/v1/connectshyft/person/${CANONICAL_PERSON_ID}/unified-timeline`)
+        .set(buildHeaders());
+
+      expect(timelineResponse.status).toBe(200);
+      expect(timelineResponse.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_UNIFIED_TIMELINE_LOADED',
+        data: {
+          person_id: CANONICAL_PERSON_ID,
+          merged_person_ids: [PROVISIONAL_PERSON_ID],
+        },
+      });
+      expect(timelineResponse.body.data.items.length).toBeGreaterThanOrEqual(2);
+      expect(timelineResponse.body.data.items).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          thread_id: mergedThread.threadId,
+          type: 'message',
+          direction: 'outbound',
+          channel: 'sms',
+          body: 'Merged person timeline item',
+          occurred_at_utc: '2026-03-24T09:59:00.000Z',
+          actor: 'user',
+          person_context: {
+            person_id: CANONICAL_PERSON_ID,
+            origin_person_id: PROVISIONAL_PERSON_ID,
+          },
+        }),
+        expect.objectContaining({
+          thread_id: canonicalThread.threadId,
+          type: 'message',
+          direction: 'inbound',
+          channel: 'sms',
+          body: 'Canonical person timeline item',
+          occurred_at_utc: '2026-03-24T10:00:00.000Z',
+          actor: 'neighbor',
+          person_context: {
+            person_id: CANONICAL_PERSON_ID,
+            origin_person_id: null,
+          },
+        }),
+      ]));
+    } finally {
+      mergePersonSpy.mockRestore();
+      getPersonSpy.mockRestore();
+      listPersonsSpy.mockRestore();
+    }
+  });
+});

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -55,6 +55,7 @@ import {
   putConnectNumberMapping,
   putConnectOperatorCallbackNumber,
 } from '../../../modules/connectshyft/handlers';
+import { getUnifiedTimeline } from '../../../modules/connectshyft/handlers/getUnifiedTimeline';
 import {
   resolveConnectShyftOrgUnitContext,
   type ResolvedConnectShyftContext,
@@ -4923,6 +4924,8 @@ router.patch('/identity-ambiguities/:ambiguityEventId', async (req: Request, res
     },
   });
 });
+
+router.get('/person/:personId/unified-timeline', getUnifiedTimeline);
 
 router.get('/threads/:threadId/timeline', getConnectThreadTimeline);
 

--- a/shared/database/migrations/20260324153000_add_peoplecore_person_merge_metadata.ts
+++ b/shared/database/migrations/20260324153000_add_peoplecore_person_merge_metadata.ts
@@ -1,0 +1,98 @@
+import { Knex } from 'knex';
+
+const PEOPLE_SCHEMA = 'people';
+const CONTACT_POINT_LINKS_TABLE = 'contact_point_links';
+const PERSONS_TABLE = 'persons';
+const CONTACT_POINT_LINKS_MERGED_INTO_INDEX = 'people_contact_point_links_merged_into_subject_idx';
+const PERSONS_SCOPE_MERGED_INTO_INDEX = 'people_persons_scope_merged_into_idx';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${CONTACT_POINT_LINKS_TABLE}
+      ADD COLUMN IF NOT EXISTS merged_into_subject_id UUID NULL REFERENCES ${PEOPLE_SCHEMA}.${PERSONS_TABLE}(id) ON DELETE SET NULL,
+      ADD COLUMN IF NOT EXISTS merged_at_utc TIMESTAMPTZ NULL,
+      ADD COLUMN IF NOT EXISTS merged_by_user_id TEXT NULL,
+      ADD COLUMN IF NOT EXISTS merge_class TEXT NOT NULL DEFAULT 'auto',
+      ADD COLUMN IF NOT EXISTS merge_reason TEXT NULL
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${CONTACT_POINT_LINKS_TABLE}
+      DROP CONSTRAINT IF EXISTS people_contact_point_links_merge_class_ck
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${CONTACT_POINT_LINKS_TABLE}
+      ADD CONSTRAINT people_contact_point_links_merge_class_ck
+      CHECK (merge_class IN ('auto', 'review'))
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${CONTACT_POINT_LINKS_MERGED_INTO_INDEX}
+    ON ${PEOPLE_SCHEMA}.${CONTACT_POINT_LINKS_TABLE} (merged_into_subject_id, id)
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${PERSONS_TABLE}
+      DROP CONSTRAINT IF EXISTS people_persons_merged_into_required_ck
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${PERSONS_TABLE}
+      ADD CONSTRAINT people_persons_merged_into_required_ck
+      CHECK (
+        (status = 'merged' AND merged_into_person_id IS NOT NULL)
+        OR status <> 'merged'
+      )
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${PERSONS_TABLE}
+      DROP CONSTRAINT IF EXISTS people_persons_not_merged_into_self_ck
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${PERSONS_TABLE}
+      ADD CONSTRAINT people_persons_not_merged_into_self_ck
+      CHECK (merged_into_person_id IS NULL OR merged_into_person_id <> id)
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${PERSONS_SCOPE_MERGED_INTO_INDEX}
+    ON ${PEOPLE_SCHEMA}.${PERSONS_TABLE} (tenant_id, org_unit_id, merged_into_person_id, id)
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${PEOPLE_SCHEMA}.${CONTACT_POINT_LINKS_MERGED_INTO_INDEX}
+  `);
+
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${PEOPLE_SCHEMA}.${PERSONS_SCOPE_MERGED_INTO_INDEX}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${PERSONS_TABLE}
+      DROP CONSTRAINT IF EXISTS people_persons_merged_into_required_ck
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${PERSONS_TABLE}
+      DROP CONSTRAINT IF EXISTS people_persons_not_merged_into_self_ck
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${CONTACT_POINT_LINKS_TABLE}
+      DROP CONSTRAINT IF EXISTS people_contact_point_links_merge_class_ck
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${PEOPLE_SCHEMA}.${CONTACT_POINT_LINKS_TABLE}
+      DROP COLUMN IF EXISTS merged_into_subject_id,
+      DROP COLUMN IF EXISTS merged_at_utc,
+      DROP COLUMN IF EXISTS merged_by_user_id,
+      DROP COLUMN IF EXISTS merge_class,
+      DROP COLUMN IF EXISTS merge_reason
+  `);
+}

--- a/shared/database/migrations/20260325153000_add_connectshyft_person_rebind_history.ts
+++ b/shared/database/migrations/20260325153000_add_connectshyft_person_rebind_history.ts
@@ -1,0 +1,74 @@
+import type { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const THREADS_TABLE = 'cs_threads';
+const DELIVERY_ATTEMPTS_TABLE = 'cs_delivery_attempts';
+const PERSON_REBIND_HISTORY_TABLE = 'person_rebind_history';
+const THREAD_ORIGIN_PERSON_COLUMN = 'origin_person_id';
+const THREAD_ORIGIN_PERSON_INDEX = 'connectshyft_cs_threads_scope_origin_person_idx';
+const DELIVERY_ATTEMPTS_PERSON_INDEX = 'connectshyft_cs_delivery_attempts_scope_person_idx';
+const PERSON_REBIND_HISTORY_PAIR_UNIQUE_INDEX = 'connectshyft_person_rebind_history_scope_pair_uq';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${THREADS_TABLE}
+      ADD COLUMN IF NOT EXISTS ${THREAD_ORIGIN_PERSON_COLUMN} UUID NULL
+      REFERENCES people.persons(id) ON DELETE RESTRICT
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${THREAD_ORIGIN_PERSON_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${THREADS_TABLE} (tenant_id, org_unit_id, ${THREAD_ORIGIN_PERSON_COLUMN}, id)
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${DELIVERY_ATTEMPTS_PERSON_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${DELIVERY_ATTEMPTS_TABLE} (tenant_id, org_unit_id, person_id, created_at_utc DESC, id)
+  `);
+
+  await knex.raw(`
+    CREATE TABLE IF NOT EXISTS ${CONNECTSHYFT_SCHEMA}.${PERSON_REBIND_HISTORY_TABLE} (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL,
+      org_unit_id TEXT NOT NULL,
+      provisional_person_id TEXT NOT NULL,
+      canonical_person_id TEXT NOT NULL,
+      rebind_class TEXT NOT NULL CHECK (rebind_class IN ('auto', 'review')),
+      performed_by_user_id TEXT NOT NULL,
+      created_at_utc TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      notes TEXT NULL
+    )
+  `);
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS ${PERSON_REBIND_HISTORY_PAIR_UNIQUE_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${PERSON_REBIND_HISTORY_TABLE} (
+      tenant_id,
+      org_unit_id,
+      provisional_person_id,
+      canonical_person_id,
+      rebind_class
+    )
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${PERSON_REBIND_HISTORY_PAIR_UNIQUE_INDEX}
+  `);
+
+  await knex.schema.withSchema(CONNECTSHYFT_SCHEMA).dropTableIfExists(PERSON_REBIND_HISTORY_TABLE);
+
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${DELIVERY_ATTEMPTS_PERSON_INDEX}
+  `);
+
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${THREAD_ORIGIN_PERSON_INDEX}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE IF EXISTS ${CONNECTSHYFT_SCHEMA}.${THREADS_TABLE}
+      DROP COLUMN IF EXISTS ${THREAD_ORIGIN_PERSON_COLUMN}
+  `);
+}

--- a/specs/slice-26-codex-ready-implementation-brief.md
+++ b/specs/slice-26-codex-ready-implementation-brief.md
@@ -1,0 +1,474 @@
+# Slice 26 — Resolver Rebinding (Codex‑Ready Implementation Brief)
+
+## 1. OBJECTIVE
+
+Enable **safe, deterministic rebinding** of provisional PeopleCore identities to canonical
+persons and automatically propagate those changes through ConnectShyft.  When a
+resolver decides that two people records represent the same individual, the system must:
+
+1. Merge the provisional person into the canonical person without losing any
+   associated contact points, events or risk flags.
+2. Update all ConnectShyft threads and telephony artifacts to point at the
+   canonical person while preserving historical authorship and timestamps.
+3. Persist merge metadata (who performed the merge, when, why) instead of
+   deleting or overwriting records.
+4. Surface review-required situations (competing primary contact links or
+   household ambiguity) to the resolver for manual intervention.
+
+This slice does **not** introduce new scoring rules or redesign existing
+telephony flows.  It focuses on person merging, contact‑point link
+normalisation, thread rebinding and unified timeline projection.
+
+## 2. ARCHITECTURAL DECISIONS (LOCKED)
+
+1. **Person states remain authoritative** – People records will be in one of
+   three states: `provisional`, `canonical`, or `merged`.  A provisional person
+   becomes merged when it is successfully rebound to a canonical person.  The
+   canonical person never changes identity; instead a `mergedIntoPersonId`
+   reference on the provisional record points to its canonical target.
+2. **ContactPointLink merging with metadata** – Rather than deleting contact
+   point links or overwriting their subject, the system must mark old links as
+   closed and persist merge metadata (`mergedIntoSubjectId`, `mergedAtUtc`,
+   `mergedByUserId`, `mergeClass`, `mergeReason`).  New links pointing at the
+   canonical person are created for any contact points that were unique to the
+   provisional person.  This ensures determinism and auditability.
+3. **Rebind classes drive automation** – Each object type (e.g. contact point
+   link, household membership) is assigned a `rebindClass` of either
+   `auto` or `review`.  Objects marked `auto` are rebound automatically.
+   Objects marked `review` require manual resolver intervention and are
+   surfaced in a ResolverReview of type `rebind`.  The `rebindClass` values
+   are locked by PeopleCore contracts and cannot be altered by this slice.
+4. **No rewriting of historical artifacts** – Messages, calls, voicemails and
+   contact point events keep their original subject attribution and
+   timestamps.  The unified person view is a **projection** built at
+   runtime by combining artifacts from both the canonical and merged
+   persons.  Underlying rows are untouched.
+5. **Thread person rebinding is idempotent** – Updating a thread’s
+   `personId` from provisional to canonical must be repeatable without
+   changing other fields.  Threads maintain an `originPersonId` field
+   (optional) to capture the original subject when rebinding occurs.  Calls
+   and bridge sessions also include `personId`; these are updated
+   transactionally with the thread.
+6. **Event‑driven rebinding** – When PeopleCore merges a person, it emits a
+   `peoplecore.person.merged` event wrapped in an `EventEnvelope`.
+   ConnectShyft subscribes to this event to trigger thread rebinding.
+
+## 3. EXECUTION FLOW
+
+### 3.1 Merge Person
+
+1. **Initiate merge** – A resolver (via UI or API) submits a merge request
+   specifying `provisionalPersonId`, `canonicalPersonId`, and optional
+   `mergeReason`.  PeopleCore validates that both persons belong to the
+   same tenant and orgUnit and that the provisional has not already been
+   merged.
+2. **Determine rebind scope** – PeopleCore evaluates all objects linked to
+   the provisional person (contact point links, household memberships, etc.)
+   and classifies them by `rebindClass` using locked rules.  Objects with
+   class `review` are added to a new `ResolverReview` of type
+   `review_rebind`.  Objects with class `auto` proceed to automatic
+   merge.
+3. **Persist merge metadata** – PeopleCore sets the provisional person’s
+   `mergedIntoPersonId` and `status = 'merged'`.  For each contact point
+   link to be auto‑merged:
+   * Mark the existing link `is_current = false` and fill
+     `merged_into_subject_id`, `merged_at_utc`, `merged_by_user_id` and
+     `merge_reason`.
+   * Insert a new link for the same contact point with `subjectId =
+     canonicalPersonId`, copying confidence band, primary flags and
+     timestamps.
+4. **Emit merge event** – PeopleCore emits a `peoplecore.person.merged`
+   `EventEnvelope` containing `provisionalPersonId` and `canonicalPersonId`,
+   plus lists of objects that were auto‑merged and those requiring review.
+   The resolver receives the `ResolverReview` id for reviewable objects.
+
+### 3.2 Auto‑Rebind Threads and Telephony Artifacts
+
+1. **Consume merge event** – A dedicated `connectshyft-person-rebind` worker
+   consumes `peoplecore.person.merged` events.  It begins a database
+   transaction.
+2. **Rebind threads** – For each thread whose `personId = provisionalPersonId`,
+   update:
+   * `originPersonId` → set to the current `personId` if not already set.
+   * `personId` → set to `canonicalPersonId`.
+   All other thread fields remain unchanged.
+3. **Rebind telephony artifacts** – For each row in
+   `connectshyft.cs_calls`, `cs_voicemails`, `cs_delivery_attempts` and
+   `cs_bridge_sessions` where `person_id = provisionalPersonId`, set
+   `person_id = canonicalPersonId`.  Do **not** modify the call status,
+   timestamps or bridge session id.
+4. **Commit transaction and acknowledge event** – Once rebinding is complete,
+   the transaction commits and the event is acknowledged.  If any step
+   fails the transaction rolls back and the event is retried.
+
+### 3.3 Unified Timeline Projection
+
+1. **Load artifacts** – When requesting a person’s communication history,
+   the timeline service loads all threads, calls, SMS messages,
+   voicemails and contact point events where `personId = canonicalPersonId`
+   **or** `mergedIntoPersonId = canonicalPersonId`.
+2. **Sort and group** – Artifacts are sorted by their `createdAt` or
+   `occurredAt` timestamps.  Threads with an `originPersonId` display both
+   the original and current person context in the UI.
+3. **Return projection** – The API returns a single `UnifiedPersonTimeline`
+   DTO containing ordered timeline items without rewriting the underlying
+   data.
+
+## 4. STATE MACHINES
+
+### 4.1 Person Merge State
+
+| State          | Description                                                         | Next States                                     |
+|----------------|---------------------------------------------------------------------|-------------------------------------------------|
+| `provisional`  | A newly created person pending confirmation.                        | `canonical`, `merged` (after merge completes)   |
+| `canonical`    | A verified person record that can receive merges.                   | — (remains canonical)                           |
+| `merged`       | A provisional record that has been merged into a canonical person. | — (terminal)                                    |
+
+Once a person is `merged`, all service calls referencing that `personId` must resolve
+the `canonicalPersonId` via `mergedIntoPersonId`.
+
+### 4.2 ContactPointLink Merge Class
+
+| Class   | Description                                                                 |
+|---------|-----------------------------------------------------------------------------|
+| `auto`  | This link can be rebound automatically to the canonical person.             |
+| `review`| This link may conflict (e.g. two primaries or household ambiguity) and must be reviewed by a resolver before rebinding. |
+
+The `rebindClass` is fixed by PeopleCore contracts based on link type,
+confirmation status, shared indicators and household rules.  It cannot be
+changed by this slice.
+
+## 5. DATABASE CONTRACTS
+
+### 5.1 `people.contact_points`
+
+No schema changes.  Contact points continue to live independently of
+persons and links.  Scoring and lifecycle state changes occur in Slice 27.
+
+### 5.2 `people.contact_point_links` (modified)
+
+Add the following columns to record merge metadata:
+
+| Column                 | Type        | Constraints                                      |
+|------------------------|-------------|--------------------------------------------------|
+| `merged_into_subject_id` | TEXT        | NULLABLE; set to the subject id the link was merged into |
+| `merged_at_utc`        | TIMESTAMPTZ | NULLABLE; timestamp when the link was closed     |
+| `merged_by_user_id`    | TEXT        | NULLABLE; resolver who performed the merge       |
+| `merge_class`          | TEXT        | NOT NULL DEFAULT 'auto'; `auto` or `review`      |
+| `merge_reason`         | TEXT        | NULLABLE; free‑form reason supplied by resolver  |
+
+These columns are only populated on the old link when rebinding; they remain
+null on current links.  Existing rows are backfilled with nulls and
+`merge_class = 'auto'`.
+
+### 5.3 `people.persons` (modified)
+
+Add a `status` enum column (`provisional`, `canonical`, `merged`) with
+default `provisional` for new rows.  Add a `merged_into_person_id` column
+with a foreign key back to `persons.id` and an index.  A person can only be
+merged once.
+
+### 5.4 `connectshyft.threads` (modified)
+
+Add an `origin_person_id` TEXT column nullable.  When a thread is
+rebound from provisional to canonical, set `originPersonId` to the old
+`personId` and update `personId` to the canonical.  Index
+`(tenant_id, person_id)` and `(tenant_id, origin_person_id)` for
+efficient lookups.
+
+### 5.5 `connectshyft.cs_calls`, `cs_voicemails`, `cs_delivery_attempts`,
+`cs_bridge_sessions` (modified)
+
+Add or update `person_id` columns to allow rebinding of telephony
+artifacts.  Create indexes on `(tenant_id, person_id)` for each table.
+
+### 5.6 `connectshyft.person_rebind_history` (new)
+
+Create a table to record rebind operations for audit and idempotency:
+
+| Column               | Type        | Constraints                                      |
+|----------------------|-------------|--------------------------------------------------|
+| `id`                 | TEXT        | Primary key; generated via `randomUUID()`        |
+| `tenant_id`          | TEXT        | NOT NULL                                         |
+| `org_unit_id`        | TEXT        | NOT NULL                                         |
+| `provisional_person_id` | TEXT     | NOT NULL                                         |
+| `canonical_person_id` | TEXT       | NOT NULL                                         |
+| `rebind_class`       | TEXT        | `auto` or `review`                               |
+| `performed_by_user_id`| TEXT       | NOT NULL                                         |
+| `created_at_utc`     | TIMESTAMPTZ | NOT NULL DEFAULT `NOW()`                         |
+| `notes`              | TEXT        | NULLABLE                                         |
+
+Primary key: `id`.  This table is appended to on each successful rebind.
+
+## 6. SERVICE LAYER (STRICT)
+
+### 6.1 PeopleCore
+
+Introduce the following interfaces in `apps/connectshyft-api/src/modules/peoplecore/service.ts` and implement them in the `store`:
+
+| Function / Signature | Responsibility |
+|---------------------|---------------|
+| `async mergePerson(input: { tenantId: string; orgUnitId: string; provisionalPersonId: string; canonicalPersonId: string; performedByUserId: string; mergeReason?: string; }): Promise<PeopleCoreMergeResult>` | Performs the merge described in **Execution Flow 3.1**.  Returns lists of auto‑merged objects and objects requiring review (to be used by the resolver).  Throws if persons belong to different tenants or if provisional has already been merged. |
+| `async getPersonMergeStatus(input: { tenantId: string; personId: string; }): Promise<'provisional' | 'canonical' | 'merged'>` | Returns the current merge status of a person, resolving through `mergedIntoPersonId` if necessary. |
+
+The `PeopleCoreMergeResult` should include: `mergedProvisionalPersonId`,
+`canonicalPersonId`, `autoMergedContactPointLinkIds`,
+`reviewContactPointLinkIds`, and the `resolverReviewId` if one was created.
+
+### 6.2 ConnectShyft
+
+Add a new `PersonRebindService` in
+`apps/connectshyft-api/src/modules/connectshyft/personRebind.ts` with these
+functions:
+
+| Function / Signature | Responsibility |
+|---------------------|---------------|
+| `async rebindPersonThreads(input: { tenantId: string; orgUnitId: string; provisionalPersonId: string; canonicalPersonId: string; performedByUserId: string; }): Promise<void>` | Consumes a `peoplecore.person.merged` event and updates threads and telephony artifacts as in **Execution Flow 3.2**.  Idempotent; re‑running with the same ids has no effect. |
+| `async projectUnifiedTimeline(input: { tenantId: string; personId: string; }): Promise<UnifiedPersonTimeline>` | Builds a unified timeline projection as in **Execution Flow 3.3**.  Returns an ordered list of timeline items spanning all merged persons. |
+
+### 6.3 HTTP Endpoints
+
+Add the following handlers under `apps/connectshyft-api/src/modules/connectshyft/handlers`:
+
+| Method & Path | Responsibility |
+|---------------|---------------|
+| `POST /api/v1/peoplecore/persons/merge` | Accepts a merge command with provisional and canonical ids, invokes `peoplecore.mergePerson`, and returns either a success envelope with lists of auto‑merged and review items or a refusal if validation fails. |
+| `GET /api/v1/connectshyft/person/:personId/unified-timeline` | Returns the unified timeline projection for the given person. |
+
+## 7. PROVIDER / INTEGRATION CONTRACTS
+
+The merge and rebinding logic is internal to PeopleCore and ConnectShyft.  No
+external provider integrations are required.  However, ConnectShyft must
+subscribe to `peoplecore.person.merged` events via the existing event bus
+(`platform.events`) and process them idempotently.
+
+## 8. EVENT HANDLING
+
+*PeopleCore* – Emits `peoplecore.person.merged` wrapped in
+`EventEnvelope` when a merge completes.  The payload includes both person
+ids and arrays of merged/review objects.
+
+*ConnectShyft* – Consumes `peoplecore.person.merged` and enqueues a
+background job (`personRebindJob`) to update threads and telephony artifacts.
+If the job fails it will be retried.  The event is acknowledged only after
+the transaction commits.
+
+## 9. IDEMPOTENCY RULES
+
+1. **mergePerson** – Idempotent with respect to the same
+   `provisionalPersonId` and `canonicalPersonId`.  Calling merge multiple
+   times returns the same lists of auto‑merged and review objects and does not
+   create duplicate links or events.
+2. **rebindPersonThreads** – Idempotent.  Updating a thread or call that
+   already has `personId = canonicalPersonId` does nothing.  Rebinding
+   telephony artifacts multiple times yields the same state.
+3. **unified timeline projection** – Pure read.  Repeated calls return the
+   same items as long as underlying data does not change.
+
+## 10. FAILURE MODES
+
+1. **Cross‑tenant merge** – If the provisional and canonical persons belong
+   to different tenants or orgUnits, PeopleCore refuses with code
+   `PEOPLECORE_MERGE_SCOPE_VIOLATION`.
+2. **Provisional already merged** – Merging a provisional that has
+   `status = 'merged'` or a non‑null `mergedIntoPersonId` returns a
+   refusal `PEOPLECORE_PERSON_ALREADY_MERGED`.
+3. **Review required** – If any `ContactPointLink` has `rebindClass = 'review'`,
+   PeopleCore returns a `ResolverReview` and the resolver must resolve
+   the review before the merge is finalised.  ConnectShyft must not
+   rebind threads until the review is complete.
+4. **Rebind transaction failure** – If rebinding threads and telephony
+   artifacts fails (e.g. due to a DB error), the transaction rolls back and
+   the merge event is retried.
+
+## 11. TEST CONTRACT
+
+### 11.1 PeopleCore Tests
+
+Create tests under `apps/connectshyft-api/src/modules/peoplecore/__tests__/mergePerson.test.ts`
+that verify:
+
+1. `mergePerson` sets `status = 'merged'` and `mergedIntoPersonId` on the
+   provisional person and does not modify the canonical person.
+2. `mergePerson` marks old contact point links with merge metadata and
+   creates new links pointing at the canonical person.  Existing
+   `is_current` flags are preserved on the new links.
+3. `mergePerson` returns review items for conflicting primaries or
+   household ambiguity.
+4. `mergePerson` is idempotent – merging the same persons twice does not
+   create additional links or events.
+
+### 11.2 ConnectShyft Tests
+
+Create tests under `apps/connectshyft-api/src/modules/connectshyft/__tests__/personRebind.test.ts`
+that verify:
+
+1. `rebindPersonThreads` updates `personId` and sets
+   `originPersonId` on threads bound to a provisional person while
+   leaving other fields untouched.
+2. `rebindPersonThreads` updates `person_id` on calls, voicemails,
+   delivery attempts and bridge sessions.
+3. `rebindPersonThreads` is idempotent – running it twice yields the same
+   state.
+4. `projectUnifiedTimeline` returns timeline items from both the
+   canonical and merged persons, ordered correctly, with threads
+   indicating their origin person.
+
+## 12. CHECKPOINTS
+
+### Checkpoint 1 — Implement Person Merge in PeopleCore
+
+**FILES:**
+
+1. `shyftunity/apps/connectshyft-api/src/modules/peoplecore/store.ts` –
+   Add merge metadata columns to `contact_point_links` and `persons` in the
+   People schema migrations folder.  Introduce `mergePerson` logic in the
+   store layer to perform auto merges and create a `ResolverReview` for
+   review items.
+2. `shyftunity/apps/connectshyft-api/src/modules/peoplecore/service.ts` –
+   Expose the `mergePerson` and `getPersonMergeStatus` methods, wiring them
+   through the store’s transaction wrapper.
+3. `shyftunity/shared/database/migrations` – Create migrations to
+   modify `people.contact_point_links` and `people.persons` tables
+   as described in **Database Contracts**.
+4. `shyftunity/apps/connectshyft-api/src/modules/peoplecore/events.ts` –
+   Add an event emitter for `peoplecore.person.merged` to wrap merge
+   notifications in an `EventEnvelope`.
+
+**LINE‑LEVEL DIFF EXPECTATIONS:**
+
+* Add new columns in the migration script using `knex.schema.alterTable` for
+  `merged_into_subject_id`, `merged_at_utc`, etc., with appropriate
+  defaults.  Create the `status` enum and `merged_into_person_id` on
+  `persons` and add an index.
+* In the store’s `createContactPointLink` and related mapping functions,
+  include the new merge metadata fields when mapping rows.
+* Implement `mergePerson` in the store using a transaction: update the
+  provisional person, insert new links, update old links, create a
+  `ResolverReview` when necessary, and return the result.
+
+**STOP CONDITION:**
+
+Run the PeopleCore unit tests for mergePerson.  All tests in
+`mergePerson.test.ts` should pass.  Do not implement rebinding or UI
+changes in this checkpoint.
+
+**COMMIT POINT:**
+
+```bash
+git add apps/connectshyft-api/src/modules/peoplecore/* shared/database/migrations
+git commit -m "feat(slice-26): implement PeopleCore person merge with merge metadata"
+```
+
+### Checkpoint 2 — Implement Rebinding in ConnectShyft
+
+**FILES:**
+
+1. `shyftunity/apps/connectshyft-api/src/modules/connectshyft/personRebind.ts` –
+   New service implementing `rebindPersonThreads` and `projectUnifiedTimeline`.
+2. `shyftunity/apps/connectshyft-api/src/modules/connectshyft/threads.ts` –
+   Modify the thread model to include `originPersonId` and update
+   persistence functions to handle rebinding.
+3. `shyftunity/apps/connectshyft-api/src/modules/connectshyft/calls.ts`,
+   `voicemails.ts`, `deliveryAttempts.ts`, `bridgeSessions.ts` –
+   Update persistence functions to allow updating `person_id` during a
+   rebind.  Do **not** alter call state logic.
+4. `shyftunity/shared/database/migrations` – Create a migration to add
+   `origin_person_id` to `connectshyft.threads` and create the
+   `connectshyft.person_rebind_history` table.
+5. `shyftunity/apps/connectshyft-api/src/modules/connectshyft/events.ts` –
+   Subscribe to `peoplecore.person.merged` and call `rebindPersonThreads`.
+
+**LINE‑LEVEL DIFF EXPECTATIONS:**
+
+* In each persistence layer (threads, calls, etc.), add a method to update
+  `person_id` and set `originPersonId` (for threads) when rebinding.  Use
+  transactions to ensure atomic updates.
+* Implement `rebindPersonThreads` to fetch all relevant records,
+  perform updates, record a row in `person_rebind_history`, and commit.
+* Implement `projectUnifiedTimeline` by querying both the canonical and
+  merged persons and assembling timeline items in memory.
+
+**STOP CONDITION:**
+
+Run the ConnectShyft unit tests for person rebinding and unified timeline.
+All tests in `personRebind.test.ts` should pass.  Do not implement UI
+handlers in this checkpoint.
+
+**COMMIT POINT:**
+
+```bash
+git add apps/connectshyft-api/src/modules/connectshyft/* shared/database/migrations
+git commit -m "feat(slice-26): implement ConnectShyft thread and telephony rebinding"
+```
+
+### Checkpoint 3 — Expose Merge and Unified Timeline APIs
+
+**FILES:**
+
+1. `shyftunity/apps/connectshyft-api/src/modules/peoplecore/handlers/postMergePerson.ts` –
+   HTTP handler to invoke `peoplecore.mergePerson`, return success or
+   refusal envelopes and the resolver review id when applicable.
+2. `shyftunity/apps/connectshyft-api/src/modules/connectshyft/handlers/getUnifiedTimeline.ts` –
+   HTTP handler to call `projectUnifiedTimeline` and return a
+   `UnifiedPersonTimeline` DTO.
+3. `shyftunity/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts` –
+   Register the new endpoints.
+
+**LINE‑LEVEL DIFF EXPECTATIONS:**
+
+* In the merge handler, validate input, call `mergePerson`, map the
+  result to a success envelope, and handle refusal cases.  Do not
+  implement UI logic here.
+* In the unified timeline handler, resolve tenant/context, call
+  `projectUnifiedTimeline`, and return a success envelope.
+
+**STOP CONDITION:**
+
+Run end‑to‑end tests invoking the merge API and verifying that threads
+and telephony artifacts are rebound and that the unified timeline reflects
+the merged history.  All integration tests should pass.
+
+**COMMIT POINT:**
+
+```bash
+git add apps/connectshyft-api/src/modules/* apps/connectshyft-api/src/routes/api/v1
+git commit -m "feat(slice-26): expose merge person and unified timeline APIs"
+```
+
+## 13. DEFINITION OF DONE
+
+The slice is complete when:
+
+1. The PeopleCore person merge functionality persists merge metadata,
+   returns auto‑merge and review items, and emits a merge event.
+2. Rebinding of threads and telephony artifacts occurs automatically via
+   event consumption, updating `personId` and setting `originPersonId`.
+3. Contact point links are merged deterministically with merge metadata,
+   and conflicting links trigger a resolver review.
+4. A unified timeline can be requested for a canonical person and includes
+   artifacts from any merged persons without altering the underlying records.
+5. All unit and integration tests specified in the Test Contract pass.
+
+## 14. NON‑GOALS
+
+* Designing or implementing the resolver UI.  The UI will be addressed in
+  a subsequent slice.
+* Changing identity scoring logic or contact point lifecycle state (Slice 27).
+* Automatically performing merges based on heuristics; merges remain an
+  explicit resolver action.
+* Introducing new telephony behaviour beyond updating `personId` on
+  existing artifacts.
+
+## 15. FUTURE EXTENSION POINTS
+
+1. **Household‑level rebinding** – Merge entire households when multiple
+   persons are consolidated.  Extend the `rebindClass` rules to cover
+   household memberships and roles.
+2. **Bulk merge operations** – Allow resolvers to merge multiple
+   provisional persons into one canonical person in a single transaction.
+3. **Cross‑module notifications** – Publish `person.rebound` events to
+   notify third‑party systems of identity consolidation.
+4. **Metrics and observability** – Track merge durations, number of
+   auto‑merged vs review links, and rebinding latency for operational
+   insights.


### PR DESCRIPTION
## Summary
- implement PeopleCore person merge persistence and merge-event emission
- implement ConnectShyft thread and telephony rebinding plus unified timeline projection
- expose merge and unified timeline APIs with focused integration coverage

## Validation
- ./node_modules/.bin/jest --runInBand --runTestsByPath src/modules/peoplecore/__tests__/mergePerson.test.ts
- ./node_modules/.bin/jest --runInBand --runTestsByPath src/modules/connectshyft/__tests__/personRebind.test.ts
- ./node_modules/.bin/jest --runInBand --runTestsByPath src/routes/api/v1/__tests__/connectshyft.person-merge-unified-timeline.test.ts