### PR TITLE
feat(connectshyft): complete Prep Step 2A resolver decision backbone

### DIFF
--- a/apps/connectshyft-api/src/migrations/20260325143000_add_resolver_outcome_to_connectshyft_identity_ambiguity_events.ts
+++ b/apps/connectshyft-api/src/migrations/20260325143000_add_resolver_outcome_to_connectshyft_identity_ambiguity_events.ts
@@ -1,0 +1,4 @@
+export {
+  down,
+  up,
+} from '../../../../shared/database/migrations/20260325143000_add_resolver_outcome_to_connectshyft_identity_ambiguity_events';

--- a/apps/connectshyft-api/src/migrations/__tests__/connectshyftIdentityAmbiguityResolverOutcomeMigration.test.ts
+++ b/apps/connectshyft-api/src/migrations/__tests__/connectshyftIdentityAmbiguityResolverOutcomeMigration.test.ts
@@ -1,0 +1,49 @@
+import { down, up } from '../20260325143000_add_resolver_outcome_to_connectshyft_identity_ambiguity_events';
+
+function buildKnexMock() {
+  const knex: any = {
+    raw: jest.fn(async () => undefined),
+  };
+
+  return { knex };
+}
+
+describe('20260325143000_add_resolver_outcome_to_connectshyft_identity_ambiguity_events migration', () => {
+  it('adds resolver-outcome linkage fields, terminal statuses, and supporting indexes', async () => {
+    const { knex } = buildKnexMock();
+
+    await up(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+
+    expect(rawSql).toContain('ALTER TABLE connectshyft.cs_identity_ambiguity_events');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS resolver_review_id TEXT NULL');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS resolver_consumed_by_user_id TEXT NULL');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS resolver_consumed_at_utc TIMESTAMPTZ NULL');
+    expect(rawSql).toContain('ADD COLUMN IF NOT EXISTS resolver_outcome JSONB NULL');
+    expect(rawSql).toContain('DROP CONSTRAINT IF EXISTS cs_identity_ambiguity_events_status_ck');
+    expect(rawSql).toContain(`CHECK (status IN ('pending', 'reviewed', 'resolved', 'dismissed'))`);
+    expect(rawSql).toContain('connectshyft_cs_identity_ambiguity_events_tenant_resolver_review_idx');
+    expect(rawSql).toContain('(tenant_id, resolver_review_id)');
+    expect(rawSql).toContain('connectshyft_cs_identity_ambiguity_events_tenant_source_context_id_status_idx');
+    expect(rawSql).toContain('source_context_id');
+  });
+
+  it('drops resolver-outcome linkage fields and restores the prior status check on down migration', async () => {
+    const { knex } = buildKnexMock();
+
+    await down(knex);
+
+    const rawSql = knex.raw.mock.calls.map((call: [string]) => call[0]).join('\n');
+
+    expect(rawSql).toContain(
+      'DROP INDEX IF EXISTS connectshyft.connectshyft_cs_identity_ambiguity_events_tenant_source_context_id_status_idx',
+    );
+    expect(rawSql).toContain(
+      'DROP INDEX IF EXISTS connectshyft.connectshyft_cs_identity_ambiguity_events_tenant_resolver_review_idx',
+    );
+    expect(rawSql).toContain(`CHECK (status IN ('pending', 'reviewed'))`);
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS resolver_outcome');
+    expect(rawSql).toContain('DROP COLUMN IF EXISTS resolver_review_id');
+  });
+});

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/ambiguityEvents.test.ts
@@ -1,6 +1,7 @@
 import {
   AsyncConnectShyftIdentityAmbiguityEventService,
   createIdentityAmbiguityEvent,
+  getIdentityAmbiguityEvent,
   InMemoryConnectShyftIdentityAmbiguityEventStore,
   listIdentityAmbiguityEvents,
   markIdentityAmbiguityEventReviewed,
@@ -149,6 +150,222 @@ describe('connectshyft ambiguity events', () => {
     });
   });
 
+  it('consumes linked ambiguity events as resolved and persists resolver outcome linkage', async () => {
+    const created = await service.createIdentityAmbiguityEvent({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:resolved',
+      normalizedContactPoint: '+12605550006',
+      candidateNeighborIds: ['neighbor-g'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+
+    const consumed = await service.consumeAmbiguityEventsForResolverOutcome({
+      tenantId: 'tenant-a',
+      resolverReviewId: 'review-1',
+      triggerSourceId: 'identity-match:resolved',
+      outcome: 'resolved',
+      consumedByUserId: 'resolver-1',
+      consumedAtUtc: '2026-03-21T12:20:00.000Z',
+      resolverOutcome: {
+        reviewId: 'review-1',
+        action: 'confirm_existing_person',
+        reviewStatus: 'resolved_confirmed_existing',
+        actorUserId: 'resolver-1',
+        occurredAtUtc: '2026-03-21T12:20:00.000Z',
+        reason: 'Matched the existing person.',
+        personId: 'person-existing',
+        contactPointId: 'contact-point-1',
+      },
+    });
+
+    expect(consumed.events).toEqual([
+      expect.objectContaining({
+        id: created.id,
+        status: 'resolved',
+        resolverReviewId: 'review-1',
+        resolverConsumedByUserId: 'resolver-1',
+        resolverConsumedAtUtc: '2026-03-21T12:20:00.000Z',
+        resolverOutcome: expect.objectContaining({
+          action: 'confirm_existing_person',
+          reviewStatus: 'resolved_confirmed_existing',
+          personId: 'person-existing',
+        }),
+      }),
+    ]);
+
+    const detailed = await service.getIdentityAmbiguityEvent({
+      tenantId: 'tenant-a',
+      ambiguityEventId: created.id,
+    });
+
+    expect(detailed).toMatchObject({
+      id: created.id,
+      status: 'resolved',
+      resolverReviewId: 'review-1',
+      resolverOutcome: expect.objectContaining({
+        action: 'confirm_existing_person',
+      }),
+    });
+  });
+
+  it('consumes linked ambiguity events as dismissed for dismiss_no_action outcomes', async () => {
+    const created = await service.createIdentityAmbiguityEvent({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:dismissed',
+      normalizedContactPoint: '+12605550007',
+      candidateNeighborIds: ['neighbor-h'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+
+    const consumed = await service.consumeAmbiguityEventsForResolverOutcome({
+      tenantId: 'tenant-a',
+      resolverReviewId: 'review-dismissed',
+      triggerSourceId: 'identity-match:dismissed',
+      outcome: 'dismissed',
+      consumedByUserId: 'resolver-2',
+      consumedAtUtc: '2026-03-21T12:25:00.000Z',
+      resolverOutcome: {
+        reviewId: 'review-dismissed',
+        action: 'dismiss_no_action',
+        reviewStatus: 'dismissed',
+        actorUserId: 'resolver-2',
+        occurredAtUtc: '2026-03-21T12:25:00.000Z',
+        reason: 'No identity change required.',
+        contactPointId: 'contact-point-2',
+      },
+    });
+
+    expect(consumed.events).toEqual([
+      expect.objectContaining({
+        id: created.id,
+        status: 'dismissed',
+        resolverReviewId: 'review-dismissed',
+        resolverOutcome: expect.objectContaining({
+          action: 'dismiss_no_action',
+          reviewStatus: 'dismissed',
+        }),
+      }),
+    ]);
+  });
+
+  it('keeps repeated resolver-outcome consumption idempotent', async () => {
+    const created = await service.createIdentityAmbiguityEvent({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:idempotent',
+      normalizedContactPoint: '+12605550008',
+      candidateNeighborIds: ['neighbor-i'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+
+    const input = {
+      tenantId: 'tenant-a',
+      resolverReviewId: 'review-idempotent',
+      triggerSourceId: 'identity-match:idempotent',
+      outcome: 'resolved' as const,
+      consumedByUserId: 'resolver-3',
+      consumedAtUtc: '2026-03-21T12:30:00.000Z',
+      resolverOutcome: {
+        reviewId: 'review-idempotent',
+        action: 'merge_people' as const,
+        reviewStatus: 'resolved_merged' as const,
+        actorUserId: 'resolver-3',
+        occurredAtUtc: '2026-03-21T12:30:00.000Z',
+        sourcePersonId: 'person-source',
+        targetPersonId: 'person-target',
+      },
+    };
+
+    const first = await service.consumeAmbiguityEventsForResolverOutcome(input);
+    const second = await service.consumeAmbiguityEventsForResolverOutcome({
+      ...input,
+      consumedAtUtc: '2026-03-21T12:45:00.000Z',
+    });
+
+    expect(first.events[0]).toMatchObject({
+      id: created.id,
+      status: 'resolved',
+      resolverConsumedAtUtc: '2026-03-21T12:30:00.000Z',
+    });
+    expect(second.events[0]).toMatchObject({
+      id: created.id,
+      status: 'resolved',
+      resolverConsumedAtUtc: '2026-03-21T12:30:00.000Z',
+    });
+  });
+
+  it('supports active-list filtering while preserving terminal detail retrieval', async () => {
+    const pending = await service.createIdentityAmbiguityEvent({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:pending-detail',
+      normalizedContactPoint: '+12605550009',
+      candidateNeighborIds: ['neighbor-j'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+      createdAtUtc: '2026-03-21T12:00:00.000Z',
+    });
+    const resolved = await service.createIdentityAmbiguityEvent({
+      tenantId: 'tenant-a',
+      orgUnitId: 'org-east',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:terminal-detail',
+      normalizedContactPoint: '+12605550010',
+      candidateNeighborIds: ['neighbor-k'],
+      ambiguityReasonCode: 'PEOPLECORE_MULTI_CURRENT_LINKS',
+      createdAtUtc: '2026-03-21T12:05:00.000Z',
+    });
+
+    await service.consumeAmbiguityEventsForResolverOutcome({
+      tenantId: 'tenant-a',
+      resolverReviewId: 'review-terminal-detail',
+      triggerSourceId: 'identity-match:terminal-detail',
+      outcome: 'resolved',
+      consumedByUserId: 'resolver-4',
+      consumedAtUtc: '2026-03-21T12:40:00.000Z',
+      resolverOutcome: {
+        reviewId: 'review-terminal-detail',
+        action: 'link_without_merge',
+        reviewStatus: 'resolved_confirmed_existing',
+        actorUserId: 'resolver-4',
+        occurredAtUtc: '2026-03-21T12:40:00.000Z',
+        personId: 'person-keep-distinct',
+      },
+    });
+
+    const active = await service.listIdentityAmbiguityEvents({
+      tenantId: 'tenant-a',
+      status: 'pending',
+    });
+    const terminalDetail = await service.getIdentityAmbiguityEvent({
+      tenantId: 'tenant-a',
+      ambiguityEventId: resolved.id,
+    });
+
+    expect(active.events).toEqual([
+      expect.objectContaining({
+        id: pending.id,
+        status: 'pending',
+      }),
+    ]);
+    expect(terminalDetail).toMatchObject({
+      id: resolved.id,
+      status: 'resolved',
+      resolverReviewId: 'review-terminal-detail',
+      resolverOutcome: expect.objectContaining({
+        action: 'link_without_merge',
+      }),
+    });
+  });
+
   it('uses the exported module surface with in-memory persistence for non-uuid test scope ids', async () => {
     const created = await createIdentityAmbiguityEvent({
       tenantId: 'tenant-test-scope',
@@ -178,6 +395,16 @@ describe('connectshyft ambiguity events', () => {
     });
 
     expect(reviewed).toMatchObject({
+      id: created.id,
+      status: 'reviewed',
+    });
+
+    const detailed = await getIdentityAmbiguityEvent({
+      tenantId: 'tenant-test-scope',
+      ambiguityEventId: created.id,
+    });
+
+    expect(detailed).toMatchObject({
       id: created.id,
       status: 'reviewed',
     });

--- a/apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import type {
+  ConnectShyftIdentityAmbiguityEvent,
   ConnectShyftIdentityAmbiguityConsumptionOutcome,
+  ConnectShyftIdentityAmbiguityReasonCode,
   ConnectShyftIdentityAmbiguityStatus,
   ConnectShyftResolverOutcomeAudit,
 } from '@shyft/contracts';
@@ -11,39 +13,16 @@ import {
 import type { Knex } from 'knex';
 import db from '../../config/knex';
 
+export type {
+  ConnectShyftIdentityAmbiguityEvent,
+  ConnectShyftIdentityAmbiguityReasonCode,
+} from '@shyft/contracts';
+
 const CONNECTSHYFT_SCHEMA = 'connectshyft';
 const AMBIGUITY_EVENTS_TABLE = 'cs_identity_ambiguity_events';
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const DEFAULT_LIST_LIMIT = 50;
 const MAX_LIST_LIMIT = 200;
-
-export type ConnectShyftIdentityAmbiguityReasonCode =
-  | 'IDENTITY_MATCH_AMBIGUOUS'
-  | 'PEOPLECORE_LEGACY_DISAGREEMENT'
-  | 'PEOPLECORE_MULTI_CURRENT_LINKS';
-
-export type ConnectShyftIdentityAmbiguityEvent = {
-  id: string;
-  tenantId: string;
-  orgUnitId: string | null;
-  sourceContext: string;
-  sourceContextId: string | null;
-  normalizedContactPoint: string;
-  contactPointType: 'phone';
-  candidateNeighborIds: string[];
-  candidateCount: number;
-  ambiguityReasonCode: ConnectShyftIdentityAmbiguityReasonCode;
-  status: ConnectShyftIdentityAmbiguityStatus;
-  requestedByUserId: string | null;
-  correlationId: string | null;
-  idempotencyKey: string | null;
-  resolverReviewId: string | null;
-  resolverConsumedByUserId: string | null;
-  resolverConsumedAtUtc: string | null;
-  resolverOutcome: ConnectShyftResolverOutcomeAudit | null;
-  createdAtUtc: string;
-  updatedAtUtc: string;
-};
 
 export type CreateIdentityAmbiguityEventInput = {
   id?: string;

--- a/apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
@@ -1,4 +1,13 @@
 import { randomUUID } from 'node:crypto';
+import type {
+  ConnectShyftIdentityAmbiguityConsumptionOutcome,
+  ConnectShyftIdentityAmbiguityStatus,
+  ConnectShyftResolverOutcomeAudit,
+} from '@shyft/contracts';
+import {
+  isConnectShyftIdentityAmbiguityStatus,
+  isConnectShyftIdentityAmbiguityTerminalStatus,
+} from '@shyft/contracts';
 import type { Knex } from 'knex';
 import db from '../../config/knex';
 
@@ -12,8 +21,6 @@ export type ConnectShyftIdentityAmbiguityReasonCode =
   | 'IDENTITY_MATCH_AMBIGUOUS'
   | 'PEOPLECORE_LEGACY_DISAGREEMENT'
   | 'PEOPLECORE_MULTI_CURRENT_LINKS';
-
-export type ConnectShyftIdentityAmbiguityStatus = 'pending' | 'reviewed';
 
 export type ConnectShyftIdentityAmbiguityEvent = {
   id: string;
@@ -30,6 +37,10 @@ export type ConnectShyftIdentityAmbiguityEvent = {
   requestedByUserId: string | null;
   correlationId: string | null;
   idempotencyKey: string | null;
+  resolverReviewId: string | null;
+  resolverConsumedByUserId: string | null;
+  resolverConsumedAtUtc: string | null;
+  resolverOutcome: ConnectShyftResolverOutcomeAudit | null;
   createdAtUtc: string;
   updatedAtUtc: string;
 };
@@ -49,6 +60,10 @@ export type CreateIdentityAmbiguityEventInput = {
   requestedByUserId?: string | null;
   correlationId?: string | null;
   idempotencyKey?: string | null;
+  resolverReviewId?: string | null;
+  resolverConsumedByUserId?: string | null;
+  resolverConsumedAtUtc?: string | null;
+  resolverOutcome?: ConnectShyftResolverOutcomeAudit | null;
   createdAtUtc?: string;
   updatedAtUtc?: string;
 };
@@ -59,6 +74,7 @@ export type ListIdentityAmbiguityEventsInput = {
   status?: ConnectShyftIdentityAmbiguityStatus | null;
   normalizedContactPoint?: string | null;
   sourceContext?: string | null;
+  sourceContextId?: string | null;
   limit?: number;
   cursor?: string | null;
 };
@@ -72,6 +88,36 @@ export type MarkIdentityAmbiguityEventReviewedInput = {
   tenantId: string;
   ambiguityEventId: string;
   reviewedAtUtc?: string;
+};
+
+export type GetIdentityAmbiguityEventInput = {
+  tenantId: string;
+  ambiguityEventId: string;
+};
+
+export type ConsumeAmbiguityEventsForResolverOutcomeInput = {
+  tenantId: string;
+  resolverReviewId: string;
+  triggerSourceId?: string | null;
+  ambiguityEventId?: string | null;
+  outcome: ConnectShyftIdentityAmbiguityConsumptionOutcome;
+  consumedByUserId: string;
+  consumedAtUtc?: string;
+  resolverOutcome: ConnectShyftResolverOutcomeAudit;
+};
+
+export type ConsumeIdentityAmbiguityEventInput = {
+  tenantId: string;
+  ambiguityEventId: string;
+  outcome: ConnectShyftIdentityAmbiguityConsumptionOutcome;
+  resolverReviewId: string;
+  consumedByUserId: string;
+  consumedAtUtc?: string;
+  resolverOutcome: ConnectShyftResolverOutcomeAudit;
+};
+
+export type AmbiguityConsumptionResult = {
+  events: ConnectShyftIdentityAmbiguityEvent[];
 };
 
 type DbIdentityAmbiguityEventRow = {
@@ -89,6 +135,10 @@ type DbIdentityAmbiguityEventRow = {
   requested_by_user_id: string | null;
   correlation_id: string | null;
   idempotency_key: string | null;
+  resolver_review_id: string | null;
+  resolver_consumed_by_user_id: string | null;
+  resolver_consumed_at_utc: string | Date | null;
+  resolver_outcome: ConnectShyftResolverOutcomeAudit | null;
   created_at_utc: string | Date;
   updated_at_utc: string | Date;
 };
@@ -105,8 +155,14 @@ export interface ConnectShyftIdentityAmbiguityEventStore {
   listEvents(
     input: ListIdentityAmbiguityEventsInput,
   ): Promise<ListIdentityAmbiguityEventsResult>;
+  getEvent(
+    input: GetIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null>;
   markReviewed(
     input: MarkIdentityAmbiguityEventReviewedInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null>;
+  consumeEvent(
+    input: ConsumeIdentityAmbiguityEventInput,
   ): Promise<ConnectShyftIdentityAmbiguityEvent | null>;
 }
 
@@ -128,7 +184,39 @@ const normalizeContactPointType = (value: unknown): 'phone' => {
 };
 
 const normalizeStatus = (value: unknown): ConnectShyftIdentityAmbiguityStatus => {
-  return value === 'reviewed' ? 'reviewed' : 'pending';
+  return isConnectShyftIdentityAmbiguityStatus(value) ? value : 'pending';
+};
+
+const normalizeResolverOutcome = (
+  value: unknown,
+): ConnectShyftResolverOutcomeAudit | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const reviewId = normalizeOptionalString(candidate.reviewId);
+  const action = normalizeOptionalString(candidate.action);
+  const reviewStatus = normalizeOptionalString(candidate.reviewStatus);
+  const actorUserId = normalizeOptionalString(candidate.actorUserId);
+  const occurredAtUtc = normalizeOptionalString(candidate.occurredAtUtc);
+  if (!reviewId || !action || !reviewStatus || !actorUserId || !occurredAtUtc) {
+    return null;
+  }
+
+  return {
+    reviewId,
+    action: action as ConnectShyftResolverOutcomeAudit['action'],
+    reviewStatus: reviewStatus as ConnectShyftResolverOutcomeAudit['reviewStatus'],
+    actorUserId,
+    occurredAtUtc,
+    reason: normalizeOptionalString(candidate.reason),
+    notes: normalizeOptionalString(candidate.notes),
+    personId: normalizeOptionalString(candidate.personId),
+    sourcePersonId: normalizeOptionalString(candidate.sourcePersonId),
+    targetPersonId: normalizeOptionalString(candidate.targetPersonId),
+    contactPointId: normalizeOptionalString(candidate.contactPointId),
+  };
 };
 
 const normalizeLimit = (value: unknown): number => {
@@ -163,6 +251,9 @@ const cloneEvent = (
 ): ConnectShyftIdentityAmbiguityEvent => ({
   ...event,
   candidateNeighborIds: [...event.candidateNeighborIds],
+  resolverOutcome: event.resolverOutcome
+    ? { ...event.resolverOutcome }
+    : null,
 });
 
 const compareEventsNewestFirst = (
@@ -276,6 +367,12 @@ const mapDbRowToEvent = (
   requestedByUserId: row.requested_by_user_id,
   correlationId: row.correlation_id,
   idempotencyKey: row.idempotency_key,
+  resolverReviewId: normalizeOptionalString(row.resolver_review_id),
+  resolverConsumedByUserId: normalizeOptionalString(row.resolver_consumed_by_user_id),
+  resolverConsumedAtUtc: row.resolver_consumed_at_utc instanceof Date
+    ? row.resolver_consumed_at_utc.toISOString()
+    : normalizeOptionalString(row.resolver_consumed_at_utc),
+  resolverOutcome: normalizeResolverOutcome(row.resolver_outcome),
   createdAtUtc: row.created_at_utc instanceof Date
     ? row.created_at_utc.toISOString()
     : String(row.created_at_utc),
@@ -306,6 +403,12 @@ const buildStoredEvent = (
     requestedByUserId: normalizeOptionalString(input.requestedByUserId),
     correlationId: normalizeOptionalString(input.correlationId),
     idempotencyKey: normalizeOptionalString(input.idempotencyKey),
+    resolverReviewId: normalizeOptionalString(input.resolverReviewId),
+    resolverConsumedByUserId: normalizeOptionalString(input.resolverConsumedByUserId),
+    resolverConsumedAtUtc: input.resolverConsumedAtUtc
+      ? toIsoUtc(input.resolverConsumedAtUtc)
+      : null,
+    resolverOutcome: normalizeResolverOutcome(input.resolverOutcome),
     createdAtUtc,
     updatedAtUtc,
   };
@@ -330,6 +433,7 @@ implements ConnectShyftIdentityAmbiguityEventStore {
     const status = normalizeOptionalString(input.status);
     const normalizedContactPoint = normalizeOptionalString(input.normalizedContactPoint);
     const sourceContext = normalizeOptionalString(input.sourceContext);
+    const sourceContextId = normalizeOptionalString(input.sourceContextId);
     const cursor = decodeCursor(input.cursor);
     const limit = normalizeLimit(input.limit);
 
@@ -339,6 +443,7 @@ implements ConnectShyftIdentityAmbiguityEventStore {
       .filter((event) => !status || event.status === status)
       .filter((event) => !normalizedContactPoint || event.normalizedContactPoint === normalizedContactPoint)
       .filter((event) => !sourceContext || event.sourceContext === sourceContext)
+      .filter((event) => !sourceContextId || event.sourceContextId === sourceContextId)
       .filter((event) => isAfterCursor(event, cursor))
       .sort(compareEventsNewestFirst);
 
@@ -358,6 +463,17 @@ implements ConnectShyftIdentityAmbiguityEventStore {
     };
   }
 
+  async getEvent(
+    input: GetIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
+    const existing = this.eventsById.get(input.ambiguityEventId);
+    if (!existing || existing.tenantId !== input.tenantId) {
+      return null;
+    }
+
+    return cloneEvent(existing);
+  }
+
   async markReviewed(
     input: MarkIdentityAmbiguityEventReviewedInput,
   ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
@@ -366,7 +482,7 @@ implements ConnectShyftIdentityAmbiguityEventStore {
       return null;
     }
 
-    if (existing.status === 'reviewed') {
+    if (existing.status !== 'pending') {
       return cloneEvent(existing);
     }
 
@@ -374,6 +490,50 @@ implements ConnectShyftIdentityAmbiguityEventStore {
       ...existing,
       status: 'reviewed',
       updatedAtUtc: input.reviewedAtUtc ? toIsoUtc(input.reviewedAtUtc) : new Date().toISOString(),
+    };
+    this.eventsById.set(updated.id, updated);
+    return cloneEvent(updated);
+  }
+
+  async consumeEvent(
+    input: ConsumeIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
+    const existing = this.eventsById.get(input.ambiguityEventId);
+    if (!existing || existing.tenantId !== input.tenantId) {
+      return null;
+    }
+
+    const consumedAtUtc = input.consumedAtUtc
+      ? toIsoUtc(input.consumedAtUtc)
+      : new Date().toISOString();
+    const normalizedOutcome = normalizeResolverOutcome(input.resolverOutcome);
+    if (!normalizedOutcome) {
+      return cloneEvent(existing);
+    }
+
+    if (existing.status === input.outcome) {
+      if (existing.resolverReviewId === input.resolverReviewId) {
+        return cloneEvent(existing);
+      }
+
+      return cloneEvent(existing);
+    }
+
+    if (
+      isConnectShyftIdentityAmbiguityTerminalStatus(existing.status)
+      && existing.status !== 'reviewed'
+    ) {
+      return cloneEvent(existing);
+    }
+
+    const updated: ConnectShyftIdentityAmbiguityEvent = {
+      ...existing,
+      status: input.outcome,
+      resolverReviewId: input.resolverReviewId,
+      resolverConsumedByUserId: input.consumedByUserId,
+      resolverConsumedAtUtc: consumedAtUtc,
+      resolverOutcome: normalizedOutcome,
+      updatedAtUtc: consumedAtUtc,
     };
     this.eventsById.set(updated.id, updated);
     return cloneEvent(updated);
@@ -415,6 +575,10 @@ implements ConnectShyftIdentityAmbiguityEventStore {
         requested_by_user_id: event.requestedByUserId,
         correlation_id: event.correlationId,
         idempotency_key: event.idempotencyKey,
+        resolver_review_id: event.resolverReviewId,
+        resolver_consumed_by_user_id: event.resolverConsumedByUserId,
+        resolver_consumed_at_utc: event.resolverConsumedAtUtc,
+        resolver_outcome: event.resolverOutcome,
         created_at_utc: event.createdAtUtc,
         updated_at_utc: event.updatedAtUtc,
       })
@@ -431,6 +595,7 @@ implements ConnectShyftIdentityAmbiguityEventStore {
     const status = normalizeOptionalString(input.status);
     const normalizedContactPoint = normalizeOptionalString(input.normalizedContactPoint);
     const sourceContext = normalizeOptionalString(input.sourceContext);
+    const sourceContextId = normalizeOptionalString(input.sourceContextId);
     const cursor = decodeCursor(input.cursor);
     const limit = normalizeLimit(input.limit);
 
@@ -453,6 +618,9 @@ implements ConnectShyftIdentityAmbiguityEventStore {
     }
     if (sourceContext) {
       query.andWhere('source_context', sourceContext);
+    }
+    if (sourceContextId) {
+      query.andWhere('source_context_id', sourceContextId);
     }
     if (cursor) {
       query.andWhere((builder) => {
@@ -483,6 +651,19 @@ implements ConnectShyftIdentityAmbiguityEventStore {
     };
   }
 
+  async getEvent(
+    input: GetIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
+    const existing = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        id: input.ambiguityEventId,
+      })
+      .first();
+
+    return existing ? mapDbRowToEvent(existing) : null;
+  }
+
   async markReviewed(
     input: MarkIdentityAmbiguityEventReviewedInput,
   ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
@@ -497,7 +678,7 @@ implements ConnectShyftIdentityAmbiguityEventStore {
       return null;
     }
 
-    if (existing.status === 'reviewed') {
+    if (existing.status !== 'pending') {
       return mapDbRowToEvent(existing);
     }
 
@@ -509,6 +690,55 @@ implements ConnectShyftIdentityAmbiguityEventStore {
       .update({
         status: 'reviewed',
         updated_at_utc: input.reviewedAtUtc ? toIsoUtc(input.reviewedAtUtc) : new Date().toISOString(),
+      })
+      .returning('*');
+
+    const updated = updatedRows[0];
+    return updated ? mapDbRowToEvent(updated) : mapDbRowToEvent(existing);
+  }
+
+  async consumeEvent(
+    input: ConsumeIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
+    const existing = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        id: input.ambiguityEventId,
+      })
+      .first();
+
+    if (!existing) {
+      return null;
+    }
+
+    if (existing.status === input.outcome && existing.resolver_review_id === input.resolverReviewId) {
+      return mapDbRowToEvent(existing);
+    }
+
+    if (
+      isConnectShyftIdentityAmbiguityTerminalStatus(existing.status)
+      && existing.status !== 'reviewed'
+    ) {
+      return mapDbRowToEvent(existing);
+    }
+
+    const consumedAtUtc = input.consumedAtUtc
+      ? toIsoUtc(input.consumedAtUtc)
+      : new Date().toISOString();
+    const normalizedOutcome = normalizeResolverOutcome(input.resolverOutcome);
+
+    const updatedRows = await this.table()
+      .where({
+        tenant_id: input.tenantId,
+        id: input.ambiguityEventId,
+      })
+      .update({
+        status: input.outcome,
+        resolver_review_id: input.resolverReviewId,
+        resolver_consumed_by_user_id: input.consumedByUserId,
+        resolver_consumed_at_utc: consumedAtUtc,
+        resolver_outcome: normalizedOutcome,
+        updated_at_utc: consumedAtUtc,
       })
       .returning('*');
 
@@ -553,6 +783,15 @@ export class AsyncConnectShyftIdentityAmbiguityEventService {
     }).listEvents(input);
   }
 
+  async getIdentityAmbiguityEvent(
+    input: GetIdentityAmbiguityEventInput,
+  ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
+    return this.resolveStore({
+      tenantId: input.tenantId,
+      ambiguityEventId: input.ambiguityEventId,
+    }).getEvent(input);
+  }
+
   async markIdentityAmbiguityEventReviewed(
     input: MarkIdentityAmbiguityEventReviewedInput,
   ): Promise<ConnectShyftIdentityAmbiguityEvent | null> {
@@ -560,6 +799,56 @@ export class AsyncConnectShyftIdentityAmbiguityEventService {
       tenantId: input.tenantId,
       ambiguityEventId: input.ambiguityEventId,
     }).markReviewed(input);
+  }
+
+  async consumeAmbiguityEventsForResolverOutcome(
+    input: ConsumeAmbiguityEventsForResolverOutcomeInput,
+  ): Promise<AmbiguityConsumptionResult> {
+    const store = this.resolveStore({
+      tenantId: input.tenantId,
+      ambiguityEventId: input.ambiguityEventId,
+    });
+    const consumedEvents = new Map<string, ConnectShyftIdentityAmbiguityEvent>();
+
+    if (input.triggerSourceId) {
+      const linked = await store.listEvents({
+        tenantId: input.tenantId,
+        sourceContextId: input.triggerSourceId,
+        limit: MAX_LIST_LIMIT,
+      });
+
+      linked.events
+        .filter((event) => event.status === 'pending' || event.resolverReviewId === input.resolverReviewId)
+        .forEach((event) => {
+          consumedEvents.set(event.id, event);
+        });
+    }
+
+    if (input.ambiguityEventId) {
+      const explicit = await store.getEvent({
+        tenantId: input.tenantId,
+        ambiguityEventId: input.ambiguityEventId,
+      });
+      if (explicit) {
+        consumedEvents.set(explicit.id, explicit);
+      }
+    }
+
+    const events = await Promise.all(
+      Array.from(consumedEvents.values()).map(async (event) => store.consumeEvent({
+        tenantId: input.tenantId,
+        ambiguityEventId: event.id,
+        outcome: input.outcome,
+        resolverReviewId: input.resolverReviewId,
+        consumedByUserId: input.consumedByUserId,
+        consumedAtUtc: input.consumedAtUtc,
+        resolverOutcome: input.resolverOutcome,
+      })),
+    );
+
+    return {
+      events: events.filter((event): event is ConnectShyftIdentityAmbiguityEvent => Boolean(event)),
+    };
   }
 }
 
@@ -587,6 +876,16 @@ export const markIdentityAmbiguityEventReviewed = (
   input: MarkIdentityAmbiguityEventReviewedInput,
 ): Promise<ConnectShyftIdentityAmbiguityEvent | null> =>
   defaultConnectShyftIdentityAmbiguityEventService.markIdentityAmbiguityEventReviewed(input);
+
+export const getIdentityAmbiguityEvent = (
+  input: GetIdentityAmbiguityEventInput,
+): Promise<ConnectShyftIdentityAmbiguityEvent | null> =>
+  defaultConnectShyftIdentityAmbiguityEventService.getIdentityAmbiguityEvent(input);
+
+export const consumeAmbiguityEventsForResolverOutcome = (
+  input: ConsumeAmbiguityEventsForResolverOutcomeInput,
+): Promise<AmbiguityConsumptionResult> =>
+  defaultConnectShyftIdentityAmbiguityEventService.consumeAmbiguityEventsForResolverOutcome(input);
 
 export const resetIdentityAmbiguityEventsForTests = (): void => {
   inMemoryConnectShyftIdentityAmbiguityEventStore.reset();

--- a/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
@@ -1,4 +1,7 @@
-import { RESOLVER_ACTION_TYPES } from '@shyft/contracts';
+import {
+  RESOLVER_ACTION_STATUS_MAP,
+  RESOLVER_ACTION_TYPES,
+} from '@shyft/contracts';
 import {
   AsyncPeopleCoreService,
   assertResolverReviewTransitionAllowed,
@@ -9,6 +12,7 @@ import {
   validateResolverDecisionInput,
 } from '../service';
 import type { CreateResolverReviewInput } from '../store';
+import { personRebindServiceAsync } from '../../connectshyft/personRebind';
 
 const PERSON_INPUT = {
   tenantId: 'tenant-1',
@@ -75,7 +79,66 @@ const buildResolverReview = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const CONTACT_POINT_LINK_BASE = {
+  tenantId: 'tenant-1',
+  contactPointId: 'contact-point-1',
+  subjectType: 'person' as const,
+  linkType: 'primary' as const,
+  confidenceBand: 'high' as const,
+  isCurrent: true,
+  isPrimary: true,
+  manuallyConfirmed: true,
+  confirmationSource: 'resolver' as const,
+  firstLinkedAt: '2026-03-21T12:00:00.000Z',
+  linkedBy: 'resolver' as const,
+  createdAt: '2026-03-21T12:00:00.000Z',
+  updatedAt: '2026-03-21T12:00:00.000Z',
+};
+
+const buildContactPointLink = (subjectId: string, overrides: Record<string, unknown> = {}) => ({
+  ...CONTACT_POINT_LINK_BASE,
+  id: `link-${subjectId}`,
+  subjectId,
+  ...overrides,
+});
+
+const buildDecisionReview = (overrides: Record<string, unknown> = {}) => buildResolverReview({
+  contactPointId: 'contact-point-1',
+  provisionalPersonId: 'person-provisional',
+  candidatePersonIds: ['person-existing'],
+  ...overrides,
+});
+
+const buildResolvedReviewForAction = (
+  action: keyof typeof RESOLVER_ACTION_STATUS_MAP,
+  overrides: Record<string, unknown> = {},
+) => buildDecisionReview({
+  reviewStatus: RESOLVER_ACTION_STATUS_MAP[action],
+  resolutionType: action,
+  resolutionReason: 'Resolver decision applied.',
+  resolvedAt: '2026-03-21T12:12:00.000Z',
+  assignedResolverUserId: 'resolver-1',
+  ...overrides,
+});
+
+const createApplyResolverDecisionStore = (overrides: Record<string, jest.Mock> = {}) => ({
+  getResolverReview: jest.fn(),
+  listCurrentContactPointLinks: jest.fn(),
+  setResolverContactPointPersons: jest.fn(),
+  updateResolverReview: jest.fn(),
+  appendContactPointEvent: jest.fn(),
+  getContactPoint: jest.fn(),
+  listContactPointEvents: jest.fn(),
+  updateContactPointStatus: jest.fn(),
+  mergePerson: jest.fn(),
+  ...overrides,
+});
+
 describe('AsyncPeopleCoreService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('delegates persistence-backed operations to the configured store', async () => {
     const store = {
       createPerson: jest.fn(async () => ({ id: 'person-1' })),
@@ -391,6 +454,406 @@ describe('AsyncPeopleCoreService', () => {
       reviewStatus: 'resolved_confirmed_existing',
       resolutionType: 'confirm_existing_person',
       resolutionReason: 'Attempting to resolve after dismissal.',
+    })).rejects.toBeInstanceOf(InvalidResolverReviewTransitionError);
+    expect(store.updateResolverReview).not.toHaveBeenCalled();
+  });
+
+  it('applies confirm_existing_person through the authoritative decision path and triggers rebind when ownership changes', async () => {
+    const currentReview = buildDecisionReview();
+    const updatedReview = buildResolvedReviewForAction('confirm_existing_person', {
+      candidatePersonIds: ['person-existing'],
+    });
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      listCurrentContactPointLinks: jest.fn(async () => [
+        buildContactPointLink('person-provisional'),
+      ]),
+      setResolverContactPointPersons: jest.fn(async () => [
+        buildContactPointLink('person-existing'),
+      ]),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    });
+    const rebindSpy = jest.spyOn(personRebindServiceAsync, 'rebindPersonThreads')
+      .mockResolvedValue(undefined);
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'confirm_existing_person',
+      personId: 'person-existing',
+      reason: 'Matched the existing person.',
+    });
+
+    expect(store.setResolverContactPointPersons).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      contactPointId: 'contact-point-1',
+      personIds: ['person-existing'],
+      primaryPersonId: 'person-existing',
+      resolutionType: 'confirm_existing_person',
+    }));
+    expect(rebindSpy).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      provisionalPersonId: 'person-provisional',
+      canonicalPersonId: 'person-existing',
+      performedByUserId: 'resolver-1',
+    });
+    expect(result).toMatchObject({
+      reviewId: 'review-1',
+      status: 'resolved',
+      action: 'confirm_existing_person',
+      reviewStatus: 'resolved_confirmed_existing',
+      resolutionType: 'confirm_existing_person',
+      affectedPersonIds: ['person-provisional', 'person-existing'],
+      affectedContactPointIds: ['contact-point-1'],
+      mergeApplied: false,
+      rebindTriggered: true,
+    });
+  });
+
+  it('applies confirm_new_person without invoking merge and preserves the provisional identity', async () => {
+    const currentReview = buildDecisionReview();
+    const updatedReview = buildResolvedReviewForAction('confirm_new_person');
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      listCurrentContactPointLinks: jest.fn(async () => [
+        buildContactPointLink('person-provisional'),
+      ]),
+      setResolverContactPointPersons: jest.fn(async () => [
+        buildContactPointLink('person-provisional'),
+      ]),
+      updateResolverReview: jest.fn(async () => updatedReview),
+      mergePerson: jest.fn(),
+    });
+    const rebindSpy = jest.spyOn(personRebindServiceAsync, 'rebindPersonThreads')
+      .mockResolvedValue(undefined);
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'confirm_new_person',
+      provisionalPersonId: 'person-provisional',
+      reason: 'The provisional person is correct.',
+    });
+
+    expect(store.setResolverContactPointPersons).toHaveBeenCalledWith(expect.objectContaining({
+      personIds: ['person-provisional'],
+      primaryPersonId: 'person-provisional',
+      resolutionType: 'confirm_new_person',
+    }));
+    expect(store.mergePerson).not.toHaveBeenCalled();
+    expect(rebindSpy).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      action: 'confirm_new_person',
+      reviewStatus: 'resolved_confirmed_new',
+      resolutionType: 'confirm_new_person',
+      affectedPersonIds: ['person-provisional', 'person-existing'],
+      mergeApplied: false,
+      rebindTriggered: false,
+    });
+  });
+
+  it('applies merge_people through the existing merge path and emits merge-safe flags', async () => {
+    const currentReview = buildDecisionReview({
+      reviewType: 'merge_review',
+      candidatePersonIds: ['person-canonical'],
+    });
+    const updatedReview = buildResolvedReviewForAction('merge_people', {
+      reviewType: 'merge_review',
+      candidatePersonIds: ['person-canonical'],
+    });
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      mergePerson: jest.fn(async () => ({
+        mergedProvisionalPersonId: 'person-provisional',
+        canonicalPersonId: 'person-canonical',
+        autoMergedContactPointLinkIds: ['link-person-provisional'],
+        reviewContactPointLinkIds: [],
+        resolverReviewId: 'review-1',
+        didPersistMerge: true,
+      })),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    });
+    const mergeEventPublisher = {
+      publishPersonMerged: jest.fn(async () => undefined),
+    };
+    const rebindSpy = jest.spyOn(personRebindServiceAsync, 'rebindPersonThreads')
+      .mockResolvedValue(undefined);
+    const service = new AsyncPeopleCoreService(store as any, mergeEventPublisher as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'merge_people',
+      sourcePersonId: 'person-provisional',
+      targetPersonId: 'person-canonical',
+      reason: 'Merge the duplicate people.',
+    });
+
+    expect(store.mergePerson).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      provisionalPersonId: 'person-provisional',
+      canonicalPersonId: 'person-canonical',
+      performedByUserId: 'resolver-1',
+      resolverReviewId: 'review-1',
+      skipResolverReviewCreation: true,
+    }));
+    expect(mergeEventPublisher.publishPersonMerged).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      provisionalPersonId: 'person-provisional',
+      canonicalPersonId: 'person-canonical',
+      resolverReviewId: 'review-1',
+    }));
+    expect(rebindSpy).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      provisionalPersonId: 'person-provisional',
+      canonicalPersonId: 'person-canonical',
+      performedByUserId: 'resolver-1',
+    });
+    expect(result).toMatchObject({
+      action: 'merge_people',
+      reviewStatus: 'resolved_merged',
+      resolutionType: 'merge_people',
+      mergeApplied: true,
+      rebindTriggered: true,
+      affectedPersonIds: ['person-provisional', 'person-canonical'],
+    });
+  });
+
+  it('applies link_without_merge without merge or broad rebind fanout', async () => {
+    const currentReview = buildDecisionReview();
+    const updatedReview = buildResolvedReviewForAction('link_without_merge');
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      listCurrentContactPointLinks: jest.fn(async () => [
+        buildContactPointLink('person-provisional'),
+      ]),
+      setResolverContactPointPersons: jest.fn(async () => [
+        buildContactPointLink('person-existing'),
+      ]),
+      updateResolverReview: jest.fn(async () => updatedReview),
+      mergePerson: jest.fn(),
+    });
+    const rebindSpy = jest.spyOn(personRebindServiceAsync, 'rebindPersonThreads')
+      .mockResolvedValue(undefined);
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'link_without_merge',
+      personId: 'person-existing',
+      reason: 'Keep both people distinct but maintain the operational link.',
+    });
+
+    expect(store.mergePerson).not.toHaveBeenCalled();
+    expect(rebindSpy).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      action: 'link_without_merge',
+      reviewStatus: 'resolved_confirmed_existing',
+      resolutionType: 'link_without_merge',
+      mergeApplied: false,
+      rebindTriggered: false,
+    });
+  });
+
+  it('applies mark_shared_contact without forcing exclusive ownership', async () => {
+    const currentReview = buildDecisionReview();
+    const updatedLinks = [
+      buildContactPointLink('person-existing'),
+      buildContactPointLink('person-provisional', {
+        id: 'link-person-provisional-secondary',
+        isPrimary: false,
+        linkType: 'secondary',
+      }),
+    ];
+    const updatedReview = buildResolvedReviewForAction('mark_shared_contact');
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      listCurrentContactPointLinks: jest.fn()
+        .mockResolvedValueOnce([
+          buildContactPointLink('person-existing'),
+        ])
+        .mockResolvedValueOnce(updatedLinks),
+      setResolverContactPointPersons: jest.fn(async () => updatedLinks),
+      appendContactPointEvent: jest.fn(async () => ({ id: 'event-1' })),
+      getContactPoint: jest.fn(async () => ({
+        id: 'contact-point-1',
+        status: 'active_personal',
+      })),
+      listContactPointEvents: jest.fn(async () => []),
+      updateContactPointStatus: jest.fn(async () => undefined),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    });
+    const rebindSpy = jest.spyOn(personRebindServiceAsync, 'rebindPersonThreads')
+      .mockResolvedValue(undefined);
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'mark_shared_contact',
+      reason: 'This phone number is intentionally shared.',
+    });
+
+    expect(store.setResolverContactPointPersons).toHaveBeenCalledWith(expect.objectContaining({
+      personIds: ['person-existing', 'person-provisional'],
+      primaryPersonId: 'person-existing',
+      resolutionType: 'mark_shared_contact',
+    }));
+    expect(store.appendContactPointEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'shared_detected',
+      relatedObjectId: 'review-1',
+    }));
+    expect(rebindSpy).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      action: 'mark_shared_contact',
+      reviewStatus: 'resolved_shared_contact',
+      resolutionType: 'mark_shared_contact',
+      mergeApplied: false,
+      rebindTriggered: false,
+      affectedPersonIds: ['person-provisional', 'person-existing'],
+    });
+  });
+
+  it('applies reassign_contact_point and triggers rebind when current subject truth changes', async () => {
+    const currentReview = buildDecisionReview();
+    const updatedReview = buildResolvedReviewForAction('reassign_contact_point');
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      listCurrentContactPointLinks: jest.fn(async () => [
+        buildContactPointLink('person-provisional'),
+      ]),
+      setResolverContactPointPersons: jest.fn(async () => [
+        buildContactPointLink('person-existing'),
+      ]),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    });
+    const rebindSpy = jest.spyOn(personRebindServiceAsync, 'rebindPersonThreads')
+      .mockResolvedValue(undefined);
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'reassign_contact_point',
+      personId: 'person-existing',
+      contactPointId: 'contact-point-1',
+      reason: 'The contact point should belong to the existing person.',
+    });
+
+    expect(store.setResolverContactPointPersons).toHaveBeenCalledWith(expect.objectContaining({
+      contactPointId: 'contact-point-1',
+      personIds: ['person-existing'],
+      primaryPersonId: 'person-existing',
+      resolutionType: 'reassign_contact_point',
+    }));
+    expect(rebindSpy).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      provisionalPersonId: 'person-provisional',
+      canonicalPersonId: 'person-existing',
+      performedByUserId: 'resolver-1',
+    });
+    expect(result).toMatchObject({
+      action: 'reassign_contact_point',
+      reviewStatus: 'resolved_reassigned',
+      resolutionType: 'reassign_contact_point',
+      mergeApplied: false,
+      rebindTriggered: true,
+    });
+  });
+
+  it('applies dismiss_no_action without mutating identity truth', async () => {
+    const currentReview = buildDecisionReview();
+    const updatedReview = buildResolvedReviewForAction('dismiss_no_action', {
+      reviewStatus: 'dismissed',
+      resolutionType: 'dismiss_no_action',
+    });
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      updateResolverReview: jest.fn(async () => updatedReview),
+      setResolverContactPointPersons: jest.fn(),
+      mergePerson: jest.fn(),
+    });
+    const rebindSpy = jest.spyOn(personRebindServiceAsync, 'rebindPersonThreads')
+      .mockResolvedValue(undefined);
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'dismiss_no_action',
+      reason: 'No identity change is required.',
+    });
+
+    expect(store.setResolverContactPointPersons).not.toHaveBeenCalled();
+    expect(store.mergePerson).not.toHaveBeenCalled();
+    expect(rebindSpy).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      action: 'dismiss_no_action',
+      status: 'dismissed',
+      reviewStatus: 'dismissed',
+      resolutionType: 'dismiss_no_action',
+      mergeApplied: false,
+      rebindTriggered: false,
+    });
+  });
+
+  it('replays an identical terminal resolver decision safely without mutating the review again', async () => {
+    const terminalReview = buildResolvedReviewForAction('confirm_existing_person', {
+      resolutionReason: 'Matched the existing person.',
+    });
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => terminalReview),
+      updateResolverReview: jest.fn(),
+    });
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'confirm_existing_person',
+      personId: 'person-existing',
+      reason: 'Matched the existing person.',
+    });
+
+    expect(store.updateResolverReview).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      action: 'confirm_existing_person',
+      status: 'resolved',
+      reviewStatus: 'resolved_confirmed_existing',
+      resolutionType: 'confirm_existing_person',
+    });
+  });
+
+  it('rejects changing a terminal resolver decision to a different action through applyResolverDecision', async () => {
+    const terminalReview = buildResolvedReviewForAction('confirm_existing_person');
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => terminalReview),
+      updateResolverReview: jest.fn(),
+    });
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'dismiss_no_action',
+      reason: 'Trying to override the existing terminal outcome.',
     })).rejects.toBeInstanceOf(InvalidResolverReviewTransitionError);
     expect(store.updateResolverReview).not.toHaveBeenCalled();
   });

--- a/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
@@ -1,7 +1,12 @@
+import { RESOLVER_ACTION_TYPES } from '@shyft/contracts';
 import {
   AsyncPeopleCoreService,
+  assertResolverReviewTransitionAllowed,
   ContactPointLifecycleComputationError,
+  InvalidResolverReviewTransitionError,
   PeopleCorePersistenceUnavailableError,
+  ResolverReviewValidationError,
+  validateResolverDecisionInput,
 } from '../service';
 import type { CreateResolverReviewInput } from '../store';
 
@@ -47,6 +52,28 @@ const RESOLVER_REVIEW_INPUT: CreateResolverReviewInput = {
   requestedByUserId: 'user-1',
   requestedAt: '2026-03-21T12:00:00.000Z',
 };
+
+const BASE_RESOLVER_REVIEW = {
+  id: 'review-1',
+  tenantId: 'tenant-1',
+  orgUnitId: 'org-1',
+  reviewType: 'identity_conflict' as const,
+  reviewStatus: 'pending' as const,
+  priority: 'normal' as const,
+  triggerSourceType: 'conversation',
+  triggerSourceId: 'conversation-1',
+  candidatePersonIds: ['person-a', 'person-b'],
+  confidenceBand: 'high' as const,
+  confidenceReasons: ['exact phone match'],
+  riskFlags: ['duplicate_creation_attempt'] as const,
+  requestedByUserId: 'user-1',
+  requestedAt: '2026-03-21T12:00:00.000Z',
+};
+
+const buildResolverReview = (overrides: Record<string, unknown> = {}) => ({
+  ...BASE_RESOLVER_REVIEW,
+  ...overrides,
+});
 
 describe('AsyncPeopleCoreService', () => {
   it('delegates persistence-backed operations to the configured store', async () => {
@@ -174,5 +201,197 @@ describe('AsyncPeopleCoreService', () => {
     const service = new AsyncPeopleCoreService(store as any);
 
     await expect(invoke(service)).rejects.toBeInstanceOf(PeopleCorePersistenceUnavailableError);
+  });
+
+  it.each(RESOLVER_ACTION_TYPES)('accepts canonical resolver decision action %s', (action) => {
+    expect(validateResolverDecisionInput({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action,
+      ...(action === 'confirm_existing_person' ? { personId: 'person-1' } : {}),
+      ...(action === 'confirm_new_person' ? { provisionalPersonId: 'person-provisional' } : {}),
+      ...(action === 'merge_people'
+        ? { sourcePersonId: 'person-source', targetPersonId: 'person-target' }
+        : {}),
+      ...(action === 'link_without_merge' ? { personId: 'person-1' } : {}),
+      ...(action === 'reassign_contact_point'
+        ? { personId: 'person-1', contactPointId: 'contact-point-1' }
+        : {}),
+      ...(action === 'dismiss_no_action' ? { reason: 'No identity change required.' } : {}),
+    }).action).toBe(action);
+  });
+
+  it('rejects unknown resolver decision actions', () => {
+    expect(() => validateResolverDecisionInput({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'maybe_merge_later' as any,
+    })).toThrow(ResolverReviewValidationError);
+  });
+
+  it.each([
+    ['pending', 'in_review'],
+    ['pending', 'resolved_confirmed_existing'],
+    ['queued', 'in_review'],
+    ['in_review', 'resolved_merged'],
+    ['waiting_for_more_info', 'dismissed'],
+  ] as const)('allows resolver review transition %s -> %s', (currentStatus, nextStatus) => {
+    expect(() => assertResolverReviewTransitionAllowed(currentStatus, nextStatus)).not.toThrow();
+  });
+
+  it.each([
+    ['resolved_confirmed_existing', 'in_review'],
+    ['dismissed', 'resolved_confirmed_existing'],
+    ['pending', 'pending'],
+    ['pending', 'waiting_for_more_info'],
+  ] as const)('rejects invalid resolver review transition %s -> %s when appropriate', (currentStatus, nextStatus) => {
+    if (currentStatus === 'pending' && nextStatus === 'pending') {
+      expect(() => assertResolverReviewTransitionAllowed(currentStatus, nextStatus)).not.toThrow();
+      return;
+    }
+
+    expect(() => assertResolverReviewTransitionAllowed(currentStatus, nextStatus))
+      .toThrow(InvalidResolverReviewTransitionError);
+  });
+
+  it('rejects merge_people when source and target match', () => {
+    expect(() => validateResolverDecisionInput({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'merge_people',
+      sourcePersonId: 'person-1',
+      targetPersonId: 'person-1',
+    })).toThrow(ResolverReviewValidationError);
+  });
+
+  it('requires a reason for dismiss_no_action', () => {
+    expect(() => validateResolverDecisionInput({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'dismiss_no_action',
+    })).toThrow(ResolverReviewValidationError);
+  });
+
+  it('normalizes confirm_new_person from provisionalPersonId', () => {
+    expect(validateResolverDecisionInput({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'confirm_new_person',
+      provisionalPersonId: 'person-provisional',
+    })).toMatchObject({
+      personId: 'person-provisional',
+      action: 'confirm_new_person',
+    });
+  });
+
+  it('moves a resolver review from pending to in_review through the service lifecycle guard', async () => {
+    const currentReview = buildResolverReview();
+    const updatedReview = buildResolverReview({
+      reviewStatus: 'in_review',
+      startedAt: '2026-03-21T12:10:00.000Z',
+      assignedResolverUserId: 'resolver-1',
+    });
+    const store = {
+      getResolverReview: jest.fn(async () => currentReview),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.updateResolverReview({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      reviewStatus: 'in_review',
+      assignedResolverUserId: 'resolver-1',
+      startedAt: '2026-03-21T12:10:00.000Z',
+    })).resolves.toEqual(updatedReview);
+    expect(store.updateResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      reviewStatus: 'in_review',
+      assignedResolverUserId: 'resolver-1',
+      startedAt: '2026-03-21T12:10:00.000Z',
+      resolvedAt: null,
+      resolutionType: null,
+    }));
+  });
+
+  it('moves a resolver review to a valid terminal resolution state', async () => {
+    const currentReview = buildResolverReview({
+      reviewStatus: 'in_review',
+      startedAt: '2026-03-21T12:10:00.000Z',
+      assignedResolverUserId: 'resolver-1',
+    });
+    const updatedReview = buildResolverReview({
+      reviewStatus: 'resolved_confirmed_existing',
+      startedAt: '2026-03-21T12:10:00.000Z',
+      resolvedAt: '2026-03-21T12:12:00.000Z',
+      assignedResolverUserId: 'resolver-1',
+      resolutionType: 'confirm_existing_person',
+      resolutionReason: 'Matched against the existing canonical person.',
+    });
+    const store = {
+      getResolverReview: jest.fn(async () => currentReview),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.updateResolverReview({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      reviewStatus: 'resolved_confirmed_existing',
+      assignedResolverUserId: 'resolver-1',
+      resolutionType: 'confirm_existing_person',
+      resolutionReason: 'Matched against the existing canonical person.',
+      resolvedAt: '2026-03-21T12:12:00.000Z',
+    })).resolves.toEqual(updatedReview);
+  });
+
+  it('rejects changing an already resolved review to a different terminal outcome', async () => {
+    const store = {
+      getResolverReview: jest.fn(async () => buildResolverReview({
+        reviewStatus: 'resolved_confirmed_existing',
+        resolvedAt: '2026-03-21T12:12:00.000Z',
+        resolutionType: 'confirm_existing_person',
+        resolutionReason: 'Matched against the existing canonical person.',
+      })),
+      updateResolverReview: jest.fn(),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.updateResolverReview({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      reviewStatus: 'resolved_merged',
+      resolutionType: 'merge_people',
+      resolutionReason: 'Merge the duplicate people.',
+    })).rejects.toBeInstanceOf(InvalidResolverReviewTransitionError);
+    expect(store.updateResolverReview).not.toHaveBeenCalled();
+  });
+
+  it('rejects resolving a dismissed review later', async () => {
+    const store = {
+      getResolverReview: jest.fn(async () => buildResolverReview({
+        reviewStatus: 'dismissed',
+        resolvedAt: '2026-03-21T12:12:00.000Z',
+        resolutionType: 'dismiss_no_action',
+        resolutionReason: 'No identity change required.',
+      })),
+      updateResolverReview: jest.fn(),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.updateResolverReview({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      reviewStatus: 'resolved_confirmed_existing',
+      resolutionType: 'confirm_existing_person',
+      resolutionReason: 'Attempting to resolve after dismissal.',
+    })).rejects.toBeInstanceOf(InvalidResolverReviewTransitionError);
+    expect(store.updateResolverReview).not.toHaveBeenCalled();
   });
 });

--- a/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
@@ -3,6 +3,11 @@ import {
   RESOLVER_ACTION_TYPES,
 } from '@shyft/contracts';
 import {
+  createIdentityAmbiguityEvent,
+  getIdentityAmbiguityEvent,
+  resetIdentityAmbiguityEventsForTests,
+} from '../../connectshyft/ambiguityEvents';
+import {
   AsyncPeopleCoreService,
   assertResolverReviewTransitionAllowed,
   ContactPointLifecycleComputationError,
@@ -137,6 +142,7 @@ const createApplyResolverDecisionStore = (overrides: Record<string, jest.Mock> =
 describe('AsyncPeopleCoreService', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    resetIdentityAmbiguityEventsForTests();
   });
 
   it('delegates persistence-backed operations to the configured store', async () => {
@@ -856,5 +862,228 @@ describe('AsyncPeopleCoreService', () => {
       reason: 'Trying to override the existing terminal outcome.',
     })).rejects.toBeInstanceOf(InvalidResolverReviewTransitionError);
     expect(store.updateResolverReview).not.toHaveBeenCalled();
+  });
+
+  it('consumes linked ambiguity events when confirm_existing_person resolves a review', async () => {
+    const currentReview = buildDecisionReview({
+      triggerSourceId: 'identity-match:confirm-existing',
+    });
+    const updatedReview = buildResolvedReviewForAction('confirm_existing_person', {
+      triggerSourceId: 'identity-match:confirm-existing',
+    });
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      listCurrentContactPointLinks: jest.fn(async () => [
+        buildContactPointLink('person-provisional'),
+      ]),
+      setResolverContactPointPersons: jest.fn(async () => [
+        buildContactPointLink('person-existing'),
+      ]),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    });
+    jest.spyOn(personRebindServiceAsync, 'rebindPersonThreads').mockResolvedValue(undefined);
+    const event = await createIdentityAmbiguityEvent({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:confirm-existing',
+      normalizedContactPoint: '+12605550021',
+      candidateNeighborIds: ['neighbor-1'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+    });
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'confirm_existing_person',
+      personId: 'person-existing',
+      reason: 'Matched the existing person.',
+    });
+
+    const consumed = await getIdentityAmbiguityEvent({
+      tenantId: 'tenant-1',
+      ambiguityEventId: event.id,
+    });
+
+    expect(result.ambiguityEventIds).toEqual([event.id]);
+    expect(consumed).toMatchObject({
+      id: event.id,
+      status: 'resolved',
+      resolverReviewId: 'review-1',
+      resolverOutcome: expect.objectContaining({
+        action: 'confirm_existing_person',
+        personId: 'person-existing',
+      }),
+    });
+  });
+
+  it('consumes linked ambiguity events when merge_people resolves a review', async () => {
+    const currentReview = buildDecisionReview({
+      reviewType: 'merge_review',
+      triggerSourceId: 'identity-match:merge-people',
+      candidatePersonIds: ['person-canonical'],
+    });
+    const updatedReview = buildResolvedReviewForAction('merge_people', {
+      reviewType: 'merge_review',
+      triggerSourceId: 'identity-match:merge-people',
+      candidatePersonIds: ['person-canonical'],
+    });
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      mergePerson: jest.fn(async () => ({
+        mergedProvisionalPersonId: 'person-provisional',
+        canonicalPersonId: 'person-canonical',
+        autoMergedContactPointLinkIds: [],
+        reviewContactPointLinkIds: [],
+        resolverReviewId: 'review-1',
+        didPersistMerge: true,
+      })),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    });
+    const mergeEventPublisher = {
+      publishPersonMerged: jest.fn(async () => undefined),
+    };
+    jest.spyOn(personRebindServiceAsync, 'rebindPersonThreads').mockResolvedValue(undefined);
+    const event = await createIdentityAmbiguityEvent({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:merge-people',
+      normalizedContactPoint: '+12605550022',
+      candidateNeighborIds: ['neighbor-merge'],
+      ambiguityReasonCode: 'PEOPLECORE_LEGACY_DISAGREEMENT',
+    });
+    const service = new AsyncPeopleCoreService(store as any, mergeEventPublisher as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'merge_people',
+      sourcePersonId: 'person-provisional',
+      targetPersonId: 'person-canonical',
+      reason: 'Merge the duplicate people.',
+    });
+
+    const consumed = await getIdentityAmbiguityEvent({
+      tenantId: 'tenant-1',
+      ambiguityEventId: event.id,
+    });
+
+    expect(result.ambiguityEventIds).toEqual([event.id]);
+    expect(consumed).toMatchObject({
+      id: event.id,
+      status: 'resolved',
+      resolverReviewId: 'review-1',
+      resolverOutcome: expect.objectContaining({
+        action: 'merge_people',
+        sourcePersonId: 'person-provisional',
+        targetPersonId: 'person-canonical',
+      }),
+    });
+  });
+
+  it('dismisses linked ambiguity events when dismiss_no_action resolves a review', async () => {
+    const currentReview = buildDecisionReview({
+      triggerSourceId: 'identity-match:dismiss-no-action',
+    });
+    const updatedReview = buildResolvedReviewForAction('dismiss_no_action', {
+      triggerSourceId: 'identity-match:dismiss-no-action',
+      reviewStatus: 'dismissed',
+      resolutionType: 'dismiss_no_action',
+    });
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    });
+    const event = await createIdentityAmbiguityEvent({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:dismiss-no-action',
+      normalizedContactPoint: '+12605550023',
+      candidateNeighborIds: ['neighbor-dismiss'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+    });
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const result = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'dismiss_no_action',
+      reason: 'No identity change is required.',
+    });
+
+    const consumed = await getIdentityAmbiguityEvent({
+      tenantId: 'tenant-1',
+      ambiguityEventId: event.id,
+    });
+
+    expect(result.ambiguityEventIds).toEqual([event.id]);
+    expect(consumed).toMatchObject({
+      id: event.id,
+      status: 'dismissed',
+      resolverReviewId: 'review-1',
+      resolverOutcome: expect.objectContaining({
+        action: 'dismiss_no_action',
+        reviewStatus: 'dismissed',
+      }),
+    });
+  });
+
+  it('uses safe terminal replay to complete ambiguity-event consumption without conflicting state changes', async () => {
+    const terminalReview = buildResolvedReviewForAction('confirm_existing_person', {
+      triggerSourceId: 'identity-match:terminal-replay',
+      resolutionReason: 'Matched the existing person.',
+    });
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => terminalReview),
+      updateResolverReview: jest.fn(),
+    });
+    const event = await createIdentityAmbiguityEvent({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      sourceContext: 'connectshyft_identity_match',
+      sourceContextId: 'identity-match:terminal-replay',
+      normalizedContactPoint: '+12605550024',
+      candidateNeighborIds: ['neighbor-replay'],
+      ambiguityReasonCode: 'IDENTITY_MATCH_AMBIGUOUS',
+    });
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const first = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'confirm_existing_person',
+      personId: 'person-existing',
+      reason: 'Matched the existing person.',
+    });
+    const second = await service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      action: 'confirm_existing_person',
+      personId: 'person-existing',
+      reason: 'Matched the existing person.',
+    });
+
+    const consumed = await getIdentityAmbiguityEvent({
+      tenantId: 'tenant-1',
+      ambiguityEventId: event.id,
+    });
+
+    expect(first.ambiguityEventIds).toEqual([event.id]);
+    expect(second.ambiguityEventIds).toEqual([event.id]);
+    expect(store.updateResolverReview).not.toHaveBeenCalled();
+    expect(consumed).toMatchObject({
+      id: event.id,
+      status: 'resolved',
+      resolverReviewId: 'review-1',
+      resolverConsumedAtUtc: '2026-03-21T12:12:00.000Z',
+    });
   });
 });

--- a/apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/__tests__/store.test.ts
@@ -13,6 +13,7 @@ type TableFixture = {
   firstQueue: any[];
   returningQueue: any[][];
   inserted: any[];
+  updated: any[];
   whereCalls: Array<Record<string, unknown>>;
   joinCalls: Array<{ table: string; left: string; operator: string; right: string }>;
   orderByCalls: Array<[string, string]>;
@@ -24,6 +25,7 @@ const createFixture = (input: Partial<TableFixture> = {}): TableFixture => ({
   firstQueue: input.firstQueue ? [...input.firstQueue] : [],
   returningQueue: input.returningQueue ? [...input.returningQueue] : [],
   inserted: [],
+  updated: [],
   whereCalls: [],
   joinCalls: [],
   orderByCalls: [],
@@ -74,6 +76,12 @@ const buildKnexMock = (initial: Record<string, Partial<TableFixture>> = {}) => {
           first: async () => (fixture.firstQueue.length > 0 ? fixture.firstQueue.shift() || null : null),
           insert: (value: Record<string, unknown>) => {
             fixture.inserted.push(value);
+            return {
+              returning: async () => (fixture.returningQueue.length > 0 ? fixture.returningQueue.shift() || [] : []),
+            };
+          },
+          update: (value: Record<string, unknown>) => {
+            fixture.updated.push(value);
             return {
               returning: async () => (fixture.returningQueue.length > 0 ? fixture.returningQueue.shift() || [] : []),
             };
@@ -439,6 +447,69 @@ describe('KnexPeopleCoreStore', () => {
       candidate_person_ids: JSON.stringify(['person-a', 'person-b']),
       confidence_reasons: JSON.stringify(['exact phone match']),
       risk_flags: JSON.stringify(['duplicate_creation_attempt']),
+    });
+  });
+
+  it('updates resolver review lifecycle fields through the shared persistence shape', async () => {
+    const updatedReviewRow = {
+      id: RESOLVER_REVIEW_ID,
+      tenant_id: 'tenant-1',
+      org_unit_id: 'org-1',
+      review_type: 'identity_conflict',
+      review_status: 'resolved_confirmed_existing',
+      priority: 'normal',
+      trigger_source_type: 'conversation',
+      trigger_source_id: 'conversation-1',
+      conversation_id: 'conversation-1',
+      provisional_person_id: PERSON_ID,
+      candidate_person_ids: ['person-a', 'person-b'],
+      contact_point_id: CONTACT_POINT_ID,
+      confidence_band: 'high',
+      confidence_reasons: ['exact phone match'],
+      risk_flags: ['duplicate_creation_attempt'],
+      requested_by_user_id: 'user-1',
+      assigned_resolver_user_id: 'resolver-1',
+      requested_at_utc: '2026-03-21T12:06:00.000Z',
+      started_at_utc: '2026-03-21T12:10:00.000Z',
+      resolved_at_utc: '2026-03-21T12:12:00.000Z',
+      resolution_type: 'confirm_existing_person',
+      resolution_reason: 'Matched against the existing canonical person.',
+      resolution_notes: 'Stable lifecycle update.',
+    };
+    const { knex, getFixture } = buildKnexMock({
+      'people.resolver_reviews': {
+        returningQueue: [[updatedReviewRow]],
+      },
+    });
+    const store = new KnexPeopleCoreStore(knex);
+
+    const updated = await store.updateResolverReview({
+      tenantId: 'tenant-1',
+      reviewId: RESOLVER_REVIEW_ID,
+      reviewStatus: 'resolved_confirmed_existing',
+      assignedResolverUserId: 'resolver-1',
+      startedAt: '2026-03-21T12:10:00.000Z',
+      resolvedAt: '2026-03-21T12:12:00.000Z',
+      resolutionType: 'confirm_existing_person',
+      resolutionReason: 'Matched against the existing canonical person.',
+      resolutionNotes: 'Stable lifecycle update.',
+    });
+
+    expect(updated).toMatchObject({
+      id: RESOLVER_REVIEW_ID,
+      reviewStatus: 'resolved_confirmed_existing',
+      assignedResolverUserId: 'resolver-1',
+      resolutionType: 'confirm_existing_person',
+      resolutionReason: 'Matched against the existing canonical person.',
+    });
+    expect(getFixture('people.resolver_reviews').updated[0]).toMatchObject({
+      review_status: 'resolved_confirmed_existing',
+      assigned_resolver_user_id: 'resolver-1',
+      started_at_utc: '2026-03-21T12:10:00.000Z',
+      resolved_at_utc: '2026-03-21T12:12:00.000Z',
+      resolution_type: 'confirm_existing_person',
+      resolution_reason: 'Matched against the existing canonical person.',
+      resolution_notes: 'Stable lifecycle update.',
     });
   });
 

--- a/apps/connectshyft-api/src/modules/peoplecore/contactPointIdentityResolution.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/contactPointIdentityResolution.ts
@@ -1,13 +1,14 @@
 import type {
   ContactPoint,
   ContactPointLink,
+  ConnectShyftIdentityResolutionOutcome,
   Household,
   HouseholdMembership,
   Person,
   ResolverReview,
-  ResolverReviewStatus,
   ResolverRiskFlag,
 } from '@shyft/contracts';
+import { isResolverReviewActiveStatus } from '@shyft/contracts';
 import {
   AsyncPeopleCoreService,
   peopleCoreServiceAsync,
@@ -27,7 +28,7 @@ export type PeopleCoreIdentityCandidateGenerationReason =
   | 'historical_household_link'
   | 'current_household_member';
 
-export type PeopleCoreIdentityResolutionOutcome = 'canonical' | 'provisional' | 'resolver_required';
+export type PeopleCoreIdentityResolutionOutcome = ConnectShyftIdentityResolutionOutcome;
 
 export interface PeopleCoreGeneratedIdentityCandidate {
   subjectType: 'person' | 'household';
@@ -98,12 +99,6 @@ const ATTACHABLE_CONFIDENCE_BANDS = new Set<PeopleCoreScoredIdentityCandidate['c
   'low',
   'medium',
   'high',
-]);
-const PENDING_RESOLVER_REVIEW_STATUSES = new Set<ResolverReviewStatus>([
-  'pending',
-  'queued',
-  'in_review',
-  'waiting_for_more_info',
 ]);
 const MAX_SCORING_CANDIDATES = 10;
 
@@ -351,7 +346,7 @@ const findExistingPendingResolverReviewAsync = async (
   return existingReviews.find((review) =>
     review.triggerSourceType === 'contact_point_resolution'
     && review.triggerSourceId === input.relatedObjectId
-    && PENDING_RESOLVER_REVIEW_STATUSES.has(review.reviewStatus)) || null;
+    && isResolverReviewActiveStatus(review.reviewStatus)) || null;
 };
 
 const createProvisionalPersonAsync = async (

--- a/apps/connectshyft-api/src/modules/peoplecore/service.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/service.ts
@@ -4,7 +4,9 @@ import type {
   ListActivitiesInput,
 } from './activity';
 import type {
+  ResolverActionType,
   ResolverDecisionInput,
+  ResolverDecisionResult,
   ResolverReview,
   ResolverReviewStatus,
   ResolverResolutionType,
@@ -184,6 +186,15 @@ export class InvalidResolverReviewTransitionError extends ResolverReviewValidati
 }
 
 const nowIsoUtc = (): string => new Date().toISOString();
+
+const uniqueStrings = (values: Iterable<string | null | undefined>): string[] =>
+  Array.from(
+    new Set(
+      Array.from(values)
+        .map((value) => normalizeOptionalString(value))
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
 
 const normalizeOptionalString = (value: unknown): string | undefined => {
   if (typeof value !== 'string') {
@@ -641,6 +652,37 @@ const assertTerminalReviewMutationAllowed = (
   }
 };
 
+const loadPersonRebindService = (): Pick<
+  import('../connectshyft/personRebind').PersonRebindService,
+  'rebindPersonThreads'
+> => {
+  // Keep the ConnectShyft dependency lazy so the existing service singleton can stay the owner.
+  const { personRebindServiceAsync } = require('../connectshyft/personRebind') as typeof import('../connectshyft/personRebind');
+  return personRebindServiceAsync;
+};
+
+const buildResolverDecisionResult = (input: {
+  review: ResolverReview;
+  action: ResolverActionType;
+  affectedPersonIds?: string[];
+  affectedContactPointIds?: string[];
+  ambiguityEventIds?: string[];
+  mergeApplied: boolean;
+  rebindTriggered: boolean;
+}): ResolverDecisionResult => ({
+  reviewId: input.review.id,
+  status: deriveResolverDecisionStatus(input.review.reviewStatus)
+    ?? (input.action === 'dismiss_no_action' ? 'dismissed' : 'resolved'),
+  action: input.action,
+  reviewStatus: input.review.reviewStatus,
+  resolutionType: input.review.resolutionType ?? input.action,
+  affectedPersonIds: uniqueStrings(input.affectedPersonIds ?? []),
+  affectedContactPointIds: uniqueStrings(input.affectedContactPointIds ?? []),
+  ambiguityEventIds: uniqueStrings(input.ambiguityEventIds ?? []),
+  mergeApplied: input.mergeApplied,
+  rebindTriggered: input.rebindTriggered,
+});
+
 export class AsyncPeopleCoreService {
   constructor(
     private readonly store: PeopleCoreStore = new KnexPeopleCoreStore(),
@@ -908,6 +950,263 @@ export class AsyncPeopleCoreService {
       }
 
       return updated;
+    });
+  }
+
+  applyResolverDecision(input: ResolverDecisionInput): Promise<ResolverDecisionResult> {
+    return this.execute(async () => {
+      const validated = validateResolverDecisionInput(input);
+      const review = await this.store.getResolverReview({
+        tenantId: validated.tenantId,
+        reviewId: validated.reviewId,
+      });
+
+      if (!review) {
+        throw new PeopleCoreScopeViolationError(
+          `Resolver review ${validated.reviewId} is not available in tenant ${validated.tenantId}.`,
+        );
+      }
+
+      const targetReviewStatus = RESOLVER_ACTION_STATUS_MAP[validated.action];
+      if (isResolverReviewTerminalStatus(review.reviewStatus)) {
+        assertTerminalReviewMutationAllowed(review, {
+          tenantId: validated.tenantId,
+          reviewId: validated.reviewId,
+          reviewStatus: targetReviewStatus,
+          assignedResolverUserId: validated.actorUserId,
+          resolutionType: validated.action,
+          resolutionReason: validated.reason,
+          resolutionNotes: validated.notes,
+        });
+
+        const replayAffectedPersonIds: Array<string | undefined> = [
+          review.provisionalPersonId,
+          ...review.candidatePersonIds,
+          validated.personId,
+          validated.sourcePersonId,
+          validated.targetPersonId,
+        ];
+        const replayAffectedContactPointIds: Array<string | undefined> = [
+          validated.contactPointId,
+          review.contactPointId,
+        ];
+        const replayAmbiguityEventIds = validated.ambiguityEventId
+          ? [validated.ambiguityEventId]
+          : [];
+
+        return buildResolverDecisionResult({
+          review,
+          action: validated.action,
+          affectedPersonIds: uniqueStrings(replayAffectedPersonIds),
+          affectedContactPointIds: uniqueStrings(replayAffectedContactPointIds),
+          ambiguityEventIds: replayAmbiguityEventIds,
+          mergeApplied: validated.action === 'merge_people',
+          rebindTriggered: false,
+        });
+      }
+
+      if (
+        validated.action === 'confirm_new_person'
+        && review.provisionalPersonId
+        && review.provisionalPersonId !== validated.personId
+      ) {
+        throw new ResolverReviewValidationError(
+          'confirm_new_person must resolve to the review provisionalPersonId.',
+          [
+            buildFieldError(
+              'personId',
+              'CONFLICT',
+              'personId must match the resolver review provisionalPersonId for confirm_new_person.',
+            ),
+          ],
+        );
+      }
+
+      if (
+        validated.action === 'confirm_existing_person'
+        && review.provisionalPersonId
+        && review.provisionalPersonId === validated.personId
+      ) {
+        throw new ResolverReviewValidationError(
+          'confirm_existing_person cannot target the review provisionalPersonId.',
+          [
+            buildFieldError(
+              'personId',
+              'CONFLICT',
+              'confirm_existing_person must target an existing person distinct from provisionalPersonId.',
+            ),
+          ],
+        );
+      }
+
+      let affectedPersonIds = uniqueStrings([
+        review.provisionalPersonId,
+        ...review.candidatePersonIds,
+        validated.personId,
+        validated.sourcePersonId,
+        validated.targetPersonId,
+      ]);
+      let affectedContactPointIds = uniqueStrings([validated.contactPointId, review.contactPointId]);
+      let mergeApplied = false;
+      let rebindTriggered = false;
+
+      switch (validated.action) {
+        case 'confirm_existing_person':
+        case 'confirm_new_person':
+        case 'link_without_merge':
+        case 'mark_shared_contact':
+        case 'reassign_contact_point': {
+          const contactPointId = validated.contactPointId ?? review.contactPointId;
+          if (!contactPointId) {
+            throw new ResolverReviewValidationError(
+              `${validated.action} requires a resolver review with contactPointId.`,
+              [
+                buildFieldError(
+                  'contactPointId',
+                  'REQUIRED',
+                  `contactPointId is required for ${validated.action}.`,
+                ),
+              ],
+            );
+          }
+
+          const currentPersonLinks = await this.store.listCurrentContactPointLinks({
+            tenantId: validated.tenantId,
+            contactPointId,
+            subjectType: 'person',
+          });
+          const currentPersonIds = uniqueStrings(currentPersonLinks.map((link) => link.subjectId));
+          const targetPersonIds = validated.action === 'mark_shared_contact'
+            ? uniqueStrings([
+              ...currentPersonIds,
+              review.provisionalPersonId,
+              ...review.candidatePersonIds,
+            ])
+            : uniqueStrings([validated.personId]);
+
+          if (validated.action === 'mark_shared_contact' && targetPersonIds.length < 2) {
+            throw new ResolverReviewValidationError(
+              'mark_shared_contact requires at least two people in the review context.',
+              [
+                buildFieldError(
+                  'reviewId',
+                  'CONFLICT',
+                  'mark_shared_contact requires at least two people in the resolver review context.',
+                ),
+              ],
+            );
+          }
+
+          const primaryPersonId = validated.action === 'mark_shared_contact'
+            ? currentPersonIds[0] ?? targetPersonIds[0]
+            : validated.personId!;
+
+          const updatedLinks = await this.store.setResolverContactPointPersons({
+            tenantId: validated.tenantId,
+            contactPointId,
+            personIds: targetPersonIds,
+            primaryPersonId,
+            performedByUserId: validated.actorUserId,
+            resolutionType: validated.action,
+          });
+
+          if (validated.action === 'mark_shared_contact') {
+            await this.store.appendContactPointEvent({
+              tenantId: validated.tenantId,
+              contactPointId,
+              eventType: 'shared_detected',
+              eventSource: 'peoplecore.resolver',
+              relatedObjectType: 'resolver_review',
+              relatedObjectId: review.id,
+            });
+            await this.recomputeContactPointLifecycle({
+              tenantId: validated.tenantId,
+              contactPointId,
+            });
+          }
+
+          const nextCurrentPersonIds = uniqueStrings(updatedLinks.map((link) => link.subjectId));
+          affectedPersonIds = uniqueStrings([
+            ...affectedPersonIds,
+            ...currentPersonIds,
+            ...nextCurrentPersonIds,
+          ]);
+          affectedContactPointIds = uniqueStrings([...affectedContactPointIds, contactPointId]);
+
+          if (
+            (validated.action === 'confirm_existing_person'
+              || validated.action === 'confirm_new_person'
+              || validated.action === 'reassign_contact_point')
+            && currentPersonIds.length === 1
+            && nextCurrentPersonIds.length === 1
+            && currentPersonIds[0] !== nextCurrentPersonIds[0]
+          ) {
+            await loadPersonRebindService().rebindPersonThreads({
+              tenantId: validated.tenantId,
+              orgUnitId: review.orgUnitId,
+              provisionalPersonId: currentPersonIds[0]!,
+              canonicalPersonId: nextCurrentPersonIds[0]!,
+              performedByUserId: validated.actorUserId,
+            });
+            rebindTriggered = true;
+          }
+
+          break;
+        }
+        case 'merge_people': {
+          const merged = await this.mergePerson({
+            tenantId: validated.tenantId,
+            orgUnitId: review.orgUnitId,
+            provisionalPersonId: validated.sourcePersonId!,
+            canonicalPersonId: validated.targetPersonId!,
+            performedByUserId: validated.actorUserId,
+            mergeReason: validated.reason,
+            resolverReviewId: review.id,
+            skipResolverReviewCreation: true,
+          });
+          mergeApplied = merged.didPersistMerge !== false;
+          if (mergeApplied && merged.reviewContactPointLinkIds.length === 0) {
+            await loadPersonRebindService().rebindPersonThreads({
+              tenantId: validated.tenantId,
+              orgUnitId: review.orgUnitId,
+              provisionalPersonId: validated.sourcePersonId!,
+              canonicalPersonId: validated.targetPersonId!,
+              performedByUserId: validated.actorUserId,
+            });
+            rebindTriggered = true;
+          }
+          break;
+        }
+        case 'dismiss_no_action':
+          break;
+        default: {
+          const exhaustiveAction: never = validated.action;
+          throw new ResolverReviewValidationError(
+            `Unsupported resolver action: ${String(exhaustiveAction)}.`,
+          );
+        }
+      }
+
+      const updatedReview = await this.updateResolverReview({
+        tenantId: validated.tenantId,
+        reviewId: validated.reviewId,
+        reviewStatus: targetReviewStatus,
+        assignedResolverUserId: validated.actorUserId,
+        resolutionType: validated.action,
+        resolutionReason: validated.reason,
+        resolutionNotes: validated.notes,
+        resolvedAt: nowIsoUtc(),
+      });
+
+      return buildResolverDecisionResult({
+        review: updatedReview,
+        action: validated.action,
+        affectedPersonIds,
+        affectedContactPointIds,
+        ambiguityEventIds: validated.ambiguityEventId ? [validated.ambiguityEventId] : [],
+        mergeApplied,
+        rebindTriggered,
+      });
     });
   }
 

--- a/apps/connectshyft-api/src/modules/peoplecore/service.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/service.ts
@@ -3,6 +3,21 @@ import type {
   GetActivityInput,
   ListActivitiesInput,
 } from './activity';
+import type {
+  ResolverDecisionInput,
+  ResolverReview,
+  ResolverReviewStatus,
+  ResolverResolutionType,
+  ValidatedResolverDecisionInput,
+} from '@shyft/contracts';
+import {
+  deriveResolverDecisionStatus,
+  isResolverActionType,
+  isResolverReviewActiveStatus,
+  isResolverReviewResolvedStatus,
+  isResolverReviewTerminalStatus,
+  RESOLVER_ACTION_STATUS_MAP,
+} from '@shyft/contracts';
 import {
   buildPeopleCoreMergeEventPublisher,
   type PeopleCoreMergeEventPublisher,
@@ -31,6 +46,7 @@ import {
   type ListPersonsInput,
   type ListResolverReviewsInput,
   type PeopleCoreStore,
+  type UpdateResolverReviewInput,
   PeopleCoreScopeViolationError,
 } from './store';
 import {
@@ -39,6 +55,73 @@ import {
 } from './lifecycle';
 
 const CONTACT_POINT_LIFECYCLE_EVENT_LIMIT = 200;
+
+const RESOLVER_ALLOWED_TRANSITIONS: Record<ResolverReviewStatus, readonly ResolverReviewStatus[]> = {
+  pending: [
+    'queued',
+    'in_review',
+    'resolved_confirmed_existing',
+    'resolved_confirmed_new',
+    'resolved_shared_contact',
+    'resolved_reassigned',
+    'resolved_merged',
+    'dismissed',
+  ],
+  queued: [
+    'in_review',
+    'waiting_for_more_info',
+    'resolved_confirmed_existing',
+    'resolved_confirmed_new',
+    'resolved_shared_contact',
+    'resolved_reassigned',
+    'resolved_merged',
+    'dismissed',
+  ],
+  in_review: [
+    'waiting_for_more_info',
+    'resolved_confirmed_existing',
+    'resolved_confirmed_new',
+    'resolved_shared_contact',
+    'resolved_reassigned',
+    'resolved_merged',
+    'dismissed',
+  ],
+  waiting_for_more_info: [
+    'in_review',
+    'resolved_confirmed_existing',
+    'resolved_confirmed_new',
+    'resolved_shared_contact',
+    'resolved_reassigned',
+    'resolved_merged',
+    'dismissed',
+  ],
+  resolved_confirmed_existing: [],
+  resolved_confirmed_new: [],
+  resolved_shared_contact: [],
+  resolved_reassigned: [],
+  resolved_merged: [],
+  dismissed: [],
+};
+
+type ResolverValidationReason = 'REQUIRED' | 'INVALID' | 'CONFLICT';
+
+export type ResolverValidationFieldError = {
+  field: string;
+  reason: ResolverValidationReason;
+  message: string;
+};
+
+export type UpdateResolverReviewLifecycleInput = {
+  tenantId: string;
+  reviewId: string;
+  reviewStatus: ResolverReviewStatus;
+  assignedResolverUserId?: string;
+  startedAt?: string;
+  resolvedAt?: string;
+  resolutionType?: ResolverResolutionType;
+  resolutionReason?: string;
+  resolutionNotes?: string;
+};
 
 const isMissingPersistenceError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {
@@ -74,6 +157,489 @@ export class ContactPointLifecycleComputationError extends Error {
     }
   }
 }
+
+export class ResolverReviewValidationError extends Error {
+  readonly code: string = 'PEOPLECORE_RESOLVER_REVIEW_VALIDATION_ERROR';
+
+  constructor(
+    message: string,
+    readonly fieldErrors: ResolverValidationFieldError[] = [],
+    cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'ResolverReviewValidationError';
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export class InvalidResolverReviewTransitionError extends ResolverReviewValidationError {
+  readonly code = 'PEOPLECORE_INVALID_RESOLVER_REVIEW_TRANSITION';
+
+  constructor(message: string, fieldErrors: ResolverValidationFieldError[] = [], cause?: unknown) {
+    super(message, fieldErrors, cause);
+    this.name = 'InvalidResolverReviewTransitionError';
+  }
+}
+
+const nowIsoUtc = (): string => new Date().toISOString();
+
+const normalizeOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const buildFieldError = (
+  field: string,
+  reason: ResolverValidationReason,
+  message: string,
+): ResolverValidationFieldError => ({
+  field,
+  reason,
+  message,
+});
+
+const requireNormalizedString = (
+  value: unknown,
+  field: string,
+  message: string,
+): string => {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    throw new ResolverReviewValidationError(message, [
+      buildFieldError(field, 'REQUIRED', message),
+    ]);
+  }
+
+  return normalized;
+};
+
+const assertResolutionTypeMatchesStatus = (
+  reviewStatus: ResolverReviewStatus,
+  resolutionType: ResolverResolutionType,
+): void => {
+  const expectedStatus = RESOLVER_ACTION_STATUS_MAP[resolutionType];
+  if (reviewStatus !== expectedStatus) {
+    throw new ResolverReviewValidationError(
+      `Resolver action ${resolutionType} requires reviewStatus ${expectedStatus}.`,
+      [
+        buildFieldError(
+          'reviewStatus',
+          'CONFLICT',
+          `reviewStatus must be ${expectedStatus} for ${resolutionType}.`,
+        ),
+      ],
+    );
+  }
+};
+
+export const assertResolverReviewTransitionAllowed = (
+  currentStatus: ResolverReviewStatus,
+  nextStatus: ResolverReviewStatus,
+): void => {
+  if (currentStatus === nextStatus) {
+    return;
+  }
+
+  if (isResolverReviewTerminalStatus(currentStatus)) {
+    throw new InvalidResolverReviewTransitionError(
+      `Resolver reviews in ${currentStatus} cannot transition to ${nextStatus}.`,
+      [
+        buildFieldError(
+          'reviewStatus',
+          'INVALID',
+          `reviewStatus ${currentStatus} is terminal and cannot transition to ${nextStatus}.`,
+        ),
+      ],
+    );
+  }
+
+  const allowedTransitions = RESOLVER_ALLOWED_TRANSITIONS[currentStatus];
+  if (!allowedTransitions.includes(nextStatus)) {
+    throw new InvalidResolverReviewTransitionError(
+      `Resolver reviews cannot transition from ${currentStatus} to ${nextStatus}.`,
+      [
+        buildFieldError(
+          'reviewStatus',
+          'INVALID',
+          `reviewStatus ${currentStatus} cannot transition to ${nextStatus}.`,
+        ),
+      ],
+    );
+  }
+};
+
+export const validateResolverDecisionInput = (
+  input: ResolverDecisionInput,
+): ValidatedResolverDecisionInput => {
+  const tenantId = requireNormalizedString(
+    input.tenantId,
+    'tenantId',
+    'tenantId is required.',
+  );
+  const reviewId = requireNormalizedString(
+    input.reviewId,
+    'reviewId',
+    'reviewId is required.',
+  );
+  const actorUserId = requireNormalizedString(
+    input.actorUserId,
+    'actorUserId',
+    'actorUserId is required.',
+  );
+  if (!isResolverActionType(input.action)) {
+    throw new ResolverReviewValidationError(
+      'action must be a canonical resolver action.',
+      [
+        buildFieldError(
+          'action',
+          'INVALID',
+          'action must be a canonical resolver action.',
+        ),
+      ],
+    );
+  }
+
+  let personId = normalizeOptionalString(input.personId);
+  const provisionalPersonId = normalizeOptionalString(input.provisionalPersonId);
+  const sourcePersonId = normalizeOptionalString(input.sourcePersonId);
+  const targetPersonId = normalizeOptionalString(input.targetPersonId);
+  const contactPointId = normalizeOptionalString(input.contactPointId);
+  const ambiguityEventId = normalizeOptionalString(input.ambiguityEventId);
+  const reason = normalizeOptionalString(input.reason);
+  const notes = normalizeOptionalString(input.notes);
+
+  switch (input.action) {
+    case 'confirm_existing_person':
+      if (!personId) {
+        throw new ResolverReviewValidationError(
+          'confirm_existing_person requires personId.',
+          [
+            buildFieldError(
+              'personId',
+              'REQUIRED',
+              'personId is required for confirm_existing_person.',
+            ),
+          ],
+        );
+      }
+      break;
+    case 'confirm_new_person':
+      if (!personId && provisionalPersonId) {
+        personId = provisionalPersonId;
+      }
+      if (!personId) {
+        throw new ResolverReviewValidationError(
+          'confirm_new_person requires personId or provisionalPersonId.',
+          [
+            buildFieldError(
+              'personId',
+              'REQUIRED',
+              'personId or provisionalPersonId is required for confirm_new_person.',
+            ),
+          ],
+        );
+      }
+      if (provisionalPersonId && personId !== provisionalPersonId) {
+        throw new ResolverReviewValidationError(
+          'confirm_new_person cannot target a different person than provisionalPersonId.',
+          [
+            buildFieldError(
+              'personId',
+              'CONFLICT',
+              'personId must match provisionalPersonId when both are provided.',
+            ),
+          ],
+        );
+      }
+      break;
+    case 'merge_people':
+      if (!sourcePersonId) {
+        throw new ResolverReviewValidationError(
+          'merge_people requires sourcePersonId.',
+          [
+            buildFieldError(
+              'sourcePersonId',
+              'REQUIRED',
+              'sourcePersonId is required for merge_people.',
+            ),
+          ],
+        );
+      }
+      if (!targetPersonId) {
+        throw new ResolverReviewValidationError(
+          'merge_people requires targetPersonId.',
+          [
+            buildFieldError(
+              'targetPersonId',
+              'REQUIRED',
+              'targetPersonId is required for merge_people.',
+            ),
+          ],
+        );
+      }
+      if (sourcePersonId === targetPersonId) {
+        throw new ResolverReviewValidationError(
+          'merge_people requires different sourcePersonId and targetPersonId.',
+          [
+            buildFieldError(
+              'targetPersonId',
+              'CONFLICT',
+              'targetPersonId must differ from sourcePersonId for merge_people.',
+            ),
+          ],
+        );
+      }
+      break;
+    case 'link_without_merge':
+      if (!personId) {
+        throw new ResolverReviewValidationError(
+          'link_without_merge requires personId.',
+          [
+            buildFieldError(
+              'personId',
+              'REQUIRED',
+              'personId is required for link_without_merge.',
+            ),
+          ],
+        );
+      }
+      break;
+    case 'mark_shared_contact':
+      break;
+    case 'reassign_contact_point':
+      if (!contactPointId) {
+        throw new ResolverReviewValidationError(
+          'reassign_contact_point requires contactPointId.',
+          [
+            buildFieldError(
+              'contactPointId',
+              'REQUIRED',
+              'contactPointId is required for reassign_contact_point.',
+            ),
+          ],
+        );
+      }
+      if (!personId) {
+        throw new ResolverReviewValidationError(
+          'reassign_contact_point requires personId.',
+          [
+            buildFieldError(
+              'personId',
+              'REQUIRED',
+              'personId is required for reassign_contact_point.',
+            ),
+          ],
+        );
+      }
+      break;
+    case 'dismiss_no_action':
+      if (!reason) {
+        throw new ResolverReviewValidationError(
+          'dismiss_no_action requires a reason.',
+          [
+            buildFieldError(
+              'reason',
+              'REQUIRED',
+              'reason is required for dismiss_no_action.',
+            ),
+          ],
+        );
+      }
+      break;
+    default: {
+      const exhaustiveAction: never = input.action;
+      throw new ResolverReviewValidationError(
+        `Unsupported resolver action: ${String(exhaustiveAction)}.`,
+      );
+    }
+  }
+
+  return {
+    tenantId,
+    reviewId,
+    action: input.action,
+    actorUserId,
+    reason,
+    notes,
+    personId,
+    sourcePersonId,
+    targetPersonId,
+    contactPointId,
+    ambiguityEventId,
+  };
+};
+
+const buildResolverReviewUpdatePayload = (
+  currentReview: ResolverReview,
+  input: UpdateResolverReviewLifecycleInput,
+): UpdateResolverReviewInput => {
+  const assignedResolverUserId = normalizeOptionalString(input.assignedResolverUserId)
+    ?? currentReview.assignedResolverUserId
+    ?? null;
+  const startedAt = normalizeOptionalString(input.startedAt)
+    ?? currentReview.startedAt
+    ?? (
+      input.reviewStatus === 'in_review'
+      || isResolverReviewResolvedStatus(input.reviewStatus)
+      || input.reviewStatus === 'dismissed'
+        ? nowIsoUtc()
+        : null
+    );
+  const resolutionReason = normalizeOptionalString(input.resolutionReason) ?? null;
+  const resolutionNotes = normalizeOptionalString(input.resolutionNotes) ?? null;
+
+  if (isResolverReviewActiveStatus(input.reviewStatus)) {
+    return {
+      tenantId: input.tenantId,
+      reviewId: input.reviewId,
+      reviewStatus: input.reviewStatus,
+      assignedResolverUserId,
+      startedAt,
+      resolvedAt: null,
+      resolutionType: null,
+      resolutionReason: null,
+      resolutionNotes: null,
+    };
+  }
+
+  const resolutionType = input.resolutionType;
+  if (!resolutionType) {
+    throw new ResolverReviewValidationError(
+      `reviewStatus ${input.reviewStatus} requires resolutionType.`,
+      [
+        buildFieldError(
+          'resolutionType',
+          'REQUIRED',
+          `resolutionType is required for reviewStatus ${input.reviewStatus}.`,
+        ),
+      ],
+    );
+  }
+
+  assertResolutionTypeMatchesStatus(input.reviewStatus, resolutionType);
+
+  if (input.reviewStatus === 'dismissed' && !resolutionReason) {
+    throw new ResolverReviewValidationError(
+      'dismissed resolver reviews require resolutionReason.',
+      [
+        buildFieldError(
+          'resolutionReason',
+          'REQUIRED',
+          'resolutionReason is required when reviewStatus is dismissed.',
+        ),
+      ],
+    );
+  }
+
+  return {
+    tenantId: input.tenantId,
+    reviewId: input.reviewId,
+    reviewStatus: input.reviewStatus,
+    assignedResolverUserId,
+    startedAt,
+    resolvedAt: normalizeOptionalString(input.resolvedAt) ?? currentReview.resolvedAt ?? nowIsoUtc(),
+    resolutionType,
+    resolutionReason,
+    resolutionNotes,
+  };
+};
+
+const assertTerminalReviewMutationAllowed = (
+  currentReview: ResolverReview,
+  input: UpdateResolverReviewLifecycleInput,
+): void => {
+  if (!isResolverReviewTerminalStatus(currentReview.reviewStatus)) {
+    return;
+  }
+
+  if (currentReview.reviewStatus !== input.reviewStatus) {
+    throw new InvalidResolverReviewTransitionError(
+      `Resolver review ${currentReview.id} is already terminal in ${currentReview.reviewStatus}.`,
+      [
+        buildFieldError(
+          'reviewStatus',
+          'INVALID',
+          `reviewStatus ${currentReview.reviewStatus} is terminal and cannot transition to ${input.reviewStatus}.`,
+        ),
+      ],
+    );
+  }
+
+  if (!input.resolutionType) {
+    throw new InvalidResolverReviewTransitionError(
+      `Resolver review ${currentReview.id} is already terminal and requires explicit resolutionType replay.`,
+      [
+        buildFieldError(
+          'resolutionType',
+          'REQUIRED',
+          'resolutionType is required when replaying a terminal resolver review update.',
+        ),
+      ],
+    );
+  }
+
+  if (currentReview.resolutionType !== input.resolutionType) {
+    throw new InvalidResolverReviewTransitionError(
+      `Resolver review ${currentReview.id} is already terminal with ${currentReview.resolutionType}.`,
+      [
+        buildFieldError(
+          'resolutionType',
+          'CONFLICT',
+          `resolutionType ${currentReview.resolutionType} cannot be replaced with ${input.resolutionType}.`,
+        ),
+      ],
+    );
+  }
+
+  const nextResolutionReason = normalizeOptionalString(input.resolutionReason);
+  if (nextResolutionReason && nextResolutionReason !== currentReview.resolutionReason) {
+    throw new InvalidResolverReviewTransitionError(
+      `Resolver review ${currentReview.id} is already terminal with a different resolutionReason.`,
+      [
+        buildFieldError(
+          'resolutionReason',
+          'CONFLICT',
+          'resolutionReason cannot change once a resolver review is terminal.',
+        ),
+      ],
+    );
+  }
+
+  const nextResolutionNotes = normalizeOptionalString(input.resolutionNotes);
+  if (nextResolutionNotes && nextResolutionNotes !== currentReview.resolutionNotes) {
+    throw new InvalidResolverReviewTransitionError(
+      `Resolver review ${currentReview.id} is already terminal with different resolutionNotes.`,
+      [
+        buildFieldError(
+          'resolutionNotes',
+          'CONFLICT',
+          'resolutionNotes cannot change once a resolver review is terminal.',
+        ),
+      ],
+    );
+  }
+
+  const nextDecisionStatus = deriveResolverDecisionStatus(input.reviewStatus);
+  const currentDecisionStatus = deriveResolverDecisionStatus(currentReview.reviewStatus);
+  if (nextDecisionStatus && currentDecisionStatus && nextDecisionStatus !== currentDecisionStatus) {
+    throw new InvalidResolverReviewTransitionError(
+      `Resolver review ${currentReview.id} is already ${currentDecisionStatus}.`,
+      [
+        buildFieldError(
+          'reviewStatus',
+          'CONFLICT',
+          `reviewStatus ${currentReview.reviewStatus} cannot be replaced with ${input.reviewStatus}.`,
+        ),
+      ],
+    );
+  }
+};
 
 export class AsyncPeopleCoreService {
   constructor(
@@ -260,7 +826,89 @@ export class AsyncPeopleCoreService {
   }
 
   createResolverReview(input: CreateResolverReviewInput) {
-    return this.execute(() => this.store.createResolverReview(input));
+    return this.execute(() => {
+      if (isResolverReviewActiveStatus(input.reviewStatus)) {
+        if (input.resolutionType || input.resolvedAt) {
+          throw new ResolverReviewValidationError(
+            `Active resolver reviews cannot persist terminal fields for ${input.reviewStatus}.`,
+            [
+              buildFieldError(
+                'resolutionType',
+                'INVALID',
+                'resolutionType is only allowed for terminal resolver reviews.',
+              ),
+            ],
+          );
+        }
+      } else {
+        if (!input.resolutionType) {
+          throw new ResolverReviewValidationError(
+            `Terminal resolver reviews require resolutionType for ${input.reviewStatus}.`,
+            [
+              buildFieldError(
+                'resolutionType',
+                'REQUIRED',
+                `resolutionType is required for reviewStatus ${input.reviewStatus}.`,
+              ),
+            ],
+          );
+        }
+        assertResolutionTypeMatchesStatus(input.reviewStatus, input.resolutionType);
+        if (input.reviewStatus === 'dismissed' && !normalizeOptionalString(input.resolutionReason)) {
+          throw new ResolverReviewValidationError(
+            'Dismissed resolver reviews require resolutionReason.',
+            [
+              buildFieldError(
+                'resolutionReason',
+                'REQUIRED',
+                'resolutionReason is required when reviewStatus is dismissed.',
+              ),
+            ],
+          );
+        }
+      }
+
+      return this.store.createResolverReview(input);
+    });
+  }
+
+  updateResolverReview(input: UpdateResolverReviewLifecycleInput) {
+    return this.execute(async () => {
+      const currentReview = await this.store.getResolverReview({
+        tenantId: input.tenantId,
+        reviewId: input.reviewId,
+      });
+
+      if (!currentReview) {
+        throw new PeopleCoreScopeViolationError(
+          `Resolver review ${input.reviewId} is not available in tenant ${input.tenantId}.`,
+        );
+      }
+
+      assertTerminalReviewMutationAllowed(currentReview, input);
+      if (!isResolverReviewTerminalStatus(currentReview.reviewStatus)) {
+        assertResolverReviewTransitionAllowed(currentReview.reviewStatus, input.reviewStatus);
+      }
+
+      if (
+        isResolverReviewTerminalStatus(currentReview.reviewStatus)
+        && currentReview.reviewStatus === input.reviewStatus
+      ) {
+        return currentReview;
+      }
+
+      const updated = await this.store.updateResolverReview(
+        buildResolverReviewUpdatePayload(currentReview, input),
+      );
+
+      if (!updated) {
+        throw new PeopleCoreScopeViolationError(
+          `Resolver review ${input.reviewId} is not available in tenant ${input.tenantId}.`,
+        );
+      }
+
+      return updated;
+    });
   }
 
   getResolverReview(input: GetResolverReviewInput) {

--- a/apps/connectshyft-api/src/modules/peoplecore/service.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/service.ts
@@ -661,6 +661,14 @@ const loadPersonRebindService = (): Pick<
   return personRebindServiceAsync;
 };
 
+const loadAmbiguityEventService = (): Pick<
+  typeof import('../connectshyft/ambiguityEvents'),
+  'consumeAmbiguityEventsForResolverOutcome'
+> => {
+  const ambiguityEvents = require('../connectshyft/ambiguityEvents') as typeof import('../connectshyft/ambiguityEvents');
+  return ambiguityEvents;
+};
+
 const buildResolverDecisionResult = (input: {
   review: ResolverReview;
   action: ResolverActionType;
@@ -953,6 +961,47 @@ export class AsyncPeopleCoreService {
     });
   }
 
+  private async consumeLinkedAmbiguityEvents(input: {
+    review: ResolverReview;
+    action: ResolverActionType;
+    actorUserId: string;
+    reviewStatus: ResolverReviewStatus;
+    resolvedAtUtc: string;
+    reason?: string;
+    notes?: string;
+    personId?: string;
+    sourcePersonId?: string;
+    targetPersonId?: string;
+    contactPointId?: string;
+    ambiguityEventId?: string;
+  }): Promise<string[]> {
+    const outcome = input.reviewStatus === 'dismissed' ? 'dismissed' : 'resolved';
+    const consumed = await loadAmbiguityEventService().consumeAmbiguityEventsForResolverOutcome({
+      tenantId: input.review.tenantId,
+      resolverReviewId: input.review.id,
+      triggerSourceId: input.review.triggerSourceId,
+      ambiguityEventId: input.ambiguityEventId,
+      outcome,
+      consumedByUserId: input.actorUserId,
+      consumedAtUtc: input.resolvedAtUtc,
+      resolverOutcome: {
+        reviewId: input.review.id,
+        action: input.action,
+        reviewStatus: input.reviewStatus,
+        actorUserId: input.actorUserId,
+        occurredAtUtc: input.resolvedAtUtc,
+        reason: input.reason ?? input.review.resolutionReason ?? null,
+        notes: input.notes ?? input.review.resolutionNotes ?? null,
+        personId: input.personId ?? null,
+        sourcePersonId: input.sourcePersonId ?? null,
+        targetPersonId: input.targetPersonId ?? null,
+        contactPointId: input.contactPointId ?? input.review.contactPointId ?? null,
+      },
+    });
+
+    return uniqueStrings(consumed.events.map((event) => event.id));
+  }
+
   applyResolverDecision(input: ResolverDecisionInput): Promise<ResolverDecisionResult> {
     return this.execute(async () => {
       const validated = validateResolverDecisionInput(input);
@@ -990,9 +1039,20 @@ export class AsyncPeopleCoreService {
           validated.contactPointId,
           review.contactPointId,
         ];
-        const replayAmbiguityEventIds = validated.ambiguityEventId
-          ? [validated.ambiguityEventId]
-          : [];
+        const replayAmbiguityEventIds = await this.consumeLinkedAmbiguityEvents({
+          review,
+          action: validated.action,
+          actorUserId: validated.actorUserId,
+          reviewStatus: review.reviewStatus,
+          resolvedAtUtc: review.resolvedAt ?? nowIsoUtc(),
+          reason: validated.reason,
+          notes: validated.notes,
+          personId: validated.personId,
+          sourcePersonId: validated.sourcePersonId,
+          targetPersonId: validated.targetPersonId,
+          contactPointId: validated.contactPointId,
+          ambiguityEventId: validated.ambiguityEventId,
+        });
 
         return buildResolverDecisionResult({
           review,
@@ -1047,6 +1107,7 @@ export class AsyncPeopleCoreService {
         validated.targetPersonId,
       ]);
       let affectedContactPointIds = uniqueStrings([validated.contactPointId, review.contactPointId]);
+      let ambiguityEventIds: string[] = [];
       let mergeApplied = false;
       let rebindTriggered = false;
 
@@ -1198,12 +1259,27 @@ export class AsyncPeopleCoreService {
         resolvedAt: nowIsoUtc(),
       });
 
+      ambiguityEventIds = await this.consumeLinkedAmbiguityEvents({
+        review: updatedReview,
+        action: validated.action,
+        actorUserId: validated.actorUserId,
+        reviewStatus: updatedReview.reviewStatus,
+        resolvedAtUtc: updatedReview.resolvedAt ?? nowIsoUtc(),
+        reason: validated.reason,
+        notes: validated.notes,
+        personId: validated.personId,
+        sourcePersonId: validated.sourcePersonId,
+        targetPersonId: validated.targetPersonId,
+        contactPointId: validated.contactPointId,
+        ambiguityEventId: validated.ambiguityEventId,
+      });
+
       return buildResolverDecisionResult({
         review: updatedReview,
         action: validated.action,
         affectedPersonIds,
         affectedContactPointIds,
-        ambiguityEventIds: validated.ambiguityEventId ? [validated.ambiguityEventId] : [],
+        ambiguityEventIds,
         mergeApplied,
         rebindTriggered,
       });

--- a/apps/connectshyft-api/src/modules/peoplecore/store.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/store.ts
@@ -3,14 +3,15 @@ import type {
   ContactPointEvent,
   ContactPointLink,
   ContactPointStatus,
-  ResolverReviewStatus,
   ContactPointLinkSubjectType,
   ContactPointType,
   Household,
   HouseholdMembership,
   Person,
   ResolverReview,
+  ResolverReviewStatus,
 } from '@shyft/contracts';
+import { isResolverReviewActiveStatus } from '@shyft/contracts';
 import type { Knex } from 'knex';
 import db from '../../config/knex';
 import {
@@ -75,13 +76,6 @@ const normalizeEventLimit = (value: unknown): number => {
 
   return Math.min(normalized, MAX_CONTACT_POINT_EVENT_LIMIT);
 };
-
-const PENDING_RESOLVER_REVIEW_STATUSES = new Set<ResolverReviewStatus>([
-  'pending',
-  'queued',
-  'in_review',
-  'waiting_for_more_info',
-]);
 
 const normalizePersonMergeStatus = (person: Pick<Person, 'status' | 'mergedIntoPersonId'>): PersonMergeStatus => {
   if (person.status === 'merged' || normalizeOptionalString(person.mergedIntoPersonId)) {
@@ -247,6 +241,18 @@ export type CreateResolverReviewInput = Omit<ResolverReview, 'id'> & {
   reviewId?: string;
 };
 
+export type UpdateResolverReviewInput = {
+  tenantId: string;
+  reviewId: string;
+  reviewStatus: ResolverReviewStatus;
+  assignedResolverUserId: string | null;
+  startedAt: string | null;
+  resolvedAt: string | null;
+  resolutionType: ResolverReview['resolutionType'] | null;
+  resolutionReason: string | null;
+  resolutionNotes: string | null;
+};
+
 export type GetResolverReviewInput = {
   tenantId: string;
   reviewId: string;
@@ -307,6 +313,7 @@ export interface PeopleCoreStore extends PeopleCoreActivityStore {
   }): Promise<void>;
   listContactPointEvents(input: ListContactPointEventsInput): Promise<ContactPointEvent[]>;
   createResolverReview(input: CreateResolverReviewInput): Promise<ResolverReview>;
+  updateResolverReview(input: UpdateResolverReviewInput): Promise<ResolverReview | null>;
   getResolverReview(input: GetResolverReviewInput): Promise<ResolverReview | null>;
   listResolverReviews(input: ListResolverReviewsInput): Promise<ResolverReview[]>;
 }
@@ -1144,7 +1151,7 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
       .find((review) =>
         review.provisionalPersonId === input.provisionalPersonId
         && review.candidatePersonIds.includes(input.canonicalPersonId)
-        && PENDING_RESOLVER_REVIEW_STATUSES.has(review.reviewStatus));
+        && isResolverReviewActiveStatus(review.reviewStatus));
 
     return existing ?? null;
   }
@@ -1867,6 +1874,29 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
       .returning<DbResolverReviewRow[]>(this.resolverReviewColumns());
 
     return mapResolverReviewRow(row);
+  }
+
+  async updateResolverReview(input: UpdateResolverReviewInput): Promise<ResolverReview | null> {
+    const rows = await this.knexClient
+      .withSchema(PEOPLE_SCHEMA)
+      .table('resolver_reviews')
+      .where({
+        id: input.reviewId,
+        tenant_id: input.tenantId,
+      })
+      .update({
+        review_status: input.reviewStatus,
+        assigned_resolver_user_id: input.assignedResolverUserId,
+        started_at_utc: input.startedAt,
+        resolved_at_utc: input.resolvedAt,
+        resolution_type: input.resolutionType,
+        resolution_reason: input.resolutionReason,
+        resolution_notes: input.resolutionNotes,
+      })
+      .returning<DbResolverReviewRow[]>(this.resolverReviewColumns());
+
+    const [row] = rows;
+    return row ? mapResolverReviewRow(row) : null;
   }
 
   async getResolverReview(input: GetResolverReviewInput): Promise<ResolverReview | null> {

--- a/apps/connectshyft-api/src/modules/peoplecore/store.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/store.ts
@@ -9,6 +9,7 @@ import type {
   HouseholdMembership,
   Person,
   ResolverReview,
+  ResolverResolutionType,
   ResolverReviewStatus,
 } from '@shyft/contracts';
 import { isResolverReviewActiveStatus } from '@shyft/contracts';
@@ -253,6 +254,16 @@ export type UpdateResolverReviewInput = {
   resolutionNotes: string | null;
 };
 
+export type SetResolverContactPointPersonsInput = {
+  tenantId: string;
+  contactPointId: string;
+  personIds: string[];
+  primaryPersonId: string;
+  performedByUserId: string;
+  resolutionType: ResolverResolutionType;
+  unlinkReason?: string;
+};
+
 export type GetResolverReviewInput = {
   tenantId: string;
   reviewId: string;
@@ -272,6 +283,8 @@ export type MergePersonInput = {
   canonicalPersonId: string;
   performedByUserId: string;
   mergeReason?: string;
+  resolverReviewId?: string;
+  skipResolverReviewCreation?: boolean;
 };
 
 export type PersonMergeStatus = 'provisional' | 'canonical' | 'merged';
@@ -314,6 +327,9 @@ export interface PeopleCoreStore extends PeopleCoreActivityStore {
   listContactPointEvents(input: ListContactPointEventsInput): Promise<ContactPointEvent[]>;
   createResolverReview(input: CreateResolverReviewInput): Promise<ResolverReview>;
   updateResolverReview(input: UpdateResolverReviewInput): Promise<ResolverReview | null>;
+  setResolverContactPointPersons(
+    input: SetResolverContactPointPersonsInput,
+  ): Promise<ContactPointLink[]>;
   getResolverReview(input: GetResolverReviewInput): Promise<ResolverReview | null>;
   listResolverReviews(input: ListResolverReviewsInput): Promise<ResolverReview[]>;
 }
@@ -1348,6 +1364,20 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
       for (const link of provisionalLinks) {
         const canonicalLinksForContactPoint = canonicalLinksByContactPointId.get(link.contact_point_id) ?? [];
         if (this.hasPrimaryContactConflict(link, canonicalLinksForContactPoint)) {
+          if (input.skipResolverReviewCreation) {
+            await this.markContactPointLinkMerged(trx, {
+              linkId: link.id,
+              canonicalPersonId: input.canonicalPersonId,
+              mergedAtUtc,
+              mergedByUserId: input.performedByUserId,
+              mergeClass: 'review',
+              mergeReason: input.mergeReason,
+            });
+            autoMergedContactPointLinkIds.push(link.id);
+            affectedContactPointIds.add(link.contact_point_id);
+            continue;
+          }
+
           reviewContactPointLinkIds.push(link.id);
           continue;
         }
@@ -1424,8 +1454,11 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
       const householdAmbiguity = provisionalHouseholds.some((membership) =>
         canonicalHouseholds.some((candidate) => candidate.household_id !== membership.household_id));
 
-      let resolverReviewId: string | undefined;
-      if (reviewContactPointLinkIds.length > 0 || householdAmbiguity) {
+      let resolverReviewId: string | undefined = input.resolverReviewId;
+      if (
+        !input.skipResolverReviewCreation
+        && (reviewContactPointLinkIds.length > 0 || householdAmbiguity)
+      ) {
         const existingReview = await this.findExistingMergeReview(trx, input);
         if (existingReview) {
           resolverReviewId = existingReview.id;
@@ -1897,6 +1930,119 @@ export class KnexPeopleCoreStore implements PeopleCoreStore {
 
     const [row] = rows;
     return row ? mapResolverReviewRow(row) : null;
+  }
+
+  async setResolverContactPointPersons(
+    input: SetResolverContactPointPersonsInput,
+  ): Promise<ContactPointLink[]> {
+    const personIds = uniqueStrings(input.personIds);
+    if (personIds.length === 0) {
+      throw new PeopleCoreConflictError(
+        `Resolver contact-point updates require at least one person for ${input.contactPointId}.`,
+      );
+    }
+
+    if (!personIds.includes(input.primaryPersonId)) {
+      throw new PeopleCoreConflictError(
+        `Primary resolver contact-point person ${input.primaryPersonId} must be included in the target set.`,
+      );
+    }
+
+    await this.assertContactPointInTenant(input.tenantId, input.contactPointId);
+    await Promise.all(personIds.map((personId) => this.assertPersonInTenant(input.tenantId, personId)));
+
+    return this.knexClient.transaction(async (trx) => {
+      const transactionalStore = new KnexPeopleCoreStore(trx as unknown as Knex);
+      const updatedAtUtc = new Date().toISOString();
+      const linkRows = await trx
+        .withSchema(PEOPLE_SCHEMA)
+        .table('contact_point_links')
+        .where({
+          contact_point_id: input.contactPointId,
+          subject_type: 'person',
+        })
+        .orderBy('created_at_utc', 'asc')
+        .orderBy('id', 'asc')
+        .select<DbContactPointLinkRow[]>(this.contactPointLinkColumns());
+
+      const currentRows = linkRows.filter((row) => row.is_current);
+      const targetPersonIds = new Set(personIds);
+
+      for (const row of currentRows) {
+        if (targetPersonIds.has(row.subject_id)) {
+          await trx
+            .withSchema(PEOPLE_SCHEMA)
+            .table('contact_point_links')
+            .where({ id: row.id })
+            .update({
+              is_primary: row.subject_id === input.primaryPersonId,
+              manually_confirmed: true,
+              confirmation_source: 'resolver',
+              last_confirmed_at_utc: updatedAtUtc,
+              unlink_reason: null,
+              unlinked_at_utc: null,
+              updated_at_utc: updatedAtUtc,
+            });
+          continue;
+        }
+
+        await trx
+          .withSchema(PEOPLE_SCHEMA)
+          .table('contact_point_links')
+          .where({ id: row.id })
+          .update({
+            is_current: false,
+            is_primary: false,
+            unlink_reason: input.unlinkReason ?? `resolver_${input.resolutionType}`,
+            unlinked_at_utc: updatedAtUtc,
+            updated_at_utc: updatedAtUtc,
+          });
+      }
+
+      for (const personId of personIds) {
+        if (currentRows.some((row) => row.subject_id === personId)) {
+          continue;
+        }
+
+        const priorLink = [...linkRows].reverse().find((row) => row.subject_id === personId);
+        await transactionalStore.createContactPointLink({
+          tenantId: input.tenantId,
+          contactPointId: input.contactPointId,
+          subjectType: 'person',
+          subjectId: personId,
+          linkType: personId === input.primaryPersonId
+            ? 'primary'
+            : priorLink?.link_type === 'primary'
+              ? 'secondary'
+              : priorLink?.link_type ?? 'secondary',
+          confidenceBand: priorLink?.confidence_band ?? 'high',
+          isCurrent: true,
+          isPrimary: personId === input.primaryPersonId,
+          manuallyConfirmed: true,
+          confirmationSource: 'resolver',
+          firstLinkedAt: updatedAtUtc,
+          lastConfirmedAt: updatedAtUtc,
+          lastUsedAt: priorLink?.last_used_at_utc
+            ? toIsoUtc(priorLink.last_used_at_utc, updatedAtUtc)
+            : undefined,
+          linkedBy: 'resolver',
+          linkedByUserId: input.performedByUserId,
+        });
+      }
+
+      await this.recomputeContactPointStatusWithinTransaction(trx as unknown as Knex, {
+        tenantId: input.tenantId,
+        contactPointId: input.contactPointId,
+      });
+
+      const rows = await this.listCurrentContactPointLinkRowsForContactPoint(trx as unknown as Knex, {
+        contactPointId: input.contactPointId,
+      });
+
+      return rows
+        .filter((row) => row.subject_type === 'person')
+        .map(mapContactPointLinkRow);
+    });
   }
 
   async getResolverReview(input: GetResolverReviewInput): Promise<ResolverReview | null> {

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
@@ -2,6 +2,7 @@
 import express from 'express';
 import request from 'supertest';
 import {
+  consumeAmbiguityEventsForResolverOutcome,
   createIdentityAmbiguityEvent,
   resetIdentityAmbiguityEventsForTests,
 } from '../../../../modules/connectshyft/ambiguityEvents';
@@ -251,6 +252,10 @@ describe('connectshyft identity ambiguity ops route', () => {
       'normalizedContactPoint',
       'orgUnitId',
       'requestedByUserId',
+      'resolverConsumedAtUtc',
+      'resolverConsumedByUserId',
+      'resolverOutcome',
+      'resolverReviewId',
       'sourceContext',
       'sourceContextId',
       'status',
@@ -617,6 +622,130 @@ describe('connectshyft identity ambiguity ops route', () => {
       ok: false,
       code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_UPDATE_FORBIDDEN',
       message: 'Identity ambiguity review requires a tenant-privileged ConnectShyft admin role.',
+    });
+  });
+
+  it('lists only active ambiguity events by default while allowing explicit terminal-status filters', async () => {
+    const pending = await createEvent({
+      id: 'ambiguity-event-pending-default-list',
+      sourceContextId: 'identity-match:pending-default-list',
+      createdAtUtc: '2026-03-21T14:00:00.000Z',
+      updatedAtUtc: '2026-03-21T14:00:00.000Z',
+    });
+    await createEvent({
+      id: 'ambiguity-event-reviewed-default-list',
+      status: 'reviewed',
+      sourceContextId: 'identity-match:reviewed-default-list',
+      createdAtUtc: '2026-03-21T14:05:00.000Z',
+      updatedAtUtc: '2026-03-21T14:05:00.000Z',
+    });
+    await createEvent({
+      id: 'ambiguity-event-resolved-default-list',
+      sourceContextId: 'identity-match:resolved-default-list',
+      createdAtUtc: '2026-03-21T14:10:00.000Z',
+      updatedAtUtc: '2026-03-21T14:10:00.000Z',
+    });
+
+    await consumeAmbiguityEventsForResolverOutcome({
+      tenantId: TEST_TENANT_ID,
+      resolverReviewId: 'review-default-list',
+      triggerSourceId: 'identity-match:resolved-default-list',
+      outcome: 'resolved',
+      consumedByUserId: TEST_USER_ID,
+      consumedAtUtc: '2026-03-21T14:15:00.000Z',
+      resolverOutcome: {
+        reviewId: 'review-default-list',
+        action: 'confirm_existing_person',
+        reviewStatus: 'resolved_confirmed_existing',
+        actorUserId: TEST_USER_ID,
+        occurredAtUtc: '2026-03-21T14:15:00.000Z',
+        personId: 'person-default-list',
+      },
+    });
+
+    const app = buildApp();
+    const activeResponse = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(activeResponse.status).toBe(200);
+    expect(activeResponse.body.data.events).toEqual([
+      expect.objectContaining({
+        id: pending.id,
+        status: 'pending',
+      }),
+    ]);
+
+    const resolvedResponse = await request(app)
+      .get('/api/v1/connectshyft/identity-ambiguities')
+      .query({
+        status: 'resolved',
+      })
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(resolvedResponse.status).toBe(200);
+    expect(resolvedResponse.body.data.events).toEqual([
+      expect.objectContaining({
+        id: 'ambiguity-event-resolved-default-list',
+        status: 'resolved',
+      }),
+    ]);
+  });
+
+  it('returns terminal ambiguity detail with resolver-outcome linkage intact', async () => {
+    const created = await createEvent({
+      id: 'ambiguity-event-detail-terminal',
+      sourceContextId: 'identity-match:detail-terminal',
+      createdAtUtc: '2026-03-21T14:20:00.000Z',
+      updatedAtUtc: '2026-03-21T14:20:00.000Z',
+    });
+
+    await consumeAmbiguityEventsForResolverOutcome({
+      tenantId: TEST_TENANT_ID,
+      resolverReviewId: 'review-detail-terminal',
+      triggerSourceId: 'identity-match:detail-terminal',
+      outcome: 'dismissed',
+      consumedByUserId: TEST_USER_ID,
+      consumedAtUtc: '2026-03-21T14:25:00.000Z',
+      resolverOutcome: {
+        reviewId: 'review-detail-terminal',
+        action: 'dismiss_no_action',
+        reviewStatus: 'dismissed',
+        actorUserId: TEST_USER_ID,
+        occurredAtUtc: '2026-03-21T14:25:00.000Z',
+        reason: 'No identity change required.',
+      },
+    });
+
+    const app = buildApp();
+    const response = await request(app)
+      .get(`/api/v1/connectshyft/identity-ambiguities/${created.id}`)
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_RETRIEVED',
+      data: {
+        event: {
+          id: created.id,
+          status: 'dismissed',
+          resolverReviewId: 'review-detail-terminal',
+          resolverOutcome: {
+            action: 'dismiss_no_action',
+            reviewStatus: 'dismissed',
+          },
+        },
+      },
     });
   });
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
@@ -5,6 +5,12 @@ import {
   createIdentityAmbiguityEvent,
   resetIdentityAmbiguityEventsForTests,
 } from '../../../../modules/connectshyft/ambiguityEvents';
+import {
+  InvalidResolverReviewTransitionError,
+  peopleCoreServiceAsync,
+  ResolverReviewValidationError,
+} from '../../../../modules/peoplecore/service';
+import { PeopleCoreScopeViolationError } from '../../../../modules/peoplecore/store';
 import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
 import connectShyftRouter from '../connectshyft';
 
@@ -611,6 +617,170 @@ describe('connectshyft identity ambiguity ops route', () => {
       ok: false,
       code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_UPDATE_FORBIDDEN',
       message: 'Identity ambiguity review requires a tenant-privileged ConnectShyft admin role.',
+    });
+  });
+
+  it('delegates resolver decisions to PeopleCore and returns the normalized result envelope', async () => {
+    const applySpy = jest.spyOn(peopleCoreServiceAsync, 'applyResolverDecision')
+      .mockResolvedValue({
+        reviewId: 'review-1',
+        status: 'resolved',
+        action: 'confirm_existing_person',
+        reviewStatus: 'resolved_confirmed_existing',
+        resolutionType: 'confirm_existing_person',
+        affectedPersonIds: ['person-existing'],
+        affectedContactPointIds: ['contact-point-1'],
+        ambiguityEventIds: ['ambiguity-event-1'],
+        mergeApplied: false,
+        rebindTriggered: true,
+      });
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/resolver-reviews/review-1/decision')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        action: 'confirm_existing_person',
+        personId: 'person-existing',
+        reason: 'Matched the existing person.',
+        ambiguityEventId: 'ambiguity-event-1',
+      });
+
+    expect(response.status).toBe(200);
+    expect(applySpy).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      reviewId: 'review-1',
+      actorUserId: TEST_USER_ID,
+      action: 'confirm_existing_person',
+      reason: 'Matched the existing person.',
+      notes: undefined,
+      personId: 'person-existing',
+      provisionalPersonId: undefined,
+      sourcePersonId: undefined,
+      targetPersonId: undefined,
+      contactPointId: undefined,
+      ambiguityEventId: 'ambiguity-event-1',
+    });
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_DECISION_APPLIED',
+      data: {
+        result: {
+          reviewId: 'review-1',
+          action: 'confirm_existing_person',
+          reviewStatus: 'resolved_confirmed_existing',
+          resolutionType: 'confirm_existing_person',
+          mergeApplied: false,
+          rebindTriggered: true,
+        },
+      },
+    });
+  });
+
+  it('maps terminal resolver decisions to a normalized business refusal', async () => {
+    jest.spyOn(peopleCoreServiceAsync, 'applyResolverDecision').mockRejectedValue(
+      new InvalidResolverReviewTransitionError('Resolver review is already terminal.', [
+        {
+          field: 'reviewStatus',
+          reason: 'INVALID',
+          message: 'reviewStatus resolved_confirmed_existing is terminal.',
+        },
+      ]),
+    );
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/resolver-reviews/review-1/decision')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        action: 'dismiss_no_action',
+        reason: 'Trying to override a terminal decision.',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_RESOLVER_DECISION_TERMINAL',
+      refusalType: 'business',
+      data: {
+        fieldErrors: [
+          {
+            field: 'reviewStatus',
+            reason: 'INVALID',
+            message: 'reviewStatus resolved_confirmed_existing is terminal.',
+          },
+        ],
+      },
+    });
+  });
+
+  it('maps resolver review scope misses to a normalized business refusal', async () => {
+    jest.spyOn(peopleCoreServiceAsync, 'applyResolverDecision').mockRejectedValue(
+      new PeopleCoreScopeViolationError('Resolver review review-404 is unavailable.'),
+    );
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/resolver-reviews/review-404/decision')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        action: 'dismiss_no_action',
+        reason: 'No identity change required.',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_RESOLVER_REVIEW_NOT_FOUND',
+      refusalType: 'business',
+      message: 'Resolver review is unavailable for the active tenant context.',
+    });
+  });
+
+  it('maps resolver validation failures to client refusals', async () => {
+    jest.spyOn(peopleCoreServiceAsync, 'applyResolverDecision').mockRejectedValue(
+      new ResolverReviewValidationError('personId is required for confirm_existing_person.', [
+        {
+          field: 'personId',
+          reason: 'REQUIRED',
+          message: 'personId is required for confirm_existing_person.',
+        },
+      ]),
+    );
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/resolver-reviews/review-1/decision')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        action: 'confirm_existing_person',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_RESOLVER_DECISION_INVALID',
+      data: {
+        fieldErrors: [
+          {
+            field: 'personId',
+            reason: 'REQUIRED',
+            message: 'personId is required for confirm_existing_person.',
+          },
+        ],
+      },
     });
   });
 });

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
@@ -149,6 +149,25 @@ const createEvent = async (overrides: Record<string, unknown> = {}) => createIde
   ...overrides,
 });
 
+const buildResolverReview = (overrides: Record<string, unknown> = {}) => ({
+  id: 'review-1',
+  tenantId: TEST_TENANT_ID,
+  orgUnitId: TEST_ORG_UNIT_ID,
+  reviewType: 'shared_contact_ambiguity',
+  reviewStatus: 'pending',
+  priority: 'high',
+  triggerSourceType: 'connectshyft_identity_match',
+  triggerSourceId: 'identity-match:resolver-review-route',
+  candidatePersonIds: ['person-a', 'person-b'],
+  contactPointId: 'contact-point-1',
+  confidenceBand: 'medium',
+  confidenceReasons: ['shared phone contact point'],
+  riskFlags: ['shared_contact_possible'],
+  requestedByUserId: TEST_USER_ID,
+  requestedAt: '2026-03-21T12:00:00.000Z',
+  ...overrides,
+});
+
 describe('connectshyft identity ambiguity ops route', () => {
   const previousNodeEnv = process.env.NODE_ENV;
   const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
@@ -241,6 +260,7 @@ describe('connectshyft identity ambiguity ops route', () => {
     });
     expect(response.body.data.events).toHaveLength(2);
     expect(Object.keys(response.body.data.events[0]).sort()).toEqual([
+      'actionable',
       'ambiguityReasonCode',
       'candidateCount',
       'candidateNeighborIds',
@@ -260,6 +280,7 @@ describe('connectshyft identity ambiguity ops route', () => {
       'sourceContextId',
       'status',
       'tenantId',
+      'terminal',
       'updatedAtUtc',
     ].sort());
 
@@ -676,6 +697,8 @@ describe('connectshyft identity ambiguity ops route', () => {
       expect.objectContaining({
         id: pending.id,
         status: 'pending',
+        actionable: true,
+        terminal: false,
       }),
     ]);
 
@@ -694,6 +717,8 @@ describe('connectshyft identity ambiguity ops route', () => {
       expect.objectContaining({
         id: 'ambiguity-event-resolved-default-list',
         status: 'resolved',
+        actionable: false,
+        terminal: true,
       }),
     ]);
   });
@@ -739,6 +764,8 @@ describe('connectshyft identity ambiguity ops route', () => {
         event: {
           id: created.id,
           status: 'dismissed',
+          actionable: false,
+          terminal: true,
           resolverReviewId: 'review-detail-terminal',
           resolverOutcome: {
             action: 'dismiss_no_action',
@@ -746,6 +773,112 @@ describe('connectshyft identity ambiguity ops route', () => {
           },
         },
       },
+    });
+  });
+
+  it('lists resolver reviews with normalized actionability semantics', async () => {
+    const listSpy = jest.spyOn(peopleCoreServiceAsync, 'listResolverReviews')
+      .mockResolvedValue([
+        buildResolverReview({
+          id: 'review-active',
+          reviewStatus: 'pending',
+        }) as any,
+        buildResolverReview({
+          id: 'review-terminal',
+          reviewStatus: 'resolved_confirmed_existing',
+          resolutionType: 'confirm_existing_person',
+          resolvedAt: '2026-03-21T13:00:00.000Z',
+        }) as any,
+      ]);
+
+    const app = buildApp();
+    const response = await request(app)
+      .get('/api/v1/connectshyft/resolver-reviews')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(listSpy).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: undefined,
+    });
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_REVIEWS_LISTED',
+      data: {
+        reviews: [
+          expect.objectContaining({
+            id: 'review-active',
+            reviewStatus: 'pending',
+            actionable: true,
+            terminal: false,
+            decisionStatus: null,
+          }),
+          expect.objectContaining({
+            id: 'review-terminal',
+            reviewStatus: 'resolved_confirmed_existing',
+            actionable: false,
+            terminal: true,
+            decisionStatus: 'resolved',
+          }),
+        ],
+      },
+    });
+  });
+
+  it('returns resolver review detail with stable lifecycle fields', async () => {
+    jest.spyOn(peopleCoreServiceAsync, 'getResolverReview')
+      .mockResolvedValue(buildResolverReview({
+        id: 'review-detail',
+        reviewStatus: 'resolved_confirmed_new',
+        resolutionType: 'confirm_new_person',
+        resolvedAt: '2026-03-21T14:00:00.000Z',
+      }) as any);
+
+    const app = buildApp();
+    const response = await request(app)
+      .get('/api/v1/connectshyft/resolver-reviews/review-detail')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_REVIEW_RETRIEVED',
+      data: {
+        review: {
+          id: 'review-detail',
+          reviewStatus: 'resolved_confirmed_new',
+          actionable: false,
+          terminal: true,
+          decisionStatus: 'resolved',
+          resolutionType: 'confirm_new_person',
+        },
+      },
+    });
+  });
+
+  it('maps missing resolver review detail to a normalized business refusal', async () => {
+    jest.spyOn(peopleCoreServiceAsync, 'getResolverReview').mockResolvedValue(null);
+
+    const app = buildApp();
+    const response = await request(app)
+      .get('/api/v1/connectshyft/resolver-reviews/review-missing')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_RESOLVER_REVIEW_NOT_FOUND',
+      refusalType: 'business',
+      message: 'Resolver review is unavailable for the active tenant context.',
     });
   });
 
@@ -805,6 +938,37 @@ describe('connectshyft identity ambiguity ops route', () => {
           mergeApplied: false,
           rebindTriggered: true,
         },
+      },
+    });
+  });
+
+  it('rejects malformed resolver decision payloads before service dispatch', async () => {
+    const applySpy = jest.spyOn(peopleCoreServiceAsync, 'applyResolverDecision');
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/resolver-reviews/review-1/decision')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        action: 'invented_action',
+      });
+
+    expect(response.status).toBe(400);
+    expect(applySpy).not.toHaveBeenCalled();
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_RESOLVER_DECISION_INVALID',
+      data: {
+        fieldErrors: [
+          {
+            field: 'action',
+            reason: 'INVALID',
+            message: 'action must be a canonical resolver action.',
+          },
+        ],
       },
     });
   });

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -216,7 +216,12 @@ import {
   resolveInboundContactPointIdentityAsync,
   type ResolveInboundContactPointIdentityResult,
 } from '../../../modules/peoplecore/contactPointIdentityResolution';
-import { peopleCoreServiceAsync } from '../../../modules/peoplecore/service';
+import {
+  InvalidResolverReviewTransitionError,
+  peopleCoreServiceAsync,
+  ResolverReviewValidationError,
+} from '../../../modules/peoplecore/service';
+import { PeopleCoreScopeViolationError } from '../../../modules/peoplecore/store';
 import { isStrictUtcIsoTimestamp } from '../../../platform/time/timezoneService';
 import connectShyftOpsRouter from './connectshyft/ops.routes';
 
@@ -2830,6 +2835,24 @@ const parseIdentityAmbiguityEventIdParam = (req: Request): string => {
   return req.params.ambiguityEventId.trim();
 };
 
+const parseResolverReviewIdParam = (req: Request): string => {
+  if (typeof req.params.reviewId !== 'string') {
+    return '';
+  }
+
+  return req.params.reviewId.trim();
+};
+
+const parseResolverDecisionBody = (
+  req: Request,
+): Record<string, unknown> => {
+  if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
+    return {};
+  }
+
+  return req.body as Record<string, unknown>;
+};
+
 const parseIdentityAmbiguityStatusUpdate = (
   req: Request,
 ): 'reviewed' | null => {
@@ -4836,6 +4859,98 @@ router.get('/identity-ambiguities', async (req: Request, res: Response) => {
       nextCursor: listed.nextCursor,
     },
   });
+});
+
+router.post('/resolver-reviews/:reviewId/decision', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  if (!resolveIdentityAmbiguityTenantPrivilegedScope(req, res, context)) {
+    return;
+  }
+
+  const reviewId = parseResolverReviewIdParam(req);
+  if (!reviewId) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_REVIEW_ID_REQUIRED',
+      message: 'reviewId is required',
+    });
+    return;
+  }
+
+  const body = parseResolverDecisionBody(req);
+
+  try {
+    const result = await peopleCoreServiceAsync.applyResolverDecision({
+      tenantId: context.tenantId,
+      reviewId,
+      actorUserId: resolveConnectShyftRequestedActorUserId(req) || CONNECTSHYFT_SYSTEM_ACTOR_USER_ID,
+      action: body.action as any,
+      reason: typeof body.reason === 'string' ? body.reason : undefined,
+      notes: typeof body.notes === 'string' ? body.notes : undefined,
+      personId: typeof body.personId === 'string' ? body.personId : undefined,
+      provisionalPersonId: typeof body.provisionalPersonId === 'string'
+        ? body.provisionalPersonId
+        : undefined,
+      sourcePersonId: typeof body.sourcePersonId === 'string' ? body.sourcePersonId : undefined,
+      targetPersonId: typeof body.targetPersonId === 'string' ? body.targetPersonId : undefined,
+      contactPointId: typeof body.contactPointId === 'string' ? body.contactPointId : undefined,
+      ambiguityEventId: typeof body.ambiguityEventId === 'string'
+        ? body.ambiguityEventId
+        : undefined,
+    });
+
+    return success(res, {
+      code: 'CONNECTSHYFT_RESOLVER_DECISION_APPLIED',
+      message: 'ConnectShyft resolver decision applied',
+      httpStatus: 200,
+      data: {
+        result,
+      },
+    });
+  } catch (error) {
+    if (error instanceof InvalidResolverReviewTransitionError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_DECISION_TERMINAL',
+        message: 'Resolver review is already terminal for the requested decision.',
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          fieldErrors: error.fieldErrors,
+        },
+      });
+      return;
+    }
+
+    if (error instanceof ResolverReviewValidationError) {
+      respondConnectShyftClientRefusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_DECISION_INVALID',
+        message: error.message,
+        data: {
+          fieldErrors: error.fieldErrors,
+        },
+      });
+      return;
+    }
+
+    if (error instanceof PeopleCoreScopeViolationError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_REVIEW_NOT_FOUND',
+        message: 'Resolver review is unavailable for the active tenant context.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    throw error;
+  }
 });
 
 router.patch('/identity-ambiguities/:ambiguityEventId', async (req: Request, res: Response) => {

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -2,9 +2,22 @@ import { createHash, randomUUID } from 'node:crypto';
 import { Request, Response, Router } from 'express';
 import type { Knex } from 'knex';
 import type {
+  ConnectShyftIdentityAmbiguityEvent,
+  ConnectShyftIdentityAmbiguityRecord,
+  ConnectShyftResolverReviewRecord,
   PersonProvisionalCreatedEvent,
+  ResolverDecisionInput,
+  ResolverReview,
   ResolverReviewCreatedEvent,
   SubjectContext,
+} from '@shyft/contracts';
+import {
+  deriveResolverDecisionStatus,
+  isConnectShyftIdentityAmbiguityActiveStatus,
+  isConnectShyftIdentityAmbiguityTerminalStatus,
+  isResolverActionType,
+  isResolverReviewActiveStatus,
+  isResolverReviewTerminalStatus,
 } from '@shyft/contracts';
 import {
   buildTelephonyDispatchReplayKey,
@@ -2753,6 +2766,89 @@ const resolveIdentityAmbiguityTenantPrivilegedScope = (
   return null;
 };
 
+const resolveResolverReviewReadScope = (
+  req: Request,
+  res: Response,
+  context: Pick<ResolvedConnectShyftContext, 'orgUnitId' | 'effectiveRoles'>,
+  requestedOrgUnitId: string | null,
+): {
+  actorRoles: string[];
+  orgUnitId: string | null;
+  tenantPrivileged: boolean;
+} | null => {
+  const actorRoles = resolveConnectShyftActorRoles(req, context);
+  const tenantPrivileged =
+    hasCapability(actorRoles, CAPABILITIES.NEIGHBOR_EDIT_ALL);
+  const identityResolutionCapable =
+    hasCapability(actorRoles, CAPABILITIES.ORG_UNIT_IDENTITY_RESOLVE);
+
+  if (!tenantPrivileged && !identityResolutionCapable) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_REVIEW_READ_FORBIDDEN',
+      message: 'Resolver review access requires an authorized ConnectShyft role.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return null;
+  }
+
+  if (requestedOrgUnitId && !tenantPrivileged && requestedOrgUnitId !== context.orgUnitId) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_ORGUNIT_SCOPE_VIOLATION',
+      message: 'Cross-orgUnit context overrides are not allowed for this route',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return null;
+  }
+
+  return {
+    actorRoles,
+    orgUnitId: requestedOrgUnitId ?? (tenantPrivileged ? null : context.orgUnitId),
+    tenantPrivileged,
+  };
+};
+
+const resolveResolverReviewTenantPrivilegedScope = (
+  req: Request,
+  res: Response,
+  context: Pick<ResolvedConnectShyftContext, 'effectiveRoles'>,
+): {
+  actorRoles: string[];
+} | null => {
+  const actorRoles = resolveConnectShyftActorRoles(req, context);
+  if (hasCapability(actorRoles, CAPABILITIES.NEIGHBOR_EDIT_ALL)) {
+    return {
+      actorRoles,
+    };
+  }
+
+  refusal(res, {
+    code: 'CONNECTSHYFT_RESOLVER_REVIEW_UPDATE_FORBIDDEN',
+    message: 'Resolver decision updates require a tenant-privileged ConnectShyft admin role.',
+    refusalType: 'business',
+    httpStatus: 200,
+  });
+  return null;
+};
+
+const toResolverReviewRecord = (
+  review: ResolverReview,
+): ConnectShyftResolverReviewRecord => ({
+  ...review,
+  actionable: isResolverReviewActiveStatus(review.reviewStatus),
+  terminal: isResolverReviewTerminalStatus(review.reviewStatus),
+  decisionStatus: deriveResolverDecisionStatus(review.reviewStatus),
+});
+
+const toIdentityAmbiguityRecord = (
+  event: ConnectShyftIdentityAmbiguityEvent,
+): ConnectShyftIdentityAmbiguityRecord => ({
+  ...event,
+  actionable: isConnectShyftIdentityAmbiguityActiveStatus(event.status),
+  terminal: isConnectShyftIdentityAmbiguityTerminalStatus(event.status),
+});
+
 const parseOrgUnitIdFromBody = (req: Request): string | null => {
   if (typeof req.body?.orgUnitId !== 'string') {
     return null;
@@ -2824,6 +2920,7 @@ const parseIdentityAmbiguityFilters = (req: Request): {
   status: 'pending' | 'reviewed' | 'resolved' | 'dismissed' | null;
   normalizedContactPoint: string | null;
   sourceContext: string | null;
+  sourceContextId: string | null;
   limit: number;
   cursor: string | null;
 } => ({
@@ -2833,8 +2930,15 @@ const parseIdentityAmbiguityFilters = (req: Request): {
     req.query?.normalizedContactPoint,
   ),
   sourceContext: parseIdentityAmbiguityOptionalFilter(req.query?.sourceContext),
+  sourceContextId: parseIdentityAmbiguityOptionalFilter(req.query?.sourceContextId),
   limit: parseIdentityAmbiguityLimit(req),
   cursor: parseIdentityAmbiguityOptionalFilter(req.query?.cursor),
+});
+
+const parseResolverReviewFilters = (req: Request): {
+  orgUnitId: string | null;
+} => ({
+  orgUnitId: parseOrgUnitIdFromQuery(req),
 });
 
 const parseIdentityAmbiguityEventIdParam = (req: Request): string => {
@@ -2855,12 +2959,34 @@ const parseResolverReviewIdParam = (req: Request): string => {
 
 const parseResolverDecisionBody = (
   req: Request,
-): Record<string, unknown> => {
+): Partial<ResolverDecisionInput> => {
   if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
     return {};
   }
 
-  return req.body as Record<string, unknown>;
+  const body = req.body as Record<string, unknown>;
+  const normalizeOptionalBodyString = (value: unknown): string | undefined => {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : undefined;
+  };
+
+  const action = normalizeOptionalBodyString(body.action);
+
+  return {
+    action: isResolverActionType(action) ? action : undefined,
+    reason: normalizeOptionalBodyString(body.reason),
+    notes: normalizeOptionalBodyString(body.notes),
+    personId: normalizeOptionalBodyString(body.personId),
+    provisionalPersonId: normalizeOptionalBodyString(body.provisionalPersonId),
+    sourcePersonId: normalizeOptionalBodyString(body.sourcePersonId),
+    targetPersonId: normalizeOptionalBodyString(body.targetPersonId),
+    contactPointId: normalizeOptionalBodyString(body.contactPointId),
+    ambiguityEventId: normalizeOptionalBodyString(body.ambiguityEventId),
+  };
 };
 
 const parseIdentityAmbiguityStatusUpdate = (
@@ -4829,6 +4955,96 @@ router.get('/events', async (req: Request, res: Response) => {
   });
 });
 
+router.get('/resolver-reviews', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const filters = parseResolverReviewFilters(req);
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  const readScope = resolveResolverReviewReadScope(
+    req,
+    res,
+    context,
+    filters.orgUnitId,
+  );
+  if (!readScope) {
+    return;
+  }
+
+  const reviews = await peopleCoreServiceAsync.listResolverReviews({
+    tenantId: context.tenantId,
+    orgUnitId: readScope.orgUnitId ?? undefined,
+  });
+
+  return success(res, {
+    code: 'CONNECTSHYFT_RESOLVER_REVIEWS_LISTED',
+    message: 'ConnectShyft resolver reviews listed',
+    httpStatus: 200,
+    data: {
+      reviews: reviews.map(toResolverReviewRecord),
+    },
+  });
+});
+
+router.get('/resolver-reviews/:reviewId', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  const reviewId = parseResolverReviewIdParam(req);
+  if (!reviewId) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_REVIEW_ID_REQUIRED',
+      message: 'reviewId is required',
+    });
+    return;
+  }
+
+  const readScope = resolveResolverReviewReadScope(
+    req,
+    res,
+    context,
+    null,
+  );
+  if (!readScope) {
+    return;
+  }
+
+  const review = await peopleCoreServiceAsync.getResolverReview({
+    tenantId: context.tenantId,
+    reviewId,
+  });
+
+  if (!review || (!readScope.tenantPrivileged && review.orgUnitId !== context.orgUnitId)) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_REVIEW_NOT_FOUND',
+      message: 'Resolver review is unavailable for the active tenant context.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  return success(res, {
+    code: 'CONNECTSHYFT_RESOLVER_REVIEW_RETRIEVED',
+    message: 'ConnectShyft resolver review retrieved',
+    httpStatus: 200,
+    data: {
+      review: toResolverReviewRecord(review),
+    },
+  });
+});
+
 router.get('/identity-ambiguities', async (req: Request, res: Response) => {
   if (!await enforceCapability(req, res, 'module')) {
     return;
@@ -4856,6 +5072,7 @@ router.get('/identity-ambiguities', async (req: Request, res: Response) => {
     status: filters.status,
     normalizedContactPoint: filters.normalizedContactPoint,
     sourceContext: filters.sourceContext,
+    sourceContextId: filters.sourceContextId,
     limit: filters.limit,
     cursor: filters.cursor,
   });
@@ -4865,7 +5082,7 @@ router.get('/identity-ambiguities', async (req: Request, res: Response) => {
     message: 'ConnectShyft identity ambiguities resolved',
     httpStatus: 200,
     data: {
-      events: listed.events,
+      events: listed.events.map(toIdentityAmbiguityRecord),
       nextCursor: listed.nextCursor,
     },
   });
@@ -4914,7 +5131,7 @@ router.get('/identity-ambiguities/:ambiguityEventId', async (req: Request, res: 
     message: 'ConnectShyft identity ambiguity retrieved',
     httpStatus: 200,
     data: {
-      event,
+      event: toIdentityAmbiguityRecord(event),
     },
   });
 });
@@ -4929,7 +5146,7 @@ router.post('/resolver-reviews/:reviewId/decision', async (req: Request, res: Re
     return;
   }
 
-  if (!resolveIdentityAmbiguityTenantPrivilegedScope(req, res, context)) {
+  if (!resolveResolverReviewTenantPrivilegedScope(req, res, context)) {
     return;
   }
 
@@ -4943,25 +5160,37 @@ router.post('/resolver-reviews/:reviewId/decision', async (req: Request, res: Re
   }
 
   const body = parseResolverDecisionBody(req);
+  if (!body.action) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_DECISION_INVALID',
+      message: 'action must be a canonical resolver action.',
+      data: {
+        fieldErrors: [
+          {
+            field: 'action',
+            reason: 'INVALID',
+            message: 'action must be a canonical resolver action.',
+          },
+        ],
+      },
+    });
+    return;
+  }
 
   try {
     const result = await peopleCoreServiceAsync.applyResolverDecision({
       tenantId: context.tenantId,
       reviewId,
       actorUserId: resolveConnectShyftRequestedActorUserId(req) || CONNECTSHYFT_SYSTEM_ACTOR_USER_ID,
-      action: body.action as any,
-      reason: typeof body.reason === 'string' ? body.reason : undefined,
-      notes: typeof body.notes === 'string' ? body.notes : undefined,
-      personId: typeof body.personId === 'string' ? body.personId : undefined,
-      provisionalPersonId: typeof body.provisionalPersonId === 'string'
-        ? body.provisionalPersonId
-        : undefined,
-      sourcePersonId: typeof body.sourcePersonId === 'string' ? body.sourcePersonId : undefined,
-      targetPersonId: typeof body.targetPersonId === 'string' ? body.targetPersonId : undefined,
-      contactPointId: typeof body.contactPointId === 'string' ? body.contactPointId : undefined,
-      ambiguityEventId: typeof body.ambiguityEventId === 'string'
-        ? body.ambiguityEventId
-        : undefined,
+      action: body.action,
+      reason: body.reason,
+      notes: body.notes,
+      personId: body.personId,
+      provisionalPersonId: body.provisionalPersonId,
+      sourcePersonId: body.sourcePersonId,
+      targetPersonId: body.targetPersonId,
+      contactPointId: body.contactPointId,
+      ambiguityEventId: body.ambiguityEventId,
     });
 
     return success(res, {
@@ -5071,7 +5300,7 @@ router.patch('/identity-ambiguities/:ambiguityEventId', async (req: Request, res
     message: 'ConnectShyft identity ambiguity reviewed',
     httpStatus: 200,
     data: {
-      event,
+      event: toIdentityAmbiguityRecord(event),
     },
   });
 });
@@ -8444,6 +8673,7 @@ const performInboundWebhook = async ({
         threadState: ensuredThread.state,
         thread: ensuredThread,
         identityResolution: {
+          resolvedState: identityAttachment.outcome,
           outcome: identityAttachment.outcome,
           confidenceBand: identityAttachment.confidenceBand,
           contactPointStatus: identityAttachment.contactPointStatus,

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -208,6 +208,7 @@ import {
   resetConnectShyftCommunicationAuditLogForTests,
 } from '../../../modules/connectshyft/communicationAuditLog';
 import {
+  getIdentityAmbiguityEvent,
   listIdentityAmbiguityEvents,
   markIdentityAmbiguityEventReviewed,
 } from '../../../modules/connectshyft/ambiguityEvents';
@@ -2771,17 +2772,26 @@ const parseOrgUnitIdFromQuery = (req: Request): string | null => {
 
 const parseIdentityAmbiguityStatusFromQuery = (
   req: Request,
-): 'pending' | 'reviewed' | null => {
+): 'pending' | 'reviewed' | 'resolved' | 'dismissed' | null => {
   if (typeof req.query?.status !== 'string') {
-    return null;
+    return 'pending';
   }
 
   const normalized = req.query.status.trim().toLowerCase();
-  if (normalized === 'pending' || normalized === 'reviewed') {
+  if (normalized === 'all') {
+    return null;
+  }
+
+  if (
+    normalized === 'pending'
+    || normalized === 'reviewed'
+    || normalized === 'resolved'
+    || normalized === 'dismissed'
+  ) {
     return normalized;
   }
 
-  return null;
+  return 'pending';
 };
 
 const parseIdentityAmbiguityOptionalFilter = (
@@ -2811,7 +2821,7 @@ const parseIdentityAmbiguityLimit = (req: Request): number => {
 
 const parseIdentityAmbiguityFilters = (req: Request): {
   orgUnitId: string | null;
-  status: 'pending' | 'reviewed' | null;
+  status: 'pending' | 'reviewed' | 'resolved' | 'dismissed' | null;
   normalizedContactPoint: string | null;
   sourceContext: string | null;
   limit: number;
@@ -4857,6 +4867,54 @@ router.get('/identity-ambiguities', async (req: Request, res: Response) => {
     data: {
       events: listed.events,
       nextCursor: listed.nextCursor,
+    },
+  });
+});
+
+router.get('/identity-ambiguities/:ambiguityEventId', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  if (!resolveIdentityAmbiguityTenantPrivilegedScope(req, res, context)) {
+    return;
+  }
+
+  const ambiguityEventId = parseIdentityAmbiguityEventIdParam(req);
+  if (!ambiguityEventId) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_ID_REQUIRED',
+      message: 'ambiguityEventId is required',
+    });
+    return;
+  }
+
+  const event = await getIdentityAmbiguityEvent({
+    tenantId: context.tenantId,
+    ambiguityEventId,
+  });
+
+  if (!event) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_NOT_FOUND',
+      message: 'Identity ambiguity event is unavailable for the active tenant context.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  return success(res, {
+    code: 'CONNECTSHYFT_IDENTITY_AMBIGUITY_RETRIEVED',
+    message: 'ConnectShyft identity ambiguity retrieved',
+    httpStatus: 200,
+    data: {
+      event,
     },
   });
 });

--- a/apps/connectshyft-web/src/features/connectshyft/__tests__/identityResolution.test.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/__tests__/identityResolution.test.ts
@@ -26,8 +26,9 @@ describe('resolveConnectShyftIdentityResolutionPresentation', () => {
     });
   });
 
-  it('blocks create-new when the confidence band is very_high even without an explicit resolver state', () => {
+  it('treats active resolver review states as resolver-required without inferring from confidence alone', () => {
     expect(resolveConnectShyftIdentityResolutionPresentation({
+      state: 'pending',
       confidenceBand: 'very_high',
       contactPointStatus: 'reassignment_suspected',
       candidates: [],

--- a/apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
@@ -2,6 +2,11 @@ import type {
   ConnectShyftIdentityResolutionCandidate,
   ConnectShyftIdentityResolutionResponse,
 } from '@shyft/contracts';
+import {
+  isConnectShyftIdentityResolutionOutcome,
+  isResolverReviewActiveStatus,
+  isResolverReviewResolvedStatus,
+} from '@shyft/contracts';
 
 export type {
   ConnectShyftIdentityResolutionCandidate,
@@ -29,16 +34,28 @@ export type ConnectShyftIdentityResolutionPresentation = {
 const normalizeResolutionState = (
   value: unknown,
 ): ConnectShyftIdentityResolutionPresentation['resolvedState'] | null => {
-  if (value === 'canonical' || value === 'match') {
-    return 'canonical';
+  if (isConnectShyftIdentityResolutionOutcome(value) || value === 'match') {
+    if (value === 'canonical') {
+      return 'canonical';
+    }
+
+    if (value === 'provisional') {
+      return 'provisional';
+    }
+
+    return 'resolver_required';
   }
 
-  if (value === 'provisional' || value === 'create_new') {
+  if (isResolverReviewActiveStatus(value) || value === 'review_needed') {
+    return 'resolver_required';
+  }
+
+  if (value === 'resolved_confirmed_new' || value === 'create_new') {
     return 'provisional';
   }
 
-  if (value === 'resolver_required' || value === 'review_needed') {
-    return 'resolver_required';
+  if (isResolverReviewResolvedStatus(value) || value === 'dismissed') {
+    return 'canonical';
   }
 
   return null;
@@ -48,11 +65,14 @@ export const resolveConnectShyftIdentityResolutionPresentation = (
   response: ConnectShyftIdentityResolutionResponse,
 ): ConnectShyftIdentityResolutionPresentation => {
   const resolvedState =
-    normalizeResolutionState(response.state) || normalizeResolutionState(response.outcome) || 'unknown';
+    normalizeResolutionState(response.resolvedState)
+    || normalizeResolutionState(response.outcome)
+    || normalizeResolutionState(response.state)
+    || 'unknown';
   const candidates = Array.isArray(response.candidates) ? response.candidates : [];
   const hasCandidates = candidates.length > 0;
 
-  if (resolvedState === 'resolver_required' || response.confidenceBand === 'very_high') {
+  if (resolvedState === 'resolver_required') {
     return {
       resolvedState: 'resolver_required',
       mode: 'resolver_required',

--- a/libs/contracts/src/connectshyft.ts
+++ b/libs/contracts/src/connectshyft.ts
@@ -2,6 +2,9 @@ import type {
   ContactPointStatus,
   IdentityConfidenceBand,
   ResolverActionType,
+  ResolverDecisionResult,
+  ResolverDecisionStatus,
+  ResolverReview,
   ResolverReviewStatus,
 } from './people';
 
@@ -16,6 +19,18 @@ export type ConnectShyftIdentityResolutionOutcome =
   | 'canonical'
   | 'provisional'
   | 'resolver_required';
+
+export const CONNECTSHYFT_IDENTITY_RESOLUTION_OUTCOMES = [
+  'canonical',
+  'provisional',
+  'resolver_required',
+] as const;
+
+export const isConnectShyftIdentityResolutionOutcome = (
+  value: unknown,
+): value is ConnectShyftIdentityResolutionOutcome =>
+  typeof value === 'string'
+  && (CONNECTSHYFT_IDENTITY_RESOLUTION_OUTCOMES as readonly string[]).includes(value);
 
 export const CONNECTSHYFT_IDENTITY_AMBIGUITY_ACTIVE_STATUSES = [
   'pending',
@@ -41,6 +56,11 @@ export type ConnectShyftIdentityAmbiguityTerminalStatus =
 export type ConnectShyftIdentityAmbiguityConsumptionOutcome =
   Extract<ConnectShyftIdentityAmbiguityTerminalStatus, 'resolved' | 'dismissed'>;
 
+export type ConnectShyftIdentityAmbiguityReasonCode =
+  | 'IDENTITY_MATCH_AMBIGUOUS'
+  | 'PEOPLECORE_LEGACY_DISAGREEMENT'
+  | 'PEOPLECORE_MULTI_CURRENT_LINKS';
+
 export type ConnectShyftResolverOutcomeAudit = {
   reviewId: string;
   action: ResolverActionType;
@@ -53,6 +73,61 @@ export type ConnectShyftResolverOutcomeAudit = {
   sourcePersonId?: string | null;
   targetPersonId?: string | null;
   contactPointId?: string | null;
+};
+
+export type ConnectShyftIdentityAmbiguityEvent = {
+  id: string;
+  tenantId: string;
+  orgUnitId: string | null;
+  sourceContext: string;
+  sourceContextId: string | null;
+  normalizedContactPoint: string;
+  contactPointType: 'phone';
+  candidateNeighborIds: string[];
+  candidateCount: number;
+  ambiguityReasonCode: ConnectShyftIdentityAmbiguityReasonCode;
+  status: ConnectShyftIdentityAmbiguityStatus;
+  requestedByUserId: string | null;
+  correlationId: string | null;
+  idempotencyKey: string | null;
+  resolverReviewId: string | null;
+  resolverConsumedByUserId: string | null;
+  resolverConsumedAtUtc: string | null;
+  resolverOutcome: ConnectShyftResolverOutcomeAudit | null;
+  createdAtUtc: string;
+  updatedAtUtc: string;
+};
+
+export type ConnectShyftIdentityAmbiguityRecord = ConnectShyftIdentityAmbiguityEvent & {
+  actionable: boolean;
+  terminal: boolean;
+};
+
+export type ConnectShyftIdentityAmbiguityListData = {
+  events: ConnectShyftIdentityAmbiguityRecord[];
+  nextCursor: string | null;
+};
+
+export type ConnectShyftIdentityAmbiguityDetailData = {
+  event: ConnectShyftIdentityAmbiguityRecord;
+};
+
+export type ConnectShyftResolverReviewRecord = ResolverReview & {
+  actionable: boolean;
+  terminal: boolean;
+  decisionStatus: ResolverDecisionStatus | null;
+};
+
+export type ConnectShyftResolverReviewListData = {
+  reviews: ConnectShyftResolverReviewRecord[];
+};
+
+export type ConnectShyftResolverReviewDetailData = {
+  review: ConnectShyftResolverReviewRecord;
+};
+
+export type ConnectShyftResolverDecisionData = {
+  result: ResolverDecisionResult;
 };
 
 export const isConnectShyftIdentityAmbiguityStatus = (
@@ -76,6 +151,7 @@ export const isConnectShyftIdentityAmbiguityTerminalStatus = (
 export type ConnectShyftIdentityResolutionResponse = {
   confidenceBand: IdentityConfidenceBand;
   contactPointStatus: ContactPointStatus;
+  resolvedState?: ConnectShyftIdentityResolutionOutcome | null;
   outcome?: ConnectShyftIdentityResolutionOutcome | null;
   state?: ConnectShyftIdentityResolutionOutcome | ResolverReviewStatus | null;
   resolverReviewId?: string | null;

--- a/libs/contracts/src/connectshyft.ts
+++ b/libs/contracts/src/connectshyft.ts
@@ -1,6 +1,7 @@
 import type {
   ContactPointStatus,
   IdentityConfidenceBand,
+  ResolverReviewStatus,
 } from './people';
 
 export type ConnectShyftIdentityResolutionCandidate = {
@@ -10,11 +11,16 @@ export type ConnectShyftIdentityResolutionCandidate = {
   contactPointStatus: ContactPointStatus;
 };
 
+export type ConnectShyftIdentityResolutionOutcome =
+  | 'canonical'
+  | 'provisional'
+  | 'resolver_required';
+
 export type ConnectShyftIdentityResolutionResponse = {
   confidenceBand: IdentityConfidenceBand;
   contactPointStatus: ContactPointStatus;
-  outcome?: string | null;
-  state?: string | null;
+  outcome?: ConnectShyftIdentityResolutionOutcome | null;
+  state?: ConnectShyftIdentityResolutionOutcome | ResolverReviewStatus | null;
   resolverReviewId?: string | null;
   candidates?: ConnectShyftIdentityResolutionCandidate[];
 };

--- a/libs/contracts/src/connectshyft.ts
+++ b/libs/contracts/src/connectshyft.ts
@@ -1,6 +1,7 @@
 import type {
   ContactPointStatus,
   IdentityConfidenceBand,
+  ResolverActionType,
   ResolverReviewStatus,
 } from './people';
 
@@ -15,6 +16,62 @@ export type ConnectShyftIdentityResolutionOutcome =
   | 'canonical'
   | 'provisional'
   | 'resolver_required';
+
+export const CONNECTSHYFT_IDENTITY_AMBIGUITY_ACTIVE_STATUSES = [
+  'pending',
+] as const;
+
+export const CONNECTSHYFT_IDENTITY_AMBIGUITY_TERMINAL_STATUSES = [
+  'reviewed',
+  'resolved',
+  'dismissed',
+] as const;
+
+export const CONNECTSHYFT_IDENTITY_AMBIGUITY_STATUSES = [
+  ...CONNECTSHYFT_IDENTITY_AMBIGUITY_ACTIVE_STATUSES,
+  ...CONNECTSHYFT_IDENTITY_AMBIGUITY_TERMINAL_STATUSES,
+] as const;
+
+export type ConnectShyftIdentityAmbiguityStatus =
+  typeof CONNECTSHYFT_IDENTITY_AMBIGUITY_STATUSES[number];
+
+export type ConnectShyftIdentityAmbiguityTerminalStatus =
+  typeof CONNECTSHYFT_IDENTITY_AMBIGUITY_TERMINAL_STATUSES[number];
+
+export type ConnectShyftIdentityAmbiguityConsumptionOutcome =
+  Extract<ConnectShyftIdentityAmbiguityTerminalStatus, 'resolved' | 'dismissed'>;
+
+export type ConnectShyftResolverOutcomeAudit = {
+  reviewId: string;
+  action: ResolverActionType;
+  reviewStatus: ResolverReviewStatus;
+  actorUserId: string;
+  occurredAtUtc: string;
+  reason?: string | null;
+  notes?: string | null;
+  personId?: string | null;
+  sourcePersonId?: string | null;
+  targetPersonId?: string | null;
+  contactPointId?: string | null;
+};
+
+export const isConnectShyftIdentityAmbiguityStatus = (
+  value: unknown,
+): value is ConnectShyftIdentityAmbiguityStatus =>
+  typeof value === 'string'
+  && (CONNECTSHYFT_IDENTITY_AMBIGUITY_STATUSES as readonly string[]).includes(value);
+
+export const isConnectShyftIdentityAmbiguityActiveStatus = (
+  value: unknown,
+): value is typeof CONNECTSHYFT_IDENTITY_AMBIGUITY_ACTIVE_STATUSES[number] =>
+  typeof value === 'string'
+  && (CONNECTSHYFT_IDENTITY_AMBIGUITY_ACTIVE_STATUSES as readonly string[]).includes(value);
+
+export const isConnectShyftIdentityAmbiguityTerminalStatus = (
+  value: unknown,
+): value is ConnectShyftIdentityAmbiguityTerminalStatus =>
+  typeof value === 'string'
+  && (CONNECTSHYFT_IDENTITY_AMBIGUITY_TERMINAL_STATUSES as readonly string[]).includes(value);
 
 export type ConnectShyftIdentityResolutionResponse = {
   confidenceBand: IdentityConfidenceBand;

--- a/libs/contracts/src/people/resolver-review.ts
+++ b/libs/contracts/src/people/resolver-review.ts
@@ -110,6 +110,19 @@ export type ValidatedResolverDecisionInput = {
   ambiguityEventId?: string;
 };
 
+export type ResolverDecisionResult = {
+  reviewId: string;
+  status: ResolverDecisionStatus;
+  action: ResolverActionType;
+  reviewStatus: ResolverReviewStatus;
+  resolutionType: ResolverResolutionType;
+  affectedPersonIds: string[];
+  affectedContactPointIds: string[];
+  ambiguityEventIds: string[];
+  mergeApplied: boolean;
+  rebindTriggered: boolean;
+};
+
 export const isResolverActionType = (value: unknown): value is ResolverActionType =>
   typeof value === 'string'
   && (RESOLVER_ACTION_TYPES as readonly string[]).includes(value);

--- a/libs/contracts/src/people/resolver-review.ts
+++ b/libs/contracts/src/people/resolver-review.ts
@@ -1,43 +1,150 @@
 import type { IdentityConfidenceBand } from './contact-point';
 
-export type ResolverReviewType =
-  | 'very_high_duplicate_override'
-  | 'shared_contact_ambiguity'
-  | 'contact_point_reassignment'
-  | 'merge_review'
-  | 'subject_reassignment_review'
-  | 'identity_conflict';
+export const RESOLVER_REVIEW_TYPES = [
+  'very_high_duplicate_override',
+  'shared_contact_ambiguity',
+  'contact_point_reassignment',
+  'merge_review',
+  'subject_reassignment_review',
+  'identity_conflict',
+] as const;
 
-export type ResolverReviewStatus =
-  | 'pending'
-  | 'queued'
-  | 'in_review'
-  | 'waiting_for_more_info'
-  | 'resolved_confirmed_existing'
-  | 'resolved_confirmed_new'
-  | 'resolved_shared_contact'
-  | 'resolved_reassigned'
-  | 'resolved_merged'
-  | 'dismissed';
+export type ResolverReviewType = typeof RESOLVER_REVIEW_TYPES[number];
 
-export type ResolverResolutionType =
-  | 'confirm_existing_person'
-  | 'confirm_new_person'
-  | 'mark_shared_contact'
-  | 'reassign_contact_point'
-  | 'merge_people'
-  | 'link_without_merge'
-  | 'dismiss_no_action';
+export const RESOLVER_REVIEW_ACTIVE_STATUSES = [
+  'pending',
+  'queued',
+  'in_review',
+  'waiting_for_more_info',
+] as const;
 
-export type ResolverRiskFlag =
-  | 'shared_contact_possible'
-  | 'shared_contact_confirmed'
-  | 'stale_contact'
-  | 'archived_prior_owner'
-  | 'conflicting_name_dob'
-  | 'rapid_contact_reuse'
-  | 'duplicate_creation_attempt'
-  | 'high_confidence_override_attempt';
+export const RESOLVER_REVIEW_RESOLVED_STATUSES = [
+  'resolved_confirmed_existing',
+  'resolved_confirmed_new',
+  'resolved_shared_contact',
+  'resolved_reassigned',
+  'resolved_merged',
+] as const;
+
+export const RESOLVER_REVIEW_TERMINAL_STATUSES = [
+  ...RESOLVER_REVIEW_RESOLVED_STATUSES,
+  'dismissed',
+] as const;
+
+export const RESOLVER_REVIEW_STATUSES = [
+  ...RESOLVER_REVIEW_ACTIVE_STATUSES,
+  ...RESOLVER_REVIEW_TERMINAL_STATUSES,
+] as const;
+
+export type ResolverReviewStatus = typeof RESOLVER_REVIEW_STATUSES[number];
+export type ResolverReviewResolvedStatus = typeof RESOLVER_REVIEW_RESOLVED_STATUSES[number];
+export type ResolverReviewTerminalStatus = typeof RESOLVER_REVIEW_TERMINAL_STATUSES[number];
+
+export const RESOLVER_ACTION_TYPES = [
+  'confirm_existing_person',
+  'confirm_new_person',
+  'merge_people',
+  'link_without_merge',
+  'mark_shared_contact',
+  'reassign_contact_point',
+  'dismiss_no_action',
+] as const;
+
+export type ResolverActionType = typeof RESOLVER_ACTION_TYPES[number];
+export type ResolverResolutionType = ResolverActionType;
+
+export const RESOLVER_RISK_FLAGS = [
+  'shared_contact_possible',
+  'shared_contact_confirmed',
+  'stale_contact',
+  'archived_prior_owner',
+  'conflicting_name_dob',
+  'rapid_contact_reuse',
+  'duplicate_creation_attempt',
+  'high_confidence_override_attempt',
+] as const;
+
+export type ResolverRiskFlag = typeof RESOLVER_RISK_FLAGS[number];
+
+export type ResolverDecisionStatus = 'resolved' | 'dismissed';
+
+export const RESOLVER_ACTION_STATUS_MAP: Record<
+  ResolverActionType,
+  ResolverReviewTerminalStatus
+> = {
+  confirm_existing_person: 'resolved_confirmed_existing',
+  confirm_new_person: 'resolved_confirmed_new',
+  merge_people: 'resolved_merged',
+  link_without_merge: 'resolved_confirmed_existing',
+  mark_shared_contact: 'resolved_shared_contact',
+  reassign_contact_point: 'resolved_reassigned',
+  dismiss_no_action: 'dismissed',
+};
+
+export type ResolverDecisionInput = {
+  tenantId: string;
+  reviewId: string;
+  action: ResolverActionType;
+  actorUserId: string;
+  reason?: string;
+  notes?: string;
+  personId?: string;
+  provisionalPersonId?: string;
+  sourcePersonId?: string;
+  targetPersonId?: string;
+  contactPointId?: string;
+  ambiguityEventId?: string;
+};
+
+export type ValidatedResolverDecisionInput = {
+  tenantId: string;
+  reviewId: string;
+  action: ResolverActionType;
+  actorUserId: string;
+  reason?: string;
+  notes?: string;
+  personId?: string;
+  sourcePersonId?: string;
+  targetPersonId?: string;
+  contactPointId?: string;
+  ambiguityEventId?: string;
+};
+
+export const isResolverActionType = (value: unknown): value is ResolverActionType =>
+  typeof value === 'string'
+  && (RESOLVER_ACTION_TYPES as readonly string[]).includes(value);
+
+export const isResolverReviewActiveStatus = (
+  value: unknown,
+): value is typeof RESOLVER_REVIEW_ACTIVE_STATUSES[number] =>
+  typeof value === 'string'
+  && (RESOLVER_REVIEW_ACTIVE_STATUSES as readonly string[]).includes(value);
+
+export const isResolverReviewResolvedStatus = (
+  value: unknown,
+): value is ResolverReviewResolvedStatus =>
+  typeof value === 'string'
+  && (RESOLVER_REVIEW_RESOLVED_STATUSES as readonly string[]).includes(value);
+
+export const isResolverReviewTerminalStatus = (
+  value: unknown,
+): value is ResolverReviewTerminalStatus =>
+  typeof value === 'string'
+  && (RESOLVER_REVIEW_TERMINAL_STATUSES as readonly string[]).includes(value);
+
+export const deriveResolverDecisionStatus = (
+  reviewStatus: ResolverReviewStatus,
+): ResolverDecisionStatus | null => {
+  if (isResolverReviewResolvedStatus(reviewStatus)) {
+    return 'resolved';
+  }
+
+  if (reviewStatus === 'dismissed') {
+    return 'dismissed';
+  }
+
+  return null;
+};
 
 export type ResolverReview = {
   id: string;

--- a/shared/database/migrations/20260325143000_add_resolver_outcome_to_connectshyft_identity_ambiguity_events.ts
+++ b/shared/database/migrations/20260325143000_add_resolver_outcome_to_connectshyft_identity_ambiguity_events.ts
@@ -1,0 +1,74 @@
+import { Knex } from 'knex';
+
+const CONNECTSHYFT_SCHEMA = 'connectshyft';
+const AMBIGUITY_EVENTS_TABLE = 'cs_identity_ambiguity_events';
+const STATUS_CHECK = 'cs_identity_ambiguity_events_status_ck';
+const TENANT_RESOLVER_REVIEW_INDEX =
+  'connectshyft_cs_identity_ambiguity_events_tenant_resolver_review_idx';
+const TENANT_SOURCE_CONTEXT_ID_STATUS_INDEX =
+  'connectshyft_cs_identity_ambiguity_events_tenant_source_context_id_status_idx';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+      ADD COLUMN IF NOT EXISTS resolver_review_id TEXT NULL,
+      ADD COLUMN IF NOT EXISTS resolver_consumed_by_user_id TEXT NULL,
+      ADD COLUMN IF NOT EXISTS resolver_consumed_at_utc TIMESTAMPTZ NULL,
+      ADD COLUMN IF NOT EXISTS resolver_outcome JSONB NULL
+  `);
+
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+      DROP CONSTRAINT IF EXISTS ${STATUS_CHECK}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+      ADD CONSTRAINT ${STATUS_CHECK}
+      CHECK (status IN ('pending', 'reviewed', 'resolved', 'dismissed'))
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${TENANT_RESOLVER_REVIEW_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE} (tenant_id, resolver_review_id)
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS ${TENANT_SOURCE_CONTEXT_ID_STATUS_INDEX}
+    ON ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE} (
+      tenant_id,
+      source_context_id,
+      status,
+      created_at_utc DESC
+    )
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${TENANT_SOURCE_CONTEXT_ID_STATUS_INDEX}
+  `);
+
+  await knex.raw(`
+    DROP INDEX IF EXISTS ${CONNECTSHYFT_SCHEMA}.${TENANT_RESOLVER_REVIEW_INDEX}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+      DROP CONSTRAINT IF EXISTS ${STATUS_CHECK}
+  `);
+
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+      ADD CONSTRAINT ${STATUS_CHECK}
+      CHECK (status IN ('pending', 'reviewed'))
+  `);
+
+  await knex.raw(`
+    ALTER TABLE ${CONNECTSHYFT_SCHEMA}.${AMBIGUITY_EVENTS_TABLE}
+      DROP COLUMN IF EXISTS resolver_outcome,
+      DROP COLUMN IF EXISTS resolver_consumed_at_utc,
+      DROP COLUMN IF EXISTS resolver_consumed_by_user_id,
+      DROP COLUMN IF EXISTS resolver_review_id
+  `);
+}


### PR DESCRIPTION
## Summary
- lock the PeopleCore resolver action set, lifecycle states, and central validation rules
- add the authoritative applyResolverDecision path with explicit action dispatch and reuse of the existing merge/rebind infrastructure
- consume ConnectShyft ambiguity events as a consequence of resolver outcomes and persist audit-safe resolver outcome data
- harden resolver and ambiguity API routes, add normalized resolver review list/detail transport shapes, and keep existing web consumers on contract-backed semantics only

## Testing
- backend combined Jest verification across PeopleCore resolver, ambiguity event, migration, route, and inbound SMS characterization coverage
- npm run build in apps/connectshyft-web
- npx vitest run src/features/connectshyft/__tests__/identityResolution.test.ts src/views/Shell/__tests__/PeopleView.test.ts src/views/ConnectShyft/__tests__/ConnectShyftThreadDetailView.test.ts
