### PR TITLE
Prep Step 2B: complete resolver operational surfaces

### DIFF
--- a/apps/connectshyft-api/jest.config.js
+++ b/apps/connectshyft-api/jest.config.js
@@ -30,6 +30,7 @@ module.exports = {
   },
   transformIgnorePatterns: ["/node_modules/(?!uuid)/"],
   moduleNameMapper: {
+    "^@shyft/contracts$": "<rootDir>/../../libs/contracts/src/index.ts",
     "^uuid$": "<rootDir>/src/__mocks__/uuid.ts",
   },
 };

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/personRebind.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/personRebind.test.ts
@@ -13,6 +13,7 @@ import {
   resetConnectShyftDeliveryAttemptStateForTests,
 } from '../deliveryAttempts';
 import {
+  listConnectShyftPersonRebindHistoryForTests,
   personRebindServiceAsync,
   resetConnectShyftPersonRebindStateForTests,
 } from '../personRebind';
@@ -329,6 +330,84 @@ describe('connectshyft person rebinding', () => {
 
     expect(secondThreadState).toEqual(firstThreadState);
     expect(secondCallState).toEqual(firstCallState);
+  });
+
+  it('deduplicates review-class rebind history and preserves merged review context', async () => {
+    const first = await personRebindServiceAsync.enqueueRebindReview({
+      tenantId,
+      orgUnitId,
+      provisionalPersonId,
+      canonicalPersonId,
+      performedByUserId,
+      affectedObjectType: 'contact_point_link',
+      affectedObjectIds: ['link-review-1'],
+      contactPointIds: ['contact-point-1'],
+      originatingResolverReviewId: 'resolver-review-1',
+      originatingResolutionType: 'merge_people',
+    });
+    const second = await personRebindServiceAsync.enqueueRebindReview({
+      tenantId,
+      orgUnitId,
+      provisionalPersonId,
+      canonicalPersonId,
+      performedByUserId,
+      affectedObjectType: 'contact_point_link',
+      affectedObjectIds: ['link-review-1', 'link-review-2'],
+      contactPointIds: ['contact-point-1', 'contact-point-2'],
+      originatingResolverReviewId: 'resolver-review-1',
+      originatingResolutionType: 'merge_people',
+    });
+
+    const history = listConnectShyftPersonRebindHistoryForTests();
+
+    expect(first.id).toBe(second.id);
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({
+      rebindClass: 'review',
+      provisionalPersonId,
+      canonicalPersonId,
+      reviewContext: {
+        rebindHistoryId: first.id,
+        affectedObjectType: 'contact_point_link',
+        affectedObjectIds: ['link-review-1', 'link-review-2'],
+        contactPointIds: ['contact-point-1', 'contact-point-2'],
+        sourcePersonId: provisionalPersonId,
+        targetPersonId: canonicalPersonId,
+        originatingResolverReviewId: 'resolver-review-1',
+        originatingResolutionType: 'merge_people',
+      },
+    });
+  });
+
+  it('loads structured review context for persisted review-class rebind history', async () => {
+    const history = await personRebindServiceAsync.enqueueRebindReview({
+      tenantId,
+      orgUnitId,
+      provisionalPersonId,
+      canonicalPersonId,
+      performedByUserId,
+      affectedObjectType: 'contact_point_link',
+      affectedObjectIds: ['link-review-detail-1'],
+      contactPointIds: ['contact-point-detail-1'],
+      originatingResolverReviewId: 'resolver-review-detail-1',
+      originatingResolutionType: 'merge_people',
+    });
+
+    const reviewContext = await personRebindServiceAsync.getRebindReviewContext({
+      tenantId,
+      rebindHistoryId: history.id,
+    });
+
+    expect(reviewContext).toEqual({
+      rebindHistoryId: history.id,
+      affectedObjectType: 'contact_point_link',
+      affectedObjectIds: ['link-review-detail-1'],
+      sourcePersonId: provisionalPersonId,
+      targetPersonId: canonicalPersonId,
+      contactPointIds: ['contact-point-detail-1'],
+      originatingResolverReviewId: 'resolver-review-detail-1',
+      originatingResolutionType: 'merge_people',
+    });
   });
 
   it('returns a unified, ordered timeline spanning canonical and merged person history with origin context', async () => {

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectThreadDetail.ts
@@ -1,4 +1,6 @@
 import { Request, Response } from 'express';
+import type { ConnectShyftThreadSubjectImpact } from '@shyft/contracts';
+import { isResolverReviewActiveStatus } from '@shyft/contracts';
 import { success } from '../../../platform/envelopes/response';
 import {
   listConnectShyftCanonicalEvents,
@@ -14,6 +16,11 @@ import {
   type ConnectShyftThreadDetailRecord,
 } from '../readContracts';
 import { loadConnectShyftPlatformDb } from '../http/accessContext';
+import {
+  isQueueBackedRebindReview,
+  peopleCoreServiceAsync,
+  resolveResolverQueueItemType,
+} from '../../peoplecore/service';
 import {
   buildConnectShyftThreadReadResponseContext,
   loadConnectShyftThreadReadContractAsync,
@@ -293,6 +300,101 @@ const resolveFallbackThreadDetail = (input: {
 const resolveThreadDetailActions = (thread: ConnectShyftThreadDetailRecord) =>
   [...resolveConnectShyftThreadActions(thread.state)];
 
+const matchesThreadIdentityImpact = (
+  thread: ConnectShyftThreadDetailRecord,
+  review: {
+    conversationId?: string;
+    provisionalPersonId?: string;
+    candidatePersonIds: string[];
+  },
+): boolean => {
+  const threadPersonId = normalizeString(thread.personId);
+  if (normalizeString(review.conversationId) === thread.threadId) {
+    return true;
+  }
+
+  if (!threadPersonId) {
+    return false;
+  }
+
+  return normalizeString(review.provisionalPersonId) === threadPersonId
+    || review.candidatePersonIds.includes(threadPersonId);
+};
+
+const resolveThreadSubjectImpact = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  thread: ConnectShyftThreadDetailRecord;
+}): Promise<ConnectShyftThreadSubjectImpact | null> => {
+  const threadPersonId = normalizeString(input.thread.personId);
+  let activeReviews: Awaited<ReturnType<typeof peopleCoreServiceAsync.listResolverReviews>> = [];
+
+  try {
+    activeReviews = (await peopleCoreServiceAsync.listResolverReviews({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+    })).filter((review) => isResolverReviewActiveStatus(review.reviewStatus));
+  } catch (_error) {
+    return input.thread.identityState === 'provisional'
+      ? {
+        impactType: 'provisional_identity',
+        actionable: false,
+        resolverQueueItemId: null,
+        resolverQueueItemType: null,
+      }
+      : null;
+  }
+
+  const activeIdentityReview = activeReviews.find((review) =>
+    !isQueueBackedRebindReview(review)
+    && matchesThreadIdentityImpact(input.thread, review));
+  if (activeIdentityReview) {
+    return {
+      impactType: 'resolver_required',
+      actionable: activeIdentityReview.reviewStatus !== 'waiting_for_more_info',
+      resolverQueueItemId: activeIdentityReview.id,
+      resolverQueueItemType: resolveResolverQueueItemType(activeIdentityReview),
+    };
+  }
+
+  if (threadPersonId) {
+    const activeRebindReview = activeReviews.find((review) =>
+      isQueueBackedRebindReview(review)
+      && (
+        normalizeString(review.provisionalPersonId) === threadPersonId
+        || review.candidatePersonIds.includes(threadPersonId)
+      ));
+    if (activeRebindReview) {
+      return {
+        impactType: 'rebind_review',
+        actionable: activeRebindReview.reviewStatus !== 'waiting_for_more_info',
+        resolverQueueItemId: activeRebindReview.id,
+        resolverQueueItemType: resolveResolverQueueItemType(activeRebindReview),
+      };
+    }
+  }
+
+  if (input.thread.identityState === 'provisional') {
+    return {
+      impactType: 'provisional_identity',
+      actionable: false,
+      resolverQueueItemId: null,
+      resolverQueueItemType: null,
+    };
+  }
+
+  return null;
+};
+
+export const enrichThreadDetailWithSubjectImpact = async (input: {
+  tenantId: string;
+  orgUnitId: string;
+  thread: ConnectShyftThreadDetailRecord;
+}): Promise<ConnectShyftThreadDetailRecord> => ({
+  ...input.thread,
+  subjectImpact: await resolveThreadSubjectImpact(input),
+});
+
 export const getConnectThreadDetail = async (req: Request, res: Response) => {
   const readContext = await resolveConnectShyftThreadDetailReadAccessContext(req, res);
   if (!readContext) {
@@ -321,6 +423,11 @@ export const getConnectThreadDetail = async (req: Request, res: Response) => {
       ? []
       : resolveThreadDetailActions(thread),
   };
+  thread = await enrichThreadDetailWithSubjectImpact({
+    tenantId: readContext.context.tenantId,
+    orgUnitId: readContext.context.orgUnitId,
+    thread,
+  });
 
   const timeline = await listCanonicalThreadEvents({
     tenantId: readContext.context.tenantId,

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/index.ts
@@ -9,7 +9,10 @@ export { getConnectNumberMappings } from './getConnectNumberMappings';
 export { getConnectOperatorCallbackNumber } from './getConnectOperatorCallbackNumber';
 export { getConnectSettingsNavigation } from './getConnectSettingsNavigation';
 export { getConnectTelephonyReadiness } from './getConnectTelephonyReadiness';
-export { getConnectThreadDetail } from './getConnectThreadDetail';
+export {
+  enrichThreadDetailWithSubjectImpact,
+  getConnectThreadDetail,
+} from './getConnectThreadDetail';
 export { getConnectThreadTimeline } from './getConnectThreadTimeline';
 export { getConnectWebhookReceiptMetrics } from './getConnectWebhookReceiptMetrics';
 export { deleteConnectNeighbor } from './deleteConnectNeighbor';

--- a/apps/connectshyft-api/src/modules/connectshyft/personRebind.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/personRebind.ts
@@ -1,4 +1,10 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import type {
+  ConnectShyftRebindReviewAffectedObjectType,
+  ConnectShyftRebindReviewContext,
+  ResolverActionType,
+} from '@shyft/contracts';
+import { isConnectShyftRebindReviewAffectedObjectType } from '@shyft/contracts';
 import type { Knex } from 'knex';
 import db from '../../config/knex';
 import { peopleCoreServiceAsync } from '../peoplecore/service';
@@ -43,6 +49,7 @@ const PERSON_REBIND_HISTORY_UNIQUE_INDEX = [
   'canonical_person_id',
   'rebind_class',
 ];
+const PERSON_REBIND_REVIEW_HISTORY_NAMESPACE = 'a275e6c3-bc1c-56c4-b5bd-01ef8217164c';
 
 export type RebindPersonThreadsInput = {
   tenantId: string;
@@ -50,6 +57,31 @@ export type RebindPersonThreadsInput = {
   provisionalPersonId: string;
   canonicalPersonId: string;
   performedByUserId: string;
+};
+
+export type EnqueueRebindReviewInput = {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+  performedByUserId: string;
+  affectedObjectType: ConnectShyftRebindReviewAffectedObjectType;
+  affectedObjectIds: string[];
+  contactPointIds?: string[];
+  originatingResolverReviewId?: string | null;
+  originatingResolutionType?: ResolverActionType | null;
+};
+
+export type PersonRebindHistoryRecord = {
+  id: string;
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+  rebindClass: 'auto' | 'review';
+  performedByUserId: string;
+  createdAtUtc: string;
+  reviewContext: ConnectShyftRebindReviewContext | null;
 };
 
 export type UnifiedPersonTimelineItem = ConnectShyftThreadTimelineItem & {
@@ -68,30 +100,139 @@ export type UnifiedPersonTimeline = {
 
 export type PersonRebindService = {
   rebindPersonThreads(input: RebindPersonThreadsInput): Promise<void>;
+  enqueueRebindReview(input: EnqueueRebindReviewInput): Promise<PersonRebindHistoryRecord>;
+  getRebindReviewContext(input: {
+    tenantId: string;
+    rebindHistoryId: string;
+  }): Promise<ConnectShyftRebindReviewContext | null>;
   projectUnifiedTimeline(input: {
     tenantId: string;
     personId: string;
   }): Promise<UnifiedPersonTimeline>;
 };
 
-type PersistedPersonRebindHistoryRecord = {
-  tenantId: string;
-  orgUnitId: string;
-  provisionalPersonId: string;
-  canonicalPersonId: string;
-  performedByUserId: string;
+type PersistedPersonRebindHistoryRecord = PersonRebindHistoryRecord;
+
+type PersonRebindReviewNotes = {
+  affectedObjectType: ConnectShyftRebindReviewAffectedObjectType;
+  affectedObjectIds: string[];
+  contactPointIds: string[];
+  originatingResolverReviewId: string | null;
+  originatingResolutionType: ResolverActionType | null;
+};
+
+type DbPersonRebindHistoryRow = {
+  id: string;
+  tenant_id: string;
+  org_unit_id: string;
+  provisional_person_id: string;
+  canonical_person_id: string;
+  rebind_class: 'auto' | 'review';
+  performed_by_user_id: string;
+  created_at_utc: string | Date;
+  notes: string | null;
 };
 
 const persistedPersonRebindHistoryForTests: PersistedPersonRebindHistoryRecord[] = [];
+
+const normalizeOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const uniqueSortedStrings = (values: Iterable<string | null | undefined>): string[] =>
+  Array.from(
+    new Set(
+      Array.from(values)
+        .map((value) => normalizeOptionalString(value))
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ).sort((left, right) => left.localeCompare(right));
+
+const toIsoUtc = (value: unknown): string => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return new Date().toISOString();
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? new Date().toISOString() : parsed.toISOString();
+};
+
+const cloneRebindReviewContext = (
+  reviewContext: ConnectShyftRebindReviewContext,
+): ConnectShyftRebindReviewContext => ({
+  ...reviewContext,
+  affectedObjectIds: [...reviewContext.affectedObjectIds],
+  contactPointIds: [...reviewContext.contactPointIds],
+});
+
+const clonePersonRebindHistoryRecord = (
+  record: PersonRebindHistoryRecord,
+): PersonRebindHistoryRecord => ({
+  ...record,
+  reviewContext: record.reviewContext
+    ? cloneRebindReviewContext(record.reviewContext)
+    : null,
+});
 
 const buildPersonRebindHistoryKey = (input: {
   tenantId: string;
   orgUnitId: string;
   provisionalPersonId: string;
   canonicalPersonId: string;
+  rebindClass: 'auto' | 'review';
 }): string => (
-  `${input.tenantId}:${input.orgUnitId}:${input.provisionalPersonId}:${input.canonicalPersonId}`
+  [
+    input.tenantId,
+    input.orgUnitId,
+    input.provisionalPersonId,
+    input.canonicalPersonId,
+    input.rebindClass,
+  ].join(':')
 );
+
+const buildPersonRebindReviewHistoryId = (input: {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+}): string => (
+  buildDeterministicUuid(
+    PERSON_REBIND_REVIEW_HISTORY_NAMESPACE,
+    buildPersonRebindHistoryKey({
+      ...input,
+      rebindClass: 'review',
+    }),
+  )
+);
+
+const buildDeterministicUuid = (namespace: string, value: string): string => {
+  const digest = createHash('sha1')
+    .update(`${namespace}:${value}`)
+    .digest('hex')
+    .slice(0, 32)
+    .split('');
+
+  digest[12] = '5';
+  digest[16] = ((parseInt(digest[16] || '0', 16) & 0x3) | 0x8).toString(16);
+
+  return [
+    digest.slice(0, 8).join(''),
+    digest.slice(8, 12).join(''),
+    digest.slice(12, 16).join(''),
+    digest.slice(16, 20).join(''),
+    digest.slice(20, 32).join(''),
+  ].join('-');
+};
 
 const compareUnifiedTimelineItems = (
   left: UnifiedPersonTimelineItem,
@@ -162,26 +303,204 @@ const buildRebindInputs = (
   },
 });
 
-const hasPersistedRebindHistoryForTests = (input: RebindPersonThreadsInput): boolean => {
+const parseRebindReviewNotes = (value: unknown): PersonRebindReviewNotes | null => {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(normalized) as Record<string, unknown>;
+    if (!isConnectShyftRebindReviewAffectedObjectType(parsed.affectedObjectType)) {
+      return null;
+    }
+
+    const originatingResolutionType = normalizeOptionalString(parsed.originatingResolutionType);
+
+    return {
+      affectedObjectType: parsed.affectedObjectType,
+      affectedObjectIds: uniqueSortedStrings(
+        Array.isArray(parsed.affectedObjectIds) ? parsed.affectedObjectIds : [],
+      ),
+      contactPointIds: uniqueSortedStrings(
+        Array.isArray(parsed.contactPointIds) ? parsed.contactPointIds : [],
+      ),
+      originatingResolverReviewId: normalizeOptionalString(parsed.originatingResolverReviewId) ?? null,
+      originatingResolutionType: (originatingResolutionType as ResolverActionType | undefined) ?? null,
+    };
+  } catch (_error) {
+    return null;
+  }
+};
+
+const serializeRebindReviewNotes = (notes: PersonRebindReviewNotes): string => JSON.stringify({
+  affectedObjectType: notes.affectedObjectType,
+  affectedObjectIds: notes.affectedObjectIds,
+  contactPointIds: notes.contactPointIds,
+  originatingResolverReviewId: notes.originatingResolverReviewId,
+  originatingResolutionType: notes.originatingResolutionType,
+});
+
+const mergeRebindReviewNotes = (
+  existingNotes: PersonRebindReviewNotes | null,
+  input: EnqueueRebindReviewInput,
+): PersonRebindReviewNotes => ({
+  affectedObjectType: existingNotes?.affectedObjectType ?? input.affectedObjectType,
+  affectedObjectIds: uniqueSortedStrings([
+    ...(existingNotes?.affectedObjectIds ?? []),
+    ...input.affectedObjectIds,
+  ]),
+  contactPointIds: uniqueSortedStrings([
+    ...(existingNotes?.contactPointIds ?? []),
+    ...(input.contactPointIds ?? []),
+  ]),
+  originatingResolverReviewId: existingNotes?.originatingResolverReviewId
+    ?? normalizeOptionalString(input.originatingResolverReviewId)
+    ?? null,
+  originatingResolutionType: existingNotes?.originatingResolutionType
+    ?? input.originatingResolutionType
+    ?? null,
+});
+
+const buildRebindReviewContext = (
+  row: Pick<
+    PersonRebindHistoryRecord,
+    'id' | 'provisionalPersonId' | 'canonicalPersonId' | 'rebindClass'
+  >,
+  notes: PersonRebindReviewNotes | null,
+): ConnectShyftRebindReviewContext | null => {
+  if (row.rebindClass !== 'review' || !notes) {
+    return null;
+  }
+
+  return {
+    rebindHistoryId: row.id,
+    affectedObjectType: notes.affectedObjectType,
+    affectedObjectIds: [...notes.affectedObjectIds],
+    sourcePersonId: row.provisionalPersonId,
+    targetPersonId: row.canonicalPersonId,
+    contactPointIds: [...notes.contactPointIds],
+    originatingResolverReviewId: notes.originatingResolverReviewId,
+    originatingResolutionType: notes.originatingResolutionType,
+  };
+};
+
+const mapPersonRebindHistoryRow = (
+  row: DbPersonRebindHistoryRow,
+): PersonRebindHistoryRecord => {
+  const baseRecord: PersonRebindHistoryRecord = {
+    id: row.id,
+    tenantId: row.tenant_id,
+    orgUnitId: row.org_unit_id,
+    provisionalPersonId: row.provisional_person_id,
+    canonicalPersonId: row.canonical_person_id,
+    rebindClass: row.rebind_class,
+    performedByUserId: row.performed_by_user_id,
+    createdAtUtc: toIsoUtc(row.created_at_utc),
+    reviewContext: null,
+  };
+
+  return {
+    ...baseRecord,
+    reviewContext: buildRebindReviewContext(baseRecord, parseRebindReviewNotes(row.notes)),
+  };
+};
+
+const findPersistedRebindHistoryForTests = (input: {
+  tenantId: string;
+  orgUnitId: string;
+  provisionalPersonId: string;
+  canonicalPersonId: string;
+  rebindClass: 'auto' | 'review';
+}): PersistedPersonRebindHistoryRecord | undefined => {
   const rebindKey = buildPersonRebindHistoryKey(input);
 
-  return persistedPersonRebindHistoryForTests.some((record) => (
+  return persistedPersonRebindHistoryForTests.find((record) => (
     buildPersonRebindHistoryKey(record) === rebindKey
   ));
 };
 
-const appendPersistedRebindHistoryForTests = (input: RebindPersonThreadsInput): void => {
-  if (hasPersistedRebindHistoryForTests(input)) {
+const hasPersistedAutoRebindHistoryForTests = (input: RebindPersonThreadsInput): boolean => (
+  Boolean(findPersistedRebindHistoryForTests({
+    ...input,
+    rebindClass: 'auto',
+  }))
+);
+
+const appendPersistedAutoRebindHistoryForTests = (input: RebindPersonThreadsInput): void => {
+  if (hasPersistedAutoRebindHistoryForTests(input)) {
     return;
   }
 
   persistedPersonRebindHistoryForTests.push({
+    id: randomUUID(),
     tenantId: input.tenantId,
     orgUnitId: input.orgUnitId,
     provisionalPersonId: input.provisionalPersonId,
     canonicalPersonId: input.canonicalPersonId,
+    rebindClass: 'auto',
     performedByUserId: input.performedByUserId,
+    createdAtUtc: new Date().toISOString(),
+    reviewContext: null,
   });
+};
+
+const upsertPersistedReviewRebindHistoryForTests = (
+  input: EnqueueRebindReviewInput,
+): PersonRebindHistoryRecord => {
+  const existingRecord = findPersistedRebindHistoryForTests({
+    ...input,
+    rebindClass: 'review',
+  });
+  const mergedNotes = mergeRebindReviewNotes(existingRecord?.reviewContext
+    ? {
+      affectedObjectType: existingRecord.reviewContext.affectedObjectType,
+      affectedObjectIds: existingRecord.reviewContext.affectedObjectIds,
+      contactPointIds: existingRecord.reviewContext.contactPointIds,
+      originatingResolverReviewId: existingRecord.reviewContext.originatingResolverReviewId,
+      originatingResolutionType: existingRecord.reviewContext.originatingResolutionType,
+    }
+    : null, input);
+
+  if (existingRecord) {
+    existingRecord.performedByUserId = input.performedByUserId;
+    existingRecord.reviewContext = buildRebindReviewContext(existingRecord, mergedNotes);
+    return clonePersonRebindHistoryRecord(existingRecord);
+  }
+
+  const record: PersistedPersonRebindHistoryRecord = {
+    id: buildPersonRebindReviewHistoryId(input),
+    tenantId: input.tenantId,
+    orgUnitId: input.orgUnitId,
+    provisionalPersonId: input.provisionalPersonId,
+    canonicalPersonId: input.canonicalPersonId,
+    rebindClass: 'review',
+    performedByUserId: input.performedByUserId,
+    createdAtUtc: new Date().toISOString(),
+    reviewContext: buildRebindReviewContext({
+      id: buildPersonRebindReviewHistoryId(input),
+      provisionalPersonId: input.provisionalPersonId,
+      canonicalPersonId: input.canonicalPersonId,
+      rebindClass: 'review',
+    }, mergedNotes),
+  };
+  persistedPersonRebindHistoryForTests.push(record);
+  return clonePersonRebindHistoryRecord(record);
+};
+
+const findPersistedRebindReviewContextForTests = (input: {
+  tenantId: string;
+  rebindHistoryId: string;
+}): ConnectShyftRebindReviewContext | null => {
+  const record = persistedPersonRebindHistoryForTests.find((candidate) => (
+    candidate.tenantId === input.tenantId
+    && candidate.id === input.rebindHistoryId
+    && candidate.rebindClass === 'review'
+  ));
+
+  return record?.reviewContext
+    ? cloneRebindReviewContext(record.reviewContext)
+    : null;
 };
 
 const resolveUnifiedTimelinePersonIds = async (input: {
@@ -218,7 +537,7 @@ const buildPersonRebindService = (
 ): PersonRebindService => ({
   async rebindPersonThreads(input) {
     if (isConnectShyftTestOverrideEnabled()) {
-      if (hasPersistedRebindHistoryForTests(input)) {
+      if (hasPersistedAutoRebindHistoryForTests(input)) {
         return;
       }
 
@@ -230,7 +549,7 @@ const buildPersonRebindService = (
         rebindInputs.deliveryAttempts,
       );
       await rebindConnectShyftBridgeSessionPersonsAsync(rebindInputs.bridgeSessions);
-      appendPersistedRebindHistoryForTests(input);
+      appendPersistedAutoRebindHistoryForTests(input);
       return;
     }
 
@@ -264,6 +583,141 @@ const buildPersonRebindService = (
         .onConflict(PERSON_REBIND_HISTORY_UNIQUE_INDEX)
         .ignore();
     });
+  },
+
+  async enqueueRebindReview(input) {
+    const normalizedInput: EnqueueRebindReviewInput = {
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      provisionalPersonId: input.provisionalPersonId,
+      canonicalPersonId: input.canonicalPersonId,
+      performedByUserId: input.performedByUserId,
+      affectedObjectType: input.affectedObjectType,
+      affectedObjectIds: uniqueSortedStrings(input.affectedObjectIds),
+      contactPointIds: uniqueSortedStrings(input.contactPointIds ?? []),
+      originatingResolverReviewId: normalizeOptionalString(input.originatingResolverReviewId) ?? null,
+      originatingResolutionType: input.originatingResolutionType ?? null,
+    };
+
+    if (normalizedInput.affectedObjectIds.length === 0) {
+      throw new Error('Review-class rebind work requires at least one affected object.');
+    }
+
+    if (isConnectShyftTestOverrideEnabled()) {
+      return upsertPersistedReviewRebindHistoryForTests(normalizedInput);
+    }
+
+    return knexClient.transaction(async (trx) => {
+      const scope = {
+        tenant_id: normalizedInput.tenantId,
+        org_unit_id: normalizedInput.orgUnitId,
+        provisional_person_id: normalizedInput.provisionalPersonId,
+        canonical_person_id: normalizedInput.canonicalPersonId,
+        rebind_class: 'review' as const,
+      };
+      const proposedNotes = mergeRebindReviewNotes(null, normalizedInput);
+
+      await trx
+        .withSchema(CONNECTSHYFT_SCHEMA)
+        .table(PERSON_REBIND_HISTORY_TABLE)
+        .insert({
+          id: buildPersonRebindReviewHistoryId(normalizedInput),
+          ...scope,
+          performed_by_user_id: normalizedInput.performedByUserId,
+          notes: serializeRebindReviewNotes(proposedNotes),
+        })
+        .onConflict(PERSON_REBIND_HISTORY_UNIQUE_INDEX)
+        .ignore();
+
+      const existingRow = await trx
+        .withSchema(CONNECTSHYFT_SCHEMA)
+        .table(PERSON_REBIND_HISTORY_TABLE)
+        .where(scope)
+        .first<DbPersonRebindHistoryRow>([
+          'id',
+          'tenant_id',
+          'org_unit_id',
+          'provisional_person_id',
+          'canonical_person_id',
+          'rebind_class',
+          'performed_by_user_id',
+          'created_at_utc',
+          'notes',
+        ]);
+
+      if (!existingRow) {
+        throw new Error('Unable to load persisted review-class rebind history.');
+      }
+
+      const mergedNotes = mergeRebindReviewNotes(
+        parseRebindReviewNotes(existingRow.notes),
+        normalizedInput,
+      );
+      const serializedMergedNotes = serializeRebindReviewNotes(mergedNotes);
+
+      if (existingRow.notes !== serializedMergedNotes) {
+        const [updatedRow] = await trx
+          .withSchema(CONNECTSHYFT_SCHEMA)
+          .table(PERSON_REBIND_HISTORY_TABLE)
+          .where({ id: existingRow.id })
+          .update({
+            performed_by_user_id: normalizedInput.performedByUserId,
+            notes: serializedMergedNotes,
+          })
+          .returning<DbPersonRebindHistoryRow[]>([
+            'id',
+            'tenant_id',
+            'org_unit_id',
+            'provisional_person_id',
+            'canonical_person_id',
+            'rebind_class',
+            'performed_by_user_id',
+            'created_at_utc',
+            'notes',
+          ]);
+
+        return mapPersonRebindHistoryRow(updatedRow);
+      }
+
+      return mapPersonRebindHistoryRow(existingRow);
+    });
+  },
+
+  async getRebindReviewContext(input) {
+    const tenantId = normalizeOptionalString(input.tenantId);
+    const rebindHistoryId = normalizeOptionalString(input.rebindHistoryId);
+    if (!tenantId || !rebindHistoryId) {
+      return null;
+    }
+
+    if (isConnectShyftTestOverrideEnabled()) {
+      return findPersistedRebindReviewContextForTests({
+        tenantId,
+        rebindHistoryId,
+      });
+    }
+
+    const row = await knexClient
+      .withSchema(CONNECTSHYFT_SCHEMA)
+      .table(PERSON_REBIND_HISTORY_TABLE)
+      .where({
+        tenant_id: tenantId,
+        id: rebindHistoryId,
+        rebind_class: 'review',
+      })
+      .first<DbPersonRebindHistoryRow>([
+        'id',
+        'tenant_id',
+        'org_unit_id',
+        'provisional_person_id',
+        'canonical_person_id',
+        'rebind_class',
+        'performed_by_user_id',
+        'created_at_utc',
+        'notes',
+      ]);
+
+    return row ? mapPersonRebindHistoryRow(row).reviewContext : null;
   },
 
   async projectUnifiedTimeline(input) {
@@ -303,6 +757,9 @@ const buildPersonRebindService = (
 });
 
 export const personRebindServiceAsync = buildPersonRebindService();
+
+export const listConnectShyftPersonRebindHistoryForTests = (): PersonRebindHistoryRecord[] =>
+  persistedPersonRebindHistoryForTests.map(clonePersonRebindHistoryRecord);
 
 export const resetConnectShyftPersonRebindStateForTests = (): void => {
   persistedPersonRebindHistoryForTests.splice(0, persistedPersonRebindHistoryForTests.length);

--- a/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
@@ -1,4 +1,5 @@
 import type { Knex } from 'knex';
+import type { ConnectShyftThreadSubjectImpact } from '@shyft/contracts';
 import {
   type SubjectContext,
   validateSubjectContext,
@@ -75,6 +76,7 @@ export type ConnectShyftThreadSummaryRecord = {
 export type ConnectShyftThreadDetailRecord = ConnectShyftThreadSummaryRecord & {
   personId: string | null;
   identityState: ConnectShyftThreadIdentityState | null;
+  subjectImpact: ConnectShyftThreadSubjectImpact | null;
   subjectContext: SubjectContext;
   actions: readonly ConnectShyftThreadAction[];
   lifecycle: {
@@ -982,6 +984,7 @@ const buildThreadIdentityProjection = (input: {
 }): {
   personId: string | null;
   identityState: ConnectShyftThreadIdentityState | null;
+  subjectImpact: ConnectShyftThreadSubjectImpact | null;
   subjectContext: SubjectContext;
 } => {
   const personId = normalizeOptionalString(input.personId);
@@ -994,6 +997,7 @@ const buildThreadIdentityProjection = (input: {
   return {
     personId,
     identityState,
+    subjectImpact: null,
     subjectContext: buildThreadSubjectContext({
       orgUnitId: input.orgUnitId,
       personId,

--- a/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
@@ -135,6 +135,21 @@ const buildResolvedReviewForAction = (
   ...overrides,
 });
 
+const buildRebindQueueReview = (overrides: Record<string, unknown> = {}) => buildResolverReview({
+  id: 'review-rebind-1',
+  reviewType: 'subject_reassignment_review' as const,
+  reviewStatus: 'queued' as const,
+  triggerSourceType: 'connectshyft_person_rebind_review',
+  triggerSourceId: 'rebind-history-1',
+  provisionalPersonId: 'person-provisional',
+  candidatePersonIds: ['person-canonical'],
+  contactPointId: 'contact-point-1',
+  confidenceBand: 'medium' as const,
+  confidenceReasons: ['Manual subject reassignment review is required.'],
+  riskFlags: [],
+  ...overrides,
+});
+
 const createApplyResolverDecisionStore = (overrides: Record<string, jest.Mock> = {}) => ({
   getResolverReview: jest.fn(),
   listCurrentContactPointLinks: jest.fn(),
@@ -406,6 +421,127 @@ describe('AsyncPeopleCoreService', () => {
         actionable: true,
       }),
     ]);
+  });
+
+  it('includes rebind_review items in the active resolver queue', async () => {
+    const identityReview = buildDecisionReview({
+      id: 'review-identity',
+    });
+    const rebindReview = buildRebindQueueReview({
+      id: 'review-rebind',
+    });
+    const store = {
+      listResolverReviews: jest.fn(async () => [identityReview, rebindReview]),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const items = await service.listResolverQueue({
+      tenantId: 'tenant-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
+    });
+
+    expect(items).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'review-identity',
+        itemType: 'identity_review',
+      }),
+      expect.objectContaining({
+        id: 'review-rebind',
+        itemType: 'rebind_review',
+        contactPointId: 'contact-point-1',
+        personIds: ['person-provisional', 'person-canonical'],
+      }),
+    ]));
+  });
+
+  it('returns structured rebind review detail from queue-backed history context', async () => {
+    const rebindReview = buildRebindQueueReview({
+      id: 'review-rebind-detail',
+      triggerSourceId: 'rebind-history-detail',
+    });
+    const reviewContext = {
+      rebindHistoryId: 'rebind-history-detail',
+      affectedObjectType: 'contact_point_link' as const,
+      affectedObjectIds: ['link-review-1'],
+      sourcePersonId: 'person-provisional',
+      targetPersonId: 'person-canonical',
+      contactPointIds: ['contact-point-1'],
+      originatingResolverReviewId: 'resolver-review-1',
+      originatingResolutionType: 'merge_people' as const,
+    };
+    const store = {
+      getResolverReview: jest.fn(async () => rebindReview),
+    };
+    jest.spyOn(personRebindServiceAsync, 'getRebindReviewContext').mockResolvedValue(reviewContext);
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const detail = await service.getResolverQueueItemDetail({
+      tenantId: 'tenant-1',
+      itemType: 'rebind_review',
+      itemId: 'review-rebind-detail',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
+    });
+
+    expect(detail).toMatchObject({
+      item: {
+        id: 'review-rebind-detail',
+        itemType: 'rebind_review',
+      },
+      review: {
+        reviewType: 'subject_reassignment_review',
+      },
+      rebindReview: reviewContext,
+    });
+  });
+
+  it('claims rebind_review queue items through the shared claim lifecycle', async () => {
+    const currentReview = buildRebindQueueReview({
+      reviewStatus: 'queued',
+      assignedResolverUserId: undefined,
+      startedAt: undefined,
+    });
+    const updatedReview = buildRebindQueueReview({
+      reviewStatus: 'in_review',
+      assignedResolverUserId: 'resolver-1',
+      startedAt: '2026-03-21T12:20:00.000Z',
+    });
+    const store = {
+      getResolverReview: jest.fn(async () => currentReview),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    };
+    jest.spyOn(personRebindServiceAsync, 'getRebindReviewContext').mockResolvedValue({
+      rebindHistoryId: 'rebind-history-1',
+      affectedObjectType: 'contact_point_link',
+      affectedObjectIds: ['link-review-1'],
+      sourcePersonId: 'person-provisional',
+      targetPersonId: 'person-canonical',
+      contactPointIds: ['contact-point-1'],
+      originatingResolverReviewId: 'resolver-review-1',
+      originatingResolutionType: 'merge_people',
+    });
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const detail = await service.claimResolverQueueItem({
+      tenantId: 'tenant-1',
+      itemType: 'rebind_review',
+      itemId: 'review-rebind-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
+    });
+
+    expect(store.updateResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      reviewId: 'review-rebind-1',
+      reviewStatus: 'in_review',
+      assignedResolverUserId: 'resolver-1',
+    }));
+    expect(detail.item).toMatchObject({
+      itemType: 'rebind_review',
+      claimState: 'claimed_by_current_user',
+      claimedByCurrentUser: true,
+    });
   });
 
   it('lets a tenant-admin resolver claim an unclaimed queue item', async () => {
@@ -854,6 +990,102 @@ describe('AsyncPeopleCoreService', () => {
       rebindTriggered: true,
       affectedPersonIds: ['person-provisional', 'person-canonical'],
     });
+  });
+
+  it('operationalizes review-class merge consequences as deduped rebind_review queue work', async () => {
+    const rebindHistory = {
+      id: 'rebind-history-1',
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      provisionalPersonId: 'person-provisional',
+      canonicalPersonId: 'person-canonical',
+      rebindClass: 'review' as const,
+      performedByUserId: 'resolver-1',
+      createdAtUtc: '2026-03-21T12:15:00.000Z',
+      reviewContext: {
+        rebindHistoryId: 'rebind-history-1',
+        affectedObjectType: 'contact_point_link' as const,
+        affectedObjectIds: ['link-review-1'],
+        sourcePersonId: 'person-provisional',
+        targetPersonId: 'person-canonical',
+        contactPointIds: ['contact-point-1'],
+        originatingResolverReviewId: 'review-merge',
+        originatingResolutionType: 'merge_people' as const,
+      },
+    };
+    const store = {
+      mergePerson: jest.fn()
+        .mockResolvedValueOnce({
+          mergedProvisionalPersonId: 'person-provisional',
+          canonicalPersonId: 'person-canonical',
+          autoMergedContactPointLinkIds: [],
+          reviewContactPointLinkIds: ['link-review-1'],
+          resolverReviewId: 'review-merge',
+          didPersistMerge: true,
+        })
+        .mockResolvedValueOnce({
+          mergedProvisionalPersonId: 'person-provisional',
+          canonicalPersonId: 'person-canonical',
+          autoMergedContactPointLinkIds: [],
+          reviewContactPointLinkIds: ['link-review-1'],
+          resolverReviewId: 'review-merge',
+          didPersistMerge: false,
+        }),
+      listContactPointLinks: jest.fn(async () => [
+        buildContactPointLink('person-provisional', {
+          id: 'link-review-1',
+          contactPointId: 'contact-point-1',
+        }),
+      ]),
+      getResolverReview: jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(buildRebindQueueReview({
+          id: 'generated-rebind-review-id',
+          triggerSourceId: 'rebind-history-1',
+        })),
+      createResolverReview: jest.fn(async (input) => buildRebindQueueReview({
+        id: input.reviewId,
+        triggerSourceId: String(input.triggerSourceId),
+      })),
+    };
+    const mergeEventPublisher = {
+      publishPersonMerged: jest.fn(async () => undefined),
+    };
+    const enqueueSpy = jest.spyOn(personRebindServiceAsync, 'enqueueRebindReview')
+      .mockResolvedValue(rebindHistory);
+    const service = new AsyncPeopleCoreService(store as any, mergeEventPublisher as any);
+
+    await service.mergePerson({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      provisionalPersonId: 'person-provisional',
+      canonicalPersonId: 'person-canonical',
+      performedByUserId: 'resolver-1',
+      mergeReason: 'Merge review consequence cleanup.',
+    });
+    await service.mergePerson({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      provisionalPersonId: 'person-provisional',
+      canonicalPersonId: 'person-canonical',
+      performedByUserId: 'resolver-1',
+      mergeReason: 'Merge review consequence cleanup.',
+    });
+
+    expect(enqueueSpy).toHaveBeenCalledTimes(2);
+    expect(store.createResolverReview).toHaveBeenCalledTimes(1);
+    expect(store.createResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      orgUnitId: 'org-1',
+      reviewType: 'subject_reassignment_review',
+      reviewStatus: 'queued',
+      triggerSourceType: 'connectshyft_person_rebind_review',
+      triggerSourceId: 'rebind-history-1',
+      provisionalPersonId: 'person-provisional',
+      candidatePersonIds: ['person-canonical'],
+      contactPointId: 'contact-point-1',
+    }));
+    expect(mergeEventPublisher.publishPersonMerged).toHaveBeenCalledTimes(1);
   });
 
   it('applies link_without_merge without merge or broad rebind fanout', async () => {

--- a/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
@@ -13,6 +13,9 @@ import {
   ContactPointLifecycleComputationError,
   InvalidResolverReviewTransitionError,
   PeopleCorePersistenceUnavailableError,
+  ResolverQueueAuthorizationError,
+  ResolverQueueClaimConflictError,
+  ResolverQueueClaimRequiredError,
   ResolverReviewValidationError,
   validateResolverDecisionInput,
 } from '../service';
@@ -33,6 +36,9 @@ const HOUSEHOLD_INPUT = {
   name: 'Lovelace Home',
   status: 'active' as const,
 };
+
+const TENANT_ADMIN_ACTOR_ROLES = ['TENANT_ADMIN'];
+const TENANT_STAFF_ACTOR_ROLES = ['TENANT_STAFF'];
 
 const CONTACT_POINT_INPUT = {
   tenantId: 'tenant-1',
@@ -108,6 +114,9 @@ const buildContactPointLink = (subjectId: string, overrides: Record<string, unkn
 });
 
 const buildDecisionReview = (overrides: Record<string, unknown> = {}) => buildResolverReview({
+  reviewStatus: 'in_review',
+  assignedResolverUserId: 'resolver-1',
+  startedAt: '2026-03-21T12:05:00.000Z',
   contactPointId: 'contact-point-1',
   provisionalPersonId: 'person-provisional',
   candidatePersonIds: ['person-existing'],
@@ -277,6 +286,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action,
       ...(action === 'confirm_existing_person' ? { personId: 'person-1' } : {}),
       ...(action === 'confirm_new_person' ? { provisionalPersonId: 'person-provisional' } : {}),
@@ -296,6 +306,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'maybe_merge_later' as any,
     })).toThrow(ResolverReviewValidationError);
   });
@@ -330,6 +341,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'merge_people',
       sourcePersonId: 'person-1',
       targetPersonId: 'person-1',
@@ -341,6 +353,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'dismiss_no_action',
     })).toThrow(ResolverReviewValidationError);
   });
@@ -350,12 +363,218 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'confirm_new_person',
       provisionalPersonId: 'person-provisional',
     })).toMatchObject({
       personId: 'person-provisional',
       action: 'confirm_new_person',
     });
+  });
+
+  it('lists active resolver queue items and excludes terminal items by default', async () => {
+    const activeReview = buildDecisionReview({
+      id: 'review-active',
+    });
+    const terminalReview = buildResolvedReviewForAction('confirm_existing_person', {
+      id: 'review-terminal',
+    });
+    const store = {
+      listResolverReviews: jest.fn(async () => [activeReview, terminalReview]),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const items = await service.listResolverQueue({
+      tenantId: 'tenant-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
+    });
+
+    expect(store.listResolverReviews).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      orgUnitId: undefined,
+    });
+    expect(items).toEqual([
+      expect.objectContaining({
+        id: 'review-active',
+        itemType: 'identity_review',
+        status: 'in_review',
+        active: true,
+        terminal: false,
+        claimState: 'claimed_by_current_user',
+        claimedByCurrentUser: true,
+        actionable: true,
+      }),
+    ]);
+  });
+
+  it('lets a tenant-admin resolver claim an unclaimed queue item', async () => {
+    const currentReview = buildDecisionReview({
+      reviewStatus: 'queued',
+      assignedResolverUserId: undefined,
+      startedAt: undefined,
+    });
+    const updatedReview = buildDecisionReview({
+      reviewStatus: 'in_review',
+      assignedResolverUserId: 'resolver-1',
+      startedAt: '2026-03-21T12:10:00.000Z',
+    });
+    const store = {
+      getResolverReview: jest.fn(async () => currentReview),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const detail = await service.claimResolverQueueItem({
+      tenantId: 'tenant-1',
+      itemType: 'identity_review',
+      itemId: 'review-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
+    });
+
+    expect(store.updateResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      reviewStatus: 'in_review',
+      assignedResolverUserId: 'resolver-1',
+    }));
+    expect(detail.item).toMatchObject({
+      id: 'review-1',
+      claimState: 'claimed_by_current_user',
+      claimedByCurrentUser: true,
+      actionable: true,
+    });
+  });
+
+  it('rejects queue claims from non-tenant-admin actors', async () => {
+    const store = {
+      getResolverReview: jest.fn(),
+      updateResolverReview: jest.fn(),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.claimResolverQueueItem({
+      tenantId: 'tenant-1',
+      itemType: 'identity_review',
+      itemId: 'review-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_STAFF_ACTOR_ROLES,
+    })).rejects.toBeInstanceOf(ResolverQueueAuthorizationError);
+    expect(store.getResolverReview).not.toHaveBeenCalled();
+  });
+
+  it('rejects resolver actions from non-tenant-admin actors even when the item is claimed', async () => {
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => buildDecisionReview()),
+    });
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_STAFF_ACTOR_ROLES,
+      action: 'confirm_existing_person',
+      personId: 'person-existing',
+    })).rejects.toBeInstanceOf(ResolverQueueAuthorizationError);
+  });
+
+  it('fails queue claim when the item is already claimed by another resolver', async () => {
+    const store = {
+      getResolverReview: jest.fn(async () => buildDecisionReview({
+        assignedResolverUserId: 'resolver-2',
+      })),
+      updateResolverReview: jest.fn(),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.claimResolverQueueItem({
+      tenantId: 'tenant-1',
+      itemType: 'identity_review',
+      itemId: 'review-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
+    })).rejects.toBeInstanceOf(ResolverQueueClaimConflictError);
+    expect(store.updateResolverReview).not.toHaveBeenCalled();
+  });
+
+  it('allows the claimant to release a claimed queue item', async () => {
+    const currentReview = buildDecisionReview({
+      assignedResolverUserId: 'resolver-1',
+    });
+    const updatedReview = buildDecisionReview({
+      reviewStatus: 'queued',
+      assignedResolverUserId: undefined,
+    });
+    const store = {
+      getResolverReview: jest.fn(async () => currentReview),
+      updateResolverReview: jest.fn(async () => updatedReview),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    const detail = await service.releaseResolverQueueItem({
+      tenantId: 'tenant-1',
+      itemType: 'identity_review',
+      itemId: 'review-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
+    });
+
+    expect(store.updateResolverReview).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      reviewStatus: 'queued',
+      assignedResolverUserId: null,
+    }));
+    expect(detail.item).toMatchObject({
+      status: 'queued',
+      claimState: 'unclaimed',
+      claimable: true,
+      releasable: false,
+      actionable: false,
+    });
+  });
+
+  it('rejects queue release by a non-claimant resolver', async () => {
+    const store = {
+      getResolverReview: jest.fn(async () => buildDecisionReview({
+        assignedResolverUserId: 'resolver-2',
+      })),
+      updateResolverReview: jest.fn(),
+    };
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.releaseResolverQueueItem({
+      tenantId: 'tenant-1',
+      itemType: 'identity_review',
+      itemId: 'review-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
+    })).rejects.toBeInstanceOf(ResolverQueueClaimConflictError);
+    expect(store.updateResolverReview).not.toHaveBeenCalled();
+  });
+
+  it('rejects resolver actions on unclaimed queue items', async () => {
+    const currentReview = buildDecisionReview({
+      reviewStatus: 'queued',
+      assignedResolverUserId: undefined,
+      startedAt: undefined,
+    });
+    const store = createApplyResolverDecisionStore({
+      getResolverReview: jest.fn(async () => currentReview),
+    });
+    const service = new AsyncPeopleCoreService(store as any);
+
+    await expect(service.applyResolverDecision({
+      tenantId: 'tenant-1',
+      reviewId: 'review-1',
+      actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
+      action: 'confirm_existing_person',
+      personId: 'person-existing',
+    })).rejects.toBeInstanceOf(ResolverQueueClaimRequiredError);
+    expect(store.updateResolverReview).not.toHaveBeenCalled();
   });
 
   it('moves a resolver review from pending to in_review through the service lifecycle guard', async () => {
@@ -487,6 +706,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'confirm_existing_person',
       personId: 'person-existing',
       reason: 'Matched the existing person.',
@@ -541,6 +761,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'confirm_new_person',
       provisionalPersonId: 'person-provisional',
       reason: 'The provisional person is correct.',
@@ -595,6 +816,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'merge_people',
       sourcePersonId: 'person-provisional',
       targetPersonId: 'person-canonical',
@@ -656,6 +878,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'link_without_merge',
       personId: 'person-existing',
       reason: 'Keep both people distinct but maintain the operational link.',
@@ -708,6 +931,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'mark_shared_contact',
       reason: 'This phone number is intentionally shared.',
     });
@@ -753,6 +977,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'reassign_contact_point',
       personId: 'person-existing',
       contactPointId: 'contact-point-1',
@@ -801,6 +1026,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'dismiss_no_action',
       reason: 'No identity change is required.',
     });
@@ -832,6 +1058,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'confirm_existing_person',
       personId: 'person-existing',
       reason: 'Matched the existing person.',
@@ -858,6 +1085,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'dismiss_no_action',
       reason: 'Trying to override the existing terminal outcome.',
     })).rejects.toBeInstanceOf(InvalidResolverReviewTransitionError);
@@ -897,6 +1125,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'confirm_existing_person',
       personId: 'person-existing',
       reason: 'Matched the existing person.',
@@ -961,6 +1190,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'merge_people',
       sourcePersonId: 'person-provisional',
       targetPersonId: 'person-canonical',
@@ -1013,6 +1243,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'dismiss_no_action',
       reason: 'No identity change is required.',
     });
@@ -1058,6 +1289,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'confirm_existing_person',
       personId: 'person-existing',
       reason: 'Matched the existing person.',
@@ -1066,6 +1298,7 @@ describe('AsyncPeopleCoreService', () => {
       tenantId: 'tenant-1',
       reviewId: 'review-1',
       actorUserId: 'resolver-1',
+      actorRoles: TENANT_ADMIN_ACTOR_ROLES,
       action: 'confirm_existing_person',
       personId: 'person-existing',
       reason: 'Matched the existing person.',

--- a/apps/connectshyft-api/src/modules/peoplecore/service.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/service.ts
@@ -3,6 +3,7 @@ import type {
   GetActivityInput,
   ListActivitiesInput,
 } from './activity';
+import { createHash } from 'node:crypto';
 import type {
   ConnectShyftResolverQueueDetailData,
   ConnectShyftResolverQueueItemRecord,
@@ -19,6 +20,7 @@ import type {
 import {
   deriveResolverDecisionStatus,
   isResolverActionType,
+  isResolverRebindReviewType,
   isResolverReviewActiveStatus,
   isResolverReviewResolvedStatus,
   isResolverReviewTerminalStatus,
@@ -62,6 +64,8 @@ import {
 } from './lifecycle';
 
 const CONTACT_POINT_LIFECYCLE_EVENT_LIMIT = 200;
+const CONNECTSHYFT_REBIND_REVIEW_TRIGGER_SOURCE_TYPE = 'connectshyft_person_rebind_review';
+const CONNECTSHYFT_REBIND_REVIEW_RESOLVER_REVIEW_NAMESPACE = 'f4f9a8f7-49e0-5e25-aa9b-f0f93ad7c9c4';
 
 const RESOLVER_ALLOWED_TRANSITIONS: Record<ResolverReviewStatus, readonly ResolverReviewStatus[]> = {
   pending: [
@@ -159,6 +163,14 @@ const isMissingPersistenceError = (error: unknown): boolean => {
   return candidate.code === '42P01'
     || candidate.code === '3F000'
     || candidate.code === '42703';
+};
+
+const isUniqueViolationError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  return (error as { code?: string }).code === '23505';
 };
 
 export class PeopleCorePersistenceUnavailableError extends Error {
@@ -312,6 +324,43 @@ const toResolverReviewRecord = (
   decisionStatus: deriveResolverDecisionStatus(review.reviewStatus),
 });
 
+const isQueueBackedRebindReview = (review: ResolverReview): boolean => (
+  isResolverRebindReviewType(review.reviewType)
+  && review.triggerSourceType === CONNECTSHYFT_REBIND_REVIEW_TRIGGER_SOURCE_TYPE
+);
+
+const resolveResolverQueueItemType = (
+  review: ResolverReview,
+): ConnectShyftResolverQueueItemType => (
+  isQueueBackedRebindReview(review) ? 'rebind_review' : 'identity_review'
+);
+
+const buildRebindReviewResolverReviewId = (rebindHistoryId: string): string => (
+  buildDeterministicUuid(
+    CONNECTSHYFT_REBIND_REVIEW_RESOLVER_REVIEW_NAMESPACE,
+    rebindHistoryId,
+  )
+);
+
+const buildDeterministicUuid = (namespace: string, value: string): string => {
+  const digest = createHash('sha1')
+    .update(`${namespace}:${value}`)
+    .digest('hex')
+    .slice(0, 32)
+    .split('');
+
+  digest[12] = '5';
+  digest[16] = ((parseInt(digest[16] || '0', 16) & 0x3) | 0x8).toString(16);
+
+  return [
+    digest.slice(0, 8).join(''),
+    digest.slice(8, 12).join(''),
+    digest.slice(12, 16).join(''),
+    digest.slice(16, 20).join(''),
+    digest.slice(20, 32).join(''),
+  ].join('-');
+};
+
 const buildResolverQueueClaimMetadata = (
   review: ResolverReview,
   actorUserId: string,
@@ -357,7 +406,7 @@ const buildResolverQueueClaimMetadata = (
   };
 };
 
-const toIdentityReviewQueueItem = (
+const toResolverQueueItem = (
   review: ResolverReview,
   actorUserId: string,
 ): ConnectShyftResolverQueueItemRecord => {
@@ -367,7 +416,7 @@ const toIdentityReviewQueueItem = (
 
   return {
     id: review.id,
-    itemType: 'identity_review',
+    itemType: resolveResolverQueueItemType(review),
     status: review.reviewStatus,
     active,
     terminal,
@@ -837,7 +886,7 @@ const assertTerminalReviewMutationAllowed = (
 
 const loadPersonRebindService = (): Pick<
   import('../connectshyft/personRebind').PersonRebindService,
-  'rebindPersonThreads'
+  'rebindPersonThreads' | 'enqueueRebindReview' | 'getRebindReviewContext'
 > => {
   // Keep the ConnectShyft dependency lazy so the existing service singleton can stay the owner.
   const { personRebindServiceAsync } = require('../connectshyft/personRebind') as typeof import('../connectshyft/personRebind');
@@ -887,6 +936,102 @@ export class AsyncPeopleCoreService {
     } catch (error) {
       if (isMissingPersistenceError(error)) {
         throw new PeopleCorePersistenceUnavailableError(error);
+      }
+
+      throw error;
+    }
+  }
+
+  private async buildResolverQueueItemDetail(
+    review: ResolverReview,
+    actorUserId: string,
+  ): Promise<ConnectShyftResolverQueueDetailData> {
+    const rebindReview = isQueueBackedRebindReview(review)
+      ? await loadPersonRebindService().getRebindReviewContext({
+        tenantId: review.tenantId,
+        rebindHistoryId: review.triggerSourceId,
+      })
+      : null;
+
+    return {
+      item: toResolverQueueItem(review, actorUserId),
+      review: toResolverReviewRecord(review),
+      rebindReview,
+    };
+  }
+
+  private async enqueueRebindReview(input: {
+    tenantId: string;
+    orgUnitId: string;
+    provisionalPersonId: string;
+    canonicalPersonId: string;
+    performedByUserId: string;
+    affectedObjectIds: string[];
+    contactPointIds: string[];
+    originatingResolverReviewId?: string;
+    originatingResolutionType?: ResolverActionType | null;
+  }): Promise<void> {
+    const affectedObjectIds = uniqueStrings(input.affectedObjectIds);
+    if (affectedObjectIds.length === 0) {
+      return;
+    }
+
+    const rebindHistory = await loadPersonRebindService().enqueueRebindReview({
+      tenantId: input.tenantId,
+      orgUnitId: input.orgUnitId,
+      provisionalPersonId: input.provisionalPersonId,
+      canonicalPersonId: input.canonicalPersonId,
+      performedByUserId: input.performedByUserId,
+      affectedObjectType: 'contact_point_link',
+      affectedObjectIds,
+      contactPointIds: uniqueStrings(input.contactPointIds),
+      originatingResolverReviewId: input.originatingResolverReviewId ?? null,
+      originatingResolutionType: input.originatingResolutionType ?? null,
+    });
+    const reviewId = buildRebindReviewResolverReviewId(rebindHistory.id);
+    const existingReview = await this.store.getResolverReview({
+      tenantId: input.tenantId,
+      reviewId,
+    });
+
+    if (existingReview) {
+      return;
+    }
+
+    const rebindReview = rebindHistory.reviewContext;
+    const contactPointCount = rebindReview?.contactPointIds.length ?? 0;
+    const affectedCount = rebindReview?.affectedObjectIds.length ?? affectedObjectIds.length;
+    const confidenceReasons = [
+      contactPointCount > 1
+        ? `${contactPointCount} contact points require manual subject reassignment review.`
+        : 'Manual subject reassignment review is required before finalizing contact-point truth.',
+      affectedCount > 1
+        ? `${affectedCount} current contact-point links remain review-class rebind work.`
+        : 'A current contact-point link remains review-class rebind work.',
+    ];
+
+    try {
+      await this.createResolverReview({
+        reviewId,
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        reviewType: 'subject_reassignment_review',
+        reviewStatus: 'queued',
+        priority: 'normal',
+        triggerSourceType: CONNECTSHYFT_REBIND_REVIEW_TRIGGER_SOURCE_TYPE,
+        triggerSourceId: rebindHistory.id,
+        provisionalPersonId: input.provisionalPersonId,
+        candidatePersonIds: [input.canonicalPersonId],
+        contactPointId: rebindReview?.contactPointIds[0] ?? undefined,
+        confidenceBand: 'medium',
+        confidenceReasons,
+        riskFlags: [],
+        requestedByUserId: input.performedByUserId,
+        requestedAt: rebindHistory.createdAtUtc,
+      });
+    } catch (error) {
+      if (isUniqueViolationError(error)) {
+        return;
       }
 
       throw error;
@@ -968,6 +1113,31 @@ export class AsyncPeopleCoreService {
 
   async mergePerson(input: MergePersonInput): Promise<PeopleCoreMergeResult> {
     const result = await this.execute(() => this.store.mergePerson(input));
+
+    if (result.reviewContactPointLinkIds.length > 0) {
+      const provisionalLinks = await this.listContactPointLinks({
+        tenantId: input.tenantId,
+        subjectType: 'person',
+        subjectId: result.mergedProvisionalPersonId,
+        isCurrent: true,
+      });
+      const reviewLinks = provisionalLinks.filter((link) =>
+        result.reviewContactPointLinkIds.includes(link.id));
+
+      await this.enqueueRebindReview({
+        tenantId: input.tenantId,
+        orgUnitId: input.orgUnitId,
+        provisionalPersonId: result.mergedProvisionalPersonId,
+        canonicalPersonId: result.canonicalPersonId,
+        performedByUserId: input.performedByUserId,
+        affectedObjectIds: reviewLinks.length > 0
+          ? reviewLinks.map((link) => link.id)
+          : result.reviewContactPointLinkIds,
+        contactPointIds: reviewLinks.map((link) => link.contactPointId),
+        originatingResolverReviewId: result.resolverReviewId,
+        originatingResolutionType: 'merge_people',
+      });
+    }
 
     if (result.didPersistMerge) {
       await this.mergeEventPublisher.publishPersonMerged({
@@ -1167,7 +1337,7 @@ export class AsyncPeopleCoreService {
       const includeTerminal = input.includeTerminal === true;
 
       return reviews
-        .map((review) => toIdentityReviewQueueItem(review, actorUserId))
+        .map((review) => toResolverQueueItem(review, actorUserId))
         .filter((item) => {
           if (input.itemType && item.itemType !== input.itemType) {
             return false;
@@ -1206,23 +1376,16 @@ export class AsyncPeopleCoreService {
       const actorRoles = normalizeStringList(input.actorRoles);
       assertTenantAdminResolverActor(actorRoles);
 
-      if (input.itemType !== 'identity_review') {
-        return null;
-      }
-
       const review = await this.store.getResolverReview({
         tenantId,
         reviewId: itemId,
       });
 
-      if (!review) {
+      if (!review || resolveResolverQueueItemType(review) !== input.itemType) {
         return null;
       }
 
-      return {
-        item: toIdentityReviewQueueItem(review, actorUserId),
-        review: toResolverReviewRecord(review),
-      };
+      return this.buildResolverQueueItemDetail(review, actorUserId);
     });
   }
 
@@ -1246,12 +1409,6 @@ export class AsyncPeopleCoreService {
       const actorRoles = normalizeStringList(input.actorRoles);
       assertTenantAdminResolverActor(actorRoles);
 
-      if (input.itemType !== 'identity_review') {
-        throw new PeopleCoreScopeViolationError(
-          `Resolver queue item ${input.itemType}:${itemId} is not available in tenant ${tenantId}.`,
-        );
-      }
-
       const review = await this.store.getResolverReview({
         tenantId,
         reviewId: itemId,
@@ -1260,6 +1417,12 @@ export class AsyncPeopleCoreService {
       if (!review) {
         throw new PeopleCoreScopeViolationError(
           `Resolver review ${itemId} is not available in tenant ${tenantId}.`,
+        );
+      }
+
+      if (resolveResolverQueueItemType(review) !== input.itemType) {
+        throw new PeopleCoreScopeViolationError(
+          `Resolver queue item ${input.itemType}:${itemId} is not available in tenant ${tenantId}.`,
         );
       }
 
@@ -1296,10 +1459,7 @@ export class AsyncPeopleCoreService {
           startedAt: review.startedAt ?? nowIsoUtc(),
         });
 
-      return {
-        item: toIdentityReviewQueueItem(updatedReview, actorUserId),
-        review: toResolverReviewRecord(updatedReview),
-      };
+      return this.buildResolverQueueItemDetail(updatedReview, actorUserId);
     });
   }
 
@@ -1323,12 +1483,6 @@ export class AsyncPeopleCoreService {
       const actorRoles = normalizeStringList(input.actorRoles);
       assertTenantAdminResolverActor(actorRoles);
 
-      if (input.itemType !== 'identity_review') {
-        throw new PeopleCoreScopeViolationError(
-          `Resolver queue item ${input.itemType}:${itemId} is not available in tenant ${tenantId}.`,
-        );
-      }
-
       const review = await this.store.getResolverReview({
         tenantId,
         reviewId: itemId,
@@ -1337,6 +1491,12 @@ export class AsyncPeopleCoreService {
       if (!review) {
         throw new PeopleCoreScopeViolationError(
           `Resolver review ${itemId} is not available in tenant ${tenantId}.`,
+        );
+      }
+
+      if (resolveResolverQueueItemType(review) !== input.itemType) {
+        throw new PeopleCoreScopeViolationError(
+          `Resolver queue item ${input.itemType}:${itemId} is not available in tenant ${tenantId}.`,
         );
       }
 
@@ -1372,10 +1532,7 @@ export class AsyncPeopleCoreService {
         assignedResolverUserId: null,
       });
 
-      return {
-        item: toIdentityReviewQueueItem(updatedReview, actorUserId),
-        review: toResolverReviewRecord(updatedReview),
-      };
+      return this.buildResolverQueueItemDetail(updatedReview, actorUserId);
     });
   }
 
@@ -1432,6 +1589,19 @@ export class AsyncPeopleCoreService {
       if (!review) {
         throw new PeopleCoreScopeViolationError(
           `Resolver review ${validated.reviewId} is not available in tenant ${validated.tenantId}.`,
+        );
+      }
+
+      if (isQueueBackedRebindReview(review)) {
+        throw new ResolverReviewValidationError(
+          'Rebind-review queue work is not processed through identity resolver actions.',
+          [
+            buildFieldError(
+              'reviewId',
+              'CONFLICT',
+              'Use the rebind-review workflow to resolve subject reassignment queue work.',
+            ),
+          ],
         );
       }
 

--- a/apps/connectshyft-api/src/modules/peoplecore/service.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/service.ts
@@ -4,6 +4,10 @@ import type {
   ListActivitiesInput,
 } from './activity';
 import type {
+  ConnectShyftResolverQueueDetailData,
+  ConnectShyftResolverQueueItemRecord,
+  ConnectShyftResolverQueueItemType,
+  ConnectShyftResolverReviewRecord,
   ResolverActionType,
   ResolverDecisionInput,
   ResolverDecisionResult,
@@ -20,6 +24,7 @@ import {
   isResolverReviewTerminalStatus,
   RESOLVER_ACTION_STATUS_MAP,
 } from '@shyft/contracts';
+import { normalizeRoles } from '../../platform/rbac/capabilities';
 import {
   buildPeopleCoreMergeEventPublisher,
   type PeopleCoreMergeEventPublisher,
@@ -80,6 +85,7 @@ const RESOLVER_ALLOWED_TRANSITIONS: Record<ResolverReviewStatus, readonly Resolv
     'dismissed',
   ],
   in_review: [
+    'queued',
     'waiting_for_more_info',
     'resolved_confirmed_existing',
     'resolved_confirmed_new',
@@ -89,6 +95,7 @@ const RESOLVER_ALLOWED_TRANSITIONS: Record<ResolverReviewStatus, readonly Resolv
     'dismissed',
   ],
   waiting_for_more_info: [
+    'queued',
     'in_review',
     'resolved_confirmed_existing',
     'resolved_confirmed_new',
@@ -117,12 +124,30 @@ export type UpdateResolverReviewLifecycleInput = {
   tenantId: string;
   reviewId: string;
   reviewStatus: ResolverReviewStatus;
-  assignedResolverUserId?: string;
-  startedAt?: string;
-  resolvedAt?: string;
-  resolutionType?: ResolverResolutionType;
-  resolutionReason?: string;
-  resolutionNotes?: string;
+  assignedResolverUserId?: string | null;
+  startedAt?: string | null;
+  resolvedAt?: string | null;
+  resolutionType?: ResolverResolutionType | null;
+  resolutionReason?: string | null;
+  resolutionNotes?: string | null;
+};
+
+type ResolverQueueActorInput = {
+  tenantId: string;
+  actorUserId: string;
+  actorRoles: string[];
+};
+
+export type ListResolverQueueInput = ResolverQueueActorInput & {
+  orgUnitId?: string;
+  itemType?: ConnectShyftResolverQueueItemType;
+  status?: ResolverReviewStatus | null;
+  includeTerminal?: boolean;
+};
+
+export type ResolverQueueItemLocatorInput = ResolverQueueActorInput & {
+  itemType: ConnectShyftResolverQueueItemType;
+  itemId: string;
 };
 
 const isMissingPersistenceError = (error: unknown): boolean => {
@@ -185,6 +210,33 @@ export class InvalidResolverReviewTransitionError extends ResolverReviewValidati
   }
 }
 
+export class ResolverQueueAuthorizationError extends Error {
+  readonly code = 'PEOPLECORE_RESOLVER_QUEUE_FORBIDDEN';
+
+  constructor(message = 'Resolver queue access requires a tenant-admin actor.') {
+    super(message);
+    this.name = 'ResolverQueueAuthorizationError';
+  }
+}
+
+export class ResolverQueueClaimRequiredError extends Error {
+  readonly code = 'PEOPLECORE_RESOLVER_QUEUE_CLAIM_REQUIRED';
+
+  constructor(message = 'Resolver queue work must be claimed before action.') {
+    super(message);
+    this.name = 'ResolverQueueClaimRequiredError';
+  }
+}
+
+export class ResolverQueueClaimConflictError extends Error {
+  readonly code = 'PEOPLECORE_RESOLVER_QUEUE_CLAIM_CONFLICT';
+
+  constructor(message = 'Resolver queue work is already claimed by another resolver.') {
+    super(message);
+    this.name = 'ResolverQueueClaimConflictError';
+  }
+}
+
 const nowIsoUtc = (): string => new Date().toISOString();
 
 const uniqueStrings = (values: Iterable<string | null | undefined>): string[] =>
@@ -203,6 +255,27 @@ const normalizeOptionalString = (value: unknown): string | undefined => {
 
   const normalized = value.trim();
   return normalized.length > 0 ? normalized : undefined;
+};
+
+const normalizeStringList = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => normalizeOptionalString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+};
+
+const isTenantAdminResolverActor = (actorRoles: string[]): boolean =>
+  normalizeRoles(actorRoles).includes('TENANT_ADMIN');
+
+const assertTenantAdminResolverActor = (actorRoles: string[]): void => {
+  if (!isTenantAdminResolverActor(actorRoles)) {
+    throw new ResolverQueueAuthorizationError(
+      'Resolver queue actions are limited to tenant-admin actors in MVP.',
+    );
+  }
 };
 
 const buildFieldError = (
@@ -228,6 +301,111 @@ const requireNormalizedString = (
   }
 
   return normalized;
+};
+
+const toResolverReviewRecord = (
+  review: ResolverReview,
+): ConnectShyftResolverReviewRecord => ({
+  ...review,
+  actionable: isResolverReviewActiveStatus(review.reviewStatus),
+  terminal: isResolverReviewTerminalStatus(review.reviewStatus),
+  decisionStatus: deriveResolverDecisionStatus(review.reviewStatus),
+});
+
+const buildResolverQueueClaimMetadata = (
+  review: ResolverReview,
+  actorUserId: string,
+): Pick<
+  ConnectShyftResolverQueueItemRecord,
+  'claimState' | 'claimantUserId' | 'claimedByCurrentUser' | 'claimable' | 'releasable' | 'actionable'
+> => {
+  const active = isResolverReviewActiveStatus(review.reviewStatus);
+  const actionableActiveState = active && review.reviewStatus !== 'waiting_for_more_info';
+  const claimantUserId = active
+    ? review.assignedResolverUserId ?? null
+    : null;
+
+  if (!claimantUserId) {
+    return {
+      claimState: 'unclaimed',
+      claimantUserId: null,
+      claimedByCurrentUser: false,
+      claimable: actionableActiveState,
+      releasable: false,
+      actionable: false,
+    };
+  }
+
+  if (claimantUserId === actorUserId) {
+    return {
+      claimState: 'claimed_by_current_user',
+      claimantUserId,
+      claimedByCurrentUser: true,
+      claimable: false,
+      releasable: active,
+      actionable: actionableActiveState,
+    };
+  }
+
+  return {
+    claimState: 'claimed_by_other',
+    claimantUserId,
+    claimedByCurrentUser: false,
+    claimable: false,
+    releasable: false,
+    actionable: false,
+  };
+};
+
+const toIdentityReviewQueueItem = (
+  review: ResolverReview,
+  actorUserId: string,
+): ConnectShyftResolverQueueItemRecord => {
+  const active = isResolverReviewActiveStatus(review.reviewStatus);
+  const terminal = isResolverReviewTerminalStatus(review.reviewStatus);
+  const claimMetadata = buildResolverQueueClaimMetadata(review, actorUserId);
+
+  return {
+    id: review.id,
+    itemType: 'identity_review',
+    status: review.reviewStatus,
+    active,
+    terminal,
+    ...claimMetadata,
+    resolverReviewId: review.id,
+    orgUnitId: review.orgUnitId,
+    conversationId: review.conversationId ?? null,
+    contactPointId: review.contactPointId ?? null,
+    threadId: null,
+    personIds: uniqueStrings([
+      review.provisionalPersonId,
+      ...review.candidatePersonIds,
+    ]),
+    triggerSourceType: review.triggerSourceType,
+    triggerSourceId: review.triggerSourceId,
+    requestedAt: review.requestedAt,
+    startedAt: review.startedAt ?? null,
+    resolvedAt: review.resolvedAt ?? null,
+  };
+};
+
+const assertResolverReviewClaimedByActor = (
+  review: ResolverReview,
+  actorUserId: string,
+): void => {
+  const claimantUserId = review.assignedResolverUserId ?? null;
+
+  if (!claimantUserId) {
+    throw new ResolverQueueClaimRequiredError(
+      'Claim the resolver queue item before applying a resolver action.',
+    );
+  }
+
+  if (claimantUserId !== actorUserId) {
+    throw new ResolverQueueClaimConflictError(
+      'Resolver queue item is already claimed by another tenant-admin resolver.',
+    );
+  }
 };
 
 const assertResolutionTypeMatchesStatus = (
@@ -303,6 +481,7 @@ export const validateResolverDecisionInput = (
     'actorUserId',
     'actorUserId is required.',
   );
+  const actorRoles = normalizeStringList(input.actorRoles);
   if (!isResolverActionType(input.action)) {
     throw new ResolverReviewValidationError(
       'action must be a canonical resolver action.',
@@ -476,6 +655,7 @@ export const validateResolverDecisionInput = (
     reviewId,
     action: input.action,
     actorUserId,
+    actorRoles,
     reason,
     notes,
     personId,
@@ -490,9 +670,12 @@ const buildResolverReviewUpdatePayload = (
   currentReview: ResolverReview,
   input: UpdateResolverReviewLifecycleInput,
 ): UpdateResolverReviewInput => {
-  const assignedResolverUserId = normalizeOptionalString(input.assignedResolverUserId)
-    ?? currentReview.assignedResolverUserId
-    ?? null;
+  const assignedResolverUserId = Object.prototype.hasOwnProperty.call(
+    input,
+    'assignedResolverUserId',
+  )
+    ? normalizeOptionalString(input.assignedResolverUserId) ?? null
+    : currentReview.assignedResolverUserId ?? null;
   const startedAt = normalizeOptionalString(input.startedAt)
     ?? currentReview.startedAt
     ?? (
@@ -961,6 +1144,241 @@ export class AsyncPeopleCoreService {
     });
   }
 
+  listResolverQueue(input: ListResolverQueueInput) {
+    return this.execute(async () => {
+      const tenantId = requireNormalizedString(
+        input.tenantId,
+        'tenantId',
+        'tenantId is required.',
+      );
+      const actorUserId = requireNormalizedString(
+        input.actorUserId,
+        'actorUserId',
+        'actorUserId is required.',
+      );
+      const actorRoles = normalizeStringList(input.actorRoles);
+      assertTenantAdminResolverActor(actorRoles);
+
+      const reviews = await this.store.listResolverReviews({
+        tenantId,
+        orgUnitId: normalizeOptionalString(input.orgUnitId),
+      });
+      const requestedStatus = normalizeOptionalString(input.status) as ResolverReviewStatus | undefined;
+      const includeTerminal = input.includeTerminal === true;
+
+      return reviews
+        .map((review) => toIdentityReviewQueueItem(review, actorUserId))
+        .filter((item) => {
+          if (input.itemType && item.itemType !== input.itemType) {
+            return false;
+          }
+
+          if (requestedStatus && item.status !== requestedStatus) {
+            return false;
+          }
+
+          if (!includeTerminal && !item.active) {
+            return false;
+          }
+
+          return true;
+        });
+    });
+  }
+
+  getResolverQueueItemDetail(input: ResolverQueueItemLocatorInput): Promise<ConnectShyftResolverQueueDetailData | null> {
+    return this.execute(async () => {
+      const tenantId = requireNormalizedString(
+        input.tenantId,
+        'tenantId',
+        'tenantId is required.',
+      );
+      const itemId = requireNormalizedString(
+        input.itemId,
+        'itemId',
+        'itemId is required.',
+      );
+      const actorUserId = requireNormalizedString(
+        input.actorUserId,
+        'actorUserId',
+        'actorUserId is required.',
+      );
+      const actorRoles = normalizeStringList(input.actorRoles);
+      assertTenantAdminResolverActor(actorRoles);
+
+      if (input.itemType !== 'identity_review') {
+        return null;
+      }
+
+      const review = await this.store.getResolverReview({
+        tenantId,
+        reviewId: itemId,
+      });
+
+      if (!review) {
+        return null;
+      }
+
+      return {
+        item: toIdentityReviewQueueItem(review, actorUserId),
+        review: toResolverReviewRecord(review),
+      };
+    });
+  }
+
+  claimResolverQueueItem(input: ResolverQueueItemLocatorInput): Promise<ConnectShyftResolverQueueDetailData> {
+    return this.execute(async () => {
+      const tenantId = requireNormalizedString(
+        input.tenantId,
+        'tenantId',
+        'tenantId is required.',
+      );
+      const itemId = requireNormalizedString(
+        input.itemId,
+        'itemId',
+        'itemId is required.',
+      );
+      const actorUserId = requireNormalizedString(
+        input.actorUserId,
+        'actorUserId',
+        'actorUserId is required.',
+      );
+      const actorRoles = normalizeStringList(input.actorRoles);
+      assertTenantAdminResolverActor(actorRoles);
+
+      if (input.itemType !== 'identity_review') {
+        throw new PeopleCoreScopeViolationError(
+          `Resolver queue item ${input.itemType}:${itemId} is not available in tenant ${tenantId}.`,
+        );
+      }
+
+      const review = await this.store.getResolverReview({
+        tenantId,
+        reviewId: itemId,
+      });
+
+      if (!review) {
+        throw new PeopleCoreScopeViolationError(
+          `Resolver review ${itemId} is not available in tenant ${tenantId}.`,
+        );
+      }
+
+      if (isResolverReviewTerminalStatus(review.reviewStatus)) {
+        throw new InvalidResolverReviewTransitionError(
+          `Resolver review ${review.id} is already terminal and cannot be claimed.`,
+          [
+            buildFieldError(
+              'reviewStatus',
+              'INVALID',
+              `reviewStatus ${review.reviewStatus} is terminal and cannot be claimed.`,
+            ),
+          ],
+        );
+      }
+
+      if (review.assignedResolverUserId && review.assignedResolverUserId !== actorUserId) {
+        throw new ResolverQueueClaimConflictError(
+          'Resolver queue item is already claimed by another tenant-admin resolver.',
+        );
+      }
+
+      const nextStatus = review.reviewStatus === 'waiting_for_more_info'
+        ? 'waiting_for_more_info'
+        : 'in_review';
+      const updatedReview = review.assignedResolverUserId === actorUserId
+        && review.reviewStatus === nextStatus
+        ? review
+        : await this.updateResolverReview({
+          tenantId,
+          reviewId: review.id,
+          reviewStatus: nextStatus,
+          assignedResolverUserId: actorUserId,
+          startedAt: review.startedAt ?? nowIsoUtc(),
+        });
+
+      return {
+        item: toIdentityReviewQueueItem(updatedReview, actorUserId),
+        review: toResolverReviewRecord(updatedReview),
+      };
+    });
+  }
+
+  releaseResolverQueueItem(input: ResolverQueueItemLocatorInput): Promise<ConnectShyftResolverQueueDetailData> {
+    return this.execute(async () => {
+      const tenantId = requireNormalizedString(
+        input.tenantId,
+        'tenantId',
+        'tenantId is required.',
+      );
+      const itemId = requireNormalizedString(
+        input.itemId,
+        'itemId',
+        'itemId is required.',
+      );
+      const actorUserId = requireNormalizedString(
+        input.actorUserId,
+        'actorUserId',
+        'actorUserId is required.',
+      );
+      const actorRoles = normalizeStringList(input.actorRoles);
+      assertTenantAdminResolverActor(actorRoles);
+
+      if (input.itemType !== 'identity_review') {
+        throw new PeopleCoreScopeViolationError(
+          `Resolver queue item ${input.itemType}:${itemId} is not available in tenant ${tenantId}.`,
+        );
+      }
+
+      const review = await this.store.getResolverReview({
+        tenantId,
+        reviewId: itemId,
+      });
+
+      if (!review) {
+        throw new PeopleCoreScopeViolationError(
+          `Resolver review ${itemId} is not available in tenant ${tenantId}.`,
+        );
+      }
+
+      if (!isResolverReviewActiveStatus(review.reviewStatus)) {
+        throw new InvalidResolverReviewTransitionError(
+          `Resolver review ${review.id} is already terminal and cannot be released.`,
+          [
+            buildFieldError(
+              'reviewStatus',
+              'INVALID',
+              `reviewStatus ${review.reviewStatus} is terminal and cannot be released.`,
+            ),
+          ],
+        );
+      }
+
+      if (!review.assignedResolverUserId) {
+        throw new ResolverQueueClaimRequiredError(
+          'Resolver queue item is not currently claimed by the acting resolver.',
+        );
+      }
+
+      if (review.assignedResolverUserId !== actorUserId) {
+        throw new ResolverQueueClaimConflictError(
+          'Only the current claimant may release this resolver queue item.',
+        );
+      }
+
+      const updatedReview = await this.updateResolverReview({
+        tenantId,
+        reviewId: review.id,
+        reviewStatus: 'queued',
+        assignedResolverUserId: null,
+      });
+
+      return {
+        item: toIdentityReviewQueueItem(updatedReview, actorUserId),
+        review: toResolverReviewRecord(updatedReview),
+      };
+    });
+  }
+
   private async consumeLinkedAmbiguityEvents(input: {
     review: ResolverReview;
     action: ResolverActionType;
@@ -1005,6 +1423,7 @@ export class AsyncPeopleCoreService {
   applyResolverDecision(input: ResolverDecisionInput): Promise<ResolverDecisionResult> {
     return this.execute(async () => {
       const validated = validateResolverDecisionInput(input);
+      assertTenantAdminResolverActor(validated.actorRoles);
       const review = await this.store.getResolverReview({
         tenantId: validated.tenantId,
         reviewId: validated.reviewId,
@@ -1015,6 +1434,8 @@ export class AsyncPeopleCoreService {
           `Resolver review ${validated.reviewId} is not available in tenant ${validated.tenantId}.`,
         );
       }
+
+      assertResolverReviewClaimedByActor(review, validated.actorUserId);
 
       const targetReviewStatus = RESOLVER_ACTION_STATUS_MAP[validated.action];
       if (isResolverReviewTerminalStatus(review.reviewStatus)) {

--- a/apps/connectshyft-api/src/modules/peoplecore/service.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/service.ts
@@ -64,7 +64,7 @@ import {
 } from './lifecycle';
 
 const CONTACT_POINT_LIFECYCLE_EVENT_LIMIT = 200;
-const CONNECTSHYFT_REBIND_REVIEW_TRIGGER_SOURCE_TYPE = 'connectshyft_person_rebind_review';
+export const CONNECTSHYFT_REBIND_REVIEW_TRIGGER_SOURCE_TYPE = 'connectshyft_person_rebind_review';
 const CONNECTSHYFT_REBIND_REVIEW_RESOLVER_REVIEW_NAMESPACE = 'f4f9a8f7-49e0-5e25-aa9b-f0f93ad7c9c4';
 
 const RESOLVER_ALLOWED_TRANSITIONS: Record<ResolverReviewStatus, readonly ResolverReviewStatus[]> = {
@@ -324,12 +324,12 @@ const toResolverReviewRecord = (
   decisionStatus: deriveResolverDecisionStatus(review.reviewStatus),
 });
 
-const isQueueBackedRebindReview = (review: ResolverReview): boolean => (
+export const isQueueBackedRebindReview = (review: ResolverReview): boolean => (
   isResolverRebindReviewType(review.reviewType)
   && review.triggerSourceType === CONNECTSHYFT_REBIND_REVIEW_TRIGGER_SOURCE_TYPE
 );
 
-const resolveResolverQueueItemType = (
+export const resolveResolverQueueItemType = (
   review: ResolverReview,
 ): ConnectShyftResolverQueueItemType => (
   isQueueBackedRebindReview(review) ? 'rebind_review' : 'identity_review'

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
@@ -9,6 +9,8 @@ import {
 import {
   InvalidResolverReviewTransitionError,
   peopleCoreServiceAsync,
+  ResolverQueueClaimConflictError,
+  ResolverQueueClaimRequiredError,
   ResolverReviewValidationError,
 } from '../../../../modules/peoplecore/service';
 import { PeopleCoreScopeViolationError } from '../../../../modules/peoplecore/store';
@@ -165,6 +167,32 @@ const buildResolverReview = (overrides: Record<string, unknown> = {}) => ({
   riskFlags: ['shared_contact_possible'],
   requestedByUserId: TEST_USER_ID,
   requestedAt: '2026-03-21T12:00:00.000Z',
+  ...overrides,
+});
+
+const buildResolverQueueItem = (overrides: Record<string, unknown> = {}) => ({
+  id: 'review-1',
+  itemType: 'identity_review',
+  status: 'queued',
+  active: true,
+  terminal: false,
+  claimState: 'unclaimed',
+  claimantUserId: null,
+  claimedByCurrentUser: false,
+  claimable: true,
+  releasable: false,
+  actionable: false,
+  resolverReviewId: 'review-1',
+  orgUnitId: TEST_ORG_UNIT_ID,
+  conversationId: 'conversation-1',
+  contactPointId: 'contact-point-1',
+  threadId: null,
+  personIds: ['person-a', 'person-b'],
+  triggerSourceType: 'connectshyft_identity_match',
+  triggerSourceId: 'identity-match:resolver-review-route',
+  requestedAt: '2026-03-21T12:00:00.000Z',
+  startedAt: null,
+  resolvedAt: null,
   ...overrides,
 });
 
@@ -776,6 +804,213 @@ describe('connectshyft identity ambiguity ops route', () => {
     });
   });
 
+  it('lists active resolver queue items through the backend queue service', async () => {
+    const listSpy = jest.spyOn(peopleCoreServiceAsync, 'listResolverQueue')
+      .mockResolvedValue([
+        buildResolverQueueItem(),
+      ] as any);
+
+    const app = buildApp();
+    const response = await request(app)
+      .get('/api/v1/connectshyft/resolver-queue')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(listSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: TEST_TENANT_ID,
+      actorUserId: TEST_USER_ID,
+      orgUnitId: undefined,
+      itemType: undefined,
+      status: null,
+      includeTerminal: false,
+      actorRoles: expect.arrayContaining(['TENANT_ADMIN']),
+    }));
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_LISTED',
+      data: {
+        items: [
+          expect.objectContaining({
+            id: 'review-1',
+            itemType: 'identity_review',
+            status: 'queued',
+            active: true,
+            terminal: false,
+            claimState: 'unclaimed',
+          }),
+        ],
+      },
+    });
+  });
+
+  it('returns terminal resolver queue item detail when explicitly requested', async () => {
+    const detailSpy = jest.spyOn(peopleCoreServiceAsync, 'getResolverQueueItemDetail')
+      .mockResolvedValue({
+        item: buildResolverQueueItem({
+          id: 'review-terminal',
+          status: 'resolved_confirmed_existing',
+          active: false,
+          terminal: true,
+          claimState: 'unclaimed',
+          claimable: false,
+          resolvedAt: '2026-03-21T13:00:00.000Z',
+        }),
+        review: buildResolverReview({
+          id: 'review-terminal',
+          reviewStatus: 'resolved_confirmed_existing',
+          resolutionType: 'confirm_existing_person',
+          resolvedAt: '2026-03-21T13:00:00.000Z',
+        }),
+      } as any);
+
+    const app = buildApp();
+    const response = await request(app)
+      .get('/api/v1/connectshyft/resolver-queue/identity_review/review-terminal')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(detailSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: TEST_TENANT_ID,
+      itemType: 'identity_review',
+      itemId: 'review-terminal',
+      actorRoles: expect.arrayContaining(['TENANT_ADMIN']),
+    }));
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RETRIEVED',
+      data: {
+        item: {
+          id: 'review-terminal',
+          terminal: true,
+          status: 'resolved_confirmed_existing',
+        },
+        review: {
+          id: 'review-terminal',
+          reviewStatus: 'resolved_confirmed_existing',
+        },
+      },
+    });
+  });
+
+  it('claims and releases resolver queue items through thin routes', async () => {
+    const claimSpy = jest.spyOn(peopleCoreServiceAsync, 'claimResolverQueueItem')
+      .mockResolvedValue({
+        item: buildResolverQueueItem({
+          status: 'in_review',
+          claimState: 'claimed_by_current_user',
+          claimantUserId: TEST_USER_ID,
+          claimedByCurrentUser: true,
+          claimable: false,
+          releasable: true,
+          actionable: true,
+          startedAt: '2026-03-21T12:05:00.000Z',
+        }),
+        review: buildResolverReview({
+          reviewStatus: 'in_review',
+          assignedResolverUserId: TEST_USER_ID,
+          startedAt: '2026-03-21T12:05:00.000Z',
+        }),
+      } as any);
+    const releaseSpy = jest.spyOn(peopleCoreServiceAsync, 'releaseResolverQueueItem')
+      .mockResolvedValue({
+        item: buildResolverQueueItem(),
+        review: buildResolverReview({
+          reviewStatus: 'queued',
+          assignedResolverUserId: undefined,
+        }),
+      } as any);
+
+    const app = buildApp();
+    const claimResponse = await request(app)
+      .post('/api/v1/connectshyft/resolver-queue/identity_review/review-1/claim')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+    const releaseResponse = await request(app)
+      .post('/api/v1/connectshyft/resolver-queue/identity_review/review-1/release')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(claimResponse.status).toBe(200);
+    expect(releaseResponse.status).toBe(200);
+    expect(claimSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: TEST_TENANT_ID,
+      itemType: 'identity_review',
+      itemId: 'review-1',
+      actorUserId: TEST_USER_ID,
+      actorRoles: expect.arrayContaining(['TENANT_ADMIN']),
+    }));
+    expect(releaseSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: TEST_TENANT_ID,
+      itemType: 'identity_review',
+      itemId: 'review-1',
+      actorUserId: TEST_USER_ID,
+      actorRoles: expect.arrayContaining(['TENANT_ADMIN']),
+    }));
+    expect(claimResponse.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_CLAIMED',
+    });
+    expect(releaseResponse.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RELEASED',
+    });
+  });
+
+  it('rejects resolver queue access for non-tenant-admin actors before service dispatch', async () => {
+    const listSpy = jest.spyOn(peopleCoreServiceAsync, 'listResolverQueue');
+
+    const app = buildApp({
+      defaultRole: 'TENANT_STAFF',
+    });
+    const response = await request(app)
+      .get('/api/v1/connectshyft/resolver-queue')
+      .set(buildHeaders({
+        role: 'TENANT_STAFF',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(listSpy).not.toHaveBeenCalled();
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_FORBIDDEN',
+      refusalType: 'business',
+      message: 'Resolver queue access requires a tenant-admin role.',
+    });
+  });
+
+  it('normalizes resolver queue claim conflicts without leaking internals', async () => {
+    jest.spyOn(peopleCoreServiceAsync, 'claimResolverQueueItem').mockRejectedValue(
+      new ResolverQueueClaimConflictError('debug-only internal claim collision'),
+    );
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/resolver-queue/identity_review/review-1/claim')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_CONFLICT',
+      refusalType: 'business',
+      message: 'Resolver queue item is already claimed by another resolver.',
+    });
+  });
+
   it('lists resolver reviews with normalized actionability semantics', async () => {
     const listSpy = jest.spyOn(peopleCoreServiceAsync, 'listResolverReviews')
       .mockResolvedValue([
@@ -916,6 +1151,7 @@ describe('connectshyft identity ambiguity ops route', () => {
       tenantId: TEST_TENANT_ID,
       reviewId: 'review-1',
       actorUserId: TEST_USER_ID,
+      actorRoles: expect.arrayContaining(['TENANT_ADMIN']),
       action: 'confirm_existing_person',
       reason: 'Matched the existing person.',
       notes: undefined,
@@ -939,6 +1175,32 @@ describe('connectshyft identity ambiguity ops route', () => {
           rebindTriggered: true,
         },
       },
+    });
+  });
+
+  it('maps claim-required resolver decisions to a normalized business refusal', async () => {
+    jest.spyOn(peopleCoreServiceAsync, 'applyResolverDecision').mockRejectedValue(
+      new ResolverQueueClaimRequiredError('internal claim state message'),
+    );
+
+    const app = buildApp();
+    const response = await request(app)
+      .post('/api/v1/connectshyft/resolver-reviews/review-1/decision')
+      .set(buildHeaders({
+        role: 'TENANT_ADMIN',
+        memberships: [TEST_ORG_UNIT_ID],
+      }))
+      .send({
+        action: 'confirm_existing_person',
+        personId: 'person-existing',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_REQUIRED',
+      refusalType: 'business',
+      message: 'Resolver queue item must be claimed before action.',
     });
   });
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import request from 'supertest';
 import * as BridgeSessionsModule from '../../../../modules/connectshyft/bridgeSessions';
+import * as PeopleCoreServiceModule from '../../../../modules/peoplecore/service';
 import {
   recordConnectShyftCanonicalEvent,
   resetConnectShyftCanonicalEventsForTests,
@@ -21,6 +22,7 @@ const buildThreadDetailRecord = (overrides: Record<string, unknown> = {}) => ({
   neighborId: 'neighbor-detail-characterization-1001',
   personId: 'person-detail-characterization-1001',
   identityState: 'confirmed',
+  subjectImpact: null,
   subjectContext: {
     orgUnitId: TEST_ORG_UNIT_ID,
     personId: 'person-detail-characterization-1001',
@@ -145,6 +147,10 @@ describe('connectshyft thread detail route characterization', () => {
 
   beforeEach(() => {
     resetConnectShyftCanonicalEventsForTests();
+    jest.spyOn(
+      PeopleCoreServiceModule.peopleCoreServiceAsync,
+      'listResolverReviews',
+    ).mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -218,6 +224,7 @@ describe('connectshyft thread detail route characterization', () => {
           neighborId: 'neighbor-detail-characterization-1001',
           personId: 'person-detail-characterization-1001',
           identityState: 'confirmed',
+          subjectImpact: null,
           subjectContext: {
             orgUnitId: TEST_ORG_UNIT_ID,
             personId: 'person-detail-characterization-1001',
@@ -289,6 +296,7 @@ describe('connectshyft thread detail route characterization', () => {
       'providerNeutral',
       'state',
       'statusDerivedFromCanonicalEvents',
+      'subjectImpact',
       'subjectContext',
       'summary',
       'tenantId',
@@ -335,6 +343,12 @@ describe('connectshyft thread detail route characterization', () => {
           threadId,
           personId: 'person-detail-provisional-1003',
           identityState: 'provisional',
+          subjectImpact: {
+            impactType: 'provisional_identity',
+            actionable: false,
+            resolverQueueItemId: null,
+            resolverQueueItemType: null,
+          },
           subjectContext: {
             orgUnitId: TEST_ORG_UNIT_ID,
             provisionalPersonId: 'person-detail-provisional-1003',
@@ -343,6 +357,121 @@ describe('connectshyft thread detail route characterization', () => {
       },
     });
     expect(response.body.data.thread.subjectContext).not.toHaveProperty('personId');
+  });
+
+  it('returns resolver-required subject impact only when the active review matches the current thread', async () => {
+    const threadId = 'thread-detail-resolver-impact-1007';
+    jest.spyOn(
+      ReadContractsModule,
+      'resolveConnectShyftThreadDetailContractAsync',
+    ).mockResolvedValue(buildThreadDetailRecord({
+      threadId,
+      personId: 'person-detail-resolver-impact-1007',
+      identityState: 'provisional',
+      subjectContext: {
+        orgUnitId: TEST_ORG_UNIT_ID,
+        provisionalPersonId: 'person-detail-resolver-impact-1007',
+      },
+    }) as any);
+    jest.spyOn(
+      BridgeSessionsModule,
+      'loadConnectShyftBridgeAggregateByThreadId',
+    ).mockResolvedValue(null as any);
+    jest.spyOn(
+      PeopleCoreServiceModule.peopleCoreServiceAsync,
+      'listResolverReviews',
+    ).mockResolvedValue([
+      {
+        id: 'review-thread-impact-1',
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        reviewType: 'shared_contact_ambiguity',
+        reviewStatus: 'in_review',
+        priority: 'high',
+        triggerSourceType: 'connectshyft_identity_seam',
+        triggerSourceId: 'impact-trigger-1',
+        conversationId: threadId,
+        provisionalPersonId: 'person-detail-resolver-impact-1007',
+        candidatePersonIds: ['person-detail-resolver-impact-1007'],
+        contactPointId: 'contact-point-impact-1',
+        confidenceBand: 'high',
+        confidenceReasons: ['Multiple exact matches require review.'],
+        riskFlags: ['shared_contact_possible'],
+        requestedByUserId: 'requested-by-user',
+        assignedResolverUserId: 'resolver-1',
+        requestedAt: '2026-03-19T10:05:00.000Z',
+        startedAt: '2026-03-19T10:07:00.000Z',
+      },
+    ] as any);
+
+    const app = buildApp();
+    const response = await request(app)
+      .get(`/api/v1/connectshyft/threads/${threadId}`)
+      .set(buildHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.thread.subjectImpact).toEqual({
+      impactType: 'resolver_required',
+      actionable: true,
+      resolverQueueItemId: 'review-thread-impact-1',
+      resolverQueueItemType: 'identity_review',
+    });
+  });
+
+  it('returns rebind-review subject impact when active rebind work affects the current thread person', async () => {
+    const threadId = 'thread-detail-rebind-impact-1008';
+    jest.spyOn(
+      ReadContractsModule,
+      'resolveConnectShyftThreadDetailContractAsync',
+    ).mockResolvedValue(buildThreadDetailRecord({
+      threadId,
+      personId: 'person-detail-rebind-impact-1008',
+      identityState: 'confirmed',
+      subjectContext: {
+        orgUnitId: TEST_ORG_UNIT_ID,
+        personId: 'person-detail-rebind-impact-1008',
+      },
+    }) as any);
+    jest.spyOn(
+      BridgeSessionsModule,
+      'loadConnectShyftBridgeAggregateByThreadId',
+    ).mockResolvedValue(null as any);
+    jest.spyOn(
+      PeopleCoreServiceModule.peopleCoreServiceAsync,
+      'listResolverReviews',
+    ).mockResolvedValue([
+      {
+        id: 'review-rebind-impact-1',
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        reviewType: 'subject_reassignment_review',
+        reviewStatus: 'queued',
+        priority: 'normal',
+        triggerSourceType: 'connectshyft_person_rebind_review',
+        triggerSourceId: 'rebind-history-impact-1',
+        provisionalPersonId: 'person-detail-rebind-impact-1008',
+        candidatePersonIds: ['person-detail-rebind-target-1008'],
+        contactPointId: 'contact-point-impact-2',
+        confidenceBand: 'medium',
+        confidenceReasons: ['Review-class rebind work is pending.'],
+        riskFlags: [],
+        requestedByUserId: 'requested-by-user',
+        requestedAt: '2026-03-19T10:05:00.000Z',
+      },
+    ] as any);
+
+    const app = buildApp();
+    const response = await request(app)
+      .get(`/api/v1/connectshyft/threads/${threadId}`)
+      .set(buildHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.thread.subjectImpact).toEqual({
+      impactType: 'rebind_review',
+      actionable: true,
+      resolverQueueItemId: 'review-rebind-impact-1',
+      resolverQueueItemType: 'rebind_review',
+    });
   });
 
   it('returns deleted-neighbor detail only through includeDeleted=true and clears operational actions', async () => {

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -52,6 +52,7 @@ import {
   getConnectOperatorCallbackNumber,
   getConnectSettingsNavigation,
   getConnectTelephonyReadiness,
+  enrichThreadDetailWithSubjectImpact,
   getConnectThreadDetail,
   getConnectThreadTimeline,
   getConnectWebhookReceiptMetrics,
@@ -1897,6 +1898,7 @@ const buildSyntheticThreadDetailRecord = (input: {
     neighborId: input.descriptor.neighborId || null,
     personId: null,
     identityState: null,
+    subjectImpact: null,
     subjectContext: {
       orgUnitId: input.descriptor.orgUnitId,
     },
@@ -5741,6 +5743,11 @@ const getConnectThreadDetailWithSyntheticFallback = async (req: Request, res: Re
       ? []
       : [...resolveConnectShyftThreadActions(thread.state)],
   };
+  thread = await enrichThreadDetailWithSubjectImpact({
+    tenantId: context.tenantId,
+    orgUnitId: context.orgUnitId,
+    thread,
+  });
 
   const timeline = await listCanonicalThreadEvents({
     tenantId: context.tenantId,

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -4,10 +4,12 @@ import type { Knex } from 'knex';
 import type {
   ConnectShyftIdentityAmbiguityEvent,
   ConnectShyftIdentityAmbiguityRecord,
+  ConnectShyftResolverQueueItemType,
   ConnectShyftResolverReviewRecord,
   PersonProvisionalCreatedEvent,
   ResolverDecisionInput,
   ResolverReview,
+  ResolverReviewStatus,
   ResolverReviewCreatedEvent,
   SubjectContext,
 } from '@shyft/contracts';
@@ -15,8 +17,10 @@ import {
   deriveResolverDecisionStatus,
   isConnectShyftIdentityAmbiguityActiveStatus,
   isConnectShyftIdentityAmbiguityTerminalStatus,
+  isConnectShyftResolverQueueItemType,
   isResolverActionType,
   isResolverReviewActiveStatus,
+  isResolverReviewStatus,
   isResolverReviewTerminalStatus,
 } from '@shyft/contracts';
 import {
@@ -26,7 +30,7 @@ import {
   validatePhoneForChannel,
 } from '../../../../../../domains/communication';
 import { refusal, success } from '../../../platform/envelopes/response';
-import { CAPABILITIES, hasCapability } from '../../../platform/rbac/capabilities';
+import { CAPABILITIES, hasCapability, normalizeRoles } from '../../../platform/rbac/capabilities';
 import {
   evaluateConnectShyftCapability,
   isConnectShyftTestOverrideEnabled,
@@ -233,6 +237,9 @@ import {
 import {
   InvalidResolverReviewTransitionError,
   peopleCoreServiceAsync,
+  ResolverQueueAuthorizationError,
+  ResolverQueueClaimConflictError,
+  ResolverQueueClaimRequiredError,
   ResolverReviewValidationError,
 } from '../../../modules/peoplecore/service';
 import { PeopleCoreScopeViolationError } from '../../../modules/peoplecore/store';
@@ -2547,6 +2554,9 @@ const resolveConnectShyftActorRoles = (
   return deduped;
 };
 
+const isTenantAdminResolverRoleSet = (actorRoles: string[]): boolean =>
+  normalizeRoles(actorRoles).includes('TENANT_ADMIN');
+
 const enforceThreadViewCapability = (
   req: Request,
   res: Response,
@@ -2809,7 +2819,7 @@ const resolveResolverReviewReadScope = (
   };
 };
 
-const resolveResolverReviewTenantPrivilegedScope = (
+const resolveTenantAdminResolverQueueScope = (
   req: Request,
   res: Response,
   context: Pick<ResolvedConnectShyftContext, 'effectiveRoles'>,
@@ -2817,15 +2827,15 @@ const resolveResolverReviewTenantPrivilegedScope = (
   actorRoles: string[];
 } | null => {
   const actorRoles = resolveConnectShyftActorRoles(req, context);
-  if (hasCapability(actorRoles, CAPABILITIES.NEIGHBOR_EDIT_ALL)) {
+  if (isTenantAdminResolverRoleSet(actorRoles)) {
     return {
       actorRoles,
     };
   }
 
   refusal(res, {
-    code: 'CONNECTSHYFT_RESOLVER_REVIEW_UPDATE_FORBIDDEN',
-    message: 'Resolver decision updates require a tenant-privileged ConnectShyft admin role.',
+    code: 'CONNECTSHYFT_RESOLVER_QUEUE_FORBIDDEN',
+    message: 'Resolver queue access requires a tenant-admin role.',
     refusalType: 'business',
     httpStatus: 200,
   });
@@ -2940,6 +2950,58 @@ const parseResolverReviewFilters = (req: Request): {
 } => ({
   orgUnitId: parseOrgUnitIdFromQuery(req),
 });
+
+const parseResolverQueueItemTypeValue = (
+  value: unknown,
+): ConnectShyftResolverQueueItemType | null => {
+  if (!isConnectShyftResolverQueueItemType(value)) {
+    return null;
+  }
+
+  return value;
+};
+
+const parseResolverQueueStatusValue = (value: unknown): ResolverReviewStatus | null => {
+  if (!isResolverReviewStatus(value)) {
+    return null;
+  }
+
+  return value;
+};
+
+const parseResolverQueueBooleanFlag = (value: unknown): boolean => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes';
+};
+
+const parseResolverQueueFilters = (req: Request): {
+  orgUnitId: string | null;
+  itemType: ConnectShyftResolverQueueItemType | null;
+  status: ResolverReviewStatus | null;
+  includeTerminal: boolean;
+} => ({
+  orgUnitId: parseOrgUnitIdFromQuery(req),
+  itemType: parseResolverQueueItemTypeValue(req.query?.itemType),
+  status: parseResolverQueueStatusValue(req.query?.status),
+  includeTerminal: parseResolverQueueBooleanFlag(req.query?.includeTerminal),
+});
+
+const parseResolverQueueItemTypeParam = (
+  req: Request,
+): ConnectShyftResolverQueueItemType | null => parseResolverQueueItemTypeValue(req.params.itemType);
+
+const parseResolverQueueItemIdParam = (req: Request): string | null => {
+  if (typeof req.params.itemId !== 'string') {
+    return null;
+  }
+
+  const normalized = req.params.itemId.trim();
+  return normalized.length > 0 ? normalized : null;
+};
 
 const parseIdentityAmbiguityEventIdParam = (req: Request): string => {
   if (typeof req.params.ambiguityEventId !== 'string') {
@@ -4955,6 +5017,293 @@ router.get('/events', async (req: Request, res: Response) => {
   });
 });
 
+router.get('/resolver-queue', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  const queueScope = resolveTenantAdminResolverQueueScope(req, res, context);
+  if (!queueScope) {
+    return;
+  }
+
+  const filters = parseResolverQueueFilters(req);
+  const items = await peopleCoreServiceAsync.listResolverQueue({
+    tenantId: context.tenantId,
+    actorUserId: resolveConnectShyftRequestedActorUserId(req) || CONNECTSHYFT_SYSTEM_ACTOR_USER_ID,
+    actorRoles: queueScope.actorRoles,
+    orgUnitId: filters.orgUnitId ?? undefined,
+    itemType: filters.itemType ?? undefined,
+    status: filters.status,
+    includeTerminal: filters.includeTerminal,
+  });
+
+  return success(res, {
+    code: 'CONNECTSHYFT_RESOLVER_QUEUE_LISTED',
+    message: 'ConnectShyft resolver queue listed',
+    httpStatus: 200,
+    data: {
+      items,
+    },
+  });
+});
+
+router.get('/resolver-queue/:itemType/:itemId', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  const queueScope = resolveTenantAdminResolverQueueScope(req, res, context);
+  if (!queueScope) {
+    return;
+  }
+
+  const itemType = parseResolverQueueItemTypeParam(req);
+  if (!itemType) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_TYPE_INVALID',
+      message: 'itemType must be identity_review or rebind_review.',
+    });
+    return;
+  }
+
+  const itemId = parseResolverQueueItemIdParam(req);
+  if (!itemId) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_ID_REQUIRED',
+      message: 'itemId is required',
+    });
+    return;
+  }
+
+  const detail = await peopleCoreServiceAsync.getResolverQueueItemDetail({
+    tenantId: context.tenantId,
+    itemType,
+    itemId,
+    actorUserId: resolveConnectShyftRequestedActorUserId(req) || CONNECTSHYFT_SYSTEM_ACTOR_USER_ID,
+    actorRoles: queueScope.actorRoles,
+  });
+
+  if (!detail) {
+    refusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_NOT_FOUND',
+      message: 'Resolver queue item is unavailable for the active tenant context.',
+      refusalType: 'business',
+      httpStatus: 200,
+    });
+    return;
+  }
+
+  return success(res, {
+    code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RETRIEVED',
+    message: 'ConnectShyft resolver queue item retrieved',
+    httpStatus: 200,
+    data: detail,
+  });
+});
+
+router.post('/resolver-queue/:itemType/:itemId/claim', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  const queueScope = resolveTenantAdminResolverQueueScope(req, res, context);
+  if (!queueScope) {
+    return;
+  }
+
+  const itemType = parseResolverQueueItemTypeParam(req);
+  if (!itemType) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_TYPE_INVALID',
+      message: 'itemType must be identity_review or rebind_review.',
+    });
+    return;
+  }
+
+  const itemId = parseResolverQueueItemIdParam(req);
+  if (!itemId) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_ID_REQUIRED',
+      message: 'itemId is required',
+    });
+    return;
+  }
+
+  try {
+    const detail = await peopleCoreServiceAsync.claimResolverQueueItem({
+      tenantId: context.tenantId,
+      itemType,
+      itemId,
+      actorUserId: resolveConnectShyftRequestedActorUserId(req) || CONNECTSHYFT_SYSTEM_ACTOR_USER_ID,
+      actorRoles: queueScope.actorRoles,
+    });
+
+    return success(res, {
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_CLAIMED',
+      message: 'ConnectShyft resolver queue item claimed',
+      httpStatus: 200,
+      data: detail,
+    });
+  } catch (error) {
+    if (error instanceof ResolverQueueClaimConflictError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_CONFLICT',
+        message: 'Resolver queue item is already claimed by another resolver.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    if (error instanceof ResolverQueueClaimRequiredError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_REQUIRED',
+        message: 'Resolver queue item must be claimed before action.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    if (error instanceof InvalidResolverReviewTransitionError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_INVALID',
+        message: 'Resolver queue item cannot be claimed in its current state.',
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          fieldErrors: error.fieldErrors,
+        },
+      });
+      return;
+    }
+
+    if (error instanceof PeopleCoreScopeViolationError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_NOT_FOUND',
+        message: 'Resolver queue item is unavailable for the active tenant context.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    throw error;
+  }
+});
+
+router.post('/resolver-queue/:itemType/:itemId/release', async (req: Request, res: Response) => {
+  if (!await enforceCapability(req, res, 'module')) {
+    return;
+  }
+
+  const context = await enforceOrgUnitContext(req, res);
+  if (!context) {
+    return;
+  }
+
+  const queueScope = resolveTenantAdminResolverQueueScope(req, res, context);
+  if (!queueScope) {
+    return;
+  }
+
+  const itemType = parseResolverQueueItemTypeParam(req);
+  if (!itemType) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_TYPE_INVALID',
+      message: 'itemType must be identity_review or rebind_review.',
+    });
+    return;
+  }
+
+  const itemId = parseResolverQueueItemIdParam(req);
+  if (!itemId) {
+    respondConnectShyftClientRefusal(res, {
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_ID_REQUIRED',
+      message: 'itemId is required',
+    });
+    return;
+  }
+
+  try {
+    const detail = await peopleCoreServiceAsync.releaseResolverQueueItem({
+      tenantId: context.tenantId,
+      itemType,
+      itemId,
+      actorUserId: resolveConnectShyftRequestedActorUserId(req) || CONNECTSHYFT_SYSTEM_ACTOR_USER_ID,
+      actorRoles: queueScope.actorRoles,
+    });
+
+    return success(res, {
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RELEASED',
+      message: 'ConnectShyft resolver queue item released',
+      httpStatus: 200,
+      data: detail,
+    });
+  } catch (error) {
+    if (error instanceof ResolverQueueClaimConflictError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_CONFLICT',
+        message: 'Only the current claimant may release this resolver queue item.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    if (error instanceof ResolverQueueClaimRequiredError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_REQUIRED',
+        message: 'Resolver queue item must be claimed before release.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    if (error instanceof InvalidResolverReviewTransitionError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_RELEASE_INVALID',
+        message: 'Resolver queue item cannot be released in its current state.',
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          fieldErrors: error.fieldErrors,
+        },
+      });
+      return;
+    }
+
+    if (error instanceof PeopleCoreScopeViolationError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_NOT_FOUND',
+        message: 'Resolver queue item is unavailable for the active tenant context.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    throw error;
+  }
+});
+
 router.get('/resolver-reviews', async (req: Request, res: Response) => {
   if (!await enforceCapability(req, res, 'module')) {
     return;
@@ -5146,7 +5495,8 @@ router.post('/resolver-reviews/:reviewId/decision', async (req: Request, res: Re
     return;
   }
 
-  if (!resolveResolverReviewTenantPrivilegedScope(req, res, context)) {
+  const queueScope = resolveTenantAdminResolverQueueScope(req, res, context);
+  if (!queueScope) {
     return;
   }
 
@@ -5182,6 +5532,7 @@ router.post('/resolver-reviews/:reviewId/decision', async (req: Request, res: Re
       tenantId: context.tenantId,
       reviewId,
       actorUserId: resolveConnectShyftRequestedActorUserId(req) || CONNECTSHYFT_SYSTEM_ACTOR_USER_ID,
+      actorRoles: queueScope.actorRoles,
       action: body.action,
       reason: body.reason,
       notes: body.notes,
@@ -5202,6 +5553,36 @@ router.post('/resolver-reviews/:reviewId/decision', async (req: Request, res: Re
       },
     });
   } catch (error) {
+    if (error instanceof ResolverQueueAuthorizationError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_FORBIDDEN',
+        message: 'Resolver queue access requires a tenant-admin role.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    if (error instanceof ResolverQueueClaimRequiredError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_REQUIRED',
+        message: 'Resolver queue item must be claimed before action.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
+    if (error instanceof ResolverQueueClaimConflictError) {
+      refusal(res, {
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_CONFLICT',
+        message: 'Resolver queue item is already claimed by another resolver.',
+        refusalType: 'business',
+        httpStatus: 200,
+      });
+      return;
+    }
+
     if (error instanceof InvalidResolverReviewTransitionError) {
       refusal(res, {
         code: 'CONNECTSHYFT_RESOLVER_DECISION_TERMINAL',

--- a/apps/connectshyft-web/src/features/connectshyft/__tests__/identityResolution.test.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/__tests__/identityResolution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   resolveConnectShyftIdentityResolutionPresentation,
+  resolveConnectShyftThreadSubjectImpactPresentation,
 } from '../identityResolution';
 
 describe('resolveConnectShyftIdentityResolutionPresentation', () => {
@@ -89,6 +90,34 @@ describe('resolveConnectShyftIdentityResolutionPresentation', () => {
       showAttachAction: true,
       showCreateNewAction: true,
       createNewAllowed: true,
+    });
+  });
+
+  it('maps contextual thread impact states into plain-language banner copy', () => {
+    expect(resolveConnectShyftThreadSubjectImpactPresentation({
+      subjectImpact: {
+        impactType: 'resolver_required',
+        actionable: true,
+        resolverQueueItemId: 'review-1',
+        resolverQueueItemType: 'identity_review',
+      },
+      isTenantAdminResolver: false,
+    })).toEqual({
+      message: 'Identity for this conversation is still being reviewed. Conversation context may update once the review is complete.',
+      ctaLabel: null,
+    });
+
+    expect(resolveConnectShyftThreadSubjectImpactPresentation({
+      subjectImpact: {
+        impactType: 'rebind_review',
+        actionable: true,
+        resolverQueueItemId: 'review-2',
+        resolverQueueItemType: 'rebind_review',
+      },
+      isTenantAdminResolver: true,
+    })).toEqual({
+      message: 'This conversation is waiting on a subject-context rebind review. Review in People to continue resolver work.',
+      ctaLabel: 'Review in People',
     });
   });
 });

--- a/apps/connectshyft-web/src/features/connectshyft/__tests__/readContracts.test.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/__tests__/readContracts.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as flagsModule from '@/features/connectshyft/flags';
+import api from '@/services/api';
+import { fetchConnectShyftThreadDetail } from '../readContracts';
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@/features/connectshyft/flags', () => ({
+  buildConnectShyftTestOverrideHeaders: vi.fn(() => ({
+    'x-test-connectshyft-user-id': 'thread-detail-test-user',
+  })),
+}));
+
+const apiGetMock = vi.mocked(api.get);
+const buildHeadersMock = vi.mocked(flagsModule.buildConnectShyftTestOverrideHeaders);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  buildHeadersMock.mockReturnValue({
+    'x-test-connectshyft-user-id': 'thread-detail-test-user',
+  });
+});
+
+describe('fetchConnectShyftThreadDetail', () => {
+  it('parses backend-authored subject impact for contextual banners', async () => {
+    apiGetMock.mockResolvedValue({
+      data: {
+        ok: true,
+        code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+        message: 'ConnectShyft thread detail loaded',
+        data: {
+          thread: {
+            threadId: 'thread-1',
+            neighborId: 'neighbor-1',
+            neighborDeleted: false,
+            neighbor_deleted: false,
+            neighborDeletedAtUtc: null,
+            neighbor_deleted_at_utc: null,
+            orgUnitId: 'org-1',
+            tenantId: 'tenant-1',
+            state: 'CLAIMED',
+            claimedByUserId: 'user-1',
+            claimed_by_user_id: 'user-1',
+            bucket: 'mine',
+            escalationStage: 1,
+            isNewUnread: false,
+            priorityRank: 2,
+            urgencyLabel: 'Needs attention soon',
+            lastActivityAtUtc: '2026-03-24T10:00:00.000Z',
+            lastInboundCsNumberId: '+12605550191',
+            last_inbound_cs_number_id: '+12605550191',
+            preferredOutboundCsNumberId: '+12605550191',
+            preferred_outbound_cs_number_id: '+12605550191',
+            preferredOutboundContext: {
+              csNumberId: '+12605550191',
+              label: 'Primary Queue',
+            },
+            preferred_outbound_context: {
+              cs_number_id: '+12605550191',
+              label: 'Primary Queue',
+            },
+            voicemailIndicator: false,
+            voicemailLabel: null,
+            summary: 'Jordan Lee',
+            preview: 'Latest update: Jordan Lee',
+            display: {
+              title: 'Jordan Lee',
+              preview: 'Latest update: Jordan Lee',
+              urgencyLabel: 'Needs attention soon',
+              stateLabel: 'Claimed',
+              inboundContext: 'Mapped inbound number configured',
+              outboundContext: 'Primary Queue',
+              neighborContext: 'Neighbor context: Jordan Lee',
+              conferenceContext: 'Conference context: Primary Queue',
+              claimContext: 'Claimed by you',
+              voicemailLabel: '',
+            },
+            personId: 'person-1',
+            identityState: 'provisional',
+            subjectImpact: {
+              impactType: 'resolver_required',
+              actionable: true,
+              resolverQueueItemId: 'review-1',
+              resolverQueueItemType: 'identity_review',
+            },
+            subjectContext: {
+              orgUnitId: 'org-1',
+              provisionalPersonId: 'person-1',
+            },
+            actions: ['Call', 'Text', 'Close'],
+            timeline: [],
+            lifecycle: {
+              reopenedByInbound: false,
+            },
+          },
+        },
+      },
+    });
+
+    const result = await fetchConnectShyftThreadDetail('thread-1');
+
+    expect(apiGetMock).toHaveBeenCalledWith('/connectshyft/threads/thread-1', {
+      headers: {
+        'x-test-connectshyft-user-id': 'thread-detail-test-user',
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.thread.subjectImpact).toEqual({
+        impactType: 'resolver_required',
+        actionable: true,
+        resolverQueueItemId: 'review-1',
+        resolverQueueItemType: 'identity_review',
+      });
+      expect(result.thread.subjectContext).toEqual({
+        orgUnitId: 'org-1',
+        provisionalPersonId: 'person-1',
+      });
+    }
+  });
+});

--- a/apps/connectshyft-web/src/features/connectshyft/__tests__/resolverQueue.test.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/__tests__/resolverQueue.test.ts
@@ -1,0 +1,334 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as flagsModule from '@/features/connectshyft/flags';
+import api from '@/services/api';
+import {
+  claimConnectShyftResolverQueueItem,
+  fetchConnectShyftResolverQueue,
+  fetchConnectShyftResolverQueueDetail,
+  releaseConnectShyftResolverQueueItem,
+} from '../resolverQueue';
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('@/features/connectshyft/flags', () => ({
+  buildConnectShyftTestOverrideHeaders: vi.fn(() => ({
+    'x-test-connectshyft-user-id': 'resolver-test-user',
+  })),
+}));
+
+const apiGetMock = vi.mocked(api.get);
+const apiPostMock = vi.mocked(api.post);
+const buildHeadersMock = vi.mocked(flagsModule.buildConnectShyftTestOverrideHeaders);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  buildHeadersMock.mockReturnValue({
+    'x-test-connectshyft-user-id': 'resolver-test-user',
+  });
+});
+
+describe('resolverQueue client', () => {
+  it('loads typed resolver queue items from the backend contract', async () => {
+    apiGetMock.mockResolvedValue({
+      data: {
+        ok: true,
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_LISTED',
+        message: 'ConnectShyft resolver queue listed',
+        data: {
+          items: [
+            {
+              id: 'identity-item',
+              itemType: 'identity_review',
+              status: 'queued',
+              active: true,
+              terminal: false,
+              claimState: 'unclaimed',
+              claimantUserId: null,
+              claimedByCurrentUser: false,
+              claimable: true,
+              releasable: false,
+              actionable: false,
+              resolverReviewId: 'identity-item',
+              orgUnitId: 'org-1',
+              conversationId: 'conversation-1',
+              contactPointId: 'contact-point-1',
+              threadId: null,
+              personIds: ['person-1'],
+              triggerSourceType: 'connectshyft_identity_seam',
+              triggerSourceId: 'trigger-1',
+              requestedAt: '2026-03-24T10:00:00.000Z',
+              startedAt: null,
+              resolvedAt: null,
+            },
+            {
+              id: 'rebind-item',
+              itemType: 'rebind_review',
+              status: 'in_review',
+              active: true,
+              terminal: false,
+              claimState: 'claimed_by_current_user',
+              claimantUserId: 'resolver-1',
+              claimedByCurrentUser: true,
+              claimable: false,
+              releasable: true,
+              actionable: true,
+              resolverReviewId: 'rebind-item',
+              orgUnitId: 'org-1',
+              conversationId: null,
+              contactPointId: 'contact-point-2',
+              threadId: null,
+              personIds: ['person-2', 'person-3'],
+              triggerSourceType: 'connectshyft_person_rebind_review',
+              triggerSourceId: 'rebind-history-1',
+              requestedAt: '2026-03-24T10:05:00.000Z',
+              startedAt: '2026-03-24T10:06:00.000Z',
+              resolvedAt: null,
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await fetchConnectShyftResolverQueue();
+
+    expect(apiGetMock).toHaveBeenCalledWith('/connectshyft/resolver-queue', {
+      headers: {
+        'x-test-connectshyft-user-id': 'resolver-test-user',
+      },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].itemType).toBe('identity_review');
+      expect(result.items[1].itemType).toBe('rebind_review');
+      expect(result.items[1].claimState).toBe('claimed_by_current_user');
+    }
+  });
+
+  it('loads resolver detail with rebind review context', async () => {
+    apiGetMock.mockResolvedValue({
+      data: {
+        ok: true,
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RETRIEVED',
+        message: 'ConnectShyft resolver queue item retrieved',
+        data: {
+          item: {
+            id: 'rebind-item',
+            itemType: 'rebind_review',
+            status: 'in_review',
+            active: true,
+            terminal: false,
+            claimState: 'claimed_by_other',
+            claimantUserId: 'resolver-2',
+            claimedByCurrentUser: false,
+            claimable: false,
+            releasable: false,
+            actionable: false,
+            resolverReviewId: 'rebind-item',
+            orgUnitId: 'org-1',
+            conversationId: null,
+            contactPointId: 'contact-point-2',
+            threadId: null,
+            personIds: ['person-2', 'person-3'],
+            triggerSourceType: 'connectshyft_person_rebind_review',
+            triggerSourceId: 'rebind-history-1',
+            requestedAt: '2026-03-24T10:05:00.000Z',
+            startedAt: '2026-03-24T10:06:00.000Z',
+            resolvedAt: null,
+          },
+          review: {
+            id: 'rebind-item',
+            tenantId: 'tenant-1',
+            orgUnitId: 'org-1',
+            reviewType: 'subject_reassignment_review',
+            reviewStatus: 'in_review',
+            priority: 'normal',
+            triggerSourceType: 'connectshyft_person_rebind_review',
+            triggerSourceId: 'rebind-history-1',
+            candidatePersonIds: ['person-2', 'person-3'],
+            confidenceBand: 'medium',
+            confidenceReasons: [],
+            riskFlags: [],
+            requestedByUserId: 'requested-by-user',
+            requestedAt: '2026-03-24T10:05:00.000Z',
+            actionable: true,
+            terminal: false,
+            decisionStatus: null,
+          },
+          rebindReview: {
+            rebindHistoryId: 'rebind-history-1',
+            affectedObjectType: 'contact_point_link',
+            affectedObjectIds: ['link-1', 'link-2'],
+            sourcePersonId: 'person-old',
+            targetPersonId: 'person-new',
+            contactPointIds: ['contact-point-2'],
+            originatingResolverReviewId: 'origin-review-1',
+            originatingResolutionType: 'reassign_contact_point',
+          },
+        },
+      },
+    });
+
+    const result = await fetchConnectShyftResolverQueueDetail('rebind_review', 'rebind-item');
+
+    expect(apiGetMock).toHaveBeenCalledWith(
+      '/connectshyft/resolver-queue/rebind_review/rebind-item',
+      {
+        headers: {
+          'x-test-connectshyft-user-id': 'resolver-test-user',
+        },
+      },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.detail.item.claimState).toBe('claimed_by_other');
+      expect(result.detail.rebindReview?.affectedObjectType).toBe('contact_point_link');
+      expect(result.detail.rebindReview?.originatingResolutionType).toBe('reassign_contact_point');
+    }
+  });
+
+  it('uses backend-backed claim and release routes without inventing local semantics', async () => {
+    apiPostMock
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_CLAIMED',
+          message: 'ConnectShyft resolver queue item claimed',
+          data: {
+            item: {
+              id: 'identity-item',
+              itemType: 'identity_review',
+              status: 'in_review',
+              active: true,
+              terminal: false,
+              claimState: 'claimed_by_current_user',
+              claimantUserId: 'resolver-1',
+              claimedByCurrentUser: true,
+              claimable: false,
+              releasable: true,
+              actionable: true,
+              resolverReviewId: 'identity-item',
+              orgUnitId: 'org-1',
+              conversationId: null,
+              contactPointId: 'contact-point-1',
+              threadId: null,
+              personIds: ['person-1'],
+              triggerSourceType: 'connectshyft_identity_seam',
+              triggerSourceId: 'trigger-1',
+              requestedAt: '2026-03-24T10:00:00.000Z',
+              startedAt: '2026-03-24T10:02:00.000Z',
+              resolvedAt: null,
+            },
+            review: {
+              id: 'identity-item',
+              tenantId: 'tenant-1',
+              orgUnitId: 'org-1',
+              reviewType: 'shared_contact_ambiguity',
+              reviewStatus: 'in_review',
+              priority: 'normal',
+              triggerSourceType: 'connectshyft_identity_seam',
+              triggerSourceId: 'trigger-1',
+              candidatePersonIds: ['person-1'],
+              confidenceBand: 'medium',
+              confidenceReasons: [],
+              riskFlags: ['shared_contact_possible'],
+              requestedByUserId: 'requested-by-user',
+              requestedAt: '2026-03-24T10:00:00.000Z',
+              actionable: true,
+              terminal: false,
+              decisionStatus: null,
+            },
+            rebindReview: null,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          ok: true,
+          code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RELEASED',
+          message: 'ConnectShyft resolver queue item released',
+          data: {
+            item: {
+              id: 'identity-item',
+              itemType: 'identity_review',
+              status: 'queued',
+              active: true,
+              terminal: false,
+              claimState: 'unclaimed',
+              claimantUserId: null,
+              claimedByCurrentUser: false,
+              claimable: true,
+              releasable: false,
+              actionable: false,
+              resolverReviewId: 'identity-item',
+              orgUnitId: 'org-1',
+              conversationId: null,
+              contactPointId: 'contact-point-1',
+              threadId: null,
+              personIds: ['person-1'],
+              triggerSourceType: 'connectshyft_identity_seam',
+              triggerSourceId: 'trigger-1',
+              requestedAt: '2026-03-24T10:00:00.000Z',
+              startedAt: null,
+              resolvedAt: null,
+            },
+            review: {
+              id: 'identity-item',
+              tenantId: 'tenant-1',
+              orgUnitId: 'org-1',
+              reviewType: 'shared_contact_ambiguity',
+              reviewStatus: 'queued',
+              priority: 'normal',
+              triggerSourceType: 'connectshyft_identity_seam',
+              triggerSourceId: 'trigger-1',
+              candidatePersonIds: ['person-1'],
+              confidenceBand: 'medium',
+              confidenceReasons: [],
+              riskFlags: ['shared_contact_possible'],
+              requestedByUserId: 'requested-by-user',
+              requestedAt: '2026-03-24T10:00:00.000Z',
+              actionable: true,
+              terminal: false,
+              decisionStatus: null,
+            },
+            rebindReview: null,
+          },
+        },
+      });
+
+    const claimResult = await claimConnectShyftResolverQueueItem('identity_review', 'identity-item');
+    const releaseResult = await releaseConnectShyftResolverQueueItem('identity_review', 'identity-item');
+
+    expect(apiPostMock).toHaveBeenNthCalledWith(
+      1,
+      '/connectshyft/resolver-queue/identity_review/identity-item/claim',
+      undefined,
+      {
+        headers: {
+          'x-test-connectshyft-user-id': 'resolver-test-user',
+        },
+      },
+    );
+    expect(apiPostMock).toHaveBeenNthCalledWith(
+      2,
+      '/connectshyft/resolver-queue/identity_review/identity-item/release',
+      undefined,
+      {
+        headers: {
+          'x-test-connectshyft-user-id': 'resolver-test-user',
+        },
+      },
+    );
+    expect(claimResult.ok).toBe(true);
+    expect(releaseResult.ok).toBe(true);
+    if (claimResult.ok && releaseResult.ok) {
+      expect(claimResult.detail.item.claimState).toBe('claimed_by_current_user');
+      expect(releaseResult.detail.item.claimState).toBe('unclaimed');
+    }
+  });
+});

--- a/apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
@@ -1,4 +1,5 @@
 import type {
+  ConnectShyftThreadSubjectImpact,
   ConnectShyftIdentityResolutionCandidate,
   ConnectShyftIdentityResolutionResponse,
 } from '@shyft/contracts';
@@ -29,6 +30,11 @@ export type ConnectShyftIdentityResolutionPresentation = {
   showCreateNewAction: boolean;
   createNewAllowed: boolean;
   guidance: string;
+};
+
+export type ConnectShyftThreadSubjectImpactPresentation = {
+  message: string;
+  ctaLabel: 'Open in People' | 'Review in People' | null;
 };
 
 const normalizeResolutionState = (
@@ -144,6 +150,41 @@ export const resolveConnectShyftIdentityResolutionPresentation = (
         showCreateNewAction: true,
         createNewAllowed: true,
         guidance: 'No strong identity match was found. Create a new person silently.',
+      };
+  }
+};
+
+export const resolveConnectShyftThreadSubjectImpactPresentation = (input: {
+  subjectImpact: ConnectShyftThreadSubjectImpact;
+  isTenantAdminResolver: boolean;
+}): ConnectShyftThreadSubjectImpactPresentation => {
+  const { subjectImpact, isTenantAdminResolver } = input;
+
+  switch (subjectImpact.impactType) {
+    case 'resolver_required':
+      return {
+        message: isTenantAdminResolver
+          ? 'Identity for this conversation is still waiting on tenant-admin review. Review in People to continue resolver work.'
+          : 'Identity for this conversation is still being reviewed. Conversation context may update once the review is complete.',
+        ctaLabel: isTenantAdminResolver
+          ? (subjectImpact.actionable ? 'Review in People' : 'Open in People')
+          : null,
+      };
+    case 'rebind_review':
+      return {
+        message: isTenantAdminResolver
+          ? 'This conversation is waiting on a subject-context rebind review. Review in People to continue resolver work.'
+          : 'Conversation context is being updated to match the latest subject record. Keep working from the current thread until the update is complete.',
+        ctaLabel: isTenantAdminResolver
+          ? (subjectImpact.actionable ? 'Review in People' : 'Open in People')
+          : null,
+      };
+    default:
+      return {
+        message: isTenantAdminResolver
+          ? 'This conversation is still tied to a provisional person record. Open in People if you need to review the latest subject context.'
+          : 'Subject details for this conversation are still settling. Keep working from the current conversation context until the person record is confirmed.',
+        ctaLabel: isTenantAdminResolver ? 'Open in People' : null,
       };
   }
 };

--- a/apps/connectshyft-web/src/features/connectshyft/readContracts.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/readContracts.ts
@@ -1,6 +1,13 @@
 import api from '@/services/api';
 import { buildConnectShyftTestOverrideHeaders } from '@/features/connectshyft/flags';
-import type { SubjectContext } from '@shyft/contracts';
+import type {
+  ConnectShyftThreadSubjectImpact,
+  SubjectContext,
+} from '@shyft/contracts';
+import {
+  isConnectShyftResolverQueueItemType,
+  isConnectShyftThreadSubjectImpactType,
+} from '@shyft/contracts';
 
 export type ConnectShyftThreadState = 'UNCLAIMED' | 'CLAIMED' | 'CLOSED';
 export type ConnectShyftInboxBucket = 'inbox' | 'mine';
@@ -56,6 +63,7 @@ export type ConnectShyftTimelineEvent = {
 export type ConnectShyftThreadDetail = ConnectShyftThreadSummary & {
   personId: string | null;
   identityState: ConnectShyftThreadIdentityState | null;
+  subjectImpact: ConnectShyftThreadSubjectImpact | null;
   subjectContext: SubjectContext;
   actions: string[];
   timeline: ConnectShyftTimelineEvent[];
@@ -117,6 +125,11 @@ const normalizeString = (value: unknown): string => {
   }
 
   return value.trim();
+};
+
+const normalizeOptionalString = (value: unknown): string | null => {
+  const normalized = normalizeString(value);
+  return normalized.length > 0 ? normalized : null;
 };
 
 const normalizeStage = (value: unknown): number => {
@@ -470,6 +483,41 @@ const parseThreadSummary = (payload: unknown): ConnectShyftThreadSummary | null 
   };
 };
 
+const parseThreadSubjectImpact = (payload: unknown): ConnectShyftThreadSubjectImpact | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const candidate = payload as {
+    impactType?: unknown;
+    impact_type?: unknown;
+    actionable?: unknown;
+    resolverQueueItemId?: unknown;
+    resolver_queue_item_id?: unknown;
+    resolverQueueItemType?: unknown;
+    resolver_queue_item_type?: unknown;
+  };
+
+  const impactType = candidate.impactType ?? candidate.impact_type;
+  const resolverQueueItemType =
+    candidate.resolverQueueItemType ?? candidate.resolver_queue_item_type;
+
+  if (!isConnectShyftThreadSubjectImpactType(impactType)) {
+    return null;
+  }
+
+  return {
+    impactType,
+    actionable: candidate.actionable === true,
+    resolverQueueItemId: normalizeOptionalString(
+      candidate.resolverQueueItemId ?? candidate.resolver_queue_item_id,
+    ),
+    resolverQueueItemType: isConnectShyftResolverQueueItemType(resolverQueueItemType)
+      ? resolverQueueItemType
+      : null,
+  };
+};
+
 const parseThreadDetail = (payload: unknown): ConnectShyftThreadDetail | null => {
   if (!payload || typeof payload !== 'object') {
     return null;
@@ -484,6 +532,7 @@ const parseThreadDetail = (payload: unknown): ConnectShyftThreadDetail | null =>
     actions?: unknown;
     personId?: unknown;
     identityState?: unknown;
+    subjectImpact?: unknown;
     subjectContext?: unknown;
     timeline?: unknown;
     lifecycle?: {
@@ -519,6 +568,7 @@ const parseThreadDetail = (payload: unknown): ConnectShyftThreadDetail | null =>
     ...summary,
     personId,
     identityState,
+    subjectImpact: parseThreadSubjectImpact(candidate.subjectImpact),
     subjectContext,
     actions,
     timeline: parseTimelineEvents(candidate.timeline),

--- a/apps/connectshyft-web/src/features/connectshyft/resolverQueue.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/resolverQueue.ts
@@ -1,0 +1,369 @@
+import api from '@/services/api';
+import { buildConnectShyftTestOverrideHeaders } from '@/features/connectshyft/flags';
+import type {
+  ConnectShyftRebindReviewContext,
+  ConnectShyftResolverQueueDetailData,
+  ConnectShyftResolverQueueItemRecord,
+  ConnectShyftResolverQueueItemType,
+  ConnectShyftResolverReviewRecord,
+  ResolverReviewStatus,
+} from '@shyft/contracts';
+import {
+  isConnectShyftRebindReviewAffectedObjectType,
+  isConnectShyftResolverQueueClaimState,
+  isConnectShyftResolverQueueItemType,
+  isResolverReviewStatus,
+} from '@shyft/contracts';
+
+type ResolverQueueEnvelope = {
+  ok?: boolean;
+  code?: string;
+  message?: string;
+  data?: {
+    items?: unknown[];
+    item?: unknown;
+    review?: unknown;
+    rebindReview?: unknown;
+  };
+};
+
+export type ConnectShyftResolverQueueListResult =
+  | {
+    ok: true;
+    code: string;
+    message: string;
+    items: ConnectShyftResolverQueueItemRecord[];
+  }
+  | {
+    ok: false;
+    code: string;
+    message: string;
+    unauthorized: boolean;
+  };
+
+export type ConnectShyftResolverQueueDetailResult =
+  | {
+    ok: true;
+    code: string;
+    message: string;
+    detail: ConnectShyftResolverQueueDetailData;
+  }
+  | {
+    ok: false;
+    code: string;
+    message: string;
+    unauthorized: boolean;
+    unavailable: boolean;
+  };
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const normalizeOptionalString = (value: unknown): string | null => {
+  const normalized = normalizeString(value);
+  return normalized.length > 0 ? normalized : null;
+};
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => normalizeOptionalString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+};
+
+const parseEnvelopeMessage = (payload: unknown, fallback: string): string => {
+  if (!payload || typeof payload !== 'object') {
+    return fallback;
+  }
+
+  const envelope = payload as ResolverQueueEnvelope;
+  return normalizeString(envelope.message) || fallback;
+};
+
+const isUnauthorizedQueueCode = (code: string): boolean => (
+  code.includes('FORBIDDEN') || code.includes('UNAUTHORIZED')
+);
+
+const isUnavailableQueueCode = (code: string): boolean => (
+  code.includes('NOT_FOUND') || code.includes('UNAVAILABLE')
+);
+
+const parseResolverQueueItem = (payload: unknown): ConnectShyftResolverQueueItemRecord | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  const id = normalizeString(candidate.id);
+  const itemType = candidate.itemType ?? candidate.item_type;
+  const status = normalizeString(candidate.status);
+
+  if (!id || !isConnectShyftResolverQueueItemType(itemType) || !isResolverReviewStatus(status)) {
+    return null;
+  }
+
+  const claimState = candidate.claimState ?? candidate.claim_state;
+
+  return {
+    id,
+    itemType,
+    status: status as ResolverReviewStatus,
+    active: candidate.active === true,
+    terminal: candidate.terminal === true,
+    claimState: isConnectShyftResolverQueueClaimState(claimState) ? claimState : 'unclaimed',
+    claimantUserId: normalizeOptionalString(candidate.claimantUserId ?? candidate.claimant_user_id),
+    claimedByCurrentUser: candidate.claimedByCurrentUser === true
+      || candidate.claimed_by_current_user === true,
+    claimable: candidate.claimable === true,
+    releasable: candidate.releasable === true,
+    actionable: candidate.actionable === true,
+    resolverReviewId: normalizeOptionalString(candidate.resolverReviewId ?? candidate.resolver_review_id),
+    orgUnitId: normalizeOptionalString(candidate.orgUnitId ?? candidate.org_unit_id),
+    conversationId: normalizeOptionalString(candidate.conversationId ?? candidate.conversation_id),
+    contactPointId: normalizeOptionalString(candidate.contactPointId ?? candidate.contact_point_id),
+    threadId: normalizeOptionalString(candidate.threadId ?? candidate.thread_id),
+    personIds: normalizeStringArray(candidate.personIds ?? candidate.person_ids),
+    triggerSourceType: normalizeOptionalString(candidate.triggerSourceType ?? candidate.trigger_source_type),
+    triggerSourceId: normalizeOptionalString(candidate.triggerSourceId ?? candidate.trigger_source_id),
+    requestedAt: normalizeOptionalString(candidate.requestedAt ?? candidate.requested_at),
+    startedAt: normalizeOptionalString(candidate.startedAt ?? candidate.started_at),
+    resolvedAt: normalizeOptionalString(candidate.resolvedAt ?? candidate.resolved_at),
+  };
+};
+
+const parseResolverReviewRecord = (payload: unknown): ConnectShyftResolverReviewRecord | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  const id = normalizeString(candidate.id);
+  const reviewStatus = normalizeString(candidate.reviewStatus ?? candidate.review_status);
+  if (!id || !isResolverReviewStatus(reviewStatus)) {
+    return null;
+  }
+
+  return {
+    id,
+    tenantId: normalizeString(candidate.tenantId ?? candidate.tenant_id),
+    orgUnitId: normalizeString(candidate.orgUnitId ?? candidate.org_unit_id),
+    reviewType: normalizeString(candidate.reviewType ?? candidate.review_type) as ConnectShyftResolverReviewRecord['reviewType'],
+    reviewStatus: reviewStatus as ResolverReviewStatus,
+    priority: (normalizeString(candidate.priority) || 'normal') as ConnectShyftResolverReviewRecord['priority'],
+    triggerSourceType: normalizeString(candidate.triggerSourceType ?? candidate.trigger_source_type),
+    triggerSourceId: normalizeString(candidate.triggerSourceId ?? candidate.trigger_source_id),
+    conversationId: normalizeOptionalString(candidate.conversationId ?? candidate.conversation_id) ?? undefined,
+    provisionalPersonId: normalizeOptionalString(candidate.provisionalPersonId ?? candidate.provisional_person_id) ?? undefined,
+    candidatePersonIds: normalizeStringArray(candidate.candidatePersonIds ?? candidate.candidate_person_ids),
+    contactPointId: normalizeOptionalString(candidate.contactPointId ?? candidate.contact_point_id) ?? undefined,
+    confidenceBand: (normalizeString(candidate.confidenceBand ?? candidate.confidence_band) || 'low') as ConnectShyftResolverReviewRecord['confidenceBand'],
+    confidenceReasons: normalizeStringArray(candidate.confidenceReasons ?? candidate.confidence_reasons),
+    riskFlags: normalizeStringArray(candidate.riskFlags ?? candidate.risk_flags) as ConnectShyftResolverReviewRecord['riskFlags'],
+    requestedByUserId: normalizeString(candidate.requestedByUserId ?? candidate.requested_by_user_id),
+    assignedResolverUserId: normalizeOptionalString(candidate.assignedResolverUserId ?? candidate.assigned_resolver_user_id) ?? undefined,
+    requestedAt: normalizeString(candidate.requestedAt ?? candidate.requested_at),
+    startedAt: normalizeOptionalString(candidate.startedAt ?? candidate.started_at) ?? undefined,
+    resolvedAt: normalizeOptionalString(candidate.resolvedAt ?? candidate.resolved_at) ?? undefined,
+    resolutionType: normalizeOptionalString(candidate.resolutionType ?? candidate.resolution_type) as ConnectShyftResolverReviewRecord['resolutionType'] ?? undefined,
+    resolutionReason: normalizeOptionalString(candidate.resolutionReason ?? candidate.resolution_reason) ?? undefined,
+    resolutionNotes: normalizeOptionalString(candidate.resolutionNotes ?? candidate.resolution_notes) ?? undefined,
+    actionable: candidate.actionable === true,
+    terminal: candidate.terminal === true,
+    decisionStatus: normalizeOptionalString(candidate.decisionStatus ?? candidate.decision_status) as ConnectShyftResolverReviewRecord['decisionStatus'] ?? null,
+  };
+};
+
+const parseRebindReviewContext = (payload: unknown): ConnectShyftRebindReviewContext | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  const rebindHistoryId = normalizeString(candidate.rebindHistoryId ?? candidate.rebind_history_id);
+  const affectedObjectType = candidate.affectedObjectType ?? candidate.affected_object_type;
+
+  if (!rebindHistoryId || !isConnectShyftRebindReviewAffectedObjectType(affectedObjectType)) {
+    return null;
+  }
+
+  return {
+    rebindHistoryId,
+    affectedObjectType,
+    affectedObjectIds: normalizeStringArray(candidate.affectedObjectIds ?? candidate.affected_object_ids),
+    sourcePersonId: normalizeString(candidate.sourcePersonId ?? candidate.source_person_id),
+    targetPersonId: normalizeString(candidate.targetPersonId ?? candidate.target_person_id),
+    contactPointIds: normalizeStringArray(candidate.contactPointIds ?? candidate.contact_point_ids),
+    originatingResolverReviewId: normalizeOptionalString(
+      candidate.originatingResolverReviewId ?? candidate.originating_resolver_review_id,
+    ),
+    originatingResolutionType: normalizeOptionalString(
+      candidate.originatingResolutionType ?? candidate.originating_resolution_type,
+    ) as ConnectShyftRebindReviewContext['originatingResolutionType'],
+  };
+};
+
+const parseResolverQueueDetail = (payload: unknown): ConnectShyftResolverQueueDetailData | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const envelope = payload as ResolverQueueEnvelope;
+  const item = parseResolverQueueItem(envelope.data?.item);
+  if (!item) {
+    return null;
+  }
+
+  return {
+    item,
+    review: parseResolverReviewRecord(envelope.data?.review),
+    rebindReview: parseRebindReviewContext(envelope.data?.rebindReview),
+  };
+};
+
+const buildListFailure = (payload: unknown, fallbackCode: string, fallbackMessage: string): ConnectShyftResolverQueueListResult => {
+  const envelope = payload as ResolverQueueEnvelope | undefined;
+  const code = normalizeString(envelope?.code) || fallbackCode;
+  return {
+    ok: false,
+    code,
+    message: parseEnvelopeMessage(payload, fallbackMessage),
+    unauthorized: isUnauthorizedQueueCode(code),
+  };
+};
+
+const buildDetailFailure = (payload: unknown, fallbackCode: string, fallbackMessage: string): ConnectShyftResolverQueueDetailResult => {
+  const envelope = payload as ResolverQueueEnvelope | undefined;
+  const code = normalizeString(envelope?.code) || fallbackCode;
+  return {
+    ok: false,
+    code,
+    message: parseEnvelopeMessage(payload, fallbackMessage),
+    unauthorized: isUnauthorizedQueueCode(code),
+    unavailable: isUnavailableQueueCode(code),
+  };
+};
+
+export const fetchConnectShyftResolverQueue = async (): Promise<ConnectShyftResolverQueueListResult> => {
+  try {
+    const response = await api.get('/connectshyft/resolver-queue', {
+      headers: buildConnectShyftTestOverrideHeaders(),
+    });
+    const envelope = response.data as ResolverQueueEnvelope;
+    if (envelope?.ok !== true) {
+      return buildListFailure(response.data, 'CONNECTSHYFT_RESOLVER_QUEUE_REFUSED', 'Unable to load resolver queue.');
+    }
+
+    return {
+      ok: true,
+      code: normalizeString(envelope.code) || 'CONNECTSHYFT_RESOLVER_QUEUE_LISTED',
+      message: parseEnvelopeMessage(response.data, 'Resolver queue loaded.'),
+      items: Array.isArray(envelope.data?.items)
+        ? envelope.data.items
+          .map(parseResolverQueueItem)
+          .filter((item): item is ConnectShyftResolverQueueItemRecord => item !== null)
+        : [],
+    };
+  } catch (error: unknown) {
+    return buildListFailure(
+      (error as { response?: { data?: unknown } })?.response?.data,
+      'CONNECTSHYFT_RESOLVER_QUEUE_REQUEST_FAILED',
+      'Unable to load resolver queue.',
+    );
+  }
+};
+
+export const fetchConnectShyftResolverQueueDetail = async (
+  itemType: ConnectShyftResolverQueueItemType,
+  itemId: string,
+): Promise<ConnectShyftResolverQueueDetailResult> => {
+  try {
+    const response = await api.get(
+      `/connectshyft/resolver-queue/${encodeURIComponent(itemType)}/${encodeURIComponent(itemId)}`,
+      {
+        headers: buildConnectShyftTestOverrideHeaders(),
+      },
+    );
+    const envelope = response.data as ResolverQueueEnvelope;
+    if (envelope?.ok !== true) {
+      return buildDetailFailure(response.data, 'CONNECTSHYFT_RESOLVER_QUEUE_DETAIL_REFUSED', 'Unable to load resolver detail.');
+    }
+
+    const detail = parseResolverQueueDetail(response.data);
+    if (!detail) {
+      return buildDetailFailure(response.data, 'CONNECTSHYFT_RESOLVER_QUEUE_DETAIL_INVALID', 'Resolver detail payload was incomplete.');
+    }
+
+    return {
+      ok: true,
+      code: normalizeString(envelope.code) || 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RETRIEVED',
+      message: parseEnvelopeMessage(response.data, 'Resolver detail loaded.'),
+      detail,
+    };
+  } catch (error: unknown) {
+    return buildDetailFailure(
+      (error as { response?: { data?: unknown } })?.response?.data,
+      'CONNECTSHYFT_RESOLVER_QUEUE_DETAIL_REQUEST_FAILED',
+      'Unable to load resolver detail.',
+    );
+  }
+};
+
+const runResolverQueueMutation = async (
+  path: string,
+  fallbackCode: string,
+  fallbackMessage: string,
+): Promise<ConnectShyftResolverQueueDetailResult> => {
+  try {
+    const response = await api.post(path, undefined, {
+      headers: buildConnectShyftTestOverrideHeaders(),
+    });
+    const envelope = response.data as ResolverQueueEnvelope;
+    if (envelope?.ok !== true) {
+      return buildDetailFailure(response.data, fallbackCode, fallbackMessage);
+    }
+
+    const detail = parseResolverQueueDetail(response.data);
+    if (!detail) {
+      return buildDetailFailure(response.data, `${fallbackCode}_INVALID`, 'Resolver mutation payload was incomplete.');
+    }
+
+    return {
+      ok: true,
+      code: normalizeString(envelope.code) || fallbackCode,
+      message: parseEnvelopeMessage(response.data, 'Resolver workspace updated.'),
+      detail,
+    };
+  } catch (error: unknown) {
+    return buildDetailFailure(
+      (error as { response?: { data?: unknown } })?.response?.data,
+      `${fallbackCode}_REQUEST_FAILED`,
+      fallbackMessage,
+    );
+  }
+};
+
+export const claimConnectShyftResolverQueueItem = async (
+  itemType: ConnectShyftResolverQueueItemType,
+  itemId: string,
+): Promise<ConnectShyftResolverQueueDetailResult> => runResolverQueueMutation(
+  `/connectshyft/resolver-queue/${encodeURIComponent(itemType)}/${encodeURIComponent(itemId)}/claim`,
+  'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_CLAIMED',
+  'Unable to claim this resolver item right now.',
+);
+
+export const releaseConnectShyftResolverQueueItem = async (
+  itemType: ConnectShyftResolverQueueItemType,
+  itemId: string,
+): Promise<ConnectShyftResolverQueueDetailResult> => runResolverQueueMutation(
+  `/connectshyft/resolver-queue/${encodeURIComponent(itemType)}/${encodeURIComponent(itemId)}/release`,
+  'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RELEASED',
+  'Unable to release this resolver item right now.',
+);

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
@@ -44,10 +44,36 @@
           </p>
 
           <section
-            v-if="showContextualActionFeedback || detailLoadError"
+            v-if="threadSubjectImpactPresentation || showContextualActionFeedback || detailLoadError"
             data-testid="connectshyft-thread-action-feedback-contextual"
             class="space-y-3"
           >
+            <section
+              v-if="threadSubjectImpactPresentation"
+              data-testid="connectshyft-thread-subject-impact-banner"
+              class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4 text-base text-amber-900"
+            >
+              <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div class="space-y-1">
+                  <p class="font-semibold text-amber-950">
+                    Conversation context still resolving
+                  </p>
+                  <p data-testid="connectshyft-thread-subject-impact-message">
+                    {{ threadSubjectImpactPresentation.message }}
+                  </p>
+                </div>
+
+                <RouterLink
+                  v-if="threadSubjectImpactPresentation.ctaLabel"
+                  :to="peopleWorkspaceLink"
+                  data-testid="connectshyft-thread-subject-impact-people-link"
+                  class="inline-flex min-h-[44px] items-center justify-center rounded-full border border-amber-300 bg-white px-4 py-2 text-base font-semibold text-amber-900"
+                >
+                  {{ threadSubjectImpactPresentation.ctaLabel }}
+                </RouterLink>
+              </div>
+            </section>
+
             <p
               v-if="feedbackBanner"
               data-testid="connectshyft-feedback-banner"
@@ -166,12 +192,18 @@
                     </div>
                     <div>
                       <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
-                        Person context
+                        Subject snapshot
                       </p>
                       <p class="mt-2 text-base text-slate-600">
                         <span data-testid="connectshyft-thread-identity-state">
                           {{ threadDetail.identityState === 'provisional' ? 'Provisional person' : 'Confirmed person' }}
                         </span>
+                      </p>
+                      <p
+                        data-testid="connectshyft-thread-subject-snapshot-note"
+                        class="mt-2 text-sm text-slate-500"
+                      >
+                        {{ threadSubjectSnapshotNote }}
                       </p>
                     </div>
                   </div>
@@ -501,8 +533,8 @@
 
 <script setup lang="ts">
 import type { SubjectContext } from '@shyft/contracts';
-import { computed, nextTick, onMounted, ref, watch } from 'vue';
-import { useRoute } from 'vue-router';
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
+import { RouterLink, useRoute } from 'vue-router';
 import ConnectShyftComposer from '@/components/connectshyft/ConnectShyftComposer.vue';
 import ConnectShyftMessageBubble from '@/components/connectshyft/ConnectShyftMessageBubble.vue';
 import ConnectShyftNeighborSnapshot from '@/components/connectshyft/ConnectShyftNeighborSnapshot.vue';
@@ -533,6 +565,7 @@ import {
   fetchConnectShyftThreadDetail,
   type ConnectShyftThreadDetail,
 } from '@/features/connectshyft/readContracts';
+import { resolveConnectShyftThreadSubjectImpactPresentation } from '@/features/connectshyft/identityResolution';
 import {
   CONNECTSHYFT_ACCESSIBILITY_LOCKS,
   CONNECTSHYFT_DEFAULT_SMS_OVERRIDE_REASONS,
@@ -587,6 +620,7 @@ const CONNECTSHYFT_OVERRIDE_REFUSAL_CODES = new Set([
   'CONNECTSHYFT_SMS_OVERRIDE_REASON_INVALID',
   'CONNECTSHYFT_OUTBOUND_OVERRIDE_REASON_REQUIRED',
 ]);
+const THREAD_SUBJECT_IMPACT_REFRESH_INTERVAL_MS = 15000;
 const CONNECTSHYFT_MODAL_FOCUSABLE_SELECTOR = [
   'button:not([disabled])',
   '[href]',
@@ -639,6 +673,8 @@ const actorUserId = computed(() => {
 });
 
 const isViewerRole = computed(() => role.value === 'TENANT_VIEWER');
+const isTenantAdminResolver = computed(() =>
+  role.value === 'TENANT_ADMIN' || role.value === 'ADMIN');
 
 const threadId = computed(() => {
   const rawValue = route.params.threadId;
@@ -661,6 +697,27 @@ const threadSubjectContext = computed<SubjectContext>(() => {
   const subject = threadDetail.value?.subjectContext;
   return subject && subject.orgUnitId ? subject : { orgUnitId: activeOrgUnitId.value };
 });
+
+const threadSubjectImpact = computed(() => threadDetail.value?.subjectImpact || null);
+
+const threadSubjectImpactPresentation = computed(() => {
+  if (!threadSubjectImpact.value) {
+    return null;
+  }
+
+  return resolveConnectShyftThreadSubjectImpactPresentation({
+    subjectImpact: threadSubjectImpact.value,
+    isTenantAdminResolver: isTenantAdminResolver.value,
+  });
+});
+
+const peopleWorkspaceLink = computed(() => ({
+  path: '/app/people',
+  query: {
+    ...route.query,
+    ...(activeOrgUnitId.value ? { orgUnitId: activeOrgUnitId.value } : {}),
+  },
+}));
 
 const resolveQueryString = (...keys: string[]): string | null => {
   for (const key of keys) {
@@ -1000,11 +1057,39 @@ const threadTimestampLabel = computed(() => {
 });
 
 const threadSnapshotNote = computed(() => {
+  if (threadSubjectImpact.value) {
+    return 'Temporary identity warnings appear above when this conversation is still being resolved. Final subject truth updates here once that work is complete.';
+  }
+
+  if (threadDetail.value?.identityState === 'provisional') {
+    return 'This snapshot is still provisional. Final subject truth will replace it once identity confirmation is complete.';
+  }
+
   if (threadDetail.value?.voicemailIndicator) {
     return 'Keep the voicemail and the next volunteer step visible without leaking routing internals into the conversation flow.';
   }
 
-  return 'Keep the case conversation front and center. Conference, claim status, and key contact context stay visible without cluttering the timeline.';
+  return 'Final subject truth is reflected here while conversation context stays front and center.';
+});
+
+const threadSubjectSnapshotNote = computed(() => {
+  if (!threadDetail.value?.identityState) {
+    return 'Subject truth will appear here once this conversation is matched to a person.';
+  }
+
+  if (threadSubjectImpact.value?.impactType === 'resolver_required') {
+    return 'This snapshot shows the current subject while tenant-admin review is still in progress.';
+  }
+
+  if (threadSubjectImpact.value?.impactType === 'rebind_review') {
+    return 'This snapshot updates to final truth as soon as rebind review finishes.';
+  }
+
+  if (threadDetail.value.identityState === 'provisional') {
+    return 'This snapshot is still provisional until subject truth is confirmed.';
+  }
+
+  return 'Resolved subject truth is currently in sync with this conversation.';
 });
 
 const timelineEvents = computed(() => {
@@ -1611,9 +1696,31 @@ const loadThreadNeighbors = async (): Promise<void> => {
   threadNeighbors.value = neighborsResult.neighbors;
 };
 
-const refreshThreadDetail = async () => {
+let threadSubjectImpactRefreshHandle: number | null = null;
+
+const clearThreadSubjectImpactRefresh = (): void => {
+  if (threadSubjectImpactRefreshHandle === null || typeof window === 'undefined') {
+    return;
+  }
+
+  window.clearInterval(threadSubjectImpactRefreshHandle);
+  threadSubjectImpactRefreshHandle = null;
+};
+
+const refreshThreadDetail = async (options: {
+  preserveUiState?: boolean;
+  background?: boolean;
+} = {}) => {
+  if (options.background && actionPending.value) {
+    return;
+  }
+
   availability.value = await fetchConnectShyftAvailability();
   if (showUnavailableState.value) {
+    if (options.background) {
+      return;
+    }
+
     threadDetail.value = null;
     threadNeighbors.value = [];
     detailLoadError.value = '';
@@ -1629,6 +1736,10 @@ const refreshThreadDetail = async () => {
 
   const detailResult = await fetchConnectShyftThreadDetail(threadId.value);
   if (!detailResult.ok) {
+    if (options.background && threadDetail.value) {
+      return;
+    }
+
     threadDetail.value = null;
     detailLoadError.value = sanitizeConnectShyftOperatorCopy(
       detailResult.message,
@@ -1654,21 +1765,34 @@ const refreshThreadDetail = async () => {
     }),
   };
   detailLoadError.value = '';
-  lifecycleToast.value = '';
-  actionError.value = '';
-  threadComposerBody.value = '';
-  hiddenTransitionWarning.value = false;
-  closeModalOpen.value = false;
-  inactivityReset.value = false;
-  closeAddNeighborForm();
-  closePreferenceOverrideModal();
-  clearPolicyBanners();
-  clearFeedbackBanner();
+  if (!options.preserveUiState) {
+    lifecycleToast.value = '';
+    actionError.value = '';
+    threadComposerBody.value = '';
+    hiddenTransitionWarning.value = false;
+    closeModalOpen.value = false;
+    inactivityReset.value = false;
+    closeAddNeighborForm();
+    closePreferenceOverrideModal();
+    clearPolicyBanners();
+    clearFeedbackBanner();
+  }
 };
 
 onMounted(() => {
   void refreshThreadDetail();
 });
+
+const handleWindowFocus = (): void => {
+  if (!threadSubjectImpact.value) {
+    return;
+  }
+
+  void refreshThreadDetail({
+    preserveUiState: true,
+    background: true,
+  });
+};
 
 watch(preferenceOverrideModalOpen, (isOpen) => {
   if (!isOpen) {
@@ -1699,9 +1823,47 @@ watch(
 );
 
 watch(
+  threadSubjectImpact,
+  (nextImpact) => {
+    clearThreadSubjectImpactRefresh();
+
+    if (!nextImpact || typeof window === 'undefined') {
+      return;
+    }
+
+    threadSubjectImpactRefreshHandle = window.setInterval(() => {
+      void refreshThreadDetail({
+        preserveUiState: true,
+        background: true,
+      });
+    }, THREAD_SUBJECT_IMPACT_REFRESH_INTERVAL_MS);
+  },
+  {
+    immediate: true,
+  },
+);
+
+watch(
   () => route.fullPath,
   () => {
     void refreshThreadDetail();
   },
 );
+
+onMounted(() => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.addEventListener('focus', handleWindowFocus);
+});
+
+onUnmounted(() => {
+  clearThreadSubjectImpactRefresh();
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.removeEventListener('focus', handleWindowFocus);
+});
 </script>

--- a/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftThreadDetailView.test.ts
+++ b/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftThreadDetailView.test.ts
@@ -72,6 +72,7 @@ const buildThreadDetail = (overrides: Record<string, unknown> = {}) => ({
   preview: 'Latest update: Jordan Lee',
   personId: 'person-detail-view-1001',
   identityState: 'confirmed',
+  subjectImpact: null,
   subjectContext: {
     orgUnitId: 'org-connectshyft-ui-east',
     personId: 'person-detail-view-1001',
@@ -189,6 +190,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   document.body.innerHTML = '';
 });
@@ -219,6 +221,7 @@ describe('ConnectShyftThreadDetailView', () => {
     expect(wrapper.get('[data-testid="connectshyft-thread-identity-state"]').text()).toBe(
       'Provisional person',
     );
+    expect(wrapper.find('[data-testid="connectshyft-thread-subject-impact-banner"]').exists()).toBe(false);
     expect(shellSubjectContext.value).toEqual({
       orgUnitId: 'org-connectshyft-ui-east',
       provisionalPersonId: 'person-detail-view-provisional-2005',
@@ -232,10 +235,154 @@ describe('ConnectShyftThreadDetailView', () => {
     expect(wrapper.get('[data-testid="connectshyft-thread-identity-state"]').text()).toBe(
       'Confirmed person',
     );
+    expect(wrapper.find('[data-testid="connectshyft-thread-subject-impact-banner"]').exists()).toBe(false);
     expect(shellSubjectContext.value).toEqual({
       orgUnitId: 'org-connectshyft-ui-east',
       personId: 'person-detail-view-1001',
     });
     expect(shellSubjectContext.value).not.toHaveProperty('provisionalPersonId');
+  });
+
+  it('renders a plain-language banner when provisional subject impact affects the current thread', async () => {
+    fetchThreadDetailMock.mockResolvedValueOnce({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+      message: 'Thread detail loaded',
+      thread: buildThreadDetail({
+        personId: 'person-detail-view-provisional-2006',
+        identityState: 'provisional',
+        subjectImpact: {
+          impactType: 'provisional_identity',
+          actionable: false,
+          resolverQueueItemId: null,
+          resolverQueueItemType: null,
+        },
+        subjectContext: {
+          orgUnitId: 'org-connectshyft-ui-east',
+          provisionalPersonId: 'person-detail-view-provisional-2006',
+        },
+      }),
+    });
+
+    const { wrapper } = await renderThreadDetailView({
+      initialPath: '/app/connectshyft/threads/thread-detail-view-1001?tenantRole=ORGUNIT_MEMBER',
+    });
+
+    expect(wrapper.get('[data-testid="connectshyft-thread-subject-impact-banner"]').text()).toContain(
+      'Conversation context still resolving',
+    );
+    expect(wrapper.get('[data-testid="connectshyft-thread-subject-impact-message"]').text()).toContain(
+      'Subject details for this conversation are still settling',
+    );
+    expect(wrapper.find('[data-testid="connectshyft-thread-subject-impact-people-link"]').exists()).toBe(false);
+  });
+
+  it('shows a secondary People affordance for tenant-admin resolver context', async () => {
+    fetchThreadDetailMock.mockResolvedValueOnce({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+      message: 'Thread detail loaded',
+      thread: buildThreadDetail({
+        personId: 'person-detail-view-resolver-2007',
+        identityState: 'provisional',
+        subjectImpact: {
+          impactType: 'resolver_required',
+          actionable: true,
+          resolverQueueItemId: 'review-1',
+          resolverQueueItemType: 'identity_review',
+        },
+        subjectContext: {
+          orgUnitId: 'org-connectshyft-ui-east',
+          provisionalPersonId: 'person-detail-view-resolver-2007',
+        },
+      }),
+    });
+
+    const { wrapper } = await renderThreadDetailView({
+      initialPath: '/app/connectshyft/threads/thread-detail-view-1001?tenantRole=TENANT_ADMIN&orgUnitId=org-connectshyft-ui-east',
+    });
+
+    expect(wrapper.get('[data-testid="connectshyft-thread-subject-impact-message"]').text()).toContain(
+      'Identity for this conversation is still waiting on tenant-admin review',
+    );
+    expect(wrapper.get('[data-testid="connectshyft-thread-subject-impact-people-link"]').text()).toContain(
+      'Review in People',
+    );
+    expect(wrapper.get('[data-testid="connectshyft-thread-subject-impact-people-link"]').attributes('href')).toContain(
+      '/app/people',
+    );
+  });
+
+  it('refreshes impacted thread detail and clears stale banner state when backend truth resolves', async () => {
+    vi.useFakeTimers();
+    fetchThreadDetailMock
+      .mockResolvedValueOnce({
+        ok: true,
+        code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+        message: 'Thread detail loaded',
+        thread: buildThreadDetail({
+          personId: 'person-detail-view-provisional-2008',
+          identityState: 'provisional',
+          subjectImpact: {
+            impactType: 'resolver_required',
+            actionable: true,
+            resolverQueueItemId: 'review-refresh-1',
+            resolverQueueItemType: 'identity_review',
+          },
+          subjectContext: {
+            orgUnitId: 'org-connectshyft-ui-east',
+            provisionalPersonId: 'person-detail-view-provisional-2008',
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+        message: 'Thread detail loaded',
+        thread: buildThreadDetail({
+          personId: 'person-detail-view-confirmed-2008',
+          identityState: 'confirmed',
+          subjectImpact: null,
+          subjectContext: {
+            orgUnitId: 'org-connectshyft-ui-east',
+            personId: 'person-detail-view-confirmed-2008',
+          },
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        code: 'CONNECTSHYFT_THREAD_DETAIL_LOADED',
+        message: 'Thread detail loaded',
+        thread: buildThreadDetail({
+          personId: 'person-detail-view-confirmed-2008',
+          identityState: 'confirmed',
+          subjectImpact: null,
+          subjectContext: {
+            orgUnitId: 'org-connectshyft-ui-east',
+            personId: 'person-detail-view-confirmed-2008',
+          },
+        }),
+      });
+
+    const { wrapper, shellSubjectContext } = await renderThreadDetailView();
+
+    expect(wrapper.get('[data-testid="connectshyft-thread-subject-impact-banner"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="connectshyft-thread-identity-state"]').text()).toBe(
+      'Provisional person',
+    );
+
+    await vi.advanceTimersByTimeAsync(15000);
+    await flushPromises();
+    await nextTick();
+
+    expect(fetchThreadDetailMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(wrapper.find('[data-testid="connectshyft-thread-subject-impact-banner"]').exists()).toBe(false);
+    expect(wrapper.get('[data-testid="connectshyft-thread-identity-state"]').text()).toBe(
+      'Confirmed person',
+    );
+    expect(shellSubjectContext.value).toEqual({
+      orgUnitId: 'org-connectshyft-ui-east',
+      personId: 'person-detail-view-confirmed-2008',
+    });
   });
 });

--- a/apps/connectshyft-web/src/views/Shell/PeopleView.vue
+++ b/apps/connectshyft-web/src/views/Shell/PeopleView.vue
@@ -1,9 +1,22 @@
 <script setup lang="ts">
 import type {
+  ConnectShyftResolverQueueDetailData,
+  ConnectShyftResolverQueueItemRecord,
+  ConnectShyftResolverQueueItemType,
   ContactPoint,
   ContactPointStatus,
+  ResolverActionType,
+  ResolverRiskFlag,
+  ResolverReviewStatus,
+  ResolverReviewType,
 } from '@shyft/contracts';
-import { computed, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
+import {
+  claimConnectShyftResolverQueueItem,
+  fetchConnectShyftResolverQueue,
+  fetchConnectShyftResolverQueueDetail,
+  releaseConnectShyftResolverQueueItem,
+} from '@/features/connectshyft/resolverQueue';
 import {
   resolveConnectShyftIdentityResolutionPresentation,
   type ConnectShyftIdentityResolutionCandidate,
@@ -11,11 +24,35 @@ import {
 } from '@/features/connectshyft/identityResolution';
 import { useSubjectContext } from '../../shell/subjectContext';
 
+type ResolverWorkspaceFilter =
+  | 'all_active'
+  | 'identity_review'
+  | 'rebind_review'
+  | 'claimed_by_me'
+  | 'unclaimed';
+
+type ResolverFilterDefinition = {
+  id: ResolverWorkspaceFilter;
+  label: string;
+  description: string;
+};
+
 const subjectContext = useSubjectContext();
 const contactPoints = ref<ContactPoint[]>([]);
 const contactPointError = ref('');
 const decisionResult = ref<ConnectShyftIdentityResolutionResponse | null>(null);
 const decisionError = ref('');
+const resolverQueueItems = ref<ConnectShyftResolverQueueItemRecord[]>([]);
+const resolverQueueLoading = ref(false);
+const resolverQueueError = ref('');
+const resolverQueueFeedback = ref('');
+const resolverQueueAuthorized = ref<boolean | null>(null);
+const resolverQueueFilter = ref<ResolverWorkspaceFilter>('all_active');
+const resolverActionPendingKey = ref('');
+const selectedResolverQueueKey = ref('');
+const selectedResolverQueueDetail = ref<ConnectShyftResolverQueueDetailData | null>(null);
+const resolverDetailLoading = ref(false);
+const resolverDetailError = ref('');
 
 const SAMPLE_CANDIDATES: ConnectShyftIdentityResolutionCandidate[] = [
   {
@@ -29,6 +66,34 @@ const SAMPLE_CANDIDATES: ConnectShyftIdentityResolutionCandidate[] = [
     score: 60,
     reasons: ['Name similarity'],
     contactPointStatus: 'active_shared_possible',
+  },
+];
+
+const RESOLVER_FILTERS: ResolverFilterDefinition[] = [
+  {
+    id: 'all_active',
+    label: 'All active',
+    description: 'Every active resolver item in the shared workspace.',
+  },
+  {
+    id: 'identity_review',
+    label: 'Identity reviews',
+    description: 'Identity ambiguity and subject-confirmation work.',
+  },
+  {
+    id: 'rebind_review',
+    label: 'Rebind reviews',
+    description: 'Sensitive reassignment work that needs tenant-admin review.',
+  },
+  {
+    id: 'claimed_by_me',
+    label: 'Claimed by me',
+    description: 'Items currently claimed by this resolver.',
+  },
+  {
+    id: 'unclaimed',
+    label: 'Unclaimed',
+    description: 'Queue items ready for a tenant-admin to pick up.',
   },
 ];
 
@@ -64,6 +129,480 @@ const decisionPresentation = computed(() => (
     : null
 ));
 const decisionCandidates = computed(() => decisionResult.value?.candidates || []);
+
+const buildResolverQueueKey = (itemType: ConnectShyftResolverQueueItemType, itemId: string): string =>
+  `${itemType}:${itemId}`;
+
+const normalizeRequestedAt = (value: string | null): number => {
+  if (!value) {
+    return 0;
+  }
+
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const sortResolverQueueItems = (
+  items: ConnectShyftResolverQueueItemRecord[],
+): ConnectShyftResolverQueueItemRecord[] => [...items].sort((left, right) => {
+  const requestedAtDelta = normalizeRequestedAt(left.requestedAt) - normalizeRequestedAt(right.requestedAt);
+  if (requestedAtDelta !== 0) {
+    return requestedAtDelta;
+  }
+
+  return buildResolverQueueKey(left.itemType, left.id).localeCompare(
+    buildResolverQueueKey(right.itemType, right.id),
+  );
+});
+
+const resolverWorkspaceAccessible = computed(() => resolverQueueAuthorized.value !== false);
+
+const resolverQueueCounts = computed(() => ({
+  all_active: resolverQueueItems.value.filter((item) => item.active).length,
+  identity_review: resolverQueueItems.value.filter((item) => item.itemType === 'identity_review').length,
+  rebind_review: resolverQueueItems.value.filter((item) => item.itemType === 'rebind_review').length,
+  claimed_by_me: resolverQueueItems.value.filter((item) => item.claimState === 'claimed_by_current_user').length,
+  unclaimed: resolverQueueItems.value.filter((item) => item.claimState === 'unclaimed').length,
+}));
+
+const filteredResolverQueueItems = computed(() => resolverQueueItems.value.filter((item) => {
+  switch (resolverQueueFilter.value) {
+    case 'identity_review':
+      return item.itemType === 'identity_review';
+    case 'rebind_review':
+      return item.itemType === 'rebind_review';
+    case 'claimed_by_me':
+      return item.claimState === 'claimed_by_current_user';
+    case 'unclaimed':
+      return item.claimState === 'unclaimed';
+    default:
+      return item.active;
+  }
+}));
+
+const selectedResolverQueueItem = computed(() => filteredResolverQueueItems.value.find((item) =>
+  buildResolverQueueKey(item.itemType, item.id) === selectedResolverQueueKey.value)
+  || null);
+
+const resolverQueueSummary = computed(() => {
+  const total = resolverQueueCounts.value.all_active;
+  if (!resolverWorkspaceAccessible.value) {
+    return 'Resolver queue actions stay tenant-admin only. Read-safe PeopleCore identity context remains available below.';
+  }
+
+  if (resolverQueueLoading.value && total === 0) {
+    return 'Loading backend-authored resolver work for this org unit.';
+  }
+
+  if (total === 0) {
+    return 'No active resolver work is waiting right now. Identity and rebind reviews will appear here when backend truth requires action.';
+  }
+
+  const identityCount = resolverQueueCounts.value.identity_review;
+  const rebindCount = resolverQueueCounts.value.rebind_review;
+  return `${total} active resolver item${total === 1 ? '' : 's'} in one workspace, including ${identityCount} identity review${identityCount === 1 ? '' : 's'} and ${rebindCount} rebind review${rebindCount === 1 ? '' : 's'}.`;
+});
+
+const resolverWorkspaceEmptyState = computed(() => {
+  switch (resolverQueueFilter.value) {
+    case 'identity_review':
+      return 'No identity reviews are active right now.';
+    case 'rebind_review':
+      return 'No rebind reviews are active right now.';
+    case 'claimed_by_me':
+      return 'You do not currently hold any claimed resolver work.';
+    case 'unclaimed':
+      return 'No unclaimed resolver items are ready for pickup right now.';
+    default:
+      return 'No active resolver work is waiting right now.';
+  }
+});
+
+const formatResolverDateTime = (value: string | null): string => {
+  if (!value) {
+    return 'Time unavailable';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Time unavailable';
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(parsed);
+};
+
+const formatResolverQueueLabel = (value: string): string => (
+  value
+    .split('_')
+    .filter((segment) => segment.length > 0)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+);
+
+const formatItemTypeLabel = (itemType: ConnectShyftResolverQueueItemType): string => (
+  itemType === 'identity_review' ? 'Identity review' : 'Rebind review'
+);
+
+const formatClaimStateLabel = (item: ConnectShyftResolverQueueItemRecord): string => {
+  switch (item.claimState) {
+    case 'claimed_by_current_user':
+      return 'Claimed by me';
+    case 'claimed_by_other':
+      return 'Claimed by another resolver';
+    default:
+      return 'Unclaimed';
+  }
+};
+
+const formatReadinessLabel = (item: ConnectShyftResolverQueueItemRecord): string => {
+  if (item.terminal) {
+    return 'Closed';
+  }
+
+  if (item.status === 'waiting_for_more_info') {
+    return 'Waiting for more info';
+  }
+
+  if (item.claimState === 'claimed_by_current_user' && item.actionable) {
+    return 'Ready to act';
+  }
+
+  if (item.claimState === 'claimed_by_other') {
+    return 'Busy';
+  }
+
+  if (item.claimable) {
+    return 'Claim required';
+  }
+
+  if (item.status === 'in_review') {
+    return 'In review';
+  }
+
+  return item.active ? 'Active' : 'Closed';
+};
+
+const formatResolverRiskFlag = (flag: ResolverRiskFlag): string => {
+  switch (flag) {
+    case 'shared_contact_possible':
+      return 'Shared contact possible';
+    case 'shared_contact_confirmed':
+      return 'Shared contact confirmed';
+    case 'stale_contact':
+      return 'Stale contact';
+    case 'archived_prior_owner':
+      return 'Archived prior owner';
+    case 'conflicting_name_dob':
+      return 'Conflicting identity details';
+    case 'rapid_contact_reuse':
+      return 'Rapid contact reuse';
+    case 'duplicate_creation_attempt':
+      return 'Duplicate creation attempt';
+    case 'high_confidence_override_attempt':
+      return 'High-confidence override attempt';
+    default:
+      return formatResolverQueueLabel(flag);
+  }
+};
+
+const formatResolverActionType = (value: ResolverActionType | null | undefined): string => {
+  if (!value) {
+    return 'Tenant-admin review';
+  }
+
+  switch (value) {
+    case 'confirm_existing_person':
+      return 'Confirm existing person';
+    case 'confirm_new_person':
+      return 'Confirm new person';
+    case 'merge_people':
+      return 'Merge people';
+    case 'link_without_merge':
+      return 'Link without merge';
+    case 'mark_shared_contact':
+      return 'Mark shared contact';
+    case 'reassign_contact_point':
+      return 'Reassign contact point';
+    case 'dismiss_no_action':
+      return 'Dismiss without action';
+    default:
+      return formatResolverQueueLabel(value);
+  }
+};
+
+const buildQueueItemSummary = (item: ConnectShyftResolverQueueItemRecord): string => {
+  if (item.itemType === 'rebind_review') {
+    return 'Sensitive reassignment work is waiting for tenant-admin review before historical ConnectShyft context moves with the new subject truth.';
+  }
+
+  if (item.status === 'waiting_for_more_info') {
+    return 'Identity review is blocked until more information is available, but it stays in the active resolver workspace.';
+  }
+
+  return 'Identity evidence requires tenant-admin confirmation before subject truth can be applied safely across PeopleCore and ConnectShyft.';
+};
+
+const buildQueueItemContext = (item: ConnectShyftResolverQueueItemRecord): string[] => {
+  const context: string[] = [];
+  if (item.personIds.length > 0) {
+    context.push(`${item.personIds.length} person context${item.personIds.length === 1 ? '' : 's'}`);
+  } else {
+    context.push('Person context pending');
+  }
+
+  if (item.contactPointId) {
+    context.push('Contact point context attached');
+  }
+
+  if (item.conversationId || item.threadId) {
+    context.push('Conversation context attached');
+  }
+
+  context.push(`Status: ${formatResolverQueueLabel(item.status)}`);
+  return context;
+};
+
+const buildIdentityReviewReason = (
+  reviewType: ResolverReviewType | undefined,
+  riskFlags: ResolverRiskFlag[],
+): string => {
+  if (reviewType === 'contact_point_reassignment') {
+    return 'This contact point may have moved between people, so tenant-admin review is required before identity truth changes.';
+  }
+
+  if (reviewType === 'shared_contact_ambiguity' || riskFlags.includes('shared_contact_possible')) {
+    return 'This contact point may belong to more than one person, so tenant-admin review is required before assignment is confirmed.';
+  }
+
+  if (riskFlags.includes('conflicting_name_dob')) {
+    return 'The current identity evidence conflicts, so a tenant admin needs to confirm the correct person before the workspace updates.';
+  }
+
+  return 'Tenant-admin review is required before PeopleCore and ConnectShyft can rely on this identity outcome.';
+};
+
+const buildRebindReviewReason = (resolutionType: ResolverActionType | null | undefined): string => {
+  if (resolutionType === 'reassign_contact_point') {
+    return 'A contact-point reassignment created sensitive follow-up work, so tenant-admin review is required before historical context is rebound.';
+  }
+
+  if (resolutionType === 'merge_people') {
+    return 'A person merge created sensitive follow-up work, so tenant-admin review is required before historical context is rebound.';
+  }
+
+  return 'This reassignment affects sensitive ConnectShyft context, so tenant-admin review is required before the new subject truth is fully applied.';
+};
+
+const formatIdentityReviewStatus = (value: ResolverReviewStatus | undefined): string => {
+  if (!value) {
+    return 'Unknown';
+  }
+
+  if (value === 'queued') {
+    return 'Queued';
+  }
+
+  if (value === 'in_review') {
+    return 'In review';
+  }
+
+  if (value === 'waiting_for_more_info') {
+    return 'Waiting for more info';
+  }
+
+  return formatResolverQueueLabel(value);
+};
+
+const setResolverQueueItems = (items: ConnectShyftResolverQueueItemRecord[]) => {
+  resolverQueueItems.value = sortResolverQueueItems(items.filter((item) => item.active));
+};
+
+const upsertResolverQueueItem = (nextItem: ConnectShyftResolverQueueItemRecord) => {
+  const existing = resolverQueueItems.value.filter((item) =>
+    buildResolverQueueKey(item.itemType, item.id) !== buildResolverQueueKey(nextItem.itemType, nextItem.id));
+  setResolverQueueItems([...existing, nextItem]);
+};
+
+const clearSelectedResolverQueueDetail = () => {
+  selectedResolverQueueDetail.value = null;
+  resolverDetailError.value = '';
+};
+
+const loadResolverQueue = async () => {
+  resolverQueueLoading.value = true;
+  resolverQueueError.value = '';
+  resolverQueueFeedback.value = '';
+
+  const result = await fetchConnectShyftResolverQueue();
+  resolverQueueLoading.value = false;
+
+  if (!result.ok) {
+    resolverQueueAuthorized.value = result.unauthorized ? false : resolverQueueAuthorized.value;
+    if (result.unauthorized) {
+      setResolverQueueItems([]);
+      selectedResolverQueueKey.value = '';
+      clearSelectedResolverQueueDetail();
+      return;
+    }
+
+    resolverQueueError.value = result.message || 'Unable to load resolver queue.';
+    setResolverQueueItems([]);
+    selectedResolverQueueKey.value = '';
+    clearSelectedResolverQueueDetail();
+    return;
+  }
+
+  resolverQueueAuthorized.value = true;
+  setResolverQueueItems(result.items);
+};
+
+const loadResolverQueueDetail = async (
+  item: ConnectShyftResolverQueueItemRecord,
+) => {
+  const requestKey = buildResolverQueueKey(item.itemType, item.id);
+  resolverDetailLoading.value = true;
+  resolverDetailError.value = '';
+
+  const result = await fetchConnectShyftResolverQueueDetail(item.itemType, item.id);
+  if (selectedResolverQueueKey.value !== requestKey) {
+    resolverDetailLoading.value = false;
+    return;
+  }
+
+  resolverDetailLoading.value = false;
+
+  if (!result.ok) {
+    if (result.unauthorized) {
+      resolverQueueAuthorized.value = false;
+      setResolverQueueItems([]);
+      clearSelectedResolverQueueDetail();
+      return;
+    }
+
+    if (result.unavailable) {
+      resolverDetailError.value = 'This resolver item is no longer available. Refresh the queue to continue.';
+      resolverQueueFeedback.value = resolverDetailError.value;
+      setResolverQueueItems(resolverQueueItems.value.filter((queueItem) =>
+        buildResolverQueueKey(queueItem.itemType, queueItem.id) !== requestKey));
+      selectedResolverQueueDetail.value = null;
+      return;
+    }
+
+    selectedResolverQueueDetail.value = null;
+    resolverDetailError.value = result.message || 'Unable to load resolver detail.';
+    return;
+  }
+
+  resolverQueueAuthorized.value = true;
+  selectedResolverQueueDetail.value = result.detail;
+  upsertResolverQueueItem(result.detail.item);
+};
+
+const selectResolverQueueItem = (item: ConnectShyftResolverQueueItemRecord) => {
+  selectedResolverQueueKey.value = buildResolverQueueKey(item.itemType, item.id);
+};
+
+const runResolverQueueMutation = async (
+  item: ConnectShyftResolverQueueItemRecord,
+  action: 'claim' | 'release',
+) => {
+  resolverQueueFeedback.value = '';
+  resolverQueueError.value = '';
+  resolverDetailError.value = '';
+  const actionKey = buildResolverQueueKey(item.itemType, item.id);
+  resolverActionPendingKey.value = actionKey;
+
+  const result = action === 'claim'
+    ? await claimConnectShyftResolverQueueItem(item.itemType, item.id)
+    : await releaseConnectShyftResolverQueueItem(item.itemType, item.id);
+
+  resolverActionPendingKey.value = '';
+
+  if (!result.ok) {
+    if (result.unauthorized) {
+      resolverQueueAuthorized.value = false;
+      setResolverQueueItems([]);
+      selectedResolverQueueKey.value = '';
+      clearSelectedResolverQueueDetail();
+      return;
+    }
+
+    if (result.unavailable) {
+      resolverQueueFeedback.value = 'This resolver item is no longer available.';
+      setResolverQueueItems(resolverQueueItems.value.filter((queueItem) =>
+        buildResolverQueueKey(queueItem.itemType, queueItem.id) !== actionKey));
+      selectedResolverQueueDetail.value = null;
+      selectedResolverQueueKey.value = '';
+      return;
+    }
+
+    resolverQueueFeedback.value = result.message || (
+      action === 'claim'
+        ? 'Unable to claim this resolver item right now.'
+        : 'Unable to release this resolver item right now.'
+    );
+    return;
+  }
+
+  resolverQueueAuthorized.value = true;
+  resolverQueueFeedback.value = result.message;
+  selectedResolverQueueDetail.value = result.detail;
+  selectedResolverQueueKey.value = buildResolverQueueKey(
+    result.detail.item.itemType,
+    result.detail.item.id,
+  );
+  upsertResolverQueueItem(result.detail.item);
+};
+
+const claimSelectedResolverQueueItem = async () => {
+  if (!selectedResolverQueueItem.value) {
+    return;
+  }
+
+  await runResolverQueueMutation(selectedResolverQueueItem.value, 'claim');
+};
+
+const releaseSelectedResolverQueueItem = async () => {
+  if (!selectedResolverQueueItem.value) {
+    return;
+  }
+
+  await runResolverQueueMutation(selectedResolverQueueItem.value, 'release');
+};
+
+watch(filteredResolverQueueItems, (items) => {
+  if (items.length === 0) {
+    selectedResolverQueueKey.value = '';
+    clearSelectedResolverQueueDetail();
+    return;
+  }
+
+  const hasSelectedItem = items.some((item) =>
+    buildResolverQueueKey(item.itemType, item.id) === selectedResolverQueueKey.value);
+  if (!hasSelectedItem) {
+    selectedResolverQueueKey.value = buildResolverQueueKey(items[0].itemType, items[0].id);
+  }
+}, { immediate: true });
+
+watch(selectedResolverQueueKey, (nextKey) => {
+  const item = filteredResolverQueueItems.value.find((queueItem) =>
+    buildResolverQueueKey(queueItem.itemType, queueItem.id) === nextKey);
+  if (!item || !resolverWorkspaceAccessible.value) {
+    clearSelectedResolverQueueDetail();
+    return;
+  }
+
+  void loadResolverQueueDetail(item);
+});
+
+onMounted(() => {
+  void loadResolverQueue();
+});
 
 async function loadContactPoints() {
   contactPointError.value = '';
@@ -108,30 +647,513 @@ async function runSampleDecision() {
 </script>
 
 <template>
-  <section class="p-4 space-y-4">
+  <section class="space-y-6 p-4">
     <div class="space-y-1">
-      <h1 class="text-xl font-semibold">People shell</h1>
-      <p>Org unit: {{ subjectContext.orgUnitId }}</p>
-      <p>PeopleCore scaffold is using direct fetch calls in this slice.</p>
+      <h1 class="text-xl font-semibold text-slate-900">People shell</h1>
+      <p class="text-sm text-slate-600">Org unit: {{ subjectContext.orgUnitId }}</p>
+      <p class="text-sm text-slate-500">
+        Tenant-admin resolvers work the shared identity and rebind queue here. Existing PeopleCore
+        identity scaffolds stay available below for compatibility.
+      </p>
     </div>
+
+    <section
+      data-test="resolver-workspace"
+      class="rounded-[28px] border border-slate-200 bg-white/90 p-5 shadow-[0_24px_70px_-52px_rgba(15,23,42,0.28)]"
+    >
+      <div class="flex flex-col gap-4 border-b border-slate-200 pb-4 lg:flex-row lg:items-end lg:justify-between">
+        <div class="space-y-2">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+            Resolver workspace
+          </p>
+          <div class="space-y-1">
+            <h2 class="text-2xl font-semibold tracking-tight text-slate-900">
+              Primary queue for identity and rebind reviews
+            </h2>
+            <p data-test="resolver-workspace-summary" class="max-w-3xl text-sm text-slate-600">
+              {{ resolverQueueSummary }}
+            </p>
+          </div>
+        </div>
+
+        <button
+          data-test="resolver-workspace-refresh"
+          type="button"
+          class="inline-flex min-h-[44px] items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
+          :disabled="resolverQueueLoading || resolverActionPendingKey.length > 0"
+          @click="loadResolverQueue"
+        >
+          {{ resolverQueueLoading ? 'Refreshing...' : 'Refresh queue' }}
+        </button>
+      </div>
+
+      <p
+        v-if="resolverQueueAuthorized === false"
+        data-test="resolver-workspace-locked"
+        class="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+      >
+        Resolver queue actions are available only to tenant-admin resolvers. People identity status
+        remains visible below where it is safe to show.
+      </p>
+
+      <div v-else class="mt-4 grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(20rem,0.82fr)]">
+        <section class="space-y-4">
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="filter in RESOLVER_FILTERS"
+              :key="filter.id"
+              :data-test="`resolver-filter-${filter.id}`"
+              type="button"
+              class="inline-flex min-h-[44px] items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition"
+              :class="resolverQueueFilter === filter.id
+                ? 'border-slate-900 bg-slate-900 text-white'
+                : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:text-slate-900'"
+              :aria-pressed="resolverQueueFilter === filter.id"
+              @click="resolverQueueFilter = filter.id"
+            >
+              <span>{{ filter.label }}</span>
+              <span
+                class="inline-flex min-w-[1.75rem] items-center justify-center rounded-full px-2 py-0.5 text-xs font-semibold"
+                :class="resolverQueueFilter === filter.id
+                  ? 'bg-white/15 text-white'
+                  : 'bg-slate-100 text-slate-600'"
+              >
+                {{ resolverQueueCounts[filter.id] }}
+              </span>
+            </button>
+          </div>
+
+          <p
+            v-if="resolverQueueError"
+            data-test="resolver-queue-error"
+            class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+          >
+            {{ resolverQueueError }}
+          </p>
+
+          <p
+            v-if="resolverQueueFeedback"
+            data-test="resolver-queue-feedback"
+            class="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900"
+          >
+            {{ resolverQueueFeedback }}
+          </p>
+
+          <p
+            v-if="resolverQueueLoading && filteredResolverQueueItems.length === 0"
+            data-test="resolver-queue-loading"
+            class="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-sm text-slate-600"
+          >
+            Loading resolver queue...
+          </p>
+
+          <ul
+            v-else-if="filteredResolverQueueItems.length > 0"
+            class="space-y-3"
+          >
+            <li
+              v-for="item in filteredResolverQueueItems"
+              :key="buildResolverQueueKey(item.itemType, item.id)"
+            >
+              <button
+                type="button"
+                :data-test="`resolver-queue-item-${item.id}`"
+                class="w-full rounded-[24px] border px-4 py-4 text-left transition"
+                :class="selectedResolverQueueItem?.id === item.id
+                  ? 'border-slate-900 bg-slate-900 text-white shadow-[0_18px_54px_-34px_rgba(15,23,42,0.55)]'
+                  : 'border-slate-200 bg-white text-slate-800 hover:border-slate-300'"
+                :aria-pressed="selectedResolverQueueItem?.id === item.id"
+                @click="selectResolverQueueItem(item)"
+              >
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div class="space-y-3">
+                    <div class="flex flex-wrap gap-2">
+                      <span
+                        :data-test="`resolver-queue-item-type-${item.id}`"
+                        class="rounded-full border px-2.5 py-1 text-xs font-semibold"
+                        :class="selectedResolverQueueItem?.id === item.id
+                          ? 'border-white/25 bg-white/10 text-white'
+                          : item.itemType === 'identity_review'
+                            ? 'border-blue-200 bg-blue-50 text-blue-700'
+                            : 'border-amber-200 bg-amber-50 text-amber-800'"
+                      >
+                        {{ formatItemTypeLabel(item.itemType) }}
+                      </span>
+
+                      <span
+                        :data-test="`resolver-queue-item-claim-${item.id}`"
+                        class="rounded-full border px-2.5 py-1 text-xs font-semibold"
+                        :class="selectedResolverQueueItem?.id === item.id
+                          ? 'border-white/25 bg-white/10 text-white'
+                          : item.claimState === 'claimed_by_current_user'
+                            ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                            : item.claimState === 'claimed_by_other'
+                              ? 'border-rose-200 bg-rose-50 text-rose-700'
+                              : 'border-slate-200 bg-slate-50 text-slate-700'"
+                      >
+                        {{ formatClaimStateLabel(item) }}
+                      </span>
+
+                      <span
+                        :data-test="`resolver-queue-item-readiness-${item.id}`"
+                        class="rounded-full border px-2.5 py-1 text-xs font-semibold"
+                        :class="selectedResolverQueueItem?.id === item.id
+                          ? 'border-white/25 bg-white/10 text-white'
+                          : 'border-slate-200 bg-slate-50 text-slate-700'"
+                      >
+                        {{ formatReadinessLabel(item) }}
+                      </span>
+                    </div>
+
+                    <div class="space-y-1">
+                      <p class="text-base font-semibold">
+                        {{ formatItemTypeLabel(item.itemType) }}
+                      </p>
+                      <p
+                        class="text-sm leading-6"
+                        :class="selectedResolverQueueItem?.id === item.id ? 'text-slate-100' : 'text-slate-600'"
+                      >
+                        {{ buildQueueItemSummary(item) }}
+                      </p>
+                    </div>
+                  </div>
+
+                  <p
+                    class="shrink-0 text-xs font-medium"
+                    :class="selectedResolverQueueItem?.id === item.id ? 'text-slate-200' : 'text-slate-500'"
+                  >
+                    Requested {{ formatResolverDateTime(item.requestedAt) }}
+                  </p>
+                </div>
+
+                <div
+                  class="mt-3 flex flex-wrap gap-2 text-xs"
+                  :class="selectedResolverQueueItem?.id === item.id ? 'text-slate-200' : 'text-slate-500'"
+                >
+                  <span
+                    v-for="context in buildQueueItemContext(item)"
+                    :key="`${item.id}-${context}`"
+                    class="rounded-full border px-2.5 py-1"
+                    :class="selectedResolverQueueItem?.id === item.id
+                      ? 'border-white/20 bg-white/5'
+                      : 'border-slate-200 bg-slate-50'"
+                  >
+                    {{ context }}
+                  </span>
+                </div>
+              </button>
+            </li>
+          </ul>
+
+          <p
+            v-else
+            data-test="resolver-queue-empty"
+            class="rounded-2xl border border-dashed border-slate-200 px-4 py-8 text-center text-sm text-slate-500"
+          >
+            {{ resolverWorkspaceEmptyState }}
+          </p>
+        </section>
+
+        <section
+          data-test="resolver-detail"
+          class="rounded-[24px] border border-slate-200 bg-slate-50/70 p-4"
+        >
+          <div v-if="selectedResolverQueueItem" class="space-y-4">
+            <div class="space-y-3 border-b border-slate-200 pb-4">
+              <div class="flex flex-wrap items-start justify-between gap-3">
+                <div class="space-y-2">
+                  <div class="flex flex-wrap gap-2">
+                    <span
+                      data-test="resolver-detail-type"
+                      class="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-semibold text-slate-700"
+                    >
+                      {{ formatItemTypeLabel(selectedResolverQueueItem.itemType) }}
+                    </span>
+                    <span
+                      data-test="resolver-detail-status"
+                      class="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-semibold text-slate-700"
+                    >
+                      {{ formatIdentityReviewStatus(selectedResolverQueueItem.status) }}
+                    </span>
+                  </div>
+                  <div class="space-y-1">
+                    <h3 class="text-lg font-semibold text-slate-900">
+                      {{ formatItemTypeLabel(selectedResolverQueueItem.itemType) }} detail
+                    </h3>
+                    <p class="text-sm text-slate-600">
+                      {{ formatClaimStateLabel(selectedResolverQueueItem) }}. {{ formatReadinessLabel(selectedResolverQueueItem) }}.
+                    </p>
+                  </div>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                  <button
+                    v-if="selectedResolverQueueItem.claimable"
+                    data-test="resolver-detail-claim"
+                    type="button"
+                    class="inline-flex min-h-[44px] items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-slate-400"
+                    :disabled="resolverActionPendingKey === buildResolverQueueKey(selectedResolverQueueItem.itemType, selectedResolverQueueItem.id)"
+                    @click="claimSelectedResolverQueueItem"
+                  >
+                    {{ resolverActionPendingKey === buildResolverQueueKey(selectedResolverQueueItem.itemType, selectedResolverQueueItem.id)
+                      ? 'Claiming...'
+                      : 'Claim item' }}
+                  </button>
+
+                  <button
+                    v-else-if="selectedResolverQueueItem.releasable"
+                    data-test="resolver-detail-release"
+                    type="button"
+                    class="inline-flex min-h-[44px] items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
+                    :disabled="resolverActionPendingKey === buildResolverQueueKey(selectedResolverQueueItem.itemType, selectedResolverQueueItem.id)"
+                    @click="releaseSelectedResolverQueueItem"
+                  >
+                    {{ resolverActionPendingKey === buildResolverQueueKey(selectedResolverQueueItem.itemType, selectedResolverQueueItem.id)
+                      ? 'Releasing...'
+                      : 'Release item' }}
+                  </button>
+
+                  <button
+                    v-else-if="selectedResolverQueueItem.claimState === 'claimed_by_other'"
+                    data-test="resolver-detail-claim-disabled"
+                    type="button"
+                    disabled
+                    class="inline-flex min-h-[44px] items-center justify-center rounded-full border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 disabled:cursor-not-allowed"
+                  >
+                    Claimed by another resolver
+                  </button>
+                </div>
+              </div>
+
+              <p
+                v-if="selectedResolverQueueItem.claimState === 'unclaimed'"
+                data-test="resolver-detail-claim-required"
+                class="rounded-2xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900"
+              >
+                Claim this item before applying resolver actions anywhere else.
+              </p>
+              <p
+                v-else-if="selectedResolverQueueItem.claimState === 'claimed_by_other'"
+                data-test="resolver-detail-claimed-by-other"
+                class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900"
+              >
+                Another tenant-admin resolver is currently working this item, so it is not actionable here.
+              </p>
+              <p
+                v-else-if="selectedResolverQueueItem.status === 'waiting_for_more_info'"
+                data-test="resolver-detail-waiting"
+                class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+              >
+                This resolver item remains active, but it is waiting for more information before action can continue.
+              </p>
+            </div>
+
+            <p
+              v-if="resolverDetailLoading && !selectedResolverQueueDetail"
+              data-test="resolver-detail-loading"
+              class="rounded-2xl border border-slate-200 bg-white px-4 py-6 text-sm text-slate-600"
+            >
+              Loading resolver detail...
+            </p>
+
+            <p
+              v-else-if="resolverDetailError"
+              data-test="resolver-detail-error"
+              class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+            >
+              {{ resolverDetailError }}
+            </p>
+
+            <div v-else-if="selectedResolverQueueDetail" class="space-y-4">
+              <div class="grid gap-3 sm:grid-cols-2">
+                <div class="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                  <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                    Requested
+                  </p>
+                  <p class="mt-2 text-sm text-slate-700">
+                    {{ formatResolverDateTime(selectedResolverQueueDetail.item.requestedAt) }}
+                  </p>
+                </div>
+
+                <div class="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                  <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                    Queue status
+                  </p>
+                  <p class="mt-2 text-sm text-slate-700">
+                    {{ formatIdentityReviewStatus(selectedResolverQueueDetail.item.status) }}
+                  </p>
+                </div>
+              </div>
+
+              <template v-if="selectedResolverQueueDetail.item.itemType === 'identity_review'">
+                <p
+                  data-test="resolver-detail-reason"
+                  class="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700"
+                >
+                  {{ buildIdentityReviewReason(
+                    selectedResolverQueueDetail.review?.reviewType,
+                    selectedResolverQueueDetail.review?.riskFlags || [],
+                  ) }}
+                </p>
+
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <div class="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                      Person context
+                    </p>
+                    <p class="mt-2 text-sm text-slate-700">
+                      {{ selectedResolverQueueDetail.item.personIds.length }} person context{{
+                        selectedResolverQueueDetail.item.personIds.length === 1 ? '' : 's'
+                      }} attached
+                    </p>
+                    <p class="mt-1 text-sm text-slate-500">
+                      {{
+                        selectedResolverQueueDetail.review?.provisionalPersonId
+                          ? 'Includes a provisional person awaiting confirmation.'
+                          : 'Resolver review is working from existing subject context.'
+                      }}
+                    </p>
+                  </div>
+
+                  <div class="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                      Contact and thread context
+                    </p>
+                    <p class="mt-2 text-sm text-slate-700">
+                      {{
+                        selectedResolverQueueDetail.item.contactPointId
+                          ? 'Contact point context is attached to this review.'
+                          : 'Contact point context is still being gathered.'
+                      }}
+                    </p>
+                    <p class="mt-1 text-sm text-slate-500">
+                      {{
+                        selectedResolverQueueDetail.item.conversationId || selectedResolverQueueDetail.item.threadId
+                          ? 'Conversation context is available to help triage safely.'
+                          : 'No conversation context is attached yet.'
+                      }}
+                    </p>
+                  </div>
+                </div>
+
+                <div
+                  v-if="selectedResolverQueueDetail.review?.riskFlags.length"
+                  class="rounded-2xl border border-slate-200 bg-white px-4 py-3"
+                >
+                  <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                    Ambiguity signals
+                  </p>
+                  <div class="mt-2 flex flex-wrap gap-2">
+                    <span
+                      v-for="riskFlag in selectedResolverQueueDetail.review?.riskFlags || []"
+                      :key="riskFlag"
+                      class="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-700"
+                    >
+                      {{ formatResolverRiskFlag(riskFlag) }}
+                    </span>
+                  </div>
+                </div>
+              </template>
+
+              <template v-else>
+                <p
+                  data-test="resolver-detail-reason"
+                  class="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700"
+                >
+                  {{ buildRebindReviewReason(selectedResolverQueueDetail.rebindReview?.originatingResolutionType) }}
+                </p>
+
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <div class="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                      Rebind scope
+                    </p>
+                    <p class="mt-2 text-sm text-slate-700">
+                      {{ formatResolverQueueLabel(
+                        selectedResolverQueueDetail.rebindReview?.affectedObjectType || 'review',
+                      ) }} review
+                    </p>
+                    <p class="mt-1 text-sm text-slate-500">
+                      {{ selectedResolverQueueDetail.rebindReview?.affectedObjectIds.length || 0 }} affected record{{
+                        (selectedResolverQueueDetail.rebindReview?.affectedObjectIds.length || 0) === 1 ? '' : 's'
+                      }} require review before rebinding continues.
+                    </p>
+                  </div>
+
+                  <div class="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                    <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                      Identity movement
+                    </p>
+                    <p class="mt-2 text-sm text-slate-700">
+                      Source and target person context are recorded for this rebind review.
+                    </p>
+                    <p class="mt-1 text-sm text-slate-500">
+                      {{ selectedResolverQueueDetail.rebindReview?.contactPointIds.length || 0 }} contact point{{
+                        (selectedResolverQueueDetail.rebindReview?.contactPointIds.length || 0) === 1 ? '' : 's'
+                      }} are part of the reassignment.
+                    </p>
+                  </div>
+                </div>
+
+                <div class="rounded-2xl border border-slate-200 bg-white px-4 py-3">
+                  <p class="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+                    Trigger
+                  </p>
+                  <p class="mt-2 text-sm text-slate-700">
+                    {{
+                      selectedResolverQueueDetail.rebindReview?.originatingResolutionType
+                        ? `${formatResolverActionType(selectedResolverQueueDetail.rebindReview.originatingResolutionType)} created this follow-up review.`
+                        : 'A resolver decision created this follow-up review.'
+                    }}
+                  </p>
+                  <p class="mt-1 text-sm text-slate-500">
+                    Review this queue item here before sensitive ConnectShyft history follows the new subject truth.
+                  </p>
+                </div>
+              </template>
+            </div>
+
+            <p
+              v-else
+              class="rounded-2xl border border-slate-200 bg-white px-4 py-6 text-sm text-slate-600"
+            >
+              Select a resolver item to inspect its backend-authored context.
+            </p>
+          </div>
+
+          <p
+            v-else
+            data-test="resolver-detail-empty"
+            class="rounded-2xl border border-dashed border-slate-200 px-4 py-8 text-center text-sm text-slate-500"
+          >
+            Select a resolver item to inspect its context and claim state.
+          </p>
+        </section>
+      </div>
+    </section>
 
     <div class="space-y-2">
       <button
         data-test="load-contact-points"
         type="button"
-        class="border border-slate-300 px-3 py-2"
+        class="rounded-full border border-slate-300 px-3 py-2 text-sm text-slate-700"
         @click="loadContactPoints"
       >
         Load contact points
       </button>
 
-      <p v-if="contactPointError">{{ contactPointError }}</p>
+      <p
+        v-if="contactPointError"
+        class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+      >
+        {{ contactPointError }}
+      </p>
 
-      <ul v-if="contactPoints.length > 0" class="list-disc pl-5 space-y-2">
+      <ul v-if="contactPoints.length > 0" class="space-y-2 pl-5">
         <li
           v-for="contactPoint in contactPoints"
           :key="contactPoint.id"
-          class="flex flex-wrap items-center gap-2"
+          class="flex flex-wrap items-center gap-2 text-sm text-slate-700"
         >
           <span>{{ contactPoint.type }} | {{ contactPoint.normalizedValue }} | {{ contactPoint.status }}</span>
           <span
@@ -163,38 +1185,43 @@ async function runSampleDecision() {
           </span>
         </li>
       </ul>
-      <p v-else>No contact points loaded yet.</p>
+      <p v-else class="text-sm text-slate-500">No contact points loaded yet.</p>
     </div>
 
     <div class="space-y-2">
       <button
         data-test="run-sample-decision"
         type="button"
-        class="border border-slate-300 px-3 py-2"
+        class="rounded-full border border-slate-300 px-3 py-2 text-sm text-slate-700"
         @click="runSampleDecision"
       >
         Run sample identity decision
       </button>
 
-      <p v-if="decisionError">{{ decisionError }}</p>
+      <p
+        v-if="decisionError"
+        class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+      >
+        {{ decisionError }}
+      </p>
 
       <div v-if="decisionResult && decisionPresentation" data-test="decision-result" class="space-y-2">
-        <p>Confidence band: {{ decisionResult.confidenceBand }}</p>
-        <p>Resolution state: {{ decisionPresentation.resolvedState }}</p>
-        <p>Default action: {{ decisionPresentation.defaultAction }}</p>
-        <p data-test="decision-guidance">{{ decisionPresentation.guidance }}</p>
-        <p v-if="decisionResult.resolverReviewId" data-test="resolver-review-id">
+        <p class="text-sm text-slate-700">Confidence band: {{ decisionResult.confidenceBand }}</p>
+        <p class="text-sm text-slate-700">Resolution state: {{ decisionPresentation.resolvedState }}</p>
+        <p class="text-sm text-slate-700">Default action: {{ decisionPresentation.defaultAction }}</p>
+        <p data-test="decision-guidance" class="text-sm text-slate-600">{{ decisionPresentation.guidance }}</p>
+        <p v-if="decisionResult.resolverReviewId" data-test="resolver-review-id" class="text-sm text-slate-700">
           Resolver review: {{ decisionResult.resolverReviewId }}
         </p>
         <ul
           v-if="decisionPresentation.showCandidates && decisionCandidates.length > 0"
           data-test="decision-candidates"
-          class="list-disc pl-5"
+          class="space-y-2 pl-5"
         >
           <li
             v-for="candidate in decisionCandidates"
             :key="candidate.personId"
-            class="flex flex-wrap items-center gap-2"
+            class="flex flex-wrap items-center gap-2 text-sm text-slate-700"
           >
             <span>{{ candidate.personId }} (score {{ candidate.score }})</span>
             <span data-test="decision-candidate-status">
@@ -234,7 +1261,7 @@ async function runSampleDecision() {
             v-if="decisionPresentation.showAttachAction"
             data-test="attach-existing"
             type="button"
-            class="border border-slate-300 px-3 py-2"
+            class="rounded-full border border-slate-300 px-3 py-2 text-sm text-slate-700"
           >
             Attach to suggested match
           </button>
@@ -242,7 +1269,7 @@ async function runSampleDecision() {
             v-if="decisionPresentation.showCreateNewAction"
             data-test="create-new"
             type="button"
-            class="border border-slate-300 px-3 py-2"
+            class="rounded-full border border-slate-300 px-3 py-2 text-sm text-slate-700 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
             :disabled="!decisionPresentation.createNewAllowed"
           >
             Create new person
@@ -251,11 +1278,12 @@ async function runSampleDecision() {
         <p
           v-if="decisionPresentation.mode === 'resolver_required'"
           data-test="resolver-required-message"
+          class="text-sm text-slate-600"
         >
           Resolver review is required before creating a new person.
         </p>
       </div>
-      <p v-else>No identity decision run yet.</p>
+      <p v-else class="text-sm text-slate-500">No identity decision run yet.</p>
     </div>
   </section>
 </template>

--- a/apps/connectshyft-web/src/views/Shell/__tests__/PeopleView.test.ts
+++ b/apps/connectshyft-web/src/views/Shell/__tests__/PeopleView.test.ts
@@ -1,16 +1,148 @@
+import type {
+  ConnectShyftResolverQueueDetailData,
+  ConnectShyftResolverQueueItemRecord,
+} from '@shyft/contracts';
 import { mount } from '@vue/test-utils';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick, ref } from 'vue';
+import * as resolverQueueApi from '@/features/connectshyft/resolverQueue';
 import PeopleView from '../PeopleView.vue';
 import { SUBJECT_CONTEXT_KEY } from '../../../shell/subjectContext';
 
+vi.mock('@/features/connectshyft/resolverQueue', () => ({
+  fetchConnectShyftResolverQueue: vi.fn(),
+  fetchConnectShyftResolverQueueDetail: vi.fn(),
+  claimConnectShyftResolverQueueItem: vi.fn(),
+  releaseConnectShyftResolverQueueItem: vi.fn(),
+}));
+
+const fetchResolverQueueMock = vi.mocked(resolverQueueApi.fetchConnectShyftResolverQueue);
+const fetchResolverQueueDetailMock = vi.mocked(resolverQueueApi.fetchConnectShyftResolverQueueDetail);
+const claimResolverQueueItemMock = vi.mocked(resolverQueueApi.claimConnectShyftResolverQueueItem);
+const releaseResolverQueueItemMock = vi.mocked(resolverQueueApi.releaseConnectShyftResolverQueueItem);
+
 const flushPromises = async () => {
+  await Promise.resolve();
   await Promise.resolve();
   await nextTick();
 };
 
-const renderPeopleView = () =>
-  mount(PeopleView, {
+const buildQueueItem = (
+  overrides: Partial<ConnectShyftResolverQueueItemRecord> = {},
+): ConnectShyftResolverQueueItemRecord => ({
+  id: 'resolver-item-1',
+  itemType: 'identity_review',
+  status: 'queued',
+  active: true,
+  terminal: false,
+  claimState: 'unclaimed',
+  claimantUserId: null,
+  claimedByCurrentUser: false,
+  claimable: true,
+  releasable: false,
+  actionable: false,
+  resolverReviewId: 'resolver-item-1',
+  orgUnitId: 'test-org',
+  conversationId: 'conversation-1',
+  contactPointId: 'contact-point-1',
+  threadId: 'thread-1',
+  personIds: ['person-a', 'person-b'],
+  triggerSourceType: 'connectshyft_identity_seam',
+  triggerSourceId: 'trigger-1',
+  requestedAt: '2026-03-24T10:00:00.000Z',
+  startedAt: null,
+  resolvedAt: null,
+  ...overrides,
+});
+
+const buildQueueDetail = (
+  item: ConnectShyftResolverQueueItemRecord,
+  overrides: Partial<ConnectShyftResolverQueueDetailData> = {},
+): ConnectShyftResolverQueueDetailData => ({
+  item,
+  review: {
+    id: item.id,
+    tenantId: 'tenant-1',
+    orgUnitId: item.orgUnitId || 'test-org',
+    reviewType: item.itemType === 'rebind_review'
+      ? 'subject_reassignment_review'
+      : 'shared_contact_ambiguity',
+    reviewStatus: item.status,
+    priority: 'normal',
+    triggerSourceType: item.triggerSourceType || 'connectshyft_identity_seam',
+    triggerSourceId: item.triggerSourceId || 'trigger-1',
+    conversationId: item.conversationId || undefined,
+    provisionalPersonId: item.personIds[0],
+    candidatePersonIds: item.personIds,
+    contactPointId: item.contactPointId || undefined,
+    confidenceBand: 'medium',
+    confidenceReasons: ['manual review required'],
+    riskFlags: item.itemType === 'rebind_review' ? [] : ['shared_contact_possible'],
+    requestedByUserId: 'requested-by-user',
+    assignedResolverUserId: item.claimantUserId || undefined,
+    requestedAt: item.requestedAt || '2026-03-24T10:00:00.000Z',
+    startedAt: item.startedAt || undefined,
+    resolvedAt: item.resolvedAt || undefined,
+    resolutionType: undefined,
+    resolutionReason: undefined,
+    resolutionNotes: undefined,
+    actionable: item.active,
+    terminal: item.terminal,
+    decisionStatus: null,
+  },
+  rebindReview: item.itemType === 'rebind_review'
+    ? {
+      rebindHistoryId: `rebind-${item.id}`,
+      affectedObjectType: 'contact_point_link',
+      affectedObjectIds: ['link-1', 'link-2'],
+      sourcePersonId: 'person-old',
+      targetPersonId: 'person-new',
+      contactPointIds: ['contact-point-1'],
+      originatingResolverReviewId: 'origin-review-1',
+      originatingResolutionType: 'reassign_contact_point',
+    }
+    : null,
+  ...overrides,
+});
+
+const buildResolverQueueKey = (item: ConnectShyftResolverQueueItemRecord): string =>
+  `${item.itemType}:${item.id}`;
+
+const setupResolverQueue = (items: ConnectShyftResolverQueueItemRecord[]) => {
+  const detailMap = new Map(items.map((item) => [buildResolverQueueKey(item), buildQueueDetail(item)]));
+
+  fetchResolverQueueMock.mockResolvedValue({
+    ok: true,
+    code: 'CONNECTSHYFT_RESOLVER_QUEUE_LISTED',
+    message: 'ConnectShyft resolver queue listed',
+    items,
+  });
+
+  fetchResolverQueueDetailMock.mockImplementation(async (itemType, itemId) => {
+    const detail = detailMap.get(`${itemType}:${itemId}`);
+    if (!detail) {
+      return {
+        ok: false,
+        code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_NOT_FOUND',
+        message: 'Resolver queue item is unavailable for the active tenant context.',
+        unauthorized: false,
+        unavailable: true,
+      };
+    }
+
+    return {
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RETRIEVED',
+      message: 'ConnectShyft resolver queue item retrieved',
+      detail,
+    };
+  });
+
+  return detailMap;
+};
+
+const renderPeopleView = async () => {
+  const wrapper = mount(PeopleView, {
     global: {
       provide: {
         [SUBJECT_CONTEXT_KEY as symbol]: ref({
@@ -20,19 +152,270 @@ const renderPeopleView = () =>
     },
   });
 
+  await flushPromises();
+  return wrapper;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchResolverQueueMock.mockResolvedValue({
+    ok: true,
+    code: 'CONNECTSHYFT_RESOLVER_QUEUE_LISTED',
+    message: 'ConnectShyft resolver queue listed',
+    items: [],
+  });
+  fetchResolverQueueDetailMock.mockResolvedValue({
+    ok: false,
+    code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_NOT_FOUND',
+    message: 'Resolver queue item is unavailable for the active tenant context.',
+    unauthorized: false,
+    unavailable: true,
+  });
+  claimResolverQueueItemMock.mockResolvedValue({
+    ok: false,
+    code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_NOT_FOUND',
+    message: 'Resolver queue item is unavailable for the active tenant context.',
+    unauthorized: false,
+    unavailable: true,
+  });
+  releaseResolverQueueItemMock.mockResolvedValue({
+    ok: false,
+    code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_NOT_FOUND',
+    message: 'Resolver queue item is unavailable for the active tenant context.',
+    unauthorized: false,
+    unavailable: true,
+  });
+});
+
 afterEach(() => {
-  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
 describe('PeopleView', () => {
-  it('renders the people shell and current org unit', () => {
-    const wrapper = renderPeopleView();
+  it('renders PeopleView with the resolver workspace for tenant-admin queue work', async () => {
+    const identityItem = buildQueueItem({
+      id: 'identity-item',
+      itemType: 'identity_review',
+      claimState: 'unclaimed',
+    });
+    const rebindItem = buildQueueItem({
+      id: 'rebind-item',
+      itemType: 'rebind_review',
+      claimState: 'claimed_by_current_user',
+      claimantUserId: 'resolver-1',
+      claimedByCurrentUser: true,
+      claimable: false,
+      releasable: true,
+      actionable: true,
+      status: 'in_review',
+    });
+    setupResolverQueue([identityItem, rebindItem]);
 
+    const wrapper = await renderPeopleView();
+
+    expect(fetchResolverQueueMock).toHaveBeenCalledTimes(1);
     expect(wrapper.text()).toContain('People shell');
     expect(wrapper.text()).toContain('Org unit: test-org');
-    expect(wrapper.text()).toContain('Load contact points');
-    expect(wrapper.text()).toContain('Run sample identity decision');
+    expect(wrapper.get('[data-test="resolver-workspace"]').text()).toContain(
+      'Primary queue for identity and rebind reviews',
+    );
+    expect(wrapper.get('[data-test="resolver-workspace-summary"]').text()).toContain(
+      '2 active resolver items in one workspace',
+    );
+    expect(wrapper.find('[data-test="resolver-filter-all_active"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="resolver-filter-claimed_by_me"]').exists()).toBe(true);
+  });
+
+  it('keeps resolver controls hidden for non-tenant-admin users', async () => {
+    fetchResolverQueueMock.mockResolvedValue({
+      ok: false,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_FORBIDDEN',
+      message: 'Resolver queue access requires a tenant-admin role.',
+      unauthorized: true,
+    });
+
+    const wrapper = await renderPeopleView();
+
+    expect(wrapper.get('[data-test="resolver-workspace-locked"]').text()).toContain(
+      'available only to tenant-admin resolvers',
+    );
+    expect(wrapper.find('[data-test="resolver-filter-all_active"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="resolver-detail-claim"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="resolver-detail-release"]').exists()).toBe(false);
+  });
+
+  it('renders identity_review and rebind_review items with distinct claim states', async () => {
+    const identityItem = buildQueueItem({
+      id: 'identity-item',
+      itemType: 'identity_review',
+      claimState: 'claimed_by_current_user',
+      claimantUserId: 'resolver-1',
+      claimedByCurrentUser: true,
+      claimable: false,
+      releasable: true,
+      actionable: true,
+      status: 'in_review',
+    });
+    const rebindItem = buildQueueItem({
+      id: 'rebind-item',
+      itemType: 'rebind_review',
+      claimState: 'claimed_by_other',
+      claimantUserId: 'resolver-2',
+      claimable: false,
+      releasable: false,
+      actionable: false,
+      status: 'in_review',
+    });
+    setupResolverQueue([identityItem, rebindItem]);
+
+    const wrapper = await renderPeopleView();
+
+    expect(wrapper.get('[data-test="resolver-queue-item-type-identity-item"]').text()).toContain(
+      'Identity review',
+    );
+    expect(wrapper.get('[data-test="resolver-queue-item-type-rebind-item"]').text()).toContain(
+      'Rebind review',
+    );
+    expect(wrapper.get('[data-test="resolver-queue-item-claim-identity-item"]').text()).toContain(
+      'Claimed by me',
+    );
+    expect(wrapper.get('[data-test="resolver-queue-item-claim-rebind-item"]').text()).toContain(
+      'Claimed by another resolver',
+    );
+  });
+
+  it('claims and releases resolver work through backend-backed operations', async () => {
+    const queueItem = buildQueueItem({
+      id: 'identity-item',
+      itemType: 'identity_review',
+      claimState: 'unclaimed',
+      claimable: true,
+      releasable: false,
+      actionable: false,
+    });
+    setupResolverQueue([queueItem]);
+
+    const claimedItem = buildQueueItem({
+      ...queueItem,
+      claimState: 'claimed_by_current_user',
+      claimantUserId: 'resolver-1',
+      claimedByCurrentUser: true,
+      claimable: false,
+      releasable: true,
+      actionable: true,
+      status: 'in_review',
+      startedAt: '2026-03-24T10:05:00.000Z',
+    });
+
+    claimResolverQueueItemMock.mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_CLAIMED',
+      message: 'ConnectShyft resolver queue item claimed',
+      detail: buildQueueDetail(claimedItem),
+    });
+
+    releaseResolverQueueItemMock.mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_RESOLVER_QUEUE_ITEM_RELEASED',
+      message: 'ConnectShyft resolver queue item released',
+      detail: buildQueueDetail(queueItem),
+    });
+
+    const wrapper = await renderPeopleView();
+
+    await wrapper.get('[data-test="resolver-detail-claim"]').trigger('click');
+    await flushPromises();
+
+    expect(claimResolverQueueItemMock).toHaveBeenCalledWith('identity_review', 'identity-item');
+    expect(wrapper.get('[data-test="resolver-queue-feedback"]').text()).toContain('claimed');
+    expect(wrapper.get('[data-test="resolver-queue-item-claim-identity-item"]').text()).toContain(
+      'Claimed by me',
+    );
+    expect(wrapper.find('[data-test="resolver-detail-claim"]').exists()).toBe(false);
+    expect(wrapper.get('[data-test="resolver-detail-release"]').text()).toContain('Release item');
+
+    await wrapper.get('[data-test="resolver-detail-release"]').trigger('click');
+    await flushPromises();
+
+    expect(releaseResolverQueueItemMock).toHaveBeenCalledWith('identity_review', 'identity-item');
+    expect(wrapper.get('[data-test="resolver-queue-item-claim-identity-item"]').text()).toContain(
+      'Unclaimed',
+    );
+    expect(wrapper.get('[data-test="resolver-detail-claim"]').text()).toContain('Claim item');
+  });
+
+  it('shows claimed-by-other work as explicit and non-actionable', async () => {
+    const queueItem = buildQueueItem({
+      id: 'rebind-item',
+      itemType: 'rebind_review',
+      claimState: 'claimed_by_other',
+      claimantUserId: 'resolver-2',
+      claimable: false,
+      releasable: false,
+      actionable: false,
+      status: 'in_review',
+    });
+    setupResolverQueue([queueItem]);
+
+    const wrapper = await renderPeopleView();
+
+    expect(wrapper.get('[data-test="resolver-detail-claim-disabled"]').attributes('disabled')).toBeDefined();
+    expect(wrapper.get('[data-test="resolver-detail-claimed-by-other"]').text()).toContain(
+      'currently working this item',
+    );
+    expect(wrapper.get('[data-test="resolver-detail-reason"]').text()).toContain(
+      'contact-point reassignment created sensitive follow-up work',
+    );
+  });
+
+  it('filters the resolver workspace using typed queue and claim fields', async () => {
+    const unclaimedIdentity = buildQueueItem({
+      id: 'identity-unclaimed',
+      itemType: 'identity_review',
+      claimState: 'unclaimed',
+      claimable: true,
+    });
+    const claimedRebind = buildQueueItem({
+      id: 'rebind-claimed',
+      itemType: 'rebind_review',
+      claimState: 'claimed_by_current_user',
+      claimantUserId: 'resolver-1',
+      claimedByCurrentUser: true,
+      claimable: false,
+      releasable: true,
+      actionable: true,
+      status: 'in_review',
+    });
+    const claimedByOtherIdentity = buildQueueItem({
+      id: 'identity-other',
+      itemType: 'identity_review',
+      claimState: 'claimed_by_other',
+      claimantUserId: 'resolver-2',
+      claimable: false,
+      releasable: false,
+      actionable: false,
+      status: 'in_review',
+    });
+    setupResolverQueue([unclaimedIdentity, claimedRebind, claimedByOtherIdentity]);
+
+    const wrapper = await renderPeopleView();
+
+    await wrapper.get('[data-test="resolver-filter-rebind_review"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="resolver-queue-item-rebind-claimed"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="resolver-queue-item-identity-unclaimed"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="resolver-queue-item-identity-other"]').exists()).toBe(false);
+
+    await wrapper.get('[data-test="resolver-filter-claimed_by_me"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="resolver-queue-item-rebind-claimed"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="resolver-queue-item-identity-unclaimed"]').exists()).toBe(false);
+
+    await wrapper.get('[data-test="resolver-filter-unclaimed"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[data-test="resolver-queue-item-identity-unclaimed"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="resolver-queue-item-rebind-claimed"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="resolver-queue-item-identity-other"]').exists()).toBe(false);
   });
 
   it('renders shared, stale, and reassignment indicators for contact points', async () => {
@@ -86,7 +469,7 @@ describe('PeopleView', () => {
 
     vi.stubGlobal('fetch', fetchMock);
 
-    const wrapper = renderPeopleView();
+    const wrapper = await renderPeopleView();
 
     await wrapper.get('[data-test="load-contact-points"]').trigger('click');
     await flushPromises();
@@ -96,7 +479,7 @@ describe('PeopleView', () => {
     expect(wrapper.findAll('[data-test="contact-point-reassignment-indicator"]')).toHaveLength(1);
   });
 
-  it('runs the sample identity decision and renders the result', async () => {
+  it('runs the sample identity decision and keeps resolver-required guidance compatible', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -110,7 +493,7 @@ describe('PeopleView', () => {
 
     vi.stubGlobal('fetch', fetchMock);
 
-    const wrapper = renderPeopleView();
+    const wrapper = await renderPeopleView();
 
     await wrapper.get('[data-test="run-sample-decision"]').trigger('click');
     await flushPromises();
@@ -132,34 +515,5 @@ describe('PeopleView', () => {
     expect(wrapper.get('[data-test="resolver-required-message"]').text()).toContain(
       'Resolver review is required before creating a new person.',
     );
-  });
-
-  it('shows candidate suggestions while keeping create-new as the default for low confidence', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        confidenceBand: 'low',
-        contactPointStatus: 'active_shared_possible',
-        candidates: [{
-          personId: 'person-low',
-          score: 24,
-          reasons: ['historical contact match'],
-          contactPointStatus: 'active_shared_possible',
-        }],
-      }),
-    });
-
-    vi.stubGlobal('fetch', fetchMock);
-
-    const wrapper = renderPeopleView();
-
-    await wrapper.get('[data-test="run-sample-decision"]').trigger('click');
-    await flushPromises();
-
-    expect(wrapper.text()).toContain('Default action: create_new');
-    expect(wrapper.get('[data-test="decision-candidates"]').text()).toContain('person-low');
-    expect(wrapper.findAll('[data-test="decision-candidate-shared-indicator"]')).toHaveLength(1);
-    expect(wrapper.find('[data-test="attach-existing"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="create-new"]').exists()).toBe(true);
   });
 });

--- a/libs/contracts/src/connectshyft.ts
+++ b/libs/contracts/src/connectshyft.ts
@@ -143,6 +143,24 @@ export const CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_STATES = [
 export type ConnectShyftResolverQueueClaimState =
   typeof CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_STATES[number];
 
+export const CONNECTSHYFT_REBIND_REVIEW_AFFECTED_OBJECT_TYPES = [
+  'contact_point_link',
+] as const;
+
+export type ConnectShyftRebindReviewAffectedObjectType =
+  typeof CONNECTSHYFT_REBIND_REVIEW_AFFECTED_OBJECT_TYPES[number];
+
+export type ConnectShyftRebindReviewContext = {
+  rebindHistoryId: string;
+  affectedObjectType: ConnectShyftRebindReviewAffectedObjectType;
+  affectedObjectIds: string[];
+  sourcePersonId: string;
+  targetPersonId: string;
+  contactPointIds: string[];
+  originatingResolverReviewId: string | null;
+  originatingResolutionType: ResolverActionType | null;
+};
+
 export type ConnectShyftResolverQueueItemRecord = {
   id: string;
   itemType: ConnectShyftResolverQueueItemType;
@@ -175,6 +193,7 @@ export type ConnectShyftResolverQueueListData = {
 export type ConnectShyftResolverQueueDetailData = {
   item: ConnectShyftResolverQueueItemRecord;
   review: ConnectShyftResolverReviewRecord | null;
+  rebindReview: ConnectShyftRebindReviewContext | null;
 };
 
 export type ConnectShyftResolverDecisionData = {
@@ -210,6 +229,12 @@ export const isConnectShyftResolverQueueClaimState = (
 ): value is ConnectShyftResolverQueueClaimState =>
   typeof value === 'string'
   && (CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_STATES as readonly string[]).includes(value);
+
+export const isConnectShyftRebindReviewAffectedObjectType = (
+  value: unknown,
+): value is ConnectShyftRebindReviewAffectedObjectType =>
+  typeof value === 'string'
+  && (CONNECTSHYFT_REBIND_REVIEW_AFFECTED_OBJECT_TYPES as readonly string[]).includes(value);
 
 export type ConnectShyftIdentityResolutionResponse = {
   confidenceBand: IdentityConfidenceBand;

--- a/libs/contracts/src/connectshyft.ts
+++ b/libs/contracts/src/connectshyft.ts
@@ -143,6 +143,22 @@ export const CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_STATES = [
 export type ConnectShyftResolverQueueClaimState =
   typeof CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_STATES[number];
 
+export const CONNECTSHYFT_THREAD_SUBJECT_IMPACT_TYPES = [
+  'provisional_identity',
+  'resolver_required',
+  'rebind_review',
+] as const;
+
+export type ConnectShyftThreadSubjectImpactType =
+  typeof CONNECTSHYFT_THREAD_SUBJECT_IMPACT_TYPES[number];
+
+export type ConnectShyftThreadSubjectImpact = {
+  impactType: ConnectShyftThreadSubjectImpactType;
+  actionable: boolean;
+  resolverQueueItemId: string | null;
+  resolverQueueItemType: ConnectShyftResolverQueueItemType | null;
+};
+
 export const CONNECTSHYFT_REBIND_REVIEW_AFFECTED_OBJECT_TYPES = [
   'contact_point_link',
 ] as const;
@@ -229,6 +245,12 @@ export const isConnectShyftResolverQueueClaimState = (
 ): value is ConnectShyftResolverQueueClaimState =>
   typeof value === 'string'
   && (CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_STATES as readonly string[]).includes(value);
+
+export const isConnectShyftThreadSubjectImpactType = (
+  value: unknown,
+): value is ConnectShyftThreadSubjectImpactType =>
+  typeof value === 'string'
+  && (CONNECTSHYFT_THREAD_SUBJECT_IMPACT_TYPES as readonly string[]).includes(value);
 
 export const isConnectShyftRebindReviewAffectedObjectType = (
   value: unknown,

--- a/libs/contracts/src/connectshyft.ts
+++ b/libs/contracts/src/connectshyft.ts
@@ -126,6 +126,57 @@ export type ConnectShyftResolverReviewDetailData = {
   review: ConnectShyftResolverReviewRecord;
 };
 
+export const CONNECTSHYFT_RESOLVER_QUEUE_ITEM_TYPES = [
+  'identity_review',
+  'rebind_review',
+] as const;
+
+export type ConnectShyftResolverQueueItemType =
+  typeof CONNECTSHYFT_RESOLVER_QUEUE_ITEM_TYPES[number];
+
+export const CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_STATES = [
+  'unclaimed',
+  'claimed_by_current_user',
+  'claimed_by_other',
+] as const;
+
+export type ConnectShyftResolverQueueClaimState =
+  typeof CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_STATES[number];
+
+export type ConnectShyftResolverQueueItemRecord = {
+  id: string;
+  itemType: ConnectShyftResolverQueueItemType;
+  status: ResolverReviewStatus;
+  active: boolean;
+  terminal: boolean;
+  claimState: ConnectShyftResolverQueueClaimState;
+  claimantUserId: string | null;
+  claimedByCurrentUser: boolean;
+  claimable: boolean;
+  releasable: boolean;
+  actionable: boolean;
+  resolverReviewId: string | null;
+  orgUnitId: string | null;
+  conversationId: string | null;
+  contactPointId: string | null;
+  threadId: string | null;
+  personIds: string[];
+  triggerSourceType: string | null;
+  triggerSourceId: string | null;
+  requestedAt: string | null;
+  startedAt: string | null;
+  resolvedAt: string | null;
+};
+
+export type ConnectShyftResolverQueueListData = {
+  items: ConnectShyftResolverQueueItemRecord[];
+};
+
+export type ConnectShyftResolverQueueDetailData = {
+  item: ConnectShyftResolverQueueItemRecord;
+  review: ConnectShyftResolverReviewRecord | null;
+};
+
 export type ConnectShyftResolverDecisionData = {
   result: ResolverDecisionResult;
 };
@@ -147,6 +198,18 @@ export const isConnectShyftIdentityAmbiguityTerminalStatus = (
 ): value is ConnectShyftIdentityAmbiguityTerminalStatus =>
   typeof value === 'string'
   && (CONNECTSHYFT_IDENTITY_AMBIGUITY_TERMINAL_STATUSES as readonly string[]).includes(value);
+
+export const isConnectShyftResolverQueueItemType = (
+  value: unknown,
+): value is ConnectShyftResolverQueueItemType =>
+  typeof value === 'string'
+  && (CONNECTSHYFT_RESOLVER_QUEUE_ITEM_TYPES as readonly string[]).includes(value);
+
+export const isConnectShyftResolverQueueClaimState = (
+  value: unknown,
+): value is ConnectShyftResolverQueueClaimState =>
+  typeof value === 'string'
+  && (CONNECTSHYFT_RESOLVER_QUEUE_CLAIM_STATES as readonly string[]).includes(value);
 
 export type ConnectShyftIdentityResolutionResponse = {
   confidenceBand: IdentityConfidenceBand;

--- a/libs/contracts/src/people/resolver-review.ts
+++ b/libs/contracts/src/people/resolver-review.ts
@@ -11,6 +11,12 @@ export const RESOLVER_REVIEW_TYPES = [
 
 export type ResolverReviewType = typeof RESOLVER_REVIEW_TYPES[number];
 
+export const RESOLVER_REBIND_REVIEW_TYPES = [
+  'subject_reassignment_review',
+] as const;
+
+export type ResolverRebindReviewType = typeof RESOLVER_REBIND_REVIEW_TYPES[number];
+
 export const RESOLVER_REVIEW_ACTIVE_STATUSES = [
   'pending',
   'queued',
@@ -128,6 +134,12 @@ export type ResolverDecisionResult = {
 export const isResolverActionType = (value: unknown): value is ResolverActionType =>
   typeof value === 'string'
   && (RESOLVER_ACTION_TYPES as readonly string[]).includes(value);
+
+export const isResolverRebindReviewType = (
+  value: unknown,
+): value is ResolverRebindReviewType =>
+  typeof value === 'string'
+  && (RESOLVER_REBIND_REVIEW_TYPES as readonly string[]).includes(value);
 
 export const isResolverReviewActiveStatus = (
   value: unknown,

--- a/libs/contracts/src/people/resolver-review.ts
+++ b/libs/contracts/src/people/resolver-review.ts
@@ -86,6 +86,7 @@ export type ResolverDecisionInput = {
   reviewId: string;
   action: ResolverActionType;
   actorUserId: string;
+  actorRoles?: string[];
   reason?: string;
   notes?: string;
   personId?: string;
@@ -101,6 +102,7 @@ export type ValidatedResolverDecisionInput = {
   reviewId: string;
   action: ResolverActionType;
   actorUserId: string;
+  actorRoles: string[];
   reason?: string;
   notes?: string;
   personId?: string;
@@ -132,6 +134,12 @@ export const isResolverReviewActiveStatus = (
 ): value is typeof RESOLVER_REVIEW_ACTIVE_STATUSES[number] =>
   typeof value === 'string'
   && (RESOLVER_REVIEW_ACTIVE_STATUSES as readonly string[]).includes(value);
+
+export const isResolverReviewStatus = (
+  value: unknown,
+): value is ResolverReviewStatus =>
+  typeof value === 'string'
+  && (RESOLVER_REVIEW_STATUSES as readonly string[]).includes(value);
 
 export const isResolverReviewResolvedStatus = (
   value: unknown,

--- a/libs/contracts/tests/connectshyft.test.ts
+++ b/libs/contracts/tests/connectshyft.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import type {
   ConnectShyftRebindReviewContext,
   ConnectShyftResolverQueueDetailData,

--- a/libs/contracts/tests/connectshyft.test.ts
+++ b/libs/contracts/tests/connectshyft.test.ts
@@ -1,5 +1,10 @@
-import type { ConnectShyftResolverQueueItemRecord } from '../src/connectshyft';
+import type {
+  ConnectShyftRebindReviewContext,
+  ConnectShyftResolverQueueDetailData,
+  ConnectShyftResolverQueueItemRecord,
+} from '../src/connectshyft';
 import {
+  isConnectShyftRebindReviewAffectedObjectType,
   isConnectShyftResolverQueueItemType,
   isConnectShyftResolverQueueClaimState,
 } from '../src/connectshyft';
@@ -35,14 +40,32 @@ describe('connectshyft contracts', () => {
       ...identityItem,
       id: 'rebind-1',
       itemType: 'rebind_review',
-      resolverReviewId: null,
-      threadId: 'thread-1',
+      resolverReviewId: 'review-rebind-1',
+    };
+
+    const rebindReview: ConnectShyftRebindReviewContext = {
+      rebindHistoryId: 'rebind-history-1',
+      affectedObjectType: 'contact_point_link',
+      affectedObjectIds: ['link-review-1'],
+      sourcePersonId: 'person-1',
+      targetPersonId: 'person-2',
+      contactPointIds: ['contact-point-1'],
+      originatingResolverReviewId: 'review-1',
+      originatingResolutionType: 'merge_people',
+    };
+
+    const detail: ConnectShyftResolverQueueDetailData = {
+      item: rebindItem,
+      review: null,
+      rebindReview,
     };
 
     expect(identityItem.itemType).toBe('identity_review');
     expect(rebindItem.itemType).toBe('rebind_review');
+    expect(detail.rebindReview?.rebindHistoryId).toBe('rebind-history-1');
     expect(isConnectShyftResolverQueueItemType(identityItem.itemType)).toBe(true);
     expect(isConnectShyftResolverQueueItemType(rebindItem.itemType)).toBe(true);
     expect(isConnectShyftResolverQueueClaimState(identityItem.claimState)).toBe(true);
+    expect(isConnectShyftRebindReviewAffectedObjectType(rebindReview.affectedObjectType)).toBe(true);
   });
 });

--- a/libs/contracts/tests/connectshyft.test.ts
+++ b/libs/contracts/tests/connectshyft.test.ts
@@ -1,12 +1,15 @@
+import { describe, expect, it } from 'vitest';
 import type {
   ConnectShyftRebindReviewContext,
   ConnectShyftResolverQueueDetailData,
   ConnectShyftResolverQueueItemRecord,
+  ConnectShyftThreadSubjectImpact,
 } from '../src/connectshyft';
 import {
   isConnectShyftRebindReviewAffectedObjectType,
   isConnectShyftResolverQueueItemType,
   isConnectShyftResolverQueueClaimState,
+  isConnectShyftThreadSubjectImpactType,
 } from '../src/connectshyft';
 
 describe('connectshyft contracts', () => {
@@ -67,5 +70,18 @@ describe('connectshyft contracts', () => {
     expect(isConnectShyftResolverQueueItemType(rebindItem.itemType)).toBe(true);
     expect(isConnectShyftResolverQueueClaimState(identityItem.claimState)).toBe(true);
     expect(isConnectShyftRebindReviewAffectedObjectType(rebindReview.affectedObjectType)).toBe(true);
+  });
+
+  it('supports contract-backed thread subject impact states for contextual banners', () => {
+    const impact: ConnectShyftThreadSubjectImpact = {
+      impactType: 'resolver_required',
+      actionable: true,
+      resolverQueueItemId: 'review-1',
+      resolverQueueItemType: 'identity_review',
+    };
+
+    expect(isConnectShyftThreadSubjectImpactType(impact.impactType)).toBe(true);
+    expect(isConnectShyftResolverQueueItemType(impact.resolverQueueItemType)).toBe(true);
+    expect(impact.actionable).toBe(true);
   });
 });

--- a/libs/contracts/tests/connectshyft.test.ts
+++ b/libs/contracts/tests/connectshyft.test.ts
@@ -1,0 +1,48 @@
+import type { ConnectShyftResolverQueueItemRecord } from '../src/connectshyft';
+import {
+  isConnectShyftResolverQueueItemType,
+  isConnectShyftResolverQueueClaimState,
+} from '../src/connectshyft';
+
+describe('connectshyft contracts', () => {
+  it('supports resolver queue items for identity and rebind review work', () => {
+    const identityItem: ConnectShyftResolverQueueItemRecord = {
+      id: 'review-1',
+      itemType: 'identity_review',
+      status: 'queued',
+      active: true,
+      terminal: false,
+      claimState: 'unclaimed',
+      claimantUserId: null,
+      claimedByCurrentUser: false,
+      claimable: true,
+      releasable: false,
+      actionable: false,
+      resolverReviewId: 'review-1',
+      orgUnitId: 'org-1',
+      conversationId: 'conversation-1',
+      contactPointId: 'contact-point-1',
+      threadId: null,
+      personIds: ['person-1', 'person-2'],
+      triggerSourceType: 'connectshyft_identity_match',
+      triggerSourceId: 'identity-match:1',
+      requestedAt: new Date().toISOString(),
+      startedAt: null,
+      resolvedAt: null,
+    };
+
+    const rebindItem: ConnectShyftResolverQueueItemRecord = {
+      ...identityItem,
+      id: 'rebind-1',
+      itemType: 'rebind_review',
+      resolverReviewId: null,
+      threadId: 'thread-1',
+    };
+
+    expect(identityItem.itemType).toBe('identity_review');
+    expect(rebindItem.itemType).toBe('rebind_review');
+    expect(isConnectShyftResolverQueueItemType(identityItem.itemType)).toBe(true);
+    expect(isConnectShyftResolverQueueItemType(rebindItem.itemType)).toBe(true);
+    expect(isConnectShyftResolverQueueClaimState(identityItem.claimState)).toBe(true);
+  });
+});

--- a/libs/contracts/tests/people/resolver-review.test.ts
+++ b/libs/contracts/tests/people/resolver-review.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import type { ResolverReview } from '../../src/people';
 import { isResolverRebindReviewType } from '../../src/people';
 

--- a/libs/contracts/tests/people/resolver-review.test.ts
+++ b/libs/contracts/tests/people/resolver-review.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import type { ResolverReview } from '../../src/people';
 import { isResolverRebindReviewType } from '../../src/people';
 

--- a/libs/contracts/tests/people/resolver-review.test.ts
+++ b/libs/contracts/tests/people/resolver-review.test.ts
@@ -1,4 +1,5 @@
 import type { ResolverReview } from '../../src/people';
+import { isResolverRebindReviewType } from '../../src/people';
 
 describe('resolver review contracts', () => {
   it('supports a first-class resolver review object', () => {
@@ -20,5 +21,10 @@ describe('resolver review contracts', () => {
     };
 
     expect(review.reviewType).toBe('identity_conflict');
+  });
+
+  it('marks subject reassignment reviews as rebind-backed review types', () => {
+    expect(isResolverRebindReviewType('subject_reassignment_review')).toBe(true);
+    expect(isResolverRebindReviewType('identity_conflict')).toBe(false);
   });
 });

--- a/specs/prep_step_1_checkpoint_6_codex_bootstrap_prompt.md
+++ b/specs/prep_step_1_checkpoint_6_codex_bootstrap_prompt.md
@@ -1,0 +1,31 @@
+You are implementing **Checkpoint 6 — Notification + Unread/Seen/Reviewed Behavior**.
+
+## Objective
+Implement correct inbound vs outbound voicemail notification and acknowledgment behavior.
+
+## Requirements
+1. Add seen_at_utc and reviewed_at_utc to voicemail artifact.
+2. Inbound voicemail:
+   - triggers notification
+   - starts unread
+3. Outbound voicemail:
+   - never triggers notification
+   - always marked seen/reviewed
+4. Thread open marks inbound voicemail as seen.
+5. Add markVoicemailReviewed service or fallback behavior.
+6. Ensure notification is idempotent.
+
+## Do not
+- redesign notification system
+- modify UI components
+- change persistence model
+- change webhook handling
+
+## Stop condition
+- inbound voicemail triggers one notification
+- outbound voicemail never unread
+- thread open marks seen correctly
+- no duplicate notifications from replay events
+
+## Commit
+feat(connectshyft): implement voicemail notification and acknowledgment behavior

--- a/specs/prep_step_1_checkpoint_6_notification_behavior.md
+++ b/specs/prep_step_1_checkpoint_6_notification_behavior.md
@@ -1,0 +1,214 @@
+# CHECKPOINT 6 — NOTIFICATION + UNREAD/SEEN/REVIEWED BEHAVIOR
+**Slice:** Prep Step 1  
+**Objective:** Implement correct inbound vs outbound voicemail notification and acknowledgment behavior with consistent unread/seen/reviewed state
+
+---
+
+## 1. Goal
+
+- Inbound voicemail:
+  - triggers notification
+  - appears as unread/new activity
+  - can be marked seen/reviewed
+
+- Outbound voicemail:
+  - never triggers inbound-style notification
+  - never appears unread
+  - exists only as documented activity
+
+- Thread-level and voicemail-level acknowledgment behavior is deterministic and consistent
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-api/src/modules/connectshyft/threadTimeline.ts
+apps/connectshyft-api/src/modules/connectshyft/voicemails.ts
+apps/connectshyft-api/src/modules/connectshyft/callLifecycle.ts
+apps/connectshyft-api/src/modules/connectshyft/inboundVoice.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+```
+
+---
+
+## 3. Required Changes
+
+### 3.1 Add acknowledgment fields to voicemail artifact
+
+Voicemail must support:
+
+```text
+seen_at_utc
+reviewed_at_utc
+```
+
+If equivalent fields already exist, reuse them.
+
+---
+
+### 3.2 Inbound voicemail notification rule
+
+When inbound voicemail is created:
+
+- trigger notification using existing inbound activity mechanism
+- mark voicemail as:
+  - unseen
+  - unreviewed
+
+### 3.3 Outbound voicemail rule
+
+When outbound voicemail is created:
+
+- do NOT trigger notification
+- set:
+  - seen_at_utc = created_at
+  - reviewed_at_utc = created_at
+
+Outbound voicemail must never appear as unread.
+
+---
+
+### 3.4 Thread open behavior
+
+When thread is opened:
+
+- all inbound voicemails in that thread:
+  - set seen_at_utc if not already set
+
+This must be idempotent.
+
+---
+
+### 3.5 Mark reviewed action (optional but preferred)
+
+Provide service-layer method:
+
+```ts
+markVoicemailReviewed(voicemailId, actorId)
+```
+
+Behavior:
+
+- sets reviewed_at_utc
+- does not modify recording or transcription data
+
+If not implemented, fallback behavior:
+
+- seen = reviewed
+
+---
+
+### 3.6 Timeline rendering inputs
+
+ThreadTimeline must receive:
+
+- direction
+- seen/reviewed status
+
+Rendering layer should be able to distinguish:
+
+- unread (no seen_at_utc)
+- seen but not reviewed
+- reviewed
+
+No UI implementation required here, only data availability.
+
+---
+
+### 3.7 Notification idempotency
+
+Inbound voicemail notification must be:
+
+- triggered once per voicemail artifact
+- not retriggered by:
+  - webhook replay
+  - transcription callback
+  - timeline rebuild
+
+---
+
+### 3.8 Backfill safety
+
+If existing voicemail artifacts lack seen/reviewed fields:
+
+- default:
+  - inbound → unseen/unreviewed
+  - outbound → seen/reviewed
+
+---
+
+## 4. Explicit Non-Changes
+
+Do not:
+
+- redesign notification system
+- add new notification channels
+- modify UI rendering components
+- change voicemail persistence model
+- change webhook handling
+- add queue/dashboard features
+
+---
+
+## 5. Tests Required
+
+### Unit
+
+- inbound voicemail starts unseen/unreviewed
+- outbound voicemail starts seen/reviewed
+- mark reviewed sets reviewed_at_utc
+- thread open sets seen_at_utc
+
+### Integration
+
+- inbound voicemail triggers notification once
+- outbound voicemail does not trigger notification
+- duplicate webhook does not retrigger notification
+- thread open idempotently marks seen
+
+### Characterization
+
+- existing inbound SMS/call notifications unaffected
+- timeline correctly reflects seen/reviewed state
+
+---
+
+## 6. Stop Condition
+
+Complete only when:
+
+- inbound voicemail triggers notification exactly once
+- outbound voicemail never appears unread
+- thread open marks inbound voicemail as seen
+- reviewed state can be set or fallback applied
+- no duplicate notifications occur from replay events
+
+---
+
+## 7. Commit Boundary
+
+```text
+feat(connectshyft): implement voicemail notification and acknowledgment behavior
+```
+
+---
+
+## 8. Verification Commands
+
+```bash
+rg "seen_at_utc|reviewed_at_utc" apps/connectshyft-api
+```
+
+```bash
+rg "notifyInboundVoicemail|notification" apps/connectshyft-api
+```
+
+---
+
+## 9. Outcome
+
+- inbound voicemail behaves like true inbound communication
+- outbound voicemail is documented but never noisy
+- thread acknowledgment is consistent
+- system is now MVP-complete for telephony + voicemail

--- a/specs/prep_step_2A_checkpoint_1_resolver_action_set_and_lifecycle.md
+++ b/specs/prep_step_2A_checkpoint_1_resolver_action_set_and_lifecycle.md
@@ -1,0 +1,284 @@
+# CHECKPOINT 1 — RESOLVER ACTION SET, LIFECYCLE STATES, AND VALIDATION LOCK
+**Slice:** Prep Step 2A  
+**Objective:** Lock the canonical resolver action set, resolver review lifecycle rules, and action-specific validation so backend decision semantics are explicit and enforceable
+
+## 1. Goal
+
+Establish a single authoritative backend definition for:
+
+- which resolver actions exist in MVP
+- what lifecycle states resolver reviews may move through
+- what validations are required before a resolver decision may be applied
+- what action payload fields are mandatory for each action
+- what transitions are valid vs invalid
+
+This checkpoint does **not** implement full decision consequences yet. It locks the action and lifecycle backbone so later checkpoints can apply decisions without improvising semantics.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-api/src/modules/peoplecore/contactPointIdentityResolution.ts
+apps/connectshyft-api/src/modules/peoplecore/store.ts
+apps/connectshyft-api/src/modules/peoplecore/service.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+libs/contracts/src/people/resolver-review.ts
+libs/contracts/src/people/events.ts
+libs/contracts/src/connectshyft.ts
+```
+
+If action or review-state types are defined in adjacent shared contract files, include only those exact files needed to keep type truth single-sourced. Do not modify unrelated contracts.
+
+---
+
+## 3. Required Changes
+
+### 3.1 Lock the canonical resolver action type set
+
+In the shared People resolver-review contract, define or finalize the authoritative action set for MVP:
+
+```ts
+type ResolverActionType =
+  | 'confirm_existing_person'
+  | 'confirm_new_person'
+  | 'merge_people'
+  | 'link_without_merge'
+  | 'mark_shared_contact'
+  | 'reassign_contact_point'
+  | 'dismiss_no_action';
+```
+
+If the repo already uses an enum or string-literal object, preserve the existing style while locking the same semantics.
+
+No extra MVP action types may remain in active use unless they alias directly to one of the above semantic actions.
+
+### 3.2 Lock resolver review lifecycle states
+
+Preserve contract breadth where already present, but explicitly lock MVP-valid lifecycle semantics.
+
+Required active MVP path:
+
+```text
+pending -> in_review -> resolved
+pending -> dismissed
+in_review -> dismissed
+```
+
+Allowed in contract but not required for rich MVP UI:
+- `queued`
+- `waiting_for_more_info`
+
+If the repo currently represents resolution as multiple terminal statuses instead of a generic `resolved`, preserve that representation, but the lifecycle must still enforce:
+- pending/in-progress states
+- terminal resolved states
+- terminal dismissed state
+
+### 3.3 Add authoritative lifecycle guards
+
+Add or finalize a single validation path in PeopleCore service layer that can answer:
+
+```ts
+assertResolverReviewTransitionAllowed(currentStatus, nextStatus): void
+```
+
+This must reject:
+- terminal -> active transitions
+- invalid skips not allowed by the checkpoint
+- re-resolving an already resolved review unless explicit idempotent replay is intentionally supported
+
+### 3.4 Add authoritative action-payload validation
+
+Add or finalize a validation path such as:
+
+```ts
+validateResolverDecisionInput(input): ValidatedResolverDecisionInput
+```
+
+This validation must enforce action-specific required fields.
+
+#### Required validations by action
+
+**confirm_existing_person**
+- requires selected existing person id
+
+**confirm_new_person**
+- requires confirmed provisional/new person id or resolvable provisional reference
+
+**merge_people**
+- requires source person id
+- requires target person id
+- source and target must differ
+
+**link_without_merge**
+- requires sufficient target/link context to persist association
+- must not require merge ids
+
+**mark_shared_contact**
+- requires sufficient review/candidate context to resolve as shared-contact
+
+**reassign_contact_point**
+- requires contact point id
+- requires target person id
+
+**dismiss_no_action**
+- requires dismissal reason
+
+### 3.5 Lock review terminality rules
+
+Once a review is:
+- resolved
+- dismissed
+
+it must be treated as terminal for normal mutation.
+
+Allowed exception:
+- explicit idempotent replay of the same final action may be tolerated if the current repo pattern already needs safe retry behavior.
+
+But:
+- resolved -> different resolved action is forbidden
+- dismissed -> resolved is forbidden in MVP
+- resolved -> dismissed is forbidden
+
+### 3.6 Lock outcome typing
+
+Add or finalize typed result/status fields in the resolver-review contract so later checkpoints do not invent meanings ad hoc.
+
+At minimum, the shared contract must support:
+- action type
+- review status
+- resolution type / terminal outcome
+- risk flags / confidence band where already present
+- source/target references where applicable
+
+Do not allow route-local ad hoc string values that bypass the shared contract.
+
+### 3.7 Ensure contact-point identity resolution output remains compatible
+
+`contactPointIdentityResolution.ts` must continue producing the existing high-level resolution outcomes:
+
+- `canonical`
+- `provisional`
+- `resolver_required`
+
+This checkpoint must not break that flow. Instead, it should make `resolver_required` downstream semantics explicit by anchoring them to the locked resolver action/lifecycle contracts.
+
+### 3.8 Route handlers must not define business semantics
+
+In `connectshyft.ts` and any relevant PeopleCore-facing route logic:
+
+- remove or avoid inline action-name validation
+- remove or avoid inline review-lifecycle rules
+- delegate action/lifecycle validation to shared contract + PeopleCore validation/service layer
+
+Thin routes only:
+- authenticate/authorize
+- validate transport shape
+- call service
+- return normalized errors/results
+
+---
+
+## 4. Explicit Non-Changes (Guard Against Drift)
+
+Do not:
+
+- implement full action consequences yet
+- change merge/rebind downstream behavior yet
+- redesign ambiguity-event consumption yet
+- build resolver dashboard UI
+- change shell/navigation
+- add notifications
+- introduce new action types for convenience
+- redesign existing contact-point identity resolution outcomes
+
+---
+
+## 5. Tests Required
+
+### Unit
+
+- each valid action type is accepted
+- unknown action types are rejected
+- lifecycle guards allow valid transitions
+- lifecycle guards reject invalid transitions
+- terminal reviews reject mutation
+- `merge_people` rejects identical source/target
+- `dismiss_no_action` requires reason
+- each action enforces its required fields
+
+### Integration
+
+- resolver-required review can move from pending to in_review
+- resolver-required review can move to valid terminal resolution state
+- already-resolved review cannot be changed to a different outcome
+- dismissed review cannot be resolved later
+- route layer accepts valid contract-backed actions and rejects invalid ones via service validation
+
+### Regression / Characterization
+
+- current `canonical | provisional | resolver_required` identity-resolution flow still works
+- current review creation/list/get flows remain compatible with the locked contract
+- existing web consumers that read review status/action types remain type-compatible or receive deliberate mapped aliases
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- one canonical resolver action set exists in shared contract truth
+- one canonical lifecycle validation path exists in backend service logic
+- action-specific required fields are enforced centrally
+- terminal review rules are enforced
+- route handlers no longer own resolver business semantics
+- existing identity-resolution outcomes remain intact and compatible
+
+---
+
+## 7. Commit Boundary
+
+Single commit:
+
+```text
+feat(peoplecore): lock resolver action set, lifecycle states, and validation rules
+```
+
+---
+
+## 8. Verification Commands
+
+Run:
+
+```bash
+rg "confirm_existing_person|confirm_new_person|merge_people|link_without_merge|mark_shared_contact|reassign_contact_point|dismiss_no_action" apps libs
+```
+
+Verify there is one canonical shared action set and no drifting route-local variants.
+
+Run:
+
+```bash
+rg "pending|queued|in_review|waiting_for_more_info|dismissed|resolved" apps libs/contracts
+```
+
+Verify lifecycle states and usage are consistent with the locked model.
+
+Run:
+
+```bash
+rg "validateResolverDecisionInput|assertResolverReviewTransitionAllowed|resolver.*transition|review.*transition" apps/connectshyft-api libs
+```
+
+Verify central validation/lifecycle guards exist.
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- resolver action semantics are no longer implicit
+- lifecycle rules are explicit and enforceable
+- downstream checkpoints can implement decision consequences safely
+- frontend/UI work no longer needs to invent backend meanings

--- a/specs/prep_step_2A_checkpoint_2_apply_resolver_decision_service.md
+++ b/specs/prep_step_2A_checkpoint_2_apply_resolver_decision_service.md
@@ -1,0 +1,328 @@
+# CHECKPOINT 2 — AUTHORITATIVE `applyResolverDecision(...)` SERVICE, ACTION DISPATCH, AND CONSEQUENCE MATRIX
+**Slice:** Prep Step 2A  
+**Objective:** Implement one authoritative PeopleCore decision-application path that dispatches resolver actions and applies the correct backend consequences without route-owned business logic
+
+## 1. Goal
+
+Create or finalize a single backend entry point that applies resolver decisions in a deterministic, auditable, contract-backed way so that:
+
+- every resolver decision flows through one authoritative service path
+- action dispatch is explicit and typed
+- each action triggers the correct PeopleCore consequences
+- route handlers stay thin
+- downstream slices can rely on stable backend outcomes without inventing semantics
+
+This checkpoint does **not** finish ambiguity-event consumption audit closure or resolver UI surfaces. It finishes the central decision engine.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-api/src/modules/peoplecore/service.ts
+apps/connectshyft-api/src/modules/peoplecore/store.ts
+apps/connectshyft-api/src/modules/peoplecore/contactPointIdentityResolution.ts
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts
+apps/connectshyft-api/src/modules/connectshyft/personRebind.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+libs/contracts/src/people/resolver-review.ts
+libs/contracts/src/people/events.ts
+libs/contracts/src/connectshyft.ts
+```
+
+Include only adjacent files required to keep decision typing single-sourced. Do not modify unrelated modules.
+
+---
+
+## 3. Required Changes
+
+### 3.1 Add one authoritative service entry point
+
+In PeopleCore service layer, add or finalize:
+
+```ts
+applyResolverDecision(input): ResolverDecisionResult
+```
+
+This is the only approved business-logic entry point for applying resolver decisions.
+
+It must own:
+- review retrieval
+- guard checks
+- action validation (may call Checkpoint 1 validation helpers)
+- action dispatch
+- PeopleCore mutation
+- merge invocation where applicable
+- downstream consequence triggering where already required by repo contracts
+- normalized result construction
+
+### 3.2 Thin route delegation only
+
+In `connectshyft.ts` and any resolver-related route surfaces:
+
+- authenticate/authorize
+- validate transport shape
+- call `applyResolverDecision(...)`
+- return normalized result
+
+Route handlers must not embed:
+- merge semantics
+- reassignment semantics
+- shared-contact semantics
+- dismiss semantics
+- action-specific field requirements
+
+### 3.3 Lock action dispatch matrix
+
+`applyResolverDecision(...)` must dispatch explicitly by canonical action type.
+
+Required conceptual branches:
+
+```ts
+switch (input.action) {
+  case 'confirm_existing_person':
+  case 'confirm_new_person':
+  case 'merge_people':
+  case 'link_without_merge':
+  case 'mark_shared_contact':
+  case 'reassign_contact_point':
+  case 'dismiss_no_action':
+}
+```
+
+No generic “best effort” action fallback is allowed.
+
+### 3.4 Action consequences must be explicit
+
+#### `confirm_existing_person`
+Must:
+- resolve review against selected existing person
+- confirm or normalize contact-point association if needed
+- produce normalized result showing affected person/contact-point ids
+- trigger downstream rebind only where existing repo hooks require it
+
+Must not:
+- invoke merge
+
+#### `confirm_new_person`
+Must:
+- confirm the provisional/new person as the correct person
+- preserve distinct identity
+- keep or normalize contact-point association to confirmed person
+- return normalized result
+
+Must not:
+- merge into another person
+
+#### `merge_people`
+Must:
+- invoke existing PeopleCore merge path, not invent a second merge implementation
+- publish/propagate existing merge consequences through the repo’s established mechanism
+- return normalized result indicating merge occurred
+- preserve current merge/rebind contracts
+
+Must not:
+- bypass existing merge infrastructure
+
+#### `link_without_merge`
+Must:
+- persist or confirm linkage needed for operational continuity
+- keep distinct people distinct
+- return normalized result
+
+Must not:
+- collapse persons
+- invoke merge
+
+#### `mark_shared_contact`
+Must:
+- persist explicit shared-contact review outcome
+- return normalized result
+- avoid forced exclusive ownership
+
+Must not:
+- merge or reassign purely to remove ambiguity
+
+#### `reassign_contact_point`
+Must:
+- reassign the relevant contact-point truth to the selected person
+- return normalized result
+- trigger downstream rebind only where current-subject truth should follow that reassignment
+
+Must not:
+- implicitly merge persons
+
+#### `dismiss_no_action`
+Must:
+- close review as dismissed/no-action
+- return normalized result
+- leave identity truth unchanged
+
+Must not:
+- mutate person/contact-point truth
+
+### 3.5 Normalize result contract
+
+The service must return a stable result shape sufficient for downstream consumers.
+
+Required semantic payload:
+
+```ts
+type ResolverDecisionResult = {
+  reviewId: string;
+  status: 'resolved' | 'dismissed';
+  action: ResolverActionType;
+  affectedPersonIds: string[];
+  affectedContactPointIds: string[];
+  ambiguityEventIds: string[];
+  mergeApplied: boolean;
+  rebindTriggered: boolean;
+};
+```
+
+Exact field names may follow current contract style, but the semantic information must exist and be stable.
+
+### 3.6 Preserve current identity-resolution outputs
+
+`contactPointIdentityResolution.ts` must remain compatible with existing:
+- `canonical`
+- `provisional`
+- `resolver_required`
+
+This checkpoint may wire decision consequences downstream of those states, but must not redesign detection flow.
+
+### 3.7 Downstream consequence triggering boundary
+
+This checkpoint must trigger existing downstream hooks where the repo already expects them, but must not finish Slice 2B review-queue UX.
+
+Required rule:
+- `merge_people` → yes, use existing merge/rebind/event path
+- `reassign_contact_point` → yes where current-subject truth changes
+- `confirm_existing_person` / `confirm_new_person` → trigger only if current repo hooks already require normalization/rebind consequence
+- `link_without_merge` → no broad rebind fanout by default
+- `mark_shared_contact` → no broad rebind fanout by default
+- `dismiss_no_action` → no rebind
+
+### 3.8 Idempotency / terminal review safety
+
+If `applyResolverDecision(...)` is called on a terminal review:
+
+- reject mutation unless explicit safe replay of the exact same terminal result is already required by current repo patterns
+- never allow one terminal outcome to be replaced with a different outcome
+
+### 3.9 Store-layer responsibilities must stay narrow
+
+`store.ts` may support:
+- fetch review
+- update review status/outcome fields
+- persist linkage/reassignment fields
+- invoke existing merge persistence path if currently store-backed
+
+But store layer must not become the owner of cross-action orchestration logic. That belongs in service layer.
+
+---
+
+## 4. Explicit Non-Changes (Guard Against Drift)
+
+Do not:
+
+- finish ambiguity-event consumption/audit closure yet
+- build resolver dashboard/list/detail UI
+- redesign personRebind fanout behavior
+- redesign merge internals
+- change shell/navigation
+- add notification behavior
+- create a second resolver-decision system in ConnectShyft
+
+---
+
+## 5. Tests Required
+
+### Unit
+
+- `applyResolverDecision(...)` dispatches correctly for each action
+- each action returns normalized result with expected flags
+- terminal reviews reject incompatible mutation
+- `merge_people` uses existing merge path
+- `dismiss_no_action` returns non-mutating result
+- actions that should not merge never call merge path
+- actions that should not broadly rebind do not trigger rebind flag
+
+### Integration
+
+- apply `confirm_existing_person` against a resolver review and verify review resolution + contact-point consequence
+- apply `confirm_new_person` and verify distinct person preserved
+- apply `merge_people` and verify existing merge path + merge result flag
+- apply `link_without_merge` and verify no merge occurs
+- apply `mark_shared_contact` and verify shared-contact outcome without exclusive reassignment
+- apply `reassign_contact_point` and verify reassignment consequence
+- apply `dismiss_no_action` and verify identity truth unchanged
+- route layer delegates to service and returns normalized result
+
+### Regression / Characterization
+
+- existing `createResolverReview`, `getResolverReview`, `listResolverReviews`, and `mergePerson` remain functional
+- current ConnectShyft identity hooks continue working with the new decision result contract
+- existing identity-resolution detection flow remains intact
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- one authoritative `applyResolverDecision(...)` service exists
+- route handlers delegate to it instead of owning action semantics
+- all seven canonical actions dispatch through explicit branches
+- each action has locked backend consequences
+- normalized result contract exists and is stable
+- merge actions use the existing merge path, not a parallel implementation
+- terminal review safety is enforced
+
+---
+
+## 7. Commit Boundary
+
+Single commit:
+
+```text
+feat(peoplecore): add authoritative resolver decision service and action dispatch
+```
+
+---
+
+## 8. Verification Commands
+
+Run:
+
+```bash
+rg "applyResolverDecision|ResolverDecisionResult|switch \(input.action\)|confirm_existing_person|confirm_new_person|merge_people|link_without_merge|mark_shared_contact|reassign_contact_point|dismiss_no_action" apps libs
+```
+
+Verify the authoritative service path and explicit action branches exist.
+
+Run:
+
+```bash
+rg "mergePerson|merge_people|reassign_contact_point|mark_shared_contact|link_without_merge|dismiss_no_action" apps/connectshyft-api/src/modules/peoplecore apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+```
+
+Verify action consequences route through service instead of route-local logic.
+
+Run:
+
+```bash
+rg "createResolverReview|getResolverReview|listResolverReviews|mergePerson" apps/connectshyft-api/src/modules/peoplecore
+```
+
+Verify existing PeopleCore flows remain present.
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- resolver decisions have one authoritative backend application path
+- action semantics are no longer scattered across routes or consumers
+- downstream slices can safely close ambiguity events and finish rebinding/surfaces on top of a stable decision backbone

--- a/specs/prep_step_2A_checkpoint_3_ambiguity_event_consumption_and_audit.md
+++ b/specs/prep_step_2A_checkpoint_3_ambiguity_event_consumption_and_audit.md
@@ -1,0 +1,257 @@
+# CHECKPOINT 3 — AMBIGUITY-EVENT CONSUMPTION AND AUDIT-SAFE PERSISTENCE OF RESOLVER OUTCOMES
+**Slice:** Prep Step 2A  
+**Objective:** Ensure resolver decisions close or dismiss ConnectShyft ambiguity events consistently and leave an audit-safe, backend-authoritative outcome trail
+
+## 1. Goal
+
+Finalize the boundary between PeopleCore resolver decisions and ConnectShyft ambiguity events so that:
+
+- resolver decisions consume, resolve, or dismiss linked ambiguity events deterministically
+- ambiguity events stop surfacing as active once a definitive resolver outcome has been applied
+- every resolver outcome leaves an audit-safe persistence trail
+- decision history is backend-authoritative and not dependent on frontend interpretation
+- downstream slices can build resolver surfaces against stable review + ambiguity outcome truth
+
+This checkpoint does **not** build resolver UI or complete rebinding review UX. It closes the decision-to-operational-outcome loop.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts
+apps/connectshyft-api/src/modules/peoplecore/service.ts
+apps/connectshyft-api/src/modules/peoplecore/store.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+libs/contracts/src/people/events.ts
+libs/contracts/src/people/resolver-review.ts
+libs/contracts/src/connectshyft.ts
+```
+
+Include adjacent audit/result contract files only if required to keep outcome truth single-sourced. Do not modify unrelated modules.
+
+---
+
+## 3. Required Changes
+
+### 3.1 Lock the consumption rule
+
+Resolver decisions are applied in PeopleCore. Ambiguity-event consumption happens as a consequence of that decision.
+
+Required rule:
+
+- a resolved resolver decision must close or mark consumed all linked active ambiguity events for that review context
+- a dismissed resolver review must close linked active ambiguity events as dismissed/no-action
+- ambiguity events must not remain active after a definitive review outcome unless explicitly reopened in a later slice
+
+The ambiguity-event store/module must not become a parallel decision engine.
+
+### 3.2 Link resolver outcomes to ambiguity events explicitly
+
+Where linkage already exists, preserve and strengthen it. Where the current repo only relies on implicit linkage, finalize an explicit linkage path sufficient to answer:
+
+- which ambiguity event(s) were resolved by this review outcome?
+- which resolver review consumed this ambiguity event?
+- was the ambiguity event resolved, dismissed, or otherwise closed?
+- when and by whom?
+
+Exact field names may follow existing repo conventions, but the semantic linkage must be queryable and durable.
+
+### 3.3 Add or finalize one ambiguity-consumption path
+
+Add/finalize a service/store path such as:
+
+```ts
+consumeAmbiguityEventsForResolverOutcome(input): AmbiguityConsumptionResult
+```
+
+This path must:
+- locate linked active ambiguity events
+- transition them to the correct terminal operational state
+- persist who/when/why they were consumed
+- be safe to call repeatedly for the same review outcome without reopening or duplicating consequences
+
+### 3.4 Distinguish resolved vs dismissed consumption
+
+Consumption semantics must differ by resolver outcome:
+
+#### Resolved decision
+Use for:
+- confirm_existing_person
+- confirm_new_person
+- merge_people
+- link_without_merge
+- mark_shared_contact
+- reassign_contact_point
+
+Required ambiguity-event effect:
+- ambiguity event closes as resolved/consumed
+- active operational surfacing stops
+- audit trail records linked review/action
+
+#### Dismissed decision
+Use for:
+- dismiss_no_action
+
+Required ambiguity-event effect:
+- ambiguity event closes as dismissed/no-action
+- active operational surfacing stops
+- audit trail records dismissal reason and linked review
+
+### 3.5 Audit-safe persistence is mandatory
+
+Every resolver outcome must leave a durable trail sufficient to reconstruct:
+
+- review id
+- ambiguity event id(s)
+- action type
+- terminal review status
+- actor id
+- timestamp
+- reason/notes
+- source/target person ids where applicable
+- contact point id where applicable
+
+If the repo already stores parts of this across resolver-review fields, PeopleCore events, and ambiguity-event records, extend that pattern. Do not invent a separate shadow audit system unless absolutely required.
+
+### 3.6 Hook this into `applyResolverDecision(...)`
+
+Checkpoint 2 locked the authoritative decision service. This checkpoint must ensure that successful terminal review outcomes trigger ambiguity-event consumption through one controlled path.
+
+Required rule:
+- routes do not call ambiguity-event consumption directly
+- PeopleCore decision service or the established PeopleCore-to-ConnectShyft hook layer triggers it after decision application succeeds
+
+### 3.7 Idempotency and terminality rules
+
+If the same terminal resolver outcome is replayed safely:
+
+- ambiguity-event consumption must be idempotent
+- already-consumed events must remain terminal
+- no duplicate audit side effects should be created unless the existing repo uses append-only audit logs that intentionally record safe replay attempts
+
+Forbidden:
+- consumed ambiguity event reopens because of replay
+- dismissed ambiguity event becomes resolved because of replay
+- resolved ambiguity event is “consumed again” in a way that creates a conflicting operational state
+
+### 3.8 Route/list/detail compatibility
+
+Existing ConnectShyft routes that list or fetch ambiguity events must continue to behave sensibly once events are consumed:
+
+- active lists should exclude terminally consumed/dismissed items unless explicitly asked for historical status
+- detail routes should still be able to return the record with terminal outcome state
+- no frontend should need to infer whether an event is still actionable based on ad hoc string logic
+
+### 3.9 Outcome typing must be stable
+
+Shared contracts must support enough typed outcome truth that later slices can build resolver surfaces without inventing meaning ad hoc.
+
+At minimum, the contracts in scope must support:
+- active vs terminal ambiguity-event status
+- review outcome linkage
+- dismissed vs resolved closure semantics
+- actor/timestamp fields or stable references to those fields
+
+---
+
+## 4. Explicit Non-Changes (Guard Against Drift)
+
+Do not:
+
+- build resolver dashboard/list/detail UI
+- redesign applyResolverDecision ownership
+- redesign merge/rebind infrastructure
+- complete review_rebind queue UX
+- add new notification channels
+- change shell/navigation
+- create a second audit subsystem unrelated to existing review/event persistence
+
+---
+
+## 5. Tests Required
+
+### Unit
+
+- resolved resolver outcome consumes linked active ambiguity events
+- dismissed resolver outcome closes linked ambiguity events as dismissed/no-action
+- repeated consumption call is idempotent
+- active ambiguity-event query excludes terminal consumed/dismissed events where appropriate
+- detail retrieval still returns terminal event with outcome linkage
+- audit-safe outcome fields are persisted or linked correctly
+
+### Integration
+
+- apply `confirm_existing_person` and verify linked ambiguity event becomes resolved/consumed
+- apply `merge_people` and verify linked ambiguity event becomes resolved/consumed
+- apply `dismiss_no_action` and verify linked ambiguity event becomes dismissed/no-action
+- replay the same terminal resolver outcome and verify no conflicting ambiguity state change occurs
+- route layer continues to list only active ambiguity events by default while preserving detail/history access
+
+### Regression / Characterization
+
+- existing ambiguity-event creation flow remains intact
+- existing resolver review creation/list/get flows remain intact
+- existing ConnectShyft identity hooks remain compatible with terminal ambiguity-event states
+- no frontend consumer is forced to infer active-vs-terminal semantics from raw notes/debug strings
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- successful terminal resolver outcomes consume or dismiss linked ambiguity events through one controlled backend path
+- ambiguity events no longer remain operationally active after definitive review outcomes
+- audit-safe persistence exists for the decision-to-ambiguity closure relationship
+- replay of the same terminal outcome is safe and non-conflicting
+- existing ambiguity-event routes remain compatible for active lists and terminal detail/history access
+
+---
+
+## 7. Commit Boundary
+
+Single commit:
+
+```text
+feat(connectshyft): consume ambiguity events and persist audit-safe resolver outcomes
+```
+
+---
+
+## 8. Verification Commands
+
+Run:
+
+```bash
+rg "ambiguity|consumeAmbiguity|resolver outcome|dismissed|resolved|consumed" apps/connectshyft-api/src/modules/connectshyft apps/connectshyft-api/src/modules/peoplecore libs/contracts
+```
+
+Verify one controlled ambiguity-consumption path and stable outcome typing exist.
+
+Run:
+
+```bash
+rg "applyResolverDecision|peoplecoreIdentityHooks|ambiguityEvents" apps/connectshyft-api
+```
+
+Verify decision application and ambiguity consumption are linked through service/hook layers, not route-local logic.
+
+Run:
+
+```bash
+rg "list.*ambiguity|get.*ambiguity|review.*ambiguity|active.*ambiguity|dismissed.*ambiguity|resolved.*ambiguity" apps/connectshyft-api/src/routes/api/v1/connectshyft.ts apps/connectshyft-api/src/modules/connectshyft
+```
+
+Verify active-list vs terminal-detail compatibility remains intact.
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- resolver outcomes and ambiguity events are operationally synchronized
+- ambiguity no longer lingers as active after definitive decisions
+- later slices can build resolver/rebind surfaces on top of stable backend truth rather than inferred behavior

--- a/specs/prep_step_2A_checkpoint_4_route_api_hardening_and_web_compat.md
+++ b/specs/prep_step_2A_checkpoint_4_route_api_hardening_and_web_compat.md
@@ -1,0 +1,242 @@
+# CHECKPOINT 4 — ROUTE/API HARDENING, INTEGRATION COVERAGE, AND WEB-CONSUMER COMPATIBILITY
+**Slice:** Prep Step 2A  
+**Objective:** Harden resolver and ambiguity-related route/API surfaces so they delegate cleanly to the backend decision backbone, preserve compatibility with existing web consumers, and have integration coverage that proves the Slice 2A contract is stable
+
+## 1. Goal
+
+Finalize the route/API boundary for Slice 2A so that:
+
+- resolver-related routes are thin and backend-authoritative
+- transport validation is consistent and contract-backed
+- existing web consumers can continue to list, fetch, and act on resolver/ambiguity states without inventing business logic
+- integration coverage proves the full Slice 2A path works end-to-end
+- Slice 2B can build operational resolver/rebind surfaces on top of stable API behavior
+
+This checkpoint does **not** build resolver UI, shell context, or review-rebind queue UX. It locks the API contract and proves it.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+apps/connectshyft-api/src/modules/peoplecore/service.ts
+apps/connectshyft-api/src/modules/peoplecore/store.ts
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts
+apps/connectshyft-web/src/views/Shell/PeopleView.vue
+apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
+apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
+libs/contracts/src/people/resolver-review.ts
+libs/contracts/src/people/events.ts
+libs/contracts/src/connectshyft.ts
+```
+
+Include adjacent API/contract files only if required to keep transport typing single-sourced. Do not modify unrelated web/UI modules beyond compatibility-preserving contract consumption.
+
+---
+
+## 3. Required Changes
+
+### 3.1 Route handlers must be fully thin
+
+For resolver-review and ambiguity-event related endpoints in `connectshyft.ts`:
+
+- authenticate/authorize
+- validate transport payloads against shared contracts
+- call PeopleCore service / established hook layer
+- return normalized results/errors
+
+Route handlers must not embed:
+- action dispatch
+- lifecycle rules
+- merge semantics
+- ambiguity-consumption semantics
+- rebind policy decisions
+
+Any remaining route-local business logic in these areas must be removed or delegated.
+
+### 3.2 Lock transport shapes for current web consumers
+
+The API boundary must expose stable transport shapes for at least:
+
+- list resolver reviews
+- get resolver review detail
+- apply resolver decision
+- list ambiguity events
+- get ambiguity event detail
+
+Exact endpoint names may follow existing repo routes, but transport payloads must be stable and typed through shared contracts.
+
+### 3.3 Normalize API responses
+
+Ensure resolver- and ambiguity-related responses return normalized, contract-backed fields that current web consumers can rely on without ad hoc interpretation.
+
+At minimum, response shapes must convey:
+
+- review status
+- action / resolution outcome
+- ambiguity-event active vs terminal state
+- actor/timestamp or equivalent stable references where already expected
+- affected person/contact context needed by current People and thread-detail views
+- whether an item is still actionable vs already resolved/dismissed
+
+Do not require frontend code to infer active-vs-terminal truth from notes/debug strings.
+
+### 3.4 Preserve existing web-consumer compatibility
+
+`PeopleView.vue`, `identityResolution.ts`, and `ConnectShyftThreadDetailView.vue` must remain compatible with the backend contract after Slice 2A.
+
+Required rule:
+- if a current web consumer expects provisional or resolver-required states, the API must still supply them or a deliberate, contract-backed equivalent
+- if a current web consumer reads ambiguity/review state, that state must remain stable and typed
+- compatibility fixes in web code are allowed only to consume the improved stable contract, not to reinvent backend business logic
+
+### 3.5 Error normalization
+
+Resolver-related route/API failures must return normalized, non-leaky errors for cases such as:
+
+- invalid action payload
+- invalid lifecycle transition
+- missing review
+- terminal review mutation attempt
+- unauthorized access
+- invalid ambiguity-event reference
+
+Do not leak stack traces, internal SQL, or engineering-only phrasing to the web consumer.
+
+### 3.6 Integration coverage must prove end-to-end behavior
+
+Add or finalize integration tests proving that the route/API layer plus service layer together support the Slice 2A backbone.
+
+Required integration coverage must include:
+- review listing/detail remains available
+- valid resolver decision request succeeds and returns normalized result
+- invalid resolver decision request is rejected with normalized error
+- terminal review mutation is rejected
+- ambiguity events are consumed/dismissed and no longer appear in active list by default
+- detail/history retrieval still returns terminal ambiguity items
+- existing web-facing state expectations remain compatible
+
+### 3.7 Contract drift must be eliminated
+
+If the route layer, service layer, and web consumers currently use mismatched strings or partial aliases for review status/action/outcome semantics, this checkpoint must converge them onto the shared contract truth.
+
+Allowed:
+- deliberate adapter/mapping layer if needed for compatibility
+
+Not allowed:
+- multiple independent semantic vocabularies continuing in active use
+
+### 3.8 Keep Slice 2A boundary intact
+
+This checkpoint must not start Slice 2B by building:
+
+- resolver dashboard UX
+- review-rebind queue UI
+- post-resolution shell context
+- advanced person-detail workflow redesign
+
+Only stabilize the API boundary those later surfaces will consume.
+
+---
+
+## 4. Explicit Non-Changes (Guard Against Drift)
+
+Do not:
+
+- build new resolver UI flows beyond compatibility-preserving adjustments
+- redesign PeopleView or ThreadDetailView layout
+- redesign shell/navigation
+- finish review_rebind queue handling
+- redesign merge/rebind internals
+- add notifications
+- change telephony/voicemail behavior
+- create frontend-owned decision semantics
+
+---
+
+## 5. Tests Required
+
+### Unit / Contract-focused
+
+- route payload validation rejects malformed resolver decision input
+- normalized response mapping preserves shared contract semantics
+- normalized error mapping hides internal implementation details
+
+### Integration
+
+- list resolver reviews route returns contract-backed review states
+- get resolver review detail route returns stable review/action/outcome fields
+- apply resolver decision route delegates to service and returns normalized result
+- apply invalid resolver decision returns normalized validation/lifecycle error
+- list ambiguity events route excludes terminal items by default where expected
+- ambiguity detail route can still return terminal consumed/dismissed records
+- existing People/thread-related consumers can still read resolver/provisional/ambiguity state without ad hoc inference
+
+### Regression / Characterization
+
+- current web consumers still compile/type-check against the updated contracts
+- current provisional / resolver-required surfaces still receive the state they need
+- no route-local resolver business logic remains in active use
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- resolver and ambiguity routes are thin and backend-authoritative
+- transport shapes are stable and contract-backed
+- normalized results/errors exist for resolver decision flows
+- existing web consumers remain compatible with the locked Slice 2A contract
+- integration coverage proves the end-to-end resolver-decision and ambiguity-consumption path works
+- no frontend consumer has to invent backend semantics from raw strings or notes
+
+---
+
+## 7. Commit Boundary
+
+Single commit:
+
+```text
+feat(connectshyft): harden resolver routes and prove web-consumer compatibility
+```
+
+---
+
+## 8. Verification Commands
+
+Run:
+
+```bash
+rg "resolver|required|ambiguity|applyResolverDecision|merge_people|dismiss_no_action|mark_shared_contact|reassign_contact_point" apps/connectshyft-api/src/routes/api/v1/connectshyft.ts apps/connectshyft-web libs/contracts
+```
+
+Verify route, web, and contract layers are aligned on one semantic vocabulary.
+
+Run:
+
+```bash
+rg "throw new|Error\(|statusCode|validation|unauthorized|not found|terminal review|invalid transition" apps/connectshyft-api/src/routes/api/v1/connectshyft.ts apps/connectshyft-api/src/modules/peoplecore
+```
+
+Verify resolver-related failures are normalized and not leaking implementation detail.
+
+Run:
+
+```bash
+rg "PeopleView|identityResolution|ConnectShyftThreadDetailView|resolver_required|provisional|ambiguity" apps/connectshyft-web
+```
+
+Verify current web consumers still have stable contract-backed inputs.
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- Slice 2A is complete
+- resolver decisions, ambiguity outcomes, and API behavior are stable end-to-end
+- Slice 2B can safely build rebind/review operational surfaces on top of a locked backend contract

--- a/specs/prep_step_2A_implementation_brief.md
+++ b/specs/prep_step_2A_implementation_brief.md
@@ -1,0 +1,575 @@
+# PREP STEP 2A — IMPLEMENTATION BRIEF
+**Title:** Complete Resolver Decision Backbone for PeopleCore and ConnectShyft
+
+## 1. Objective
+
+Deliver a complete, backend-authoritative resolver decision system for ambiguous identity handling so that:
+
+- ambiguity outcomes are no longer limited to detection only
+- resolvers can apply explicit, durable decisions against resolver reviews
+- each supported resolver action has a locked semantic meaning
+- each decision produces the correct PeopleCore and ConnectShyft consequences
+- ambiguity events, resolver reviews, contact-point links, person state, and rebind behavior stay consistent
+- downstream UI surfaces can rely on a stable backend contract without improvising decision logic
+
+**Done =** the repo has a single authoritative resolver-decision backbone that supports MVP ambiguity handling without requiring frontend-specific business logic.
+
+---
+
+## 2. Architectural Position (Locked)
+
+This slice is **not** a new identity system.
+
+The repo already contains:
+
+- contact-point identity resolution with `canonical | provisional | resolver_required` outcomes
+- provisional person creation
+- resolver review creation/list/get flows
+- ambiguity event persistence in ConnectShyft
+- person merge capabilities
+- downstream rebind infrastructure
+- provisional / resolver-required state expectations in existing web views
+
+This slice completes the missing middle:
+
+> **resolver decision semantics, persistence, lifecycle transitions, and backend consequences**
+
+### Ownership model
+
+- **PeopleCore** owns resolver review truth, action application, person/contact-point consequences, and audit persistence
+- **ConnectShyft** owns ambiguity-event consumption and downstream operational consequences driven by PeopleCore outcomes
+- **Route handlers** remain thin
+- **Frontend surfaces** consume state; they do not define action semantics
+
+---
+
+## 3. Problem This Slice Solves
+
+Current repo state already detects ambiguity and records it, but MVP still lacks a fully locked answer to these questions:
+
+- What exact actions may a resolver take?
+- What does each action *mean* in backend terms?
+- When does a decision merge vs relink vs suppress vs defer?
+- What records are updated as a consequence?
+- When is rebind automatic versus review-required?
+- How are ambiguity events and resolver reviews marked consumed or resolved?
+- What audit trail exists for those decisions?
+
+This slice answers those questions definitively.
+
+---
+
+## 4. Locked Resolver Action Set
+
+The following action set is authoritative for Slice 2A unless repo implementation forces a narrower technical alias while preserving the same semantics.
+
+### 4.1 `confirm_existing_person`
+
+Use when the ambiguous contact point should resolve to an already-existing canonical person.
+
+**Semantics**
+- resolver selects one existing person
+- active contact-point association is confirmed or updated to that person
+- review resolves as an existing-person confirmation
+- ambiguity event is consumed/resolved
+- downstream rebind may run where applicable
+- no person merge occurs
+
+### 4.2 `confirm_new_person`
+
+Use when ambiguity should resolve to a distinct person and the provisional/new identity should stand as its own person.
+
+**Semantics**
+- provisional/new person is confirmed as the correct identity
+- no merge into another person occurs
+- contact point remains associated with the confirmed person
+- review resolves as new-person confirmation
+- ambiguity event is consumed/resolved
+- downstream rebind may still run if objects were temporarily attached elsewhere
+
+### 4.3 `merge_people`
+
+Use when two person records actually represent the same real person and should become one.
+
+**Semantics**
+- source person merges into target canonical person
+- merge event is published through the existing PeopleCore mechanism
+- contact-point current associations are normalized to the surviving person
+- resolver review resolves as merged
+- ambiguity event is consumed/resolved
+- rebind fanout runs according to current repo merge/rebind contracts
+
+### 4.4 `link_without_merge`
+
+Use when a contact point or ambiguous evidence should be linked to a person for operational continuity, but records should remain distinct.
+
+**Semantics**
+- no person merge occurs
+- selected contact-point linkage is attached or confirmed for operational use
+- distinct persons remain distinct
+- review resolves as linked-without-merge
+- ambiguity event is consumed/resolved
+- only linkage-level consequences occur
+
+### 4.5 `mark_shared_contact`
+
+Use when the contact point is legitimately shared and ambiguity should not be forced into a single-person answer.
+
+**Semantics**
+- review resolves as shared-contact
+- current ambiguity is recorded as intentionally shared / non-exclusive
+- no forced merge occurs
+- no exclusive reassignment occurs
+- downstream UI may continue to require careful handling, but backend truth is now explicit
+- ambiguity event is consumed/resolved
+
+### 4.6 `reassign_contact_point`
+
+Use when the current contact-point association is wrong and should move to a different person.
+
+**Semantics**
+- current association is reassigned to the selected person
+- no person merge occurs unless separately invoked
+- review resolves as reassigned
+- ambiguity event is consumed/resolved
+- downstream rebind may run for objects whose subject identity should follow the new contact-point truth
+
+### 4.7 `dismiss_no_action`
+
+Use when the review is closed without changing identity truth.
+
+**Semantics**
+- no merge
+- no reassignment
+- no new link
+- ambiguity event is closed as dismissed/no-action
+- audit reason is required
+- downstream operational state remains unchanged except resolution closure
+
+---
+
+## 5. Explicit Non-Actions
+
+The following are **not** separate action types in MVP:
+
+- “maybe merge later”
+- “soft merge”
+- “temporary assign and hope”
+- “UI-only suppress”
+- “just hide banner”
+
+Those may exist as UX affordances later, but they are not backend decision types.
+
+---
+
+## 6. Resolver Review Lifecycle (Locked)
+
+The contracts already suggest a richer lifecycle than MVP strictly needs. Slice 2A will preserve contract breadth while requiring only a minimal operational path.
+
+### Supported statuses in contract
+
+- `pending`
+- `queued`
+- `in_review`
+- `waiting_for_more_info`
+- resolved statuses
+- `dismissed`
+
+### MVP required lifecycle path
+
+```text
+pending -> in_review -> resolved
+pending -> dismissed
+in_review -> dismissed
+```
+
+### Allowed but not UI-required in MVP
+
+- `queued`
+- `waiting_for_more_info`
+
+These may remain valid persisted states without requiring rich frontend workflow in Slice 2A.
+
+### Resolution requirement
+
+Every resolved or dismissed review must persist:
+
+- action type
+- actor
+- timestamp
+- reason / notes where required by current contract
+- target/source person references as applicable
+- ambiguity event linkage / consumption outcome
+
+---
+
+## 7. Backend Consequence Matrix
+
+## 7.1 `confirm_existing_person`
+
+Must update or confirm:
+- resolver review status/resolution
+- selected person reference
+- contact-point active link if needed
+- ambiguity event resolution state
+- optional downstream rebind trigger
+- audit entry
+
+Must not:
+- merge persons
+
+## 7.2 `confirm_new_person`
+
+Must update or confirm:
+- resolver review status/resolution
+- confirmed new/provisional person as surviving identity
+- contact-point active link remains or is normalized
+- ambiguity event resolution state
+- audit entry
+
+Must not:
+- merge persons into another canonical person
+
+## 7.3 `merge_people`
+
+Must update or trigger:
+- resolver review resolution
+- PeopleCore merge operation
+- merge event publication
+- ambiguity event resolution state
+- audit entry
+- downstream rebind entry path
+
+Must not:
+- leave the source and target active as separate canonical truths
+
+## 7.4 `link_without_merge`
+
+Must update:
+- resolver review resolution
+- linkage association needed for operational continuity
+- ambiguity event resolution state
+- audit entry
+
+Must not:
+- call merge
+- collapse distinct person records
+
+## 7.5 `mark_shared_contact`
+
+Must update:
+- resolver review resolution
+- explicit shared-contact outcome
+- ambiguity event resolution state
+- audit entry
+
+Must not:
+- force exclusive ownership
+- merge records solely to eliminate ambiguity
+
+## 7.6 `reassign_contact_point`
+
+Must update:
+- resolver review resolution
+- current contact-point ownership/association
+- ambiguity event resolution state
+- audit entry
+- downstream rebind trigger if current subject truth changes
+
+Must not:
+- merge persons unless separately invoked
+
+## 7.7 `dismiss_no_action`
+
+Must update:
+- resolver review dismissed status
+- ambiguity event dismissed/closed state
+- audit reason
+
+Must not:
+- mutate identity truth
+
+---
+
+## 8. Service Layer Ownership (Locked)
+
+### PeopleCore service owns decision application
+
+Slice 2A must add or finalize a single authoritative decision-application path in PeopleCore.
+
+Required conceptual entry point:
+
+```ts
+applyResolverDecision(input): ResolverDecisionResult
+```
+
+### This service must own:
+
+- review retrieval and guard checks
+- lifecycle transition validation
+- action-type dispatch
+- person/contact-point mutation
+- merge invocation where applicable
+- review resolution persistence
+- audit persistence
+- result payload for downstream consumers
+
+### Route handlers must not own:
+
+- merge semantics
+- reassignment semantics
+- shared-contact semantics
+- ambiguity consumption logic
+- rebind policy
+
+---
+
+## 9. Guardrails and Validation
+
+## 9.1 Review guards
+
+A decision may only be applied when:
+
+- resolver review exists
+- review belongs to current tenant/orgUnit scope as required by repo contracts
+- review is not already resolved/dismissed unless idempotent reapply is explicitly supported
+- required actor identity is present
+- required target/source references are present for that action
+
+## 9.2 Action-specific validation
+
+### `merge_people`
+Requires:
+- source person
+- target person
+- source != target
+
+### `confirm_existing_person`
+Requires:
+- selected existing person id
+
+### `confirm_new_person`
+Requires:
+- confirmed provisional/new person id or review-bound provisional reference
+
+### `reassign_contact_point`
+Requires:
+- contact point id
+- target person id
+
+### `link_without_merge`
+Requires:
+- link target person/contact context sufficient to persist association
+
+### `mark_shared_contact`
+Requires:
+- evidence/candidate context sufficient to mark review outcome shared
+
+### `dismiss_no_action`
+Requires:
+- dismissal reason
+
+---
+
+## 10. Audit Model (Required)
+
+Every applied resolver decision must produce an audit-safe record containing at minimum:
+
+- resolver review id
+- action type
+- actor id
+- tenant / orgUnit context as applicable
+- before/after summary or references
+- source person id where applicable
+- target person id where applicable
+- contact point id where applicable
+- applied at timestamp
+- notes/reason
+- linked ambiguity event id(s) if present
+
+If the repo already persists this across existing review/resolution fields plus event logs, extend that pattern rather than inventing a parallel audit system.
+
+---
+
+## 11. Ambiguity Event Consumption Rules
+
+ConnectShyft ambiguity events already exist and must not become a parallel decision system.
+
+Slice 2A must lock this rule:
+
+> Resolver decisions are applied in PeopleCore; ambiguity events are then marked resolved/consumed/dismissed as a consequence.
+
+### Requirements
+
+- each resolver review should be linkable to its originating ambiguity event(s) where such linkage exists
+- resolved decisions must close the corresponding ambiguity event operationally
+- dismissed reviews must close ambiguity events as dismissed/no-action
+- ambiguity events must not continue surfacing as active once the review has been definitively resolved, unless explicitly reopened later by a future slice
+
+---
+
+## 12. Rebinding Boundary for Slice 2A
+
+Slice 2A must **not** attempt to finish all rebinding UX or review queue behavior.
+
+But it must lock when decision application should trigger downstream rebind-capable consequences.
+
+### Rule
+
+- `merge_people` → yes, downstream rebind path should fire through existing merge/rebind infrastructure
+- `reassign_contact_point` → yes, where current-subject truth changes
+- `confirm_existing_person` → maybe, if current operational objects are attached to a provisional/wrong person and existing repo hooks expect rebind
+- `confirm_new_person` → maybe, if current attachments need normalization
+- `link_without_merge` → usually no broad rebind fanout
+- `mark_shared_contact` → no broad rebind fanout by default
+- `dismiss_no_action` → no rebind
+
+Final review queue semantics for `review_rebind` objects belong to Slice 2B.
+
+---
+
+## 13. API Boundary (Required)
+
+Slice 2A should expose or finalize backend endpoints for:
+
+- list resolver reviews
+- get resolver review detail
+- apply resolver decision
+- optionally move review into `in_review` if current repo pattern supports it
+
+### API rule
+
+Route handlers must:
+- authenticate/authorize
+- validate payload
+- call PeopleCore service
+- return normalized result
+
+Route handlers must not:
+- embed business rules for resolver actions
+
+---
+
+## 14. Result Contract (Required)
+
+`applyResolverDecision(...)` should return a normalized result sufficient for current web surfaces and downstream systems, such as:
+
+```ts
+type ResolverDecisionResult = {
+  reviewId: string;
+  status: 'resolved' | 'dismissed';
+  action: ResolverActionType;
+  affectedPersonIds: string[];
+  affectedContactPointIds: string[];
+  ambiguityEventIds: string[];
+  mergeApplied: boolean;
+  rebindTriggered: boolean;
+};
+```
+
+Exact field naming may follow existing contracts, but the semantic payload must exist.
+
+---
+
+## 15. Tests (Required)
+
+### Unit tests
+
+- each action type validates required inputs correctly
+- invalid lifecycle transitions are rejected
+- resolved reviews cannot be mutated again unless explicitly idempotent
+- `merge_people` rejects identical source/target
+- `dismiss_no_action` requires reason
+- action dispatch calls the correct downstream service paths
+
+### Integration tests
+
+- ambiguous review resolves via `confirm_existing_person`
+- provisional review resolves via `confirm_new_person`
+- merge review invokes PeopleCore merge and publishes expected merge consequence
+- reassign decision updates contact-point association correctly
+- shared-contact decision resolves review without exclusive reassignment
+- dismiss decision closes review and ambiguity event without identity mutation
+- ambiguity event is consumed/closed after decision
+- rebind-capable actions trigger existing downstream hooks where expected
+
+### Regression / characterization
+
+- existing `canonical | provisional | resolver_required` resolution flow remains intact
+- existing `createResolverReview`, `getResolverReview`, `listResolverReviews`, and `mergePerson` flows are preserved and extended, not replaced
+- current ConnectShyft ambiguity-event routes remain compatible
+
+---
+
+## 16. Explicit Non-Goals
+
+The following are out of scope for Slice 2A:
+
+- resolver dashboard UX completion
+- People / ConnectShyft visual polish
+- full rebinding manual-review queue experience
+- shell integration
+- feature-flag UX
+- case creation hooks
+- new notification channels
+- AI-assisted resolution suggestions
+
+---
+
+## 17. Done Criteria
+
+Slice 2A is done only when:
+
+- resolver action set is explicit and backend-authoritative
+- PeopleCore exposes one authoritative resolver-decision application path
+- each action has locked mutation semantics
+- resolver reviews transition through valid lifecycle states only
+- ambiguity events are consumed/closed as a consequence of decision application
+- audit-safe persistence exists for every decision
+- merge/reassign actions trigger the correct existing downstream consequence paths
+- backend API contracts are stable enough for Slice 2B surfaces to consume without inventing logic
+
+---
+
+## 18. Checkpoint Shape Recommendation
+
+Slice 2A should likely be broken into these checkpoints:
+
+1. **Action types + lifecycle lock**
+   - contracts
+   - validation
+   - status transitions
+
+2. **Decision application service**
+   - `applyResolverDecision(...)`
+   - action dispatch
+   - consequence matrix
+
+3. **Ambiguity-event consumption + audit persistence**
+   - close/resolve/dismiss ambiguity events
+   - persist audit-safe result trail
+
+4. **Route/API hardening + tests**
+   - thin routes
+   - integration coverage
+   - compatibility with existing web consumers
+
+That is the recommended order unless repo specifics force 3 instead of 4 checkpoints.
+
+---
+
+## 19. Locked Recommendation
+
+Proceed next with:
+
+> **Prep Step 2A — Checkpoint 1: Resolver action set, lifecycle states, and validation lock**
+
+Do not jump to resolver UI or shell work before this backbone is complete.
+
+---
+
+## 20. Implementation Intent
+
+This is a **completion and hardening slice**, not a redesign.
+
+Use the repo's existing PeopleCore, ConnectShyft ambiguity-event, merge, and rebind infrastructure as the backbone. Extend and lock it. Do not introduce a second resolver system, parallel audit model, or UI-owned decision logic.

--- a/specs/prep_step_2B_checkpoint_1_resolver_queue_and_claim_lifecycle.md
+++ b/specs/prep_step_2B_checkpoint_1_resolver_queue_and_claim_lifecycle.md
@@ -1,0 +1,290 @@
+# CHECKPOINT 1 — RESOLVER QUEUE MODEL, CLAIM/RELEASE LIFECYCLE, AND RESOLVER AUTHORITY LOCK
+**Slice:** Prep Step 2B  
+**Objective:** Lock the backend-authoritative Resolver Queue model, claim/release lifecycle, and tenant-admin-only resolver authority so operational resolver work is safe before UI expansion
+
+## 1. Goal
+
+Establish a single authoritative backend definition for:
+
+- what a Resolver Queue item is
+- which queue item types exist in MVP
+- who may see, claim, release, and act on queue items
+- how claim state works
+- how active vs terminal queue items behave
+- how identity-review and rebind-review work coexist in one queue without becoming two separate systems
+
+This checkpoint does **not** finish rebind policy consequences, PeopleView UI, or ConnectShyft contextual banners. It locks the queue and claim model so later checkpoints can consume it safely.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts
+apps/connectshyft-api/src/modules/peoplecore/service.ts
+apps/connectshyft-api/src/modules/peoplecore/store.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+libs/contracts/src/people/resolver-review.ts
+libs/contracts/src/connectshyft.ts
+```
+
+Include adjacent contract/store files only if required to keep queue typing single-sourced. Do not modify unrelated UI modules in this checkpoint.
+
+---
+
+## 3. Required Changes
+
+### 3.1 Lock one Resolver Queue with two typed item classes
+
+The backend must support one Resolver Queue model with these typed item classes:
+
+```ts
+type ResolverQueueItemType =
+  | 'identity_review'
+  | 'rebind_review';
+```
+
+This is one queue system, not two separate queue implementations.
+
+### 3.2 Define queue truth as backend-owned
+
+Queue semantics must be defined in backend contracts/services, not inferred by frontend lists.
+
+At minimum, queue truth must support:
+
+- item id
+- item type
+- active vs terminal state
+- current status
+- claim state
+- claimant reference
+- claimed_by_current_user
+- actionable vs not actionable
+- person/contact/thread context as applicable
+
+Exact field names may follow existing repo conventions, but the semantics must exist and be typed centrally.
+
+### 3.3 Tenant-admin-only resolver authority
+
+Only tenant admins may act as resolvers in MVP.
+
+Required backend rule:
+- non-tenant-admin users may not claim resolver queue items
+- non-tenant-admin users may not release resolver queue items
+- non-tenant-admin users may not apply queue-driven resolver actions
+
+If the repo already has broader admin roles, this checkpoint must narrow effective resolver authority for queue actions to tenant admins only, without redesigning the entire role system.
+
+### 3.4 Claim-before-action rule
+
+A queue item must be claimed before action.
+
+Backend must reject:
+- resolving an unclaimed queue item
+- dismissing an unclaimed queue item
+- processing a rebind-review item without a claim
+
+This rule applies to both queue item types:
+- `identity_review`
+- `rebind_review`
+
+### 3.5 Claim exclusivity
+
+A queue item may be claimed by only one resolver at a time.
+
+Backend must reject:
+- claiming an item already claimed by another resolver
+- acting on an item claimed by another resolver
+- releasing an item claimed by another resolver, unless an intentional tenant-admin override path already exists and is explicitly preserved
+
+### 3.6 No auto-expiry on claims
+
+Claims do not expire automatically in MVP.
+
+Claim state remains until:
+- item is resolved
+- item is dismissed
+- claimant explicitly releases it
+
+This checkpoint must not introduce time-based claim expiry, auto-release, or stale-claim automation.
+
+### 3.7 Operationalize queue status semantics
+
+The repo already contains statuses such as:
+- `queued`
+- `in_review`
+- `waiting_for_more_info`
+
+This checkpoint must align queue/claim behavior with those existing contract truths instead of inventing a second state system.
+
+Recommended operational meaning:
+- `queued` = active and available / not currently being worked
+- `in_review` = claimed and actively being worked
+- `waiting_for_more_info` = active but blocked
+- resolved/dismissed terminal states = excluded from default active queue
+
+Exact naming may follow existing contracts, but the behavior must be explicit and backend-enforced.
+
+### 3.8 Add or finalize authoritative queue operations
+
+Backend must expose or finalize one controlled service path for queue operations, such as:
+
+```ts
+listResolverQueue(input): ResolverQueueListResult
+claimResolverQueueItem(input): ResolverQueueItemResult
+releaseResolverQueueItem(input): ResolverQueueItemResult
+getResolverQueueItemDetail(input): ResolverQueueItemDetail
+```
+
+These operations must be:
+- contract-backed
+- role-checked
+- claim-safe
+- thin-route-consumable
+
+### 3.9 Identity-review items must map to resolver review truth
+
+For `identity_review` items:
+- the queue item must map back to the canonical resolver-review record
+- queue state must reflect review state, not a second parallel queue truth
+- claiming/releasing must integrate with the underlying review lifecycle/state model rather than fork it
+
+### 3.10 Rebind-review items must be first-class queue citizens
+
+This checkpoint does not yet create all `review_rebind` items, but it must lock the queue model so `rebind_review` is a valid, first-class item type.
+
+That means:
+- shared contracts must recognize the type
+- queue list/detail operations must support the type
+- claim/release rules must support the type
+- no frontend-only placeholder interpretation
+
+### 3.11 Thin routes only
+
+In `connectshyft.ts`:
+- authenticate/authorize
+- validate transport shape
+- call backend queue service
+- return normalized result
+
+Route handlers must not own:
+- claim rules
+- role rules
+- queue semantics
+- item-type semantics
+
+### 3.12 Active vs terminal semantics must be explicit
+
+Default queue listing must include active work only.
+
+Terminal work must be excluded from default active lists, but backend detail/history access may still expose it where current repo patterns already support historical access.
+
+This checkpoint must not require frontend consumers to infer active-vs-terminal truth from loose strings or notes.
+
+---
+
+## 4. Explicit Non-Changes (Guard Against Drift)
+
+Do not:
+
+- finish review-rebind item creation logic yet
+- complete rebind policy consequence wiring yet
+- build PeopleView queue UI yet
+- build ConnectShyft thread banners yet
+- redesign resolver decision backbone from Slice 2A
+- redesign role system broadly
+- add claim timeout/expiry
+- add notification/escalation workflows
+
+---
+
+## 5. Tests Required
+
+### Unit
+
+- tenant-admin resolver can claim unclaimed queue item
+- non-tenant-admin cannot claim queue item
+- claim fails when item already claimed by another resolver
+- claimant can release claimed item
+- non-claimant cannot release claimed item unless intentional override is explicitly preserved
+- unclaimed item cannot be acted on
+- queue list distinguishes active vs terminal items
+- queue type contract accepts both `identity_review` and `rebind_review`
+
+### Integration
+
+- identity-review item appears in Resolver Queue and can be claimed/released by tenant-admin resolver
+- queue routes delegate to backend service and enforce tenant-admin-only resolver authority
+- active queue listing excludes terminal items by default
+- queue item detail can still return terminal item where backend supports history/detail access
+- role/claim errors are normalized and non-leaky
+
+### Regression / Characterization
+
+- Slice 2A resolver review lifecycle remains intact
+- existing review list/detail flows remain compatible with queue-backed operational semantics
+- no second parallel queue-state system is introduced
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- one backend-authoritative Resolver Queue model exists
+- queue item types `identity_review` and `rebind_review` are recognized centrally
+- only tenant admins can act as resolvers for queue work
+- claim-before-action is enforced
+- claim exclusivity is enforced
+- no auto-expiry exists for claims
+- route handlers are thin and delegate queue semantics to backend services
+- active vs terminal queue behavior is explicit and contract-backed
+
+---
+
+## 7. Commit Boundary
+
+Single commit:
+
+```text
+feat(connectshyft): lock resolver queue model and claim lifecycle
+```
+
+---
+
+## 8. Verification Commands
+
+Run:
+
+```bash
+rg "identity_review|rebind_review|claimResolverQueueItem|releaseResolverQueueItem|listResolverQueue|getResolverQueueItemDetail" apps libs
+```
+
+Verify one centrally typed queue model and operation set exists.
+
+Run:
+
+```bash
+rg "tenant admin|tenant_admin|claim|claimed_by|claimedBy|in_review|queued|waiting_for_more_info" apps/connectshyft-api libs/contracts
+```
+
+Verify role and claim semantics are centralized and consistent.
+
+Run:
+
+```bash
+rg "resolver queue|queue item|claim|release|active|terminal|dismissed|resolved" apps/connectshyft-api/src/routes/api/v1/connectshyft.ts apps/connectshyft-api/src/modules
+```
+
+Verify routes stay thin and backend semantics are authoritative.
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- the Resolver Queue model is backend-safe and authoritative
+- tenant-admin-only claim-based resolver work is locked
+- later checkpoints can add rebind queue creation and UI surfaces without inventing queue policy ad hoc

--- a/specs/prep_step_2B_checkpoint_2_rebind_policy_and_review_queue_creation.md
+++ b/specs/prep_step_2B_checkpoint_2_rebind_policy_and_review_queue_creation.md
@@ -1,0 +1,258 @@
+# CHECKPOINT 2 — REBIND POLICY COMPLETION AND `review_rebind` QUEUE ITEM CREATION
+**Slice:** Prep Step 2B  
+**Objective:** Finalize backend-authoritative `auto_rebind` vs `review_rebind` behavior, enforce thread-following-contact-point reassignment, and turn review-class rebind consequences into first-class Resolver Queue work
+
+## 1. Goal
+
+Complete the operational rebind model so that:
+
+- `auto_rebind` vs `review_rebind` is explicit, deterministic, and backend-enforced
+- existing threads always follow contact-point reassignment
+- review-class rebind consequences become visible, claimable `rebind_review` queue items
+- rebind work no longer disappears into backend-only history when human review is required
+- Slice 2B can later build PeopleView and contextual thread UI on top of stable rebind truth
+
+This checkpoint does **not** build queue UI or thread banners. It finishes the backend consequence model that those surfaces will consume.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-api/src/modules/connectshyft/personRebind.ts
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+apps/connectshyft-api/src/modules/peoplecore/service.ts
+apps/connectshyft-api/src/modules/peoplecore/store.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+libs/contracts/src/connectshyft.ts
+libs/contracts/src/people/events.ts
+libs/contracts/src/people/resolver-review.ts
+```
+
+Include adjacent schema/contract/store files only if required to persist queue-backed rebind-review state or keep type truth single-sourced. Do not modify unrelated UI modules in this checkpoint.
+
+---
+
+## 3. Required Changes
+
+### 3.1 Preserve and lock the existing `rebind_class` model
+
+The repo already has `person_rebind_history` with `rebind_class = auto | review`.
+
+This checkpoint must preserve that model and make it operationally authoritative.
+
+Required rule:
+- `auto` means the rebind consequence may execute without human confirmation
+- `review` means the rebind consequence must become queue work and remain unresolved until a resolver claims and processes it
+
+Do not invent a second rebind classification system.
+
+### 3.2 Existing threads must always follow contact-point reassignment
+
+This is a locked MVP requirement.
+
+When contact-point reassignment changes subject truth:
+- existing threads must rebind to the new person/contact-point truth
+- this must happen through the repo’s established `personRebind` / downstream consequence path
+- this must not depend on frontend action or manual cleanup
+
+If the current code path can classify thread rebinding as `review`, this checkpoint must narrow that behavior so existing thread-follow behavior remains guaranteed in MVP.
+
+### 3.3 Auto-rebind must remain backend-driven
+
+Objects whose identity should follow current operational truth may auto-rebind without queue work.
+
+At minimum, the checkpoint must preserve or finalize auto-rebind for:
+- threads
+- thread subject/context bindings
+- current operational conversation/contact-point associations
+- already-supported telephony/conversation artifacts where repo contracts classify them as current-truth operational objects
+
+Auto-rebind must continue to be:
+- idempotent
+- history-persisted
+- safe on replay
+
+### 3.4 Review-class rebinds must become queue items
+
+When `personRebind` or downstream identity hooks produce `review`-class rebind consequences:
+
+- create a first-class Resolver Queue item with `item_type = rebind_review`
+- store enough context to let a resolver understand what must be reviewed
+- ensure the item appears in active queue listing
+- ensure the item participates in claim/release semantics from Checkpoint 1
+- do not leave review-class rebind work as backend-only history
+
+### 3.5 Rebind-review item creation path must be centralized
+
+Add or finalize one controlled backend path such as:
+
+```ts
+enqueueRebindReview(input): ResolverQueueItemResult
+```
+
+This path must:
+- use existing rebind-history truth as its source
+- deduplicate queue creation for the same underlying review-class rebind consequence
+- be safe on replay or duplicate downstream events
+- avoid creating duplicate `rebind_review` items for the same unresolved consequence
+
+### 3.6 Rebind-review queue item context must be sufficient
+
+Each `rebind_review` item must carry or be able to resolve enough backend context for later UI/detail use, including as applicable:
+
+- rebind history id or stable equivalent
+- affected object type
+- affected object id
+- source person id
+- target person id
+- contact point id where applicable
+- originating resolver review or merge/reassignment context where available
+- current queue status
+- claim state
+
+Exact field names may follow repo conventions, but the semantic context must exist.
+
+### 3.7 Review-class rebinds must remain unresolved until processed
+
+A `review_rebind` consequence must not be treated as complete just because the history row exists.
+
+Required rule:
+- rebind history records the need for review
+- queue item records operational work still pending
+- only later resolver action can resolve/dismiss that review-class rebind work
+
+This checkpoint does not finish the resolver UI/action path for processing these items, but it must ensure the work is clearly pending and queue-backed.
+
+### 3.8 Preserve idempotency and replay safety
+
+This checkpoint must ensure:
+- repeated downstream triggers do not create duplicate `rebind_review` queue items
+- replay of the same merge/reassign/decision consequence does not corrupt rebind history
+- auto-rebind remains safe if invoked more than once
+- queue items for review-class rebinds are created once per underlying unresolved consequence
+
+### 3.9 Keep route handlers thin
+
+If new route/API support is required for queue inspection or rebind-review detail compatibility, route handlers must:
+- authenticate/authorize
+- validate payload
+- call backend service
+- return normalized result
+
+Do not put rebind classification or queue-creation semantics in routes.
+
+### 3.10 Do not broaden review scope unnecessarily
+
+Use current repo policy truth and the locked MVP decisions.
+
+Required guiding rule:
+- current-truth operational objects should not be forced into review if MVP explicitly requires them to auto-follow truth
+- historically sensitive or semantically risky objects should remain in `review`
+- do not let frontend convenience drive rebind classification
+
+---
+
+## 4. Explicit Non-Changes (Guard Against Drift)
+
+Do not:
+
+- build PeopleView queue UI yet
+- build ConnectShyft thread banners yet
+- redesign the core resolver queue model from Checkpoint 1
+- redesign Slice 2A decision backbone
+- introduce claim timeout/expiry
+- redesign merge internals
+- add visible resolution-history UI
+- add notification/escalation flows
+
+---
+
+## 5. Tests Required
+
+### Unit
+
+- contact-point reassignment causes existing thread rebinding through backend path
+- objects classified `auto` do not create queue items
+- objects classified `review` create exactly one `rebind_review` queue item
+- duplicate enqueue attempts for the same review-class consequence are deduplicated
+- `rebind_review` queue item carries required context fields
+- auto-rebind remains idempotent on replay
+
+### Integration
+
+- resolver decision or reassignment that changes subject truth causes existing thread to follow the new contact-point truth
+- review-class rebind consequence becomes active `rebind_review` queue work
+- active queue listing includes `rebind_review` items
+- repeated merge/reassign/rebind replay does not create duplicate queue items
+- terminal or already-resolved review-class rebind consequences do not re-enqueue active queue work
+
+### Regression / Characterization
+
+- existing `person_rebind_history` persistence remains intact
+- existing thread/call/voicemail/bridge rebind fanout remains compatible
+- Checkpoint 1 queue semantics remain intact
+- Slice 2A resolver decisions still trigger downstream consequences correctly
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- `auto_rebind` vs `review_rebind` behavior is explicit and backend-authoritative
+- existing threads always follow contact-point reassignment
+- review-class rebind consequences create active `rebind_review` queue items
+- duplicate/replayed rebind consequences do not create duplicate queue items
+- rebind history remains authoritative and is not replaced by a second ledger
+- route handlers remain thin and do not own rebind policy
+
+---
+
+## 7. Commit Boundary
+
+Single commit:
+
+```text
+feat(connectshyft): operationalize rebind policy and enqueue review-class rebind work
+```
+
+---
+
+## 8. Verification Commands
+
+Run:
+
+```bash
+rg "rebind_class|auto|review|person_rebind_history|enqueueRebindReview|rebind_review" apps libs
+```
+
+Verify the repo has one authoritative rebind classification model and queue-enqueue path.
+
+Run:
+
+```bash
+rg "thread.*rebind|rebind.*thread|contact point reassignment|reassign_contact_point|personRebind" apps/connectshyft-api
+```
+
+Verify existing threads follow contact-point reassignment through backend paths.
+
+Run:
+
+```bash
+rg "rebind_review|claimResolverQueueItem|listResolverQueue|active queue" apps/connectshyft-api/src/modules apps/connectshyft-api/src/routes/api/v1/connectshyft.ts libs/contracts
+```
+
+Verify review-class rebind work participates in the queue model rather than remaining backend-only history.
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- rebind policy is no longer implicit
+- existing threads reliably follow new subject truth
+- review-class rebind work becomes real queue work
+- later PeopleView and thread-detail checkpoints can consume stable backend rebind state

--- a/specs/prep_step_2B_checkpoint_3_peopleview_primary_resolver_workspace.md
+++ b/specs/prep_step_2B_checkpoint_3_peopleview_primary_resolver_workspace.md
@@ -1,0 +1,289 @@
+# CHECKPOINT 3 — PEOPLEVIEW AS THE PRIMARY RESOLVER WORKSPACE
+**Slice:** Prep Step 2B  
+**Objective:** Make PeopleView the primary operational workspace for tenant-admin resolvers by surfacing the Resolver Queue, typed queue items, claim/release actions, and sufficient item context without moving resolver truth into the frontend
+
+## 1. Goal
+
+Build the primary resolver workspace in PeopleView so that tenant-admin resolvers can:
+
+- see active resolver work in one place
+- distinguish `identity_review` vs `rebind_review` items
+- filter and inspect queue work
+- claim and release queue items
+- understand enough context to act safely
+- rely on backend-authored queue, claim, and identity truth
+
+This checkpoint does **not** make ConnectShyft the primary resolver interface and does **not** finish contextual thread banners. It establishes the real resolver workspace in PeopleView.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-web/src/views/Shell/PeopleView.vue
+apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+apps/connectshyft-api/src/modules/peoplecore/service.ts
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts
+libs/contracts/src/connectshyft.ts
+libs/contracts/src/people/resolver-review.ts
+libs/contracts/src/people/events.ts
+```
+
+Include adjacent frontend composables/components or route helpers only if required to implement the workspace cleanly while preserving existing architecture. Do not modify broad shell/navigation beyond what is necessary to host the workspace in PeopleView.
+
+---
+
+## 3. Required Changes
+
+### 3.1 PeopleView must become the primary resolver workspace
+
+PeopleView must expose a resolver workspace for tenant-admin resolvers that surfaces the backend Resolver Queue as the primary place to do resolver work.
+
+Required rule:
+- resolvers should not need ConnectShyft thread detail to browse queue work
+- queue listing, claim/release, item type, and actionable state must all be visible in PeopleView
+- PeopleView remains consumer of backend truth, not owner of resolver policy
+
+### 3.2 Resolver access is tenant-admin-only
+
+PeopleView resolver workspace must only be visible/actionable for tenant-admin resolvers in MVP.
+
+Required behavior:
+- non-tenant-admin users must not see operational resolver controls
+- if PeopleView already shows identity state to broader users, preserve read-safe state where appropriate, but keep resolver queue actions hidden or disabled
+- frontend must not become the real authority; backend authorization remains authoritative
+
+### 3.3 Queue list must support one workspace with typed items
+
+PeopleView must show one resolver workspace with typed queue items:
+- `identity_review`
+- `rebind_review`
+
+The workspace may use:
+- sections
+- tabs
+- filters
+- grouped lists
+
+But it must remain one operational workspace, not two separate systems.
+
+### 3.4 Required queue list fields
+
+Each rendered queue item must display enough context for a resolver to triage and safely open the item.
+
+At minimum, PeopleView must consume and present:
+
+- item type
+- current status
+- claim state
+- whether claimed by current resolver
+- whether claimed by another resolver
+- affected person/contact/thread context where available
+- actionable vs terminal state
+- any contract-backed risk/ambiguity signal already present and appropriate for resolver use
+
+Exact visual treatment may vary, but the workspace must not force the resolver to guess what the item is.
+
+### 3.5 Claim / release controls must be backend-driven
+
+PeopleView must support:
+- claim item
+- release item
+
+Required rules:
+- claim/release state must come from backend truth
+- claim/release requests must call thin routes backed by Slice 2B Checkpoint 1
+- frontend must not simulate claim success before backend confirmation unless existing repo patterns already safely support optimistic updates with rollback
+- if optimistic behavior is used, it must remain consistent with backend claim exclusivity
+
+### 3.6 Claimed-by-other state must be explicit
+
+If an item is claimed by another tenant-admin resolver:
+- PeopleView must show that it is not currently available for this resolver to act on
+- action controls must be disabled or absent accordingly
+- no frontend-only override should exist
+
+### 3.7 Item detail context must be sufficient
+
+PeopleView must allow opening enough item detail context to safely act later, even if final action controls are completed in a later or adjacent component.
+
+For `identity_review`, detail context should include as available from backend:
+- current person/candidate/contact-point context
+- review status
+- current ambiguity state
+- claim state
+
+For `rebind_review`, detail context should include as available from backend:
+- affected object type/id
+- source/target identity context
+- why review is required (backend-safe explanation, not raw debug text)
+- claim state
+
+This checkpoint does not need to finalize every action affordance if some are already driven elsewhere, but the workspace must make queue work operationally understandable.
+
+### 3.8 Filter and grouping support must be real
+
+PeopleView resolver workspace must support, at minimum:
+
+- All active items
+- Identity Reviews
+- Rebind Reviews
+- claimed by me
+- unclaimed
+- optionally blocked / waiting for more info if backend already supplies that state cleanly
+
+Filtering/grouping must use contract-backed item fields, not ad hoc string matching.
+
+### 3.9 Begin moving toward THE_GOAL where safe
+
+This checkpoint may improve clarity and presentation in PeopleView where it helps operational use:
+
+Allowed:
+- cleaner queue cards/rows
+- clearer claim-state badges
+- better grouping or tabs
+- clearer empty states for resolver queue
+- better visual distinction between identity vs rebind queue items
+
+Not allowed:
+- speculative polish that obscures backend truth
+- layout overhauls that outrun the queue model
+- a new standalone resolver app outside PeopleView
+
+### 3.10 Preserve backend authority for action semantics
+
+PeopleView may surface action entry points, but it must not:
+- decide what actions are allowed
+- decide when claim is required
+- decide queue terminality
+- infer identity truth from raw notes/debug fields
+
+All of those must continue coming from backend contract-backed results.
+
+### 3.11 Error and empty-state behavior must be plain-language
+
+For resolvers:
+- queue-load failures
+- claim/release failures
+- item no longer available
+- unauthorized state
+
+must be shown in plain language without leaking internal-only details, stack traces, IDs, or engineering notes.
+
+### 3.12 Compatibility with existing identity-state surfaces must be preserved
+
+If PeopleView already shows provisional/resolver-required identity state outside the new queue workspace:
+- keep that compatible
+- do not duplicate or contradict it
+- prefer a single contract-backed vocabulary for status display
+
+This checkpoint may consolidate toward the queue workspace where safe, but must not break current identity-state visibility while doing so.
+
+---
+
+## 4. Explicit Non-Changes (Guard Against Drift)
+
+Do not:
+
+- make ConnectShyft the primary resolver workspace
+- finish contextual thread banners yet
+- redesign global shell/navigation
+- redesign Slice 2A decision semantics
+- redesign queue policy from Checkpoint 1
+- add visible resolution-history UI
+- add notifications/escalation workflows
+- invent frontend-owned queue semantics
+
+---
+
+## 5. Tests Required
+
+### Unit / Component
+
+- tenant-admin resolver sees resolver workspace controls
+- non-tenant-admin does not see actionable resolver controls
+- queue item rendering distinguishes `identity_review` vs `rebind_review`
+- claimed-by-me vs claimed-by-other state renders correctly
+- claim/release actions call backend-backed operations
+- filters/grouping derive from typed queue fields, not ad hoc strings
+
+### Integration
+
+- PeopleView loads active resolver queue and displays typed items
+- tenant-admin resolver can claim and release an item from PeopleView
+- item claimed by another resolver is not actionable
+- queue updates after claim/release without stale contradictory state
+- `rebind_review` items appear in the same workspace alongside `identity_review` items
+- PeopleView remains compatible with existing provisional/resolver-required identity state surfaces
+
+### Regression / Characterization
+
+- Slice 2B Checkpoint 1 queue semantics remain intact
+- Slice 2B Checkpoint 2 rebind-review queue items remain consumable in PeopleView
+- existing PeopleView identity-state behavior is not broken by the resolver workspace addition
+- no frontend-only semantic drift is introduced
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- PeopleView is the primary resolver workspace for tenant-admin resolvers
+- the backend Resolver Queue is visibly consumable there
+- both `identity_review` and `rebind_review` items appear in one typed workspace
+- claim/release behavior is usable from PeopleView and remains backend-authoritative
+- claimed-by-other state is explicit and non-actionable
+- non-tenant-admin users do not get resolver action controls
+- filtering/grouping is contract-backed and stable
+
+---
+
+## 7. Commit Boundary
+
+Single commit:
+
+```text
+feat(connectshyft-web): make PeopleView the primary resolver workspace
+```
+
+---
+
+## 8. Verification Commands
+
+Run:
+
+```bash
+rg "PeopleView|identity_review|rebind_review|claim|release|claimed_by|claimedBy|resolver queue" apps/connectshyft-web libs/contracts
+```
+
+Verify PeopleView consumes the typed queue model and claim state.
+
+Run:
+
+```bash
+rg "tenant admin|tenant_admin|resolver|required|provisional|claimResolverQueueItem|releaseResolverQueueItem|listResolverQueue" apps/connectshyft-web apps/connectshyft-api libs
+```
+
+Verify PeopleView access/action behavior aligns with backend resolver authority and queue operations.
+
+Run:
+
+```bash
+rg "filter|group|claimed by me|unclaimed|waiting_for_more_info|in_review|queued" apps/connectshyft-web/src/views/Shell/PeopleView.vue apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
+```
+
+Verify grouping/filtering behavior is explicit and contract-backed.
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- tenant-admin resolvers have a real operational workspace in PeopleView
+- queue work is no longer abstract backend state
+- both identity-review and rebind-review work are surfaced in one place
+- later contextual thread-banner work can remain secondary and truly contextual

--- a/specs/prep_step_2B_checkpoint_4_connectshyft_contextual_banners_and_refresh.md
+++ b/specs/prep_step_2B_checkpoint_4_connectshyft_contextual_banners_and_refresh.md
@@ -1,0 +1,260 @@
+# CHECKPOINT 4 — CONNECTSHYFT CONTEXTUAL BANNERS AND SUBJECT/CONTEXT REFRESH
+**Slice:** Prep Step 2B  
+**Objective:** Add contextual unresolved-identity/rebind banners to ConnectShyft thread detail and ensure subject/context refreshes cleanly after resolution or rebinding without making ConnectShyft the primary resolver workspace
+
+## 1. Goal
+
+Complete the secondary, contextual ConnectShyft surface so that:
+
+- thread detail shows a plain-language banner when unresolved identity or pending rebind-review materially affects current work
+- thread detail remains secondary/contextual, not the primary resolver workspace
+- final resolved truth appears in the subject snapshot once resolution/rebind is complete
+- stale provisional/resolver-required/rebind-pending indicators do not persist after backend truth changes
+- normal operators see only the minimal unresolved warning needed for current work
+- tenant-admin resolvers can still navigate back to PeopleView when appropriate, without shifting primary resolver workflow into ConnectShyft
+
+This checkpoint does **not** redesign the whole thread view or the shell. It adds the correct contextual layer on top of the backend-safe queue/rebind model established in prior checkpoints.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
+apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts
+apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts
+apps/connectshyft-api/src/modules/peoplecore/service.ts
+libs/contracts/src/connectshyft.ts
+libs/contracts/src/people/resolver-review.ts
+libs/contracts/src/people/events.ts
+```
+
+Include adjacent frontend components/composables or API helpers only if required to implement banner rendering and subject/context refresh cleanly while preserving existing architecture. Do not modify broad shell/navigation outside the thread-detail context.
+
+---
+
+## 3. Required Changes
+
+### 3.1 ConnectShyft must remain contextual, not primary
+
+Thread detail may show contextual unresolved-state information, but it must not become the primary place to browse or process resolver queue work.
+
+Required rule:
+- queue browsing/claim/release remains centered in PeopleView
+- thread detail only reflects whether this thread is currently impacted by unresolved identity/rebind state
+- any resolver-oriented action surfaced here must route back to PeopleView or a clearly secondary detail path, not create a ConnectShyft-first resolver workflow
+
+### 3.2 Banner appears only when current thread is materially impacted
+
+Thread detail must show a contextual banner only when backend truth indicates the current thread is impacted by one of these unresolved states:
+
+- provisional identity still unresolved
+- resolver-required identity state still unresolved
+- pending `rebind_review` or unresolved review-class rebind consequence affecting this thread’s subject/context truth
+
+Do not show banners globally or generically just because some unrelated person/contact elsewhere is unresolved.
+
+### 3.3 Banner content must be plain-language and role-appropriate
+
+For normal operators:
+- explain only that identity/context for this conversation is still being resolved if that affects current work
+- do not expose resolver-only queue state, history, or internal action semantics
+- do not expose raw IDs, review statuses, debug strings, or merge/reassign internals
+
+For tenant-admin resolvers:
+- banner may include a clear path back to PeopleView resolver workspace or appropriate resolver item context
+- still do not overload thread detail with primary resolver controls
+
+### 3.4 Subject snapshot is the home of final truth
+
+Once identity/rebind state resolves:
+- the banner must disappear
+- the subject snapshot must reflect final identity truth
+- final truth should not remain trapped behind stale provisional/resolver-required labels or stale person/contact context
+
+This is a hard requirement:
+- **banner = temporary unresolved condition**
+- **subject snapshot = stable resolved truth**
+
+### 3.5 Subject/context refresh must be explicit and reliable
+
+After any backend change that can alter thread identity truth, including:
+- resolver decision application
+- ambiguity-event closure
+- contact-point reassignment
+- auto-rebind completion
+- review-rebind resolution
+
+the thread detail surface must refresh/invalidate/refetch so that:
+- the banner state updates correctly
+- the subject snapshot updates correctly
+- stale prior truth is removed
+
+Use existing repo invalidation/refetch patterns where possible. Do not rely on manual page reload as the primary consistency mechanism.
+
+### 3.6 Contextual state must come from backend contract-backed fields
+
+Thread-detail banner logic must derive from stable backend semantics, not from:
+- loose notes fields
+- ad hoc string parsing
+- inferred UI heuristics
+- hidden assumptions about queue/review status
+
+At minimum, thread-detail consumers must be able to determine through contract-backed inputs:
+- whether the current thread is impacted by unresolved identity state
+- whether the impact is provisional/resolver-required/rebind-review related
+- whether the condition is still actionable vs already resolved
+
+### 3.7 Banners must not persist after resolution
+
+This checkpoint must ensure that once the underlying backend condition is resolved:
+- the banner disappears
+- stale warning state is not cached indefinitely
+- the thread does not continue to look unresolved when the backend says it is resolved
+
+### 3.8 ConnectShyft must not expose resolver internals to normal operators
+
+Normal operators may see the existence of a current unresolved condition when relevant, but must not see:
+- claim state
+- claimant identity
+- review history
+- merge/reassign action details
+- queue-item class labels unless intentionally translated into plain-language backend-safe copy
+
+### 3.9 Resolver-accessible contextual affordance is allowed but secondary
+
+For tenant-admin resolvers only, thread detail may include a lightweight affordance such as:
+- “Open in People” / “Review in People”
+- “Go to resolver workspace”
+
+Allowed because it supports workflow continuity.
+
+Not allowed:
+- a full embedded resolver queue inside thread detail
+- duplicated resolver action matrix inside ConnectShyft that bypasses PeopleView’s primary role
+
+### 3.10 Preserve existing thread-detail behavior outside impacted state
+
+If a thread is not impacted by unresolved identity/rebind state:
+- thread detail should behave normally
+- no new banner or placeholder should appear
+- existing thread activity, voicemail, subject snapshot, and other communication surfaces should remain unaffected
+
+### 3.11 Start moving toward THE_GOAL only where safe
+
+This checkpoint may improve thread-detail clarity and polish where it helps users distinguish unresolved vs resolved identity context.
+
+Allowed:
+- clean banner styling
+- clear subject snapshot refresh
+- better visual separation between temporary warning and stable subject info
+
+Not allowed:
+- broad redesign of thread layout
+- making the banner over-dominant
+- speculative UI that assumes future shell behavior not yet built
+
+---
+
+## 4. Explicit Non-Changes (Guard Against Drift)
+
+Do not:
+
+- make ConnectShyft the main resolver workspace
+- redesign global shell/navigation
+- redesign PeopleView resolver workspace
+- redesign Slice 2A or Slice 2B queue/rebind backend policy
+- add visible resolution-history UI
+- add notifications/escalation workflows
+- introduce frontend-owned identity/rebind semantics
+
+---
+
+## 5. Tests Required
+
+### Unit / Component
+
+- banner renders when backend indicates current thread is impacted by unresolved provisional/resolver-required/rebind-review state
+- banner does not render when thread is not impacted
+- normal operator banner content omits resolver internals
+- tenant-admin resolver sees secondary affordance to open resolver workspace when appropriate
+- subject snapshot reflects resolved truth when banner condition clears
+
+### Integration
+
+- thread impacted by contact-point reassignment/rebind updates to new subject truth without stale prior labels
+- thread impacted by unresolved review-rebind shows contextual banner until backend state resolves
+- thread banner disappears after resolution/rebind and subject snapshot updates accordingly
+- resolver decision + backend refresh pipeline results in correct thread-detail state without manual reload dependency
+- non-impacted threads remain unchanged
+
+### Regression / Characterization
+
+- PeopleView remains the primary resolver workspace
+- existing thread activity/telephony surfaces are not broken by banner/state-refresh additions
+- normal operators do not receive resolver-only internals
+- stale provisional/resolver-required indicators do not persist after final truth is available
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- ConnectShyft thread detail shows contextual unresolved-state banners only when the current thread is materially impacted
+- banner content is plain-language and role-appropriate
+- subject snapshot reflects final truth after resolution/rebind
+- stale unresolved indicators disappear after backend truth changes
+- thread-detail state is driven by backend contract-backed semantics
+- ConnectShyft remains secondary/contextual and does not become the primary resolver workspace
+
+---
+
+## 7. Commit Boundary
+
+Single commit:
+
+```text
+feat(connectshyft-web): add contextual identity banners and refresh subject truth after resolution
+```
+
+---
+
+## 8. Verification Commands
+
+Run:
+
+```bash
+rg "ConnectShyftThreadDetailView|banner|resolver_required|provisional|rebind_review|subject snapshot|subject context" apps/connectshyft-web libs/contracts
+```
+
+Verify thread-detail banner and subject-context inputs are wired to stable semantics.
+
+Run:
+
+```bash
+rg "thread.*impact|affected thread|rebind_review|resolver_required|provisional|identity state" apps/connectshyft-api apps/connectshyft-web libs/contracts
+```
+
+Verify banner logic depends on backend-reported thread impact/state, not ad hoc UI inference.
+
+Run:
+
+```bash
+rg "Open in People|Review in People|resolver workspace|claimed_by|claim" apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
+```
+
+Verify resolver affordances remain secondary and non-primary.
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- ConnectShyft correctly reflects unresolved identity/rebind conditions only when they affect current conversation work
+- final truth lives in the subject snapshot after resolution
+- PeopleView remains primary, ConnectShyft remains contextual
+- Slice 2B is complete and operationally coherent

--- a/specs/prep_step_2B_implementation_brief.md
+++ b/specs/prep_step_2B_implementation_brief.md
@@ -1,0 +1,507 @@
+# PREP STEP 2B — IMPLEMENTATION BRIEF
+**Title:** Complete Rebinding Completion and Resolver Operational Surfaces for PeopleCore and ConnectShyft
+
+## 1. Objective
+
+Deliver the operational layer that sits on top of the Slice 2A resolver-decision backbone so that:
+
+- resolver work is handled through a real, claim-based resolver queue
+- rebinding outcomes are no longer just backend side effects, but operationally surfaced and manageable
+- `auto_rebind` vs `review_rebind` behavior is explicit, deterministic, and backend-authoritative
+- PeopleView becomes the primary resolver workspace for tenant-admin resolvers
+- ConnectShyft shows only contextual resolver/rebind state when current thread work is impacted
+- existing threads always follow contact-point reassignment
+- normal operators see final truth except when unresolved identity state materially affects current work
+- Slice 2B moves the system toward the target UX where safe, without sacrificing stability
+
+**Done =** tenant-admin resolvers can work a real queue, claim resolver work, process rebind-review work, and trust that PeopleView and ConnectShyft consume backend identity/rebind truth consistently.
+
+---
+
+## 2. Architectural Position (Locked)
+
+This slice is **not** a new identity or queue system.
+
+The repo already contains:
+
+- a resolver-decision backbone from Slice 2A
+- real `personRebind` fanout across threads and telephony artifacts
+- `person_rebind_history` with `rebind_class` values `auto | review`
+- People and ConnectShyft frontend surfaces already aware of provisional / resolver-required states
+- route/API surfaces for reviews and ambiguity work
+
+This slice completes the missing operational layer:
+
+> **claim-based resolver workflow, rebind policy completion, resolver queue behavior, and UI surfaces that consume stable backend truth**
+
+### Ownership model
+
+- **PeopleCore** remains the authority for resolver truth and decision application
+- **ConnectShyft backend** remains the authority for ambiguity-event and rebind operational consequences
+- **Resolver Queue truth** is backend-owned
+- **PeopleView** is the primary resolver workspace
+- **ConnectShyft** is contextual only, never the primary resolver workspace
+- **Frontend surfaces** consume queue/rebind/resolution state; they do not invent policy
+
+---
+
+## 3. Locked Product Decisions
+
+The following decisions are already locked and are authoritative for Slice 2B:
+
+### Resolver role and claim model
+- only **tenant admins** may act as resolvers in MVP
+- tenant admins are automatically eligible resolvers
+- resolver work must be **claimed** before action
+- one review may be claimed by only one resolver at a time
+- claims do **not** expire automatically
+- a claim persists until the item is resolved, dismissed, or explicitly released
+
+### Queue model
+- MVP includes a **true Resolver Queue**
+- there is one resolver workspace with typed queue items:
+  - **Identity Review**
+  - **Rebind Review**
+- PeopleView is the **primary resolver workspace**
+- ConnectShyft is **secondary/contextual only**
+
+### Rebind policy
+- existing threads always follow contact-point reassignment
+- objects that should follow current truth may auto-rebind
+- historically sensitive or semantically risky objects require review
+- no hidden or speculative exception model should be added unless already required by repo behavior
+
+### Visibility model
+- tenant-admin resolvers see resolver queue and queue-item state
+- normal operators see final truth except when unresolved identity state affects current work
+- normal operators do not see resolver internals or history after resolution
+- audit remains backend-only in MVP
+
+### Thread detail UX
+- unresolved identity/rebind state appears as a **banner**
+- final resolved truth appears in the **subject snapshot**
+- active banners should disappear once the relevant condition is resolved
+
+---
+
+## 4. Problem This Slice Solves
+
+Slice 2A made resolver decisions correct and backend-authoritative, but MVP still lacks the operational layer needed to use that safely in real work.
+
+Current gaps this slice must close:
+
+- there is not yet a fully operational resolver queue with claim/release behavior
+- `review_rebind` work is not yet treated as first-class resolver work
+- auto vs review rebind behavior is not yet fully surfaced or finalized as user-operable truth
+- PeopleView is not yet the finished primary resolver workspace
+- ConnectShyft thread detail does not yet cleanly show contextual unresolved identity/rebind banners while deferring identity authority to People
+- post-resolution/rebind state refresh must be reliable so people, threads, and subject context do not drift
+
+This slice solves those gaps.
+
+---
+
+## 5. Resolver Queue Model (Locked)
+
+### 5.1 One resolver workspace, two typed queue classes
+
+MVP must implement one backend-backed Resolver Queue workspace with typed item classes:
+
+- `identity_review`
+- `rebind_review`
+
+This is one resolver queue, not two separate systems.
+
+### 5.2 Why one typed queue is authoritative
+
+The queue must be centralized so tenant-admin resolvers have one place to work. But item types must stay explicit so identity ambiguity and rebind-review work are not flattened into a single undifferentiated list.
+
+### 5.3 Queue behavior requirements
+
+The queue must support, at minimum:
+
+- list all active resolver work
+- filter by item type
+- filter by status
+- claim item
+- release item
+- open item detail
+- act on claimed item
+- exclude terminal items from active queue by default
+- retain terminal items for detail/history access where backend already supports it
+
+---
+
+## 6. Claim / Release Lifecycle (Locked)
+
+### 6.1 Claim rule
+
+A resolver item must be claimed before action.
+
+### 6.2 Claim authority
+
+Any tenant-admin resolver may claim an unclaimed item.
+
+### 6.3 Claimed item exclusivity
+
+Only the current claimant may:
+- resolve
+- dismiss
+- release
+- move in and out of active handling states as allowed by current repo contracts
+
+### 6.4 No auto-expiry
+
+Claims do not expire automatically in MVP.
+
+### 6.5 Claim persistence
+
+A claim remains until:
+- item is resolved
+- item is dismissed
+- claimant explicitly releases it
+
+### 6.6 Claim safety rules
+
+The backend must reject:
+- claiming an item already claimed by another resolver
+- acting on an item claimed by another resolver
+- releasing an item not claimed by the actor, unless tenant-admin override already exists in repo and is explicitly preserved
+
+### 6.7 Queue status semantics
+
+The current repo already contains lifecycle statuses like:
+- `queued`
+- `in_review`
+- `waiting_for_more_info`
+
+Slice 2B must operationalize these where appropriate for queue work, without inventing a second queue-state system.
+
+Recommended mapping:
+- `queued` = active, unclaimed or awaiting pickup
+- `in_review` = actively claimed and being worked
+- `waiting_for_more_info` = active but blocked
+- resolved/dismissed = terminal and excluded from default active queue
+
+Exact string names may follow existing contract truth.
+
+---
+
+## 7. Rebind Policy Completion (Locked)
+
+### 7.1 Existing threads must follow contact-point reassignment
+
+This is mandatory for MVP.
+
+When contact-point reassignment changes subject truth, existing threads must rebind to follow that new truth unless a current repo constraint explicitly blocks it.
+
+### 7.2 Auto-rebind rule
+
+Objects that should follow current operational truth may auto-rebind.
+
+For MVP, this includes at minimum:
+- existing threads
+- subject-context bindings
+- current conversation/contact-point operational associations
+- telephony/conversation artifacts that are already part of the current-subject continuity model, where repo contracts already support this
+
+### 7.3 Review-rebind rule
+
+Objects must require review when rebinding could:
+- alter historical meaning
+- obscure prior human decisions made under different identity assumptions
+- create semantically risky reinterpretation of completed work
+- violate existing repo “review” classification rules
+
+Slice 2B must preserve and operationalize the repo’s current `rebind_class = auto | review` model rather than replacing it.
+
+### 7.4 Queue creation for `review_rebind`
+
+When a resolver decision or merge/reassignment produces `review_rebind` consequences:
+
+- those consequences must become first-class `rebind_review` queue items
+- they must appear in the Resolver Queue
+- they must be claimable and resolvable through the same claim model
+- they must not silently disappear into backend-only history
+
+### 7.5 Rebind history remains authoritative
+
+`person_rebind_history` remains the backend truth for what was auto-rebound vs review-required. Slice 2B may extend its operational consumption, but must not invent a parallel rebind ledger.
+
+---
+
+## 8. PeopleView as Primary Resolver Workspace
+
+### 8.1 Role
+
+PeopleView must become the primary place where tenant-admin resolvers:
+
+- see queue counts and queue state
+- filter resolver work
+- open identity reviews
+- open rebind reviews
+- claim and release queue items
+- act on claimed items
+- understand the current person/contact-point truth in enough detail to resolve safely
+
+### 8.2 Required behavior
+
+PeopleView must support:
+- active queue list by item type/status
+- clear claimed/unclaimed state
+- clear indication when an item is claimed by the current resolver vs another resolver
+- item detail context sufficient for safe action
+- no dependence on ConnectShyft thread detail as the primary place to do resolver work
+
+### 8.3 UX expectations
+
+This slice may begin moving toward THE_GOAL-level polish where safe, but stability and correctness come first.
+
+Allowed:
+- cleaner queue layout
+- clearer claim state
+- better banners/cards inside PeopleView
+- clearer typed queue sections
+
+Not allowed:
+- visual polish that outruns or obscures queue/rebind truth
+- speculative UX that requires backend state not yet locked
+
+---
+
+## 9. ConnectShyft Contextual Surface Rules
+
+### 9.1 ConnectShyft is not the primary resolver workspace
+
+Thread detail must not become the main place to browse or process queue work.
+
+### 9.2 Contextual banner rule
+
+If the current thread is impacted by:
+- provisional identity state
+- resolver-required identity state
+- pending rebind-review state that materially affects current thread truth
+
+then thread detail must show a contextual **banner**.
+
+### 9.3 Banner content requirements
+
+Banner content must be:
+- plain-language
+- action-oriented only where appropriate
+- free of resolver-internal jargon
+- free of IDs/debug values
+- free of unnecessary history details
+
+For normal operators:
+- banner should explain that identity/context is still being resolved if relevant to current work
+- banner should not expose resolver internals
+
+For tenant-admin resolvers:
+- banner may include path back to PeopleView resolver workspace or resolver action entry point if appropriate, but PeopleView remains primary
+
+### 9.4 Subject snapshot rule
+
+Once identity/rebind state is resolved:
+- banner should disappear
+- subject snapshot should reflect final truth
+
+The subject snapshot is the stable representation of final identity truth, not the banner.
+
+---
+
+## 10. Operator Visibility Rules
+
+### 10.1 Normal operators
+
+Normal operators should:
+- see final truth by default
+- see unresolved banners only when unresolved identity/rebind state materially affects the current thread/work
+- not see resolution history
+- not see merge/reassign internals
+- not see queue claims, claimants, or resolver-only metadata unless repo policy already requires it and it survives this slice intentionally
+
+### 10.2 Tenant-admin resolvers
+
+Tenant-admin resolvers should:
+- see queue work and item state in PeopleView
+- see contextual resolver information where appropriate in thread detail
+- be able to claim/release/act on work
+- still rely on backend truth, not frontend-derived logic
+
+---
+
+## 11. State Refresh and Consistency Rules
+
+Slice 2B must ensure that after:
+- resolver decision application
+- ambiguity-event closure
+- auto-rebind
+- review-rebind resolution
+
+the relevant consuming surfaces refresh cleanly.
+
+### Required consistency points
+
+- PeopleView queue/list state updates correctly
+- thread detail subject snapshot updates to final truth when appropriate
+- thread banners disappear or change appropriately when state resolves
+- stale provisional / resolver-required indicators do not persist after final resolution
+- existing threads following contact-point reassignment reflect the new subject truth consistently
+
+Frontend may use refetch/invalidation patterns already present in repo, but must not keep stale identity assumptions alive after backend truth changes.
+
+---
+
+## 12. Backend/API Requirements
+
+Slice 2B must expose or finalize backend support for:
+
+- resolver queue listing with typed item classes
+- claim item
+- release item
+- get queue item detail
+- list active vs terminal queue work where appropriate
+- consume `review_rebind` work through queue semantics
+- return stable queue/claim/state payloads for PeopleView and contextual thread consumers
+
+### API rule
+
+Route handlers remain thin:
+- authenticate/authorize
+- validate payload
+- call backend service
+- return normalized result
+
+Queue semantics must not be defined in frontend code.
+
+---
+
+## 13. Result / Transport Semantics (Required)
+
+Queue and contextual surfaces need stable backend semantics. At minimum, transport/result shapes must support:
+
+- item id
+- item type (`identity_review` | `rebind_review`)
+- queue status
+- claim status
+- claimed_by_current_user
+- claimant identity reference or display-safe equivalent for resolver users where appropriate
+- actionable vs terminal state
+- affected person/contact/thread context needed for the consuming surface
+- whether current thread is impacted by unresolved identity/rebind state
+
+Exact field names may follow current contract style, but the semantics must exist and be typed.
+
+---
+
+## 14. Tests (Required)
+
+### Unit tests
+
+- claim succeeds for unclaimed item by tenant-admin resolver
+- claim fails for already claimed item
+- release succeeds only for claimant or allowed backend override if intentionally preserved
+- acting on unclaimed item is rejected
+- `review_rebind` items are created for review-class rebind consequences
+- existing threads auto-rebind on contact-point reassignment
+- auto vs review rebind classification follows current repo policy rules
+- banner/state derivation logic uses backend truth, not ad hoc strings
+
+### Integration tests
+
+- resolver queue lists both identity-review and rebind-review items
+- claim/release lifecycle works end-to-end
+- tenant-admin resolver can claim and process queue item
+- non-resolver / non-tenant-admin cannot claim or process queue item
+- reassign contact point causes existing thread to follow new subject truth
+- review-class rebind consequence becomes queue work
+- PeopleView receives stable queue payloads
+- thread detail receives contextual unresolved-state payloads and resolved-state refresh
+
+### Regression / characterization
+
+- Slice 2A resolver decision backbone remains intact
+- existing PeopleView and thread-detail identity-state surfaces remain compatible
+- existing rebind history persistence remains intact
+- normal operators do not receive resolver-only history or internals after resolution
+
+---
+
+## 15. Explicit Non-Goals
+
+The following are out of scope for Slice 2B:
+
+- broad shell redesign
+- final global application shell work
+- full THE_GOAL visual completion across all ConnectShyft surfaces
+- visible resolution-history UI
+- resolver claim timeout/expiry
+- non-tenant-admin resolver roles
+- advanced SLA/reminder/escalation workflows
+- notifications beyond what existing queue/context surfaces require
+- CaseShyft integration
+
+---
+
+## 16. Done Criteria
+
+Slice 2B is done only when:
+
+- tenant-admin resolvers can work a real claim-based Resolver Queue
+- both identity-review and rebind-review work appear in that queue as typed items
+- `auto_rebind` vs `review_rebind` behavior is explicit and operationally surfaced
+- review-class rebind consequences become queue work instead of remaining backend-only
+- existing threads follow contact-point reassignment consistently
+- PeopleView is the primary resolver workspace
+- ConnectShyft thread detail shows contextual unresolved-state banners when relevant
+- subject snapshot reflects final truth after resolution
+- normal operators see final truth except for materially relevant unresolved warnings
+- queue/rebind state is backend-authoritative and frontend-consumed, not frontend-defined
+
+---
+
+## 17. Checkpoint Shape Recommendation
+
+Slice 2B should be broken into these checkpoints:
+
+1. **Resolver queue + claim/release lifecycle lock**
+   - queue item types
+   - claim/release rules
+   - resolver authority checks
+   - active vs terminal semantics
+
+2. **Rebind policy completion + `review_rebind` queue item creation**
+   - auto vs review rebind completion
+   - thread-following-contact-point rule
+   - queue creation for review-class rebind items
+
+3. **PeopleView primary resolver workspace**
+   - queue list/detail/claim/release/action consumption
+   - resolver-user compatibility
+   - typed item sections/filters
+
+4. **ConnectShyft contextual banners + subject/context refresh**
+   - thread banners
+   - final truth in subject snapshot
+   - stale-state cleanup after resolution/rebind
+
+That is the authoritative execution order unless repo reality discovered during implementation forces a narrower decomposition.
+
+---
+
+## 18. Locked Recommendation
+
+Proceed next with:
+
+> **Prep Step 2B — Checkpoint 1: Resolver queue model, claim/release lifecycle, and resolver authority lock**
+
+Do not start with frontend polish or contextual thread banners before the queue/claim model is backend-safe.
+
+---
+
+## 19. Implementation Intent
+
+This is a **completion and hardening slice**, not a redesign.
+
+Use the repo’s existing resolver backbone, rebind history, personRebind fanout, PeopleView consumption, and thread-detail identity state surfaces. Extend them into a real operational resolver system. Do not introduce a second queue model, a frontend-owned claim system, or a ConnectShyft-first resolver workflow.

--- a/specs/prep_step_2B_master_codex_bootstrap_prompt.md
+++ b/specs/prep_step_2B_master_codex_bootstrap_prompt.md
@@ -1,0 +1,268 @@
+# Master Codex Bootstrap Prompt — Prep Step 2B
+
+You are implementing **Prep Step 2B** for ConnectShyft/PeopleCore using the existing specs already present in the repo.
+
+## Spec locations
+
+Use the files already present in the repo under `specs/`:
+
+- `specs/prep_step_2B_implementation_brief.md`
+- `specs/prep_step_2B_checkpoint_1_resolver_queue_and_claim_lifecycle.md`
+- `specs/prep_step_2B_checkpoint_2_rebind_policy_and_review_queue_creation.md`
+- `specs/prep_step_2B_checkpoint_3_peopleview_primary_resolver_workspace.md`
+- `specs/prep_step_2B_checkpoint_4_connectshyft_contextual_banners_and_refresh.md`
+
+Treat those files as authoritative. Do not invent scope outside them.
+
+---
+
+## Mission
+
+Complete the **Rebinding Completion and Resolver Operational Surfaces** slice so that tenant-admin resolvers can work a real resolver queue, review-class rebind work becomes operational queue work, PeopleView becomes the primary resolver workspace, and ConnectShyft shows only contextual unresolved identity/rebind state where relevant.
+
+This is a **completion-and-hardening sequence**, not a greenfield implementation and not an architectural cleanup pass.
+
+Your job is to execute the four checkpoints **in order**, preserving the current repo architecture while closing the specific gaps defined in the implementation brief and checkpoint specs.
+
+---
+
+## Non-negotiable operating rules
+
+1. **Do not redesign architecture.**
+   - Do not create a second queue system.
+   - Do not move queue/rebind truth into the frontend.
+   - Do not make ConnectShyft the primary resolver workspace.
+   - Do not replace the existing PeopleCore / ConnectShyft split.
+
+2. **Do not expand scope.**
+   - No resolver claim timeout/expiry
+   - No broad shell redesign
+   - No visible resolution-history UI
+   - No advanced SLA/reminder/escalation workflows
+   - No non-tenant-admin resolver roles
+   - No CaseShyft work
+   - No notification work beyond what the slice explicitly requires
+   - No AI-assisted resolution or queue prioritization
+
+3. **PeopleCore and backend services remain authoritative.**
+   - Resolver truth: PeopleCore
+   - Resolver-decision backbone: Slice 2A outputs
+   - Rebind history truth: existing backend model
+   - Queue truth: backend-owned and contract-backed
+   - Frontend consumes state only
+
+4. **Resolver authority is tenant-admin-only in MVP.**
+   - Tenant admins are automatically eligible resolvers
+   - Claim before action is required
+   - Claims do not expire automatically
+
+5. **PeopleView is the primary resolver workspace.**
+   - Queue browsing and work processing center there
+   - ConnectShyft is contextual only
+
+6. **Threads must follow contact-point reassignment.**
+   - Existing threads always follow new subject truth through backend rebind logic
+   - Review-class rebind work must become queue work
+
+7. **No engineering leakage into user-facing behavior.**
+   - No IDs/debug values in banners
+   - No frontend inference from raw notes or loose strings
+   - No resolver internals shown to normal operators after resolution
+
+8. **Work surgically.**
+   - Preserve existing architecture wherever it already matches the spec
+   - Prefer extension/completion over replacement
+   - Do not refactor for style
+
+---
+
+## Execution order (mandatory)
+
+Execute these checkpoints in this exact order:
+
+1. `specs/prep_step_2B_checkpoint_1_resolver_queue_and_claim_lifecycle.md`
+2. `specs/prep_step_2B_checkpoint_2_rebind_policy_and_review_queue_creation.md`
+3. `specs/prep_step_2B_checkpoint_3_peopleview_primary_resolver_workspace.md`
+4. `specs/prep_step_2B_checkpoint_4_connectshyft_contextual_banners_and_refresh.md`
+
+Do not skip ahead. Do not merge checkpoints. Do not reorder them.
+
+---
+
+## Required workflow for each checkpoint
+
+For **each checkpoint**, follow this exact process:
+
+### Step A — Read before changing
+- Read the implementation brief
+- Read the current checkpoint spec
+- Inspect the exact files listed in scope
+- Identify existing repo behavior that already satisfies the checkpoint
+- Limit changes to the minimum needed to satisfy the checkpoint
+
+### Step B — Implement only the checkpoint
+- Apply only the changes required by that checkpoint
+- Do not start future checkpoint work early unless a tiny prerequisite is unavoidable
+- If an unavoidable prerequisite is needed, keep it minimal and directly supportive
+
+### Step C — Verify before stopping
+Run the verification commands from the checkpoint spec.
+
+Also run any checkpoint-specific tests you added or updated.
+
+Do not declare the checkpoint complete until its stop condition is met.
+
+### Step D — Commit at the checkpoint boundary
+Use the **exact commit message** defined in the checkpoint spec.
+
+Then move to the next checkpoint.
+
+---
+
+## Checkpoint commit messages (must be exact)
+
+1. `feat(connectshyft): lock resolver queue model and claim lifecycle`
+2. `feat(connectshyft): operationalize rebind policy and enqueue review-class rebind work`
+3. `feat(connectshyft-web): make PeopleView the primary resolver workspace`
+4. `feat(connectshyft-web): add contextual identity banners and refresh subject truth after resolution`
+
+Do not combine commits. Do not rename commits.
+
+---
+
+## Global success criteria
+
+At the end of all four checkpoints, the following must be true:
+
+- One backend-authoritative Resolver Queue model exists
+- Queue item types `identity_review` and `rebind_review` are both supported
+- Only tenant admins can act as resolvers for queue work
+- Claim-before-action is enforced
+- Claim exclusivity is enforced
+- Claims do not auto-expire
+- `auto_rebind` vs `review_rebind` behavior is explicit and backend-authoritative
+- Existing threads always follow contact-point reassignment
+- Review-class rebind consequences become active queue work
+- PeopleView is the primary resolver workspace
+- ConnectShyft shows contextual unresolved-state banners only when the current thread is materially impacted
+- Final resolved truth appears in the subject snapshot
+- Normal operators see final truth except for materially relevant unresolved warnings
+- No frontend consumer invents queue/rebind semantics from raw strings or notes
+
+---
+
+## Behavioral locks you must preserve
+
+### Resolver operating model
+- Resolver in MVP = tenant admin only
+- Tenant admins are automatically eligible resolvers
+- A queue item must be claimed before action
+- One claimant at a time
+- No automatic claim expiry
+- Claim persists until resolved, dismissed, or explicitly released
+
+### Queue model
+- One Resolver Queue workspace
+- Two typed item classes:
+  - `identity_review`
+  - `rebind_review`
+- PeopleView = primary resolver workspace
+- ConnectShyft = contextual only
+
+### Rebind model
+- Existing threads always follow contact-point reassignment
+- Objects that should follow current truth may auto-rebind
+- Historically sensitive or semantically risky objects remain `review`
+- `review_rebind` work becomes queue work
+- Rebind history remains authoritative
+
+### Visibility model
+- Tenant-admin resolvers see queue work and claim state
+- Normal operators see final truth except unresolved warnings relevant to current thread/work
+- Backend-only audit in MVP
+- No visible resolution-history UI
+
+### Thread-detail UX
+- Banner = temporary unresolved condition
+- Subject snapshot = stable resolved truth
+- Banner disappears after resolution
+- Any resolver affordance in thread detail remains secondary and points back to PeopleView
+
+---
+
+## How to behave if repo reality conflicts with the checkpoint
+
+If you find a mismatch between current repo code and the checkpoint spec:
+
+1. Prefer the checkpoint spec and implementation brief
+2. Preserve existing architecture where possible
+3. Make the smallest change necessary to bring repo behavior into compliance
+4. Do not widen scope
+5. Do not substitute a “cleaner” architecture
+
+If a checkpoint cannot be completed without violating a prior checkpoint, stop and report the exact conflict with:
+- file
+- function
+- conflicting behavior
+- why it blocks the checkpoint
+
+Do not silently improvise around the conflict.
+
+---
+
+## Required discipline around queue/rebind semantics
+
+### Queue
+- One backend-owned queue model
+- No separate frontend queue truth
+- No ad hoc item-type semantics
+- Active vs terminal behavior must be contract-backed
+- Claim/release rules must be backend-enforced
+
+### Rebind
+- Preserve `rebind_class = auto | review`
+- No second rebind classification system
+- Existing threads must follow contact-point reassignment
+- Review-class consequences must become queue work
+- Queue creation for review-class rebind must be deduplicated and replay-safe
+
+### PeopleView
+- Primary workspace for resolver work
+- Contract-backed filters/grouping
+- Claimed-by-other state explicit and non-actionable
+- Backend-driven claim/release only
+
+### ConnectShyft thread detail
+- Secondary/contextual only
+- Banner only when current thread is materially impacted
+- Plain-language warning content
+- Final truth in subject snapshot
+- Stale unresolved indicators must disappear after backend truth changes
+
+---
+
+## Verification discipline
+
+After each checkpoint:
+
+- Run the checkpoint's verification commands
+- Run targeted tests for the files and behaviors changed
+- Confirm the checkpoint stop condition is met
+- Commit with the exact required message
+
+At the end of all four checkpoints:
+
+- Run the full relevant test suite for resolver queue behavior, rebind queue creation, PeopleView resolver workspace behavior, and thread-detail contextual banner/subject-refresh behavior
+- Summarize:
+  - files changed
+  - tests added/updated
+  - any narrow technical debt intentionally left for later slices
+
+---
+
+## Final instruction
+
+Execute the repo's existing spec-defined plan exactly.
+
+This is not an opportunity to re-architect.  
+This is an opportunity to finish the resolver operational layer and rebind surfaces without drift.


### PR DESCRIPTION
## Summary
- lock the backend-authoritative resolver queue and claim lifecycle for tenant-admin resolvers
- operationalize auto vs review rebind policy and enqueue review-class rebind work
- make PeopleView the primary resolver workspace for browsing, claiming, and processing queue items
- add contract-backed ConnectShyft thread-detail subject impact banners and refresh the subject snapshot after backend truth changes
- add the Prep Step 2B implementation brief and checkpoint specs to the repo

## Testing
- ./node_modules/.bin/vitest run libs/contracts/tests/connectshyft.test.ts libs/contracts/tests/people/resolver-review.test.ts
- npx jest --runInBand src/modules/peoplecore/__tests__/service.test.ts src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts src/modules/connectshyft/__tests__/personRebind.test.ts src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts
- npm test -- src/features/connectshyft/__tests__/resolverQueue.test.ts src/views/Shell/__tests__/PeopleView.test.ts src/features/connectshyft/__tests__/identityResolution.test.ts src/features/connectshyft/__tests__/readContracts.test.ts src/views/ConnectShyft/__tests__/ConnectShyftThreadDetailView.test.ts
- ./apps/connectshyft-api/node_modules/.bin/tsc -p apps/connectshyft-api/tsconfig.json --noEmit
- npm run build
