### PR TITLE
Prep Step 3: shared shell and context unification

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectContext.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectContext.ts
@@ -3,9 +3,10 @@ import { success } from '../../../platform/envelopes/response';
 import { connectShyftTelephonyReadinessServiceAsync } from '../telephonyReadiness';
 import { resolveConnectShyftRequestedProviderKey } from '../providerRegistry';
 import {
-  enforceConnectShyftCapability,
+  resolveEntitlementAwareConnectShyftFlags,
   resolveConnectShyftRequestedActorUserId,
   resolveConnectShyftRouteContextDecision,
+  resolveConnectShyftShellOrgUnits,
   respondWithConnectShyftContextRefusal,
 } from '../http/accessContext';
 
@@ -23,23 +24,36 @@ const resolveProviderRegistryHeaders = (
 );
 
 export const getConnectContext = async (req: Request, res: Response) => {
-  if (!await enforceConnectShyftCapability(req, res, 'module')) {
-    return;
-  }
-
   const contextDecision = await resolveConnectShyftRouteContextDecision(req);
   if (!contextDecision.ok) {
     respondWithConnectShyftContextRefusal(res, contextDecision);
     return;
   }
 
-  const readiness = await connectShyftTelephonyReadinessServiceAsync.inspectReadiness({
-    tenantId: contextDecision.context.tenantId,
-    orgUnitId: contextDecision.context.orgUnitId,
-    userId: resolveConnectShyftRequestedActorUserId(req) || '',
-    requestedProvider: resolveConnectShyftRequestedProviderKey(req),
-    providerRegistryHeaders: resolveProviderRegistryHeaders(req),
-  });
+  const flagsResult = await resolveEntitlementAwareConnectShyftFlags(req);
+  const shellOrgUnits = await resolveConnectShyftShellOrgUnits(
+    req,
+    contextDecision.context,
+    flagsResult,
+  );
+  const activeShellOrgUnit = shellOrgUnits.find(
+    (orgUnit) => orgUnit.id === contextDecision.context.orgUnitId,
+  );
+  const connectModuleAvailable = activeShellOrgUnit?.availableModules.connect === true;
+  const readiness = connectModuleAvailable
+    ? await connectShyftTelephonyReadinessServiceAsync.inspectReadiness({
+      tenantId: contextDecision.context.tenantId,
+      orgUnitId: contextDecision.context.orgUnitId,
+      userId: resolveConnectShyftRequestedActorUserId(req) || '',
+      requestedProvider: resolveConnectShyftRequestedProviderKey(req),
+      providerRegistryHeaders: resolveProviderRegistryHeaders(req),
+    })
+    : {
+      operatorPhoneSource: null,
+      voiceReady: false,
+      smsReady: false,
+      degradedMode: false,
+    };
 
   return success(res, {
     code: 'CONNECTSHYFT_CONTEXT_RESOLVED',
@@ -49,6 +63,7 @@ export const getConnectContext = async (req: Request, res: Response) => {
         tenantId: contextDecision.context.tenantId,
         orgUnitId: contextDecision.context.orgUnitId,
         bypassedOrgUnitMembership: contextDecision.context.bypassedOrgUnitMembership,
+        orgUnits: shellOrgUnits,
         telephony: {
           operatorPhoneSource: readiness.operatorPhoneSource,
           voiceReady: readiness.voiceReady,

--- a/apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/handlers/getConnectSettingsNavigation.ts
@@ -17,29 +17,9 @@ type ConnectShyftSettingsNavigationOption = {
 
 const CONNECTSHYFT_SETTINGS_PRIMARY_OPTIONS: readonly ConnectShyftSettingsNavigationOption[] = [
   {
-    key: 'directory',
-    label: 'Directory',
-    path: '/app/connectshyft/directory',
-  },
-  {
     key: 'settings',
-    label: 'Settings',
+    label: 'Call routing',
     path: '/app/connectshyft/settings',
-  },
-  {
-    key: 'notification-preferences',
-    label: 'Notification Preferences',
-    path: '/app/connectshyft/settings',
-  },
-  {
-    key: 'display-preferences',
-    label: 'Display Preferences',
-    path: '/app/connectshyft/settings',
-  },
-  {
-    key: 'sign-out',
-    label: 'Sign Out',
-    path: '/login',
   },
 ];
 

--- a/apps/connectshyft-api/src/modules/connectshyft/http/accessContext.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/accessContext.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from 'express';
 import type { Knex } from 'knex';
+import type {
+  ConnectShyftShellModuleAvailability,
+  ConnectShyftShellOrgUnitOption,
+} from '@shyft/contracts';
 import { refusal } from '../../../platform/envelopes/response';
 import { CAPABILITIES, hasCapability, type Capability } from '../../../platform/rbac/capabilities';
 import {
@@ -27,6 +31,7 @@ import {
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const TEST_USER_ID_HEADER = 'x-test-connectshyft-user-id';
 const TEST_TENANT_OVERRIDE_HEADER = 'x-test-connectshyft-tenant-id';
+const TEST_ORG_UNIT_MEMBERSHIPS_HEADER = 'x-test-connectshyft-orgunit-memberships';
 const CONNECTSHYFT_LEGACY_ROLE_ALIASES: Record<string, string> = {
   admin: 'TENANT_ADMIN',
   member: 'ORGUNIT_MEMBER',
@@ -45,6 +50,11 @@ export type ConnectShyftEntitlementAwareFlagsResult = {
   entitlementDecision: Awaited<ReturnType<typeof evaluateActorTenantModuleEntitlement>> | null;
 };
 
+type ConnectShyftOrgUnitRow = {
+  id: unknown;
+  name?: unknown;
+};
+
 const normalizeNonEmptyString = (value: unknown): string | null => {
   if (typeof value !== 'string') {
     return null;
@@ -52,6 +62,237 @@ const normalizeNonEmptyString = (value: unknown): string | null => {
 
   const normalized = value.trim();
   return normalized.length > 0 ? normalized : null;
+};
+
+const createShellModuleAvailability = (
+  input: Partial<ConnectShyftShellModuleAvailability> = {},
+): ConnectShyftShellModuleAvailability => ({
+  people: true,
+  connect: false,
+  settings: false,
+  ...input,
+});
+
+const titleCaseSegment = (value: string): string => (
+  value.charAt(0).toUpperCase() + value.slice(1)
+);
+
+const buildSyntheticOrgUnitLabel = (orgUnitId: string): string => {
+  const normalizedId = orgUnitId
+    .replace(/^org-connectshyft-/, '')
+    .replace(/^org-/, '');
+  const segments = normalizedId
+    .split('-')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+  if (segments.length === 0) {
+    return 'Org unit';
+  }
+
+  return segments.map(titleCaseSegment).join(' ');
+};
+
+const normalizeOrgUnitLabel = (label: unknown, orgUnitId: string): string => {
+  const normalizedLabel = normalizeNonEmptyString(label);
+  return normalizedLabel || buildSyntheticOrgUnitLabel(orgUnitId);
+};
+
+const normalizeOrgUnitRows = (
+  rows: ConnectShyftOrgUnitRow[],
+): Array<{ id: string; label: string }> => {
+  const seen = new Set<string>();
+  const normalized: Array<{ id: string; label: string }> = [];
+
+  for (const row of rows) {
+    const id = normalizeNonEmptyString(row.id);
+    if (!id || seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    normalized.push({
+      id,
+      label: normalizeOrgUnitLabel(row.name, id),
+    });
+  }
+
+  return normalized;
+};
+
+const parseTestOrgUnitMemberships = (req: Request): string[] => {
+  if (!isConnectShyftTestOverrideEnabled()) {
+    return [];
+  }
+
+  const rawMemberships = req.header(TEST_ORG_UNIT_MEMBERSHIPS_HEADER);
+  if (!rawMemberships) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(rawMemberships);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return Array.from(new Set(
+      parsed
+        .map((entry) => normalizeNonEmptyString(entry))
+        .filter((entry): entry is string => entry !== null),
+    ));
+  } catch (_error) {
+    return [];
+  }
+};
+
+const listAccessibleConnectShyftOrgUnits = async (
+  req: Request,
+  context: ResolvedConnectShyftContext,
+): Promise<Array<{ id: string; label: string }>> => {
+  if (!UUID_PATTERN.test(context.tenantId)) {
+    const membershipIds = parseTestOrgUnitMemberships(req);
+    const orgUnitIds = Array.from(new Set([
+      context.orgUnitId,
+      ...membershipIds,
+    ]));
+
+    return orgUnitIds.map((orgUnitId) => ({
+      id: orgUnitId,
+      label: normalizeOrgUnitLabel(null, orgUnitId),
+    }));
+  }
+
+  const db = loadConnectShyftPlatformDb();
+  const actorUserId = resolveConnectShyftRequestedActorUserId(req);
+  const canReadTenantWide = requestHasAnyCapability(req, [CAPABILITIES.TENANT_READ_ALL], context);
+
+  if (canReadTenantWide) {
+    const tenantOrgUnits = await db
+      .withSchema('platform')
+      .table('org_units')
+      .where({
+        tenant_id: context.tenantId,
+        status: 'active',
+      })
+      .select<ConnectShyftOrgUnitRow[]>('id', 'name')
+      .orderBy('name', 'asc')
+      .orderBy('id', 'asc');
+
+    return normalizeOrgUnitRows(tenantOrgUnits);
+  }
+
+  if (!actorUserId) {
+    return [{
+      id: context.orgUnitId,
+      label: normalizeOrgUnitLabel(null, context.orgUnitId),
+    }];
+  }
+
+  const membershipOrgUnits = await db
+    .withSchema('platform')
+    .table('org_unit_memberships as om')
+    .join('org_units as ou', 'ou.id', 'om.org_unit_id')
+    .where('om.user_id', actorUserId)
+    .andWhere('ou.tenant_id', context.tenantId)
+    .andWhere('ou.status', 'active')
+    .select<ConnectShyftOrgUnitRow[]>([
+      'om.org_unit_id as id',
+      'ou.name as name',
+    ])
+    .orderBy('ou.name', 'asc')
+    .orderBy('om.org_unit_id', 'asc');
+
+  const normalizedMemberships = normalizeOrgUnitRows(membershipOrgUnits);
+  if (normalizedMemberships.some((orgUnit) => orgUnit.id === context.orgUnitId)) {
+    return normalizedMemberships;
+  }
+
+  return [
+    {
+      id: context.orgUnitId,
+      label: normalizeOrgUnitLabel(null, context.orgUnitId),
+    },
+    ...normalizedMemberships,
+  ];
+};
+
+const buildConnectShyftShellModuleAvailabilityMap = async (
+  req: Request,
+  tenantId: string,
+  orgUnitIds: string[],
+  flagsResult: ConnectShyftEntitlementAwareFlagsResult,
+): Promise<Map<string, ConnectShyftShellModuleAvailability>> => {
+  const rawFlags = resolveConnectShyftFeatureFlags(req);
+  const connectEnabledByDefault =
+    rawFlags.connectshyft_enabled
+    && (
+      !flagsResult.entitlementDecision
+      || flagsResult.entitlementDecision.enabled === true
+    );
+  const availabilityMap = new Map<string, ConnectShyftShellModuleAvailability>();
+
+  for (const orgUnitId of orgUnitIds) {
+    availabilityMap.set(orgUnitId, createShellModuleAvailability({
+      connect: connectEnabledByDefault,
+      settings: connectEnabledByDefault,
+    }));
+  }
+
+  if (
+    connectEnabledByDefault
+    || !rawFlags.connectshyft_enabled
+    || !UUID_PATTERN.test(tenantId)
+    || orgUnitIds.length === 0
+  ) {
+    return availabilityMap;
+  }
+
+  const enabledOverrideRows = await loadConnectShyftPlatformDb()
+    .withSchema('platform')
+    .table('org_unit_module_overrides')
+    .where('tenant_id', tenantId)
+    .andWhere('module_key', 'connectshyft')
+    .whereIn('org_unit_id', orgUnitIds)
+    .andWhere('enabled', true)
+    .select(['org_unit_id as orgUnitId']);
+
+  const enabledOrgUnits = new Set(
+    enabledOverrideRows
+      .map((row) => normalizeNonEmptyString((row as { orgUnitId?: unknown }).orgUnitId))
+      .filter((orgUnitId): orgUnitId is string => orgUnitId !== null),
+  );
+
+  for (const orgUnitId of orgUnitIds) {
+    const enabled = enabledOrgUnits.has(orgUnitId);
+    availabilityMap.set(orgUnitId, createShellModuleAvailability({
+      connect: enabled,
+      settings: enabled,
+    }));
+  }
+
+  return availabilityMap;
+};
+
+export const resolveConnectShyftShellOrgUnits = async (
+  req: Request,
+  context: ResolvedConnectShyftContext,
+  flagsResult: ConnectShyftEntitlementAwareFlagsResult,
+): Promise<ConnectShyftShellOrgUnitOption[]> => {
+  const orgUnits = await listAccessibleConnectShyftOrgUnits(req, context);
+  const availabilityByOrgUnit = await buildConnectShyftShellModuleAvailabilityMap(
+    req,
+    context.tenantId,
+    orgUnits.map((orgUnit) => orgUnit.id),
+    flagsResult,
+  );
+
+  return orgUnits.map((orgUnit) => ({
+    id: orgUnit.id,
+    label: orgUnit.label,
+    availableModules: availabilityByOrgUnit.get(orgUnit.id)
+      || createShellModuleAvailability(),
+  }));
 };
 
 const actorFromRequest = (req: Request): PlatformAdminActorContext => ({

--- a/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
@@ -956,6 +956,7 @@ const buildThreadDisplayRecord = (input: {
 
 const buildThreadSubjectContext = (input: {
   orgUnitId: string;
+  threadId: string;
   personId: string | null;
   identityState: ConnectShyftThreadIdentityState | null;
 }): SubjectContext => {
@@ -964,13 +965,18 @@ const buildThreadSubjectContext = (input: {
       ? {
         orgUnitId: input.orgUnitId,
         provisionalPersonId: input.personId,
+        identityState: 'provisional',
+        threadId: input.threadId,
       }
       : {
         orgUnitId: input.orgUnitId,
         personId: input.personId,
+        identityState: 'confirmed',
+        threadId: input.threadId,
       }
     : {
       orgUnitId: input.orgUnitId,
+      threadId: input.threadId,
     };
 
   validateSubjectContext(subject);
@@ -979,6 +985,7 @@ const buildThreadSubjectContext = (input: {
 
 const buildThreadIdentityProjection = (input: {
   orgUnitId: string;
+  threadId: string;
   personId?: string | null;
   personStatus?: string | null;
 }): {
@@ -1000,6 +1007,7 @@ const buildThreadIdentityProjection = (input: {
     subjectImpact: null,
     subjectContext: buildThreadSubjectContext({
       orgUnitId: input.orgUnitId,
+      threadId: input.threadId,
       personId,
       identityState,
     }),
@@ -1165,6 +1173,7 @@ export const resolveConnectShyftThreadDetailContract = (input: {
     ...summary,
     ...buildThreadIdentityProjection({
       orgUnitId: summary.orgUnitId,
+      threadId: summary.threadId,
       personId: matchedSeed.personId,
       personStatus: matchedSeed.personStatus,
     }),
@@ -1705,6 +1714,7 @@ export const resolveConnectShyftThreadDetailContractAsync = async (input: {
     ...summary,
     ...buildThreadIdentityProjection({
       orgUnitId: summary.orgUnitId,
+      threadId: summary.threadId,
       personId: threadPersonId,
       personStatus: threadPersonStatus,
     }),

--- a/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/__tests__/service.test.ts
@@ -493,6 +493,13 @@ describe('AsyncPeopleCoreService', () => {
         reviewType: 'subject_reassignment_review',
       },
       rebindReview: reviewContext,
+      subjectContext: {
+        orgUnitId: rebindReview.orgUnitId,
+        provisionalPersonId: 'person-provisional',
+        candidatePersonIds: ['person-provisional', 'person-canonical'],
+        contactPointId: 'contact-point-1',
+        identityState: 'provisional',
+      },
     });
   });
 
@@ -542,6 +549,13 @@ describe('AsyncPeopleCoreService', () => {
       claimState: 'claimed_by_current_user',
       claimedByCurrentUser: true,
     });
+    expect(detail.subjectContext).toMatchObject({
+      orgUnitId: updatedReview.orgUnitId,
+      provisionalPersonId: 'person-provisional',
+      candidatePersonIds: ['person-provisional', 'person-canonical'],
+      contactPointId: 'contact-point-1',
+      identityState: 'provisional',
+    });
   });
 
   it('lets a tenant-admin resolver claim an unclaimed queue item', async () => {
@@ -580,6 +594,13 @@ describe('AsyncPeopleCoreService', () => {
       claimState: 'claimed_by_current_user',
       claimedByCurrentUser: true,
       actionable: true,
+    });
+    expect(detail.subjectContext).toMatchObject({
+      orgUnitId: updatedReview.orgUnitId,
+      provisionalPersonId: 'person-provisional',
+      candidatePersonIds: ['person-provisional', 'person-existing'],
+      contactPointId: 'contact-point-1',
+      identityState: 'provisional',
     });
   });
 
@@ -669,6 +690,13 @@ describe('AsyncPeopleCoreService', () => {
       claimable: true,
       releasable: false,
       actionable: false,
+    });
+    expect(detail.subjectContext).toMatchObject({
+      orgUnitId: updatedReview.orgUnitId,
+      provisionalPersonId: 'person-provisional',
+      candidatePersonIds: ['person-provisional', 'person-existing'],
+      contactPointId: 'contact-point-1',
+      identityState: 'provisional',
     });
   });
 

--- a/apps/connectshyft-api/src/modules/peoplecore/service.ts
+++ b/apps/connectshyft-api/src/modules/peoplecore/service.ts
@@ -15,6 +15,7 @@ import type {
   ResolverReview,
   ResolverReviewStatus,
   ResolverResolutionType,
+  SubjectContext,
   ValidatedResolverDecisionInput,
 } from '@shyft/contracts';
 import {
@@ -25,6 +26,7 @@ import {
   isResolverReviewResolvedStatus,
   isResolverReviewTerminalStatus,
   RESOLVER_ACTION_STATUS_MAP,
+  validateSubjectContext,
 } from '@shyft/contracts';
 import { normalizeRoles } from '../../platform/rbac/capabilities';
 import {
@@ -436,6 +438,27 @@ const toResolverQueueItem = (
     startedAt: review.startedAt ?? null,
     resolvedAt: review.resolvedAt ?? null,
   };
+};
+
+const buildResolverQueueSubjectContext = (
+  review: ResolverReview,
+  item: ConnectShyftResolverQueueItemRecord,
+): SubjectContext => {
+  const subject: SubjectContext = {
+    orgUnitId: review.orgUnitId,
+    candidatePersonIds: item.personIds.length > 0 ? [...item.personIds] : undefined,
+    conversationId: review.conversationId ?? undefined,
+    contactPointId: review.contactPointId ?? undefined,
+    threadId: item.threadId ?? undefined,
+  };
+
+  if (review.provisionalPersonId && isResolverReviewActiveStatus(review.reviewStatus)) {
+    subject.provisionalPersonId = review.provisionalPersonId;
+    subject.identityState = 'provisional';
+  }
+
+  validateSubjectContext(subject);
+  return subject;
 };
 
 const assertResolverReviewClaimedByActor = (
@@ -946,6 +969,7 @@ export class AsyncPeopleCoreService {
     review: ResolverReview,
     actorUserId: string,
   ): Promise<ConnectShyftResolverQueueDetailData> {
+    const item = toResolverQueueItem(review, actorUserId);
     const rebindReview = isQueueBackedRebindReview(review)
       ? await loadPersonRebindService().getRebindReviewContext({
         tenantId: review.tenantId,
@@ -954,9 +978,10 @@ export class AsyncPeopleCoreService {
       : null;
 
     return {
-      item: toResolverQueueItem(review, actorUserId),
+      item,
       review: toResolverReviewRecord(review),
       rebindReview,
+      subjectContext: buildResolverQueueSubjectContext(review, item),
     };
   }
 

--- a/apps/connectshyft-api/src/platform/tenancy/__tests__/requestContext.test.ts
+++ b/apps/connectshyft-api/src/platform/tenancy/__tests__/requestContext.test.ts
@@ -69,7 +69,7 @@ describe('resolveTenantRequestContext', () => {
     });
   });
 
-  it('ignores caller-supplied tenant and orgunit headers for authenticated context', () => {
+  it('ignores caller-supplied tenant headers while honoring shell-selected orgunit context', () => {
     const req = {
       user: {
         userId: 'u1',
@@ -84,8 +84,8 @@ describe('resolveTenantRequestContext', () => {
         if (name.toLowerCase() === 'x-active-tenant-id') {
           return 'tenant-spoof';
         }
-        if (name.toLowerCase() === 'x-active-org-unit-id') {
-          return 'org-spoof';
+        if (name.toLowerCase() === 'x-org-unit-id') {
+          return 'org-shell-selected';
         }
         return undefined;
       },
@@ -93,8 +93,8 @@ describe('resolveTenantRequestContext', () => {
 
     expect(resolveTenantRequestContext(req)).toEqual({
       tenantId: 'tenant-safe',
-      orgUnitId: null,
-      scopeMode: 'TENANT',
+      orgUnitId: 'org-shell-selected',
+      scopeMode: 'ORG_UNIT',
       source: 'auth',
     });
   });

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.context-and-inbox.characterization.test.ts
@@ -220,6 +220,16 @@ describe('connectshyft context and inbox route characterization', () => {
           tenantId: CONTEXT_TENANT_ID,
           orgUnitId: CONTEXT_ORG_UNIT_ID,
           bypassedOrgUnitMembership: false,
+          orgUnits: expect.arrayContaining([
+            expect.objectContaining({
+              id: CONTEXT_ORG_UNIT_ID,
+              availableModules: {
+                people: true,
+                connect: true,
+                settings: true,
+              },
+            }),
+          ]),
           telephony: {
             operatorPhoneSource: 'callback_number',
             voiceReady: true,
@@ -260,6 +270,16 @@ describe('connectshyft context and inbox route characterization', () => {
           tenantId: CONTEXT_TENANT_ID,
           orgUnitId: 'org-connectshyft-alpha-west',
           bypassedOrgUnitMembership: true,
+          orgUnits: expect.arrayContaining([
+            expect.objectContaining({
+              id: 'org-connectshyft-alpha-west',
+              availableModules: {
+                people: true,
+                connect: true,
+                settings: true,
+              },
+            }),
+          ]),
           telephony: {
             operatorPhoneSource: 'orgunit_default',
             voiceReady: true,

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts
@@ -196,6 +196,14 @@ const buildResolverQueueItem = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const buildResolverQueueSubjectContext = (overrides: Record<string, unknown> = {}) => ({
+  orgUnitId: TEST_ORG_UNIT_ID,
+  candidatePersonIds: ['person-a', 'person-b'],
+  conversationId: 'conversation-1',
+  contactPointId: 'contact-point-1',
+  ...overrides,
+});
+
 describe('connectshyft identity ambiguity ops route', () => {
   const previousNodeEnv = process.env.NODE_ENV;
   const previousOverrideFlag = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
@@ -864,6 +872,7 @@ describe('connectshyft identity ambiguity ops route', () => {
           resolutionType: 'confirm_existing_person',
           resolvedAt: '2026-03-21T13:00:00.000Z',
         }),
+        subjectContext: buildResolverQueueSubjectContext(),
       } as any);
 
     const app = buildApp();
@@ -894,6 +903,9 @@ describe('connectshyft identity ambiguity ops route', () => {
           id: 'review-terminal',
           reviewStatus: 'resolved_confirmed_existing',
         },
+        subjectContext: {
+          orgUnitId: TEST_ORG_UNIT_ID,
+        },
       },
     });
   });
@@ -916,6 +928,7 @@ describe('connectshyft identity ambiguity ops route', () => {
           assignedResolverUserId: TEST_USER_ID,
           startedAt: '2026-03-21T12:05:00.000Z',
         }),
+        subjectContext: buildResolverQueueSubjectContext(),
       } as any);
     const releaseSpy = jest.spyOn(peopleCoreServiceAsync, 'releaseResolverQueueItem')
       .mockResolvedValue({
@@ -924,6 +937,7 @@ describe('connectshyft identity ambiguity ops route', () => {
           reviewStatus: 'queued',
           assignedResolverUserId: undefined,
         }),
+        subjectContext: buildResolverQueueSubjectContext(),
       } as any);
 
     const app = buildApp();

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts
@@ -229,23 +229,16 @@ describe('connectshyft settings and availability route characterization', () => 
         adminOptions: [],
       },
     });
-    expect(response.body.data.primaryOptions).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        key: 'directory',
-        path: '/app/connectshyft/directory',
-      }),
+    expect(response.body.data.primaryOptions).toEqual([
       expect.objectContaining({
         key: 'settings',
+        label: 'Call routing',
         path: '/app/connectshyft/settings',
       }),
-      expect.objectContaining({
-        key: 'sign-out',
-        path: '/login',
-      }),
-    ]));
+    ]);
     expect(response.body.data.pathways).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        path: '/app/connectshyft/directory',
+        path: '/app/connectshyft/settings',
         allowed: true,
       }),
       expect.objectContaining({
@@ -253,6 +246,8 @@ describe('connectshyft settings and availability route characterization', () => 
         allowed: false,
       }),
     ]));
+    expect(response.body.data.pathways.some((pathway: { path: string }) =>
+      /directory|notification|display|login/i.test(pathway.path))).toBe(false);
   });
 
   it('returns admin navigation pathways for admin-capable settings callers', async () => {
@@ -346,14 +341,12 @@ describe('connectshyft settings and availability route characterization', () => 
         adminOptions: [],
       },
     });
-    expect(response.body.data.primaryOptions).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        key: 'directory',
-      }),
+    expect(response.body.data.primaryOptions).toEqual([
       expect.objectContaining({
         key: 'settings',
+        label: 'Call routing',
       }),
-    ]));
+    ]);
     expect(response.body.data.pathways).toEqual(expect.arrayContaining([
       expect.objectContaining({
         path: '/app/connectshyft/settings/availability',

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts
@@ -17,52 +17,79 @@ import {
 const TEST_TENANT_ID = 'tenant-connectshyft-f1';
 const TEST_ORG_UNIT_ID = 'org-connectshyft-f1-east';
 
-const buildThreadDetailRecord = (overrides: Record<string, unknown> = {}) => ({
-  threadId: 'thread-detail-characterization-1001',
-  neighborId: 'neighbor-detail-characterization-1001',
-  personId: 'person-detail-characterization-1001',
-  identityState: 'confirmed',
-  subjectImpact: null,
-  subjectContext: {
-    orgUnitId: TEST_ORG_UNIT_ID,
+const buildThreadDetailRecord = (overrides: Record<string, unknown> = {}) => {
+  const record = {
+    threadId: 'thread-detail-characterization-1001',
+    neighborId: 'neighbor-detail-characterization-1001',
     personId: 'person-detail-characterization-1001',
-  },
-  neighborDeleted: false,
-  neighbor_deleted: false,
-  neighborDeletedAtUtc: null,
-  neighbor_deleted_at_utc: null,
-  tenantId: TEST_TENANT_ID,
-  orgUnitId: TEST_ORG_UNIT_ID,
-  state: 'CLAIMED',
-  claimedByUserId: 'user-connectshyft-f1-operator',
-  claimed_by_user_id: 'user-connectshyft-f1-operator',
-  bucket: 'mine',
-  escalationStage: 1,
-  isNewUnread: false,
-  priorityRank: 3,
-  urgencyLabel: 'Needs attention soon',
-  lastActivityAtUtc: '2026-03-19T10:05:00.000Z',
-  lastInboundCsNumberId: 'cs-number-1001',
-  last_inbound_cs_number_id: 'cs-number-1001',
-  preferredOutboundCsNumberId: 'cs-number-2001',
-  preferred_outbound_cs_number_id: 'cs-number-2001',
-  preferredOutboundContext: {
-    csNumberId: 'cs-number-2001',
-    label: 'Primary Queue',
-  },
-  preferred_outbound_context: {
-    cs_number_id: 'cs-number-2001',
-    label: 'Primary Queue',
-  },
-  voicemailIndicator: false,
-  voicemailLabel: null,
-  summary: 'Thread detail characterization baseline',
-  actions: ['Call', 'Text', 'Close'],
-  lifecycle: {
-    reopenedByInbound: false,
-  },
-  ...overrides,
-});
+    identityState: 'confirmed',
+    subjectImpact: null,
+    subjectContext: {
+      orgUnitId: TEST_ORG_UNIT_ID,
+      personId: 'person-detail-characterization-1001',
+      threadId: 'thread-detail-characterization-1001',
+      identityState: 'confirmed',
+    },
+    neighborDeleted: false,
+    neighbor_deleted: false,
+    neighborDeletedAtUtc: null,
+    neighbor_deleted_at_utc: null,
+    tenantId: TEST_TENANT_ID,
+    orgUnitId: TEST_ORG_UNIT_ID,
+    state: 'CLAIMED',
+    claimedByUserId: 'user-connectshyft-f1-operator',
+    claimed_by_user_id: 'user-connectshyft-f1-operator',
+    bucket: 'mine',
+    escalationStage: 1,
+    isNewUnread: false,
+    priorityRank: 3,
+    urgencyLabel: 'Needs attention soon',
+    lastActivityAtUtc: '2026-03-19T10:05:00.000Z',
+    lastInboundCsNumberId: 'cs-number-1001',
+    last_inbound_cs_number_id: 'cs-number-1001',
+    preferredOutboundCsNumberId: 'cs-number-2001',
+    preferred_outbound_cs_number_id: 'cs-number-2001',
+    preferredOutboundContext: {
+      csNumberId: 'cs-number-2001',
+      label: 'Primary Queue',
+    },
+    preferred_outbound_context: {
+      cs_number_id: 'cs-number-2001',
+      label: 'Primary Queue',
+    },
+    voicemailIndicator: false,
+    voicemailLabel: null,
+    summary: 'Thread detail characterization baseline',
+    actions: ['Call', 'Text', 'Close'],
+    lifecycle: {
+      reopenedByInbound: false,
+    },
+    ...overrides,
+  } as Record<string, unknown>;
+
+  if (!('subjectContext' in overrides) && typeof record.threadId === 'string') {
+    record.subjectContext = record.personId && record.identityState === 'provisional'
+      ? {
+        orgUnitId: record.orgUnitId,
+        provisionalPersonId: record.personId,
+        threadId: record.threadId,
+        identityState: record.identityState,
+      }
+      : record.personId
+        ? {
+          orgUnitId: record.orgUnitId,
+          personId: record.personId,
+          threadId: record.threadId,
+          identityState: record.identityState,
+        }
+        : {
+          orgUnitId: record.orgUnitId,
+          threadId: record.threadId,
+        };
+  }
+
+  return record;
+};
 
 const buildBridgeSessionAggregate = (overrides: Record<string, unknown> = {}) => ({
   session: {
@@ -228,6 +255,8 @@ describe('connectshyft thread detail route characterization', () => {
           subjectContext: {
             orgUnitId: TEST_ORG_UNIT_ID,
             personId: 'person-detail-characterization-1001',
+            threadId,
+            identityState: 'confirmed',
           },
           neighborDeleted: false,
           neighbor_deleted: false,
@@ -322,6 +351,8 @@ describe('connectshyft thread detail route characterization', () => {
       subjectContext: {
         orgUnitId: TEST_ORG_UNIT_ID,
         provisionalPersonId: 'person-detail-provisional-1003',
+        threadId,
+        identityState: 'provisional',
       },
     }) as any);
     jest.spyOn(
@@ -352,6 +383,8 @@ describe('connectshyft thread detail route characterization', () => {
           subjectContext: {
             orgUnitId: TEST_ORG_UNIT_ID,
             provisionalPersonId: 'person-detail-provisional-1003',
+            threadId,
+            identityState: 'provisional',
           },
         },
       },
@@ -371,6 +404,8 @@ describe('connectshyft thread detail route characterization', () => {
       subjectContext: {
         orgUnitId: TEST_ORG_UNIT_ID,
         provisionalPersonId: 'person-detail-resolver-impact-1007',
+        threadId,
+        identityState: 'provisional',
       },
     }) as any);
     jest.spyOn(
@@ -430,6 +465,8 @@ describe('connectshyft thread detail route characterization', () => {
       subjectContext: {
         orgUnitId: TEST_ORG_UNIT_ID,
         personId: 'person-detail-rebind-impact-1008',
+        threadId,
+        identityState: 'confirmed',
       },
     }) as any);
     jest.spyOn(

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -1901,6 +1901,7 @@ const buildSyntheticThreadDetailRecord = (input: {
     subjectImpact: null,
     subjectContext: {
       orgUnitId: input.descriptor.orgUnitId,
+      threadId: input.threadId,
     },
     neighborDeleted: false,
     neighbor_deleted: false,

--- a/apps/connectshyft-web/src/components/connectshyft/ConnectShyftPrimaryNav.vue
+++ b/apps/connectshyft-web/src/components/connectshyft/ConnectShyftPrimaryNav.vue
@@ -1,32 +1,25 @@
 <template>
   <nav
-    data-testid="connectshyft-bottom-nav"
-    class="fixed inset-x-0 bottom-0 z-40 border-t border-slate-300 bg-white/95 backdrop-blur-sm"
+    data-testid="connectshyft-section-nav"
+    class="flex flex-wrap gap-2"
   >
-    <div class="mx-auto flex w-full max-w-4xl items-center justify-around gap-2 px-3 py-2">
-      <RouterLink
-        v-for="item in navItems"
-        :key="item.path"
-        :to="{
-          path: item.path,
-          query: sanitizedQuery(),
-        }"
-        :data-testid="item.testId"
-        :aria-label="item.ariaLabel"
-        :style="tapTargetStyle"
-        class="inline-flex min-h-[44px] min-w-[96px] items-center justify-center rounded-lg px-3 text-base font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
-        :class="isActive(item.path) ? 'bg-slate-900 text-white' : 'text-slate-600 hover:bg-slate-100'"
-      >
-        {{ item.label }}
-        <span
-          v-if="item.path === '/app/connectshyft/more' && isActive(item.path)"
-          data-testid="connectshyft-primary-nav-more-active"
-          class="ml-2 rounded bg-white/20 px-2 py-0.5 text-xs"
-        >
-          More active
-        </span>
-      </RouterLink>
-    </div>
+    <RouterLink
+      v-for="item in navItems"
+      :key="item.path"
+      :to="{
+        path: item.path,
+        query: sanitizedQuery(),
+      }"
+      :data-testid="item.testId"
+      :aria-label="item.ariaLabel"
+      :style="tapTargetStyle"
+      class="inline-flex min-h-[44px] min-w-[96px] items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+      :class="isActive(item.path)
+        ? 'bg-slate-900 text-white shadow-sm'
+        : 'bg-slate-100 text-slate-700 hover:bg-slate-200'"
+    >
+      {{ item.label }}
+    </RouterLink>
   </nav>
 </template>
 
@@ -34,6 +27,7 @@
 import type { LocationQueryRaw } from 'vue-router';
 import { useRoute } from 'vue-router';
 import { CONNECTSHYFT_ACCESSIBILITY_LOCKS } from '@/features/connectshyft/uiContracts';
+import { SHELL_ROUTE_PATHS } from '@/shell/routes';
 
 const route = useRoute();
 const tapTargetStyle = {
@@ -44,20 +38,20 @@ const navItems = [
   {
     label: 'Inbox',
     ariaLabel: 'Open Inbox',
-    path: '/app/connectshyft/inbox',
-    testId: 'connectshyft-bottom-nav-inbox',
+    path: SHELL_ROUTE_PATHS.connect,
+    testId: 'connectshyft-section-nav-inbox',
   },
   {
     label: 'Mine',
     ariaLabel: 'Open Mine',
-    path: '/app/connectshyft/mine',
-    testId: 'connectshyft-bottom-nav-mine',
+    path: SHELL_ROUTE_PATHS.connectMine,
+    testId: 'connectshyft-section-nav-mine',
   },
   {
-    label: 'More',
-    ariaLabel: 'Open More',
-    path: '/app/connectshyft/more',
-    testId: 'connectshyft-bottom-nav-more',
+    label: 'Directory',
+    ariaLabel: 'Open Directory',
+    path: SHELL_ROUTE_PATHS.connectDirectory,
+    testId: 'connectshyft-section-nav-directory',
   },
 ];
 
@@ -73,11 +67,16 @@ const sanitizedQuery = (): LocationQueryRaw => {
 };
 
 const isActive = (path: string): boolean => {
-  if (path === '/app/connectshyft/more') {
-    return route.path.startsWith('/app/connectshyft/more')
-      || route.path.startsWith('/app/connectshyft/settings');
+  if (path === SHELL_ROUTE_PATHS.connectDirectory) {
+    return route.path === path || route.path.startsWith(`${path}/`);
   }
 
-  return route.path === path || route.path.startsWith(`${path}/`);
+  if (path === SHELL_ROUTE_PATHS.connectMine) {
+    return route.path === path || route.path.startsWith(`${path}/`);
+  }
+
+  return route.path.startsWith(SHELL_ROUTE_PATHS.connect)
+    && !route.path.startsWith(SHELL_ROUTE_PATHS.connectMine)
+    && !route.path.startsWith(SHELL_ROUTE_PATHS.connectDirectory);
 };
 </script>

--- a/apps/connectshyft-web/src/components/shell/ShellOrgUnitSelector.vue
+++ b/apps/connectshyft-web/src/components/shell/ShellOrgUnitSelector.vue
@@ -1,0 +1,49 @@
+<template>
+  <label class="flex min-w-[14rem] flex-col gap-2 text-sm text-slate-600">
+    <span class="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+      Org unit
+    </span>
+    <select
+      :value="currentOrgUnitId"
+      :disabled="disabled || loading || options.length === 0"
+      data-testid="shell-orgunit-selector"
+      class="min-h-[44px] rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400"
+      @change="handleChange"
+    >
+      <option v-if="loading" value="">
+        Loading org units...
+      </option>
+      <option
+        v-for="option in options"
+        :key="option.id"
+        :value="option.id"
+      >
+        {{ option.label }}
+      </option>
+    </select>
+  </label>
+</template>
+
+<script setup lang="ts">
+import type { ConnectShyftShellOrgUnitOption } from '@shyft/contracts';
+
+const props = defineProps<{
+  currentOrgUnitId: string;
+  options: readonly ConnectShyftShellOrgUnitOption[];
+  loading?: boolean;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  requestSwitch: [orgUnitId: string];
+}>();
+
+const handleChange = (event: Event): void => {
+  const nextOrgUnitId = (event.target as HTMLSelectElement).value.trim();
+  if (!nextOrgUnitId || nextOrgUnitId === props.currentOrgUnitId) {
+    return;
+  }
+
+  emit('requestSwitch', nextOrgUnitId);
+};
+</script>

--- a/apps/connectshyft-web/src/components/shell/ShellPrimaryNav.vue
+++ b/apps/connectshyft-web/src/components/shell/ShellPrimaryNav.vue
@@ -1,0 +1,55 @@
+<template>
+  <nav
+    aria-label="Primary navigation"
+    data-testid="shell-primary-nav"
+    class="flex flex-wrap gap-2"
+  >
+    <RouterLink
+      v-for="item in navItems"
+      :key="item.path"
+      :to="{ path: item.path, query: navigationQuery }"
+      :data-testid="`shell-primary-nav-${item.module}`"
+      class="inline-flex min-h-[44px] items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2"
+      :class="isActive(item.module)
+        ? 'bg-slate-900 text-white shadow-sm'
+        : 'bg-slate-100 text-slate-700 hover:bg-slate-200'"
+      :aria-current="isActive(item.module) ? 'page' : undefined"
+    >
+      {{ item.label }}
+    </RouterLink>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import type { LocationQueryRaw } from 'vue-router';
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { SHELL_PRIMARY_NAV_ITEMS, type ShellModuleKey } from '@/shell/routes';
+
+const route = useRoute();
+const navItems = SHELL_PRIMARY_NAV_ITEMS;
+
+const navigationQuery = computed<LocationQueryRaw>(() => {
+  const {
+    refusedPath: _refusedPath,
+    settingsRefusal: _settingsRefusal,
+    settingsRefusedPath: _settingsRefusedPath,
+    ...rest
+  } = route.query;
+
+  return rest as LocationQueryRaw;
+});
+
+const activeModule = computed<ShellModuleKey | null>(() => {
+  const matchedRecord = [...route.matched]
+    .reverse()
+    .find((record) => typeof record.meta.shellModule === 'string');
+  const moduleKey = matchedRecord?.meta.shellModule;
+
+  return moduleKey === 'people' || moduleKey === 'connect' || moduleKey === 'settings'
+    ? moduleKey
+    : null;
+});
+
+const isActive = (module: ShellModuleKey): boolean => activeModule.value === module;
+</script>

--- a/apps/connectshyft-web/src/components/shell/ShellPrimaryNav.vue
+++ b/apps/connectshyft-web/src/components/shell/ShellPrimaryNav.vue
@@ -24,10 +24,23 @@
 import type { LocationQueryRaw } from 'vue-router';
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
+import { useShellAvailableOrgUnits } from '@/shell/orgUnitContext';
+import { useActiveShellOrgUnitId } from '@/shell/orgUnitState';
+import { isShellModuleAvailable, resolveShellModuleAvailability } from '@/shell/featureFlags';
 import { SHELL_PRIMARY_NAV_ITEMS, type ShellModuleKey } from '@/shell/routes';
 
 const route = useRoute();
-const navItems = SHELL_PRIMARY_NAV_ITEMS;
+const availableOrgUnits = useShellAvailableOrgUnits();
+const currentOrgUnitId = useActiveShellOrgUnitId();
+const navItems = computed(() => {
+  const moduleAvailability = resolveShellModuleAvailability(
+    availableOrgUnits.value,
+    currentOrgUnitId.value,
+  );
+
+  return SHELL_PRIMARY_NAV_ITEMS.filter((item) =>
+    isShellModuleAvailable(moduleAvailability, item.module));
+});
 
 const navigationQuery = computed<LocationQueryRaw>(() => {
   const {

--- a/apps/connectshyft-web/src/components/shell/__tests__/ShellOrgUnitSelector.test.ts
+++ b/apps/connectshyft-web/src/components/shell/__tests__/ShellOrgUnitSelector.test.ts
@@ -1,0 +1,73 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ShellOrgUnitSelector from '../ShellOrgUnitSelector.vue';
+
+describe('ShellOrgUnitSelector', () => {
+  it('renders the available orgUnit labels', () => {
+    const wrapper = mount(ShellOrgUnitSelector, {
+      props: {
+        currentOrgUnitId: 'org-east',
+        options: [
+          {
+            id: 'org-east',
+            label: 'East Campus',
+            availableModules: {
+              people: true,
+              connect: true,
+              settings: true,
+            },
+          },
+          {
+            id: 'org-west',
+            label: 'West Campus',
+            availableModules: {
+              people: true,
+              connect: false,
+              settings: false,
+            },
+          },
+        ],
+      },
+    });
+
+    const options = wrapper.findAll('option');
+    expect(options.map((option) => option.text())).toEqual([
+      'East Campus',
+      'West Campus',
+    ]);
+  });
+
+  it('emits the selected orgUnit id when the selection changes', async () => {
+    const wrapper = mount(ShellOrgUnitSelector, {
+      props: {
+        currentOrgUnitId: 'org-east',
+        options: [
+          {
+            id: 'org-east',
+            label: 'East Campus',
+            availableModules: {
+              people: true,
+              connect: true,
+              settings: true,
+            },
+          },
+          {
+            id: 'org-west',
+            label: 'West Campus',
+            availableModules: {
+              people: true,
+              connect: true,
+              settings: true,
+            },
+          },
+        ],
+      },
+    });
+
+    await wrapper.get('[data-testid="shell-orgunit-selector"]').setValue('org-west');
+
+    expect(wrapper.emitted('requestSwitch')).toEqual([
+      ['org-west'],
+    ]);
+  });
+});

--- a/apps/connectshyft-web/src/features/connectshyft/__tests__/readContracts.test.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/__tests__/readContracts.test.ts
@@ -90,6 +90,8 @@ describe('fetchConnectShyftThreadDetail', () => {
             subjectContext: {
               orgUnitId: 'org-1',
               provisionalPersonId: 'person-1',
+              threadId: 'thread-1',
+              identityState: 'provisional',
             },
             actions: ['Call', 'Text', 'Close'],
             timeline: [],
@@ -119,6 +121,8 @@ describe('fetchConnectShyftThreadDetail', () => {
       expect(result.thread.subjectContext).toEqual({
         orgUnitId: 'org-1',
         provisionalPersonId: 'person-1',
+        threadId: 'thread-1',
+        identityState: 'provisional',
       });
     }
   });

--- a/apps/connectshyft-web/src/features/connectshyft/__tests__/resolverQueue.test.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/__tests__/resolverQueue.test.ts
@@ -160,6 +160,11 @@ describe('resolverQueue client', () => {
             terminal: false,
             decisionStatus: null,
           },
+          subjectContext: {
+            orgUnitId: 'org-1',
+            candidatePersonIds: ['person-2', 'person-3'],
+            contactPointId: 'contact-point-2',
+          },
           rebindReview: {
             rebindHistoryId: 'rebind-history-1',
             affectedObjectType: 'contact_point_link',
@@ -187,6 +192,11 @@ describe('resolverQueue client', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.detail.item.claimState).toBe('claimed_by_other');
+      expect(result.detail.subjectContext).toEqual({
+        orgUnitId: 'org-1',
+        candidatePersonIds: ['person-2', 'person-3'],
+        contactPointId: 'contact-point-2',
+      });
       expect(result.detail.rebindReview?.affectedObjectType).toBe('contact_point_link');
       expect(result.detail.rebindReview?.originatingResolutionType).toBe('reassign_contact_point');
     }
@@ -243,6 +253,11 @@ describe('resolverQueue client', () => {
               terminal: false,
               decisionStatus: null,
             },
+            subjectContext: {
+              orgUnitId: 'org-1',
+              candidatePersonIds: ['person-1'],
+              contactPointId: 'contact-point-1',
+            },
             rebindReview: null,
           },
         },
@@ -295,6 +310,11 @@ describe('resolverQueue client', () => {
               actionable: true,
               terminal: false,
               decisionStatus: null,
+            },
+            subjectContext: {
+              orgUnitId: 'org-1',
+              candidatePersonIds: ['person-1'],
+              contactPointId: 'contact-point-1',
             },
             rebindReview: null,
           },

--- a/apps/connectshyft-web/src/features/connectshyft/__tests__/settingsNavigation.test.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/__tests__/settingsNavigation.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import api from '@/services/api';
+import {
+  canAccessConnectShyftSettingsPath,
+  fetchConnectShyftSettingsNavigationState,
+} from '../settingsNavigation';
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+const apiGetMock = vi.mocked(api.get);
+
+describe('settingsNavigation', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps only allowed shell settings destinations from backend navigation', async () => {
+    apiGetMock.mockResolvedValue({
+      data: {
+        ok: true,
+        data: {
+          primaryOptions: [
+            {
+              key: 'settings',
+              label: 'Call routing',
+              path: '/app/connectshyft/settings',
+            },
+            {
+              key: 'directory',
+              label: 'Directory',
+              path: '/app/connectshyft/directory',
+            },
+          ],
+          adminOptions: [
+            {
+              key: 'availability',
+              label: 'Availability',
+              path: '/app/connectshyft/settings/availability',
+            },
+            {
+              key: 'number-mappings',
+              label: 'Number Mappings',
+              path: '/app/connectshyft/settings/numbers',
+            },
+          ],
+          pathways: [
+            {
+              path: '/app/connectshyft/settings',
+              allowed: true,
+            },
+            {
+              path: '/app/connectshyft/settings/availability',
+              allowed: false,
+            },
+            {
+              path: '/app/connectshyft/settings/numbers',
+              allowed: true,
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await fetchConnectShyftSettingsNavigationState();
+
+    expect(result.items).toEqual([
+      {
+        key: 'settings',
+        label: 'Call routing',
+        path: '/settings',
+      },
+      {
+        key: 'number-mappings',
+        label: 'Number Mappings',
+        path: '/settings/numbers',
+      },
+    ]);
+    expect(result.allowedPaths).toEqual([
+      '/settings',
+      '/settings/numbers',
+    ]);
+  });
+
+  it('fails closed for admin-only settings paths when navigation fetch falls back', async () => {
+    apiGetMock.mockRejectedValue(new Error('network down'));
+
+    await expect(canAccessConnectShyftSettingsPath('/settings/availability')).resolves.toBe(false);
+    await expect(canAccessConnectShyftSettingsPath('/settings')).resolves.toBe(true);
+  });
+});

--- a/apps/connectshyft-web/src/features/connectshyft/readContracts.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/readContracts.ts
@@ -7,6 +7,7 @@ import type {
 import {
   isConnectShyftResolverQueueItemType,
   isConnectShyftThreadSubjectImpactType,
+  validateSubjectContext,
 } from '@shyft/contracts';
 
 export type ConnectShyftThreadState = 'UNCLAIMED' | 'CLAIMED' | 'CLOSED';
@@ -130,6 +131,16 @@ const normalizeString = (value: unknown): string => {
 const normalizeOptionalString = (value: unknown): string | null => {
   const normalized = normalizeString(value);
   return normalized.length > 0 ? normalized : null;
+};
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => normalizeOptionalString(entry))
+    .filter((entry): entry is string => Boolean(entry));
 };
 
 const normalizeStage = (value: unknown): number => {
@@ -293,23 +304,29 @@ const buildFallbackSubjectContext = (input: {
   orgUnitId: string;
   personId: string | null;
   identityState: ConnectShyftThreadIdentityState | null;
+  threadId: string;
 }): SubjectContext => {
+  const baseSubject: SubjectContext = {
+    orgUnitId: input.orgUnitId,
+    threadId: input.threadId,
+  };
+
   if (!input.personId) {
-    return {
-      orgUnitId: input.orgUnitId,
-    };
+    return baseSubject;
   }
 
   if (input.identityState === 'provisional') {
     return {
-      orgUnitId: input.orgUnitId,
+      ...baseSubject,
       provisionalPersonId: input.personId,
+      identityState: 'provisional',
     };
   }
 
   return {
-    orgUnitId: input.orgUnitId,
+    ...baseSubject,
     personId: input.personId,
+    identityState: 'confirmed',
   };
 };
 
@@ -318,6 +335,7 @@ const parseSubjectContext = (input: {
   orgUnitId: string;
   personId: string | null;
   identityState: ConnectShyftThreadIdentityState | null;
+  threadId: string;
 }): SubjectContext => {
   if (!input.payload || typeof input.payload !== 'object') {
     return buildFallbackSubjectContext(input);
@@ -327,45 +345,60 @@ const parseSubjectContext = (input: {
     orgUnitId?: unknown;
     personId?: unknown;
     provisionalPersonId?: unknown;
+    candidatePersonIds?: unknown;
+    candidate_person_ids?: unknown;
     conversationId?: unknown;
     contactPointId?: unknown;
+    threadId?: unknown;
+    thread_id?: unknown;
+    identityState?: unknown;
+    identity_state?: unknown;
   };
 
   const orgUnitId = normalizeString(candidate.orgUnitId) || input.orgUnitId;
   const personId = normalizeString(candidate.personId);
   const provisionalPersonId = normalizeString(candidate.provisionalPersonId);
+  const candidatePersonIds = normalizeStringArray(
+    candidate.candidatePersonIds ?? candidate.candidate_person_ids,
+  );
   const conversationId = normalizeString(candidate.conversationId);
   const contactPointId = normalizeString(candidate.contactPointId);
-
-  if (personId && !provisionalPersonId) {
-    return {
-      orgUnitId,
-      personId,
-      conversationId: conversationId || undefined,
-      contactPointId: contactPointId || undefined,
-    };
-  }
-
-  if (provisionalPersonId && !personId) {
-    return {
-      orgUnitId,
-      provisionalPersonId,
-      conversationId: conversationId || undefined,
-      contactPointId: contactPointId || undefined,
-    };
-  }
+  const threadId = normalizeString(candidate.threadId ?? candidate.thread_id) || input.threadId;
+  const identityStateCandidate = normalizeIdentityState(
+    candidate.identityState ?? candidate.identity_state,
+  );
 
   const fallback = buildFallbackSubjectContext({
     orgUnitId,
     personId: input.personId,
     identityState: input.identityState,
+    threadId,
   });
-
-  return {
+  const subject: SubjectContext = {
     ...fallback,
+    candidatePersonIds: candidatePersonIds.length > 0 ? candidatePersonIds : fallback.candidatePersonIds,
     conversationId: conversationId || undefined,
     contactPointId: contactPointId || undefined,
+    threadId,
+    identityState: identityStateCandidate ?? fallback.identityState,
   };
+
+  if (personId && !provisionalPersonId) {
+    delete subject.provisionalPersonId;
+    subject.personId = personId;
+    subject.identityState = identityStateCandidate === 'provisional'
+      ? 'confirmed'
+      : identityStateCandidate || 'confirmed';
+  } else if (provisionalPersonId && !personId) {
+    delete subject.personId;
+    subject.provisionalPersonId = provisionalPersonId;
+    subject.identityState = identityStateCandidate === 'confirmed'
+      ? 'provisional'
+      : identityStateCandidate || 'provisional';
+  }
+
+  validateSubjectContext(subject);
+  return subject;
 };
 
 const hasVoicemailTimelineEvent = (payload: unknown): boolean => {
@@ -552,12 +585,14 @@ const parseThreadDetail = (payload: unknown): ConnectShyftThreadDetail | null =>
     orgUnitId: summary.orgUnitId,
     personId: fallbackPersonId,
     identityState: parsedIdentityState,
+    threadId: summary.threadId,
   });
   const personId = fallbackPersonId
     || subjectContext.personId
     || subjectContext.provisionalPersonId
     || null;
   const identityState = parsedIdentityState
+    || subjectContext.identityState
     || (subjectContext.provisionalPersonId
       ? 'provisional'
       : personId

--- a/apps/connectshyft-web/src/features/connectshyft/resolverQueue.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/resolverQueue.ts
@@ -7,12 +7,14 @@ import type {
   ConnectShyftResolverQueueItemType,
   ConnectShyftResolverReviewRecord,
   ResolverReviewStatus,
+  SubjectContext,
 } from '@shyft/contracts';
 import {
   isConnectShyftRebindReviewAffectedObjectType,
   isConnectShyftResolverQueueClaimState,
   isConnectShyftResolverQueueItemType,
   isResolverReviewStatus,
+  validateSubjectContext,
 } from '@shyft/contracts';
 
 type ResolverQueueEnvelope = {
@@ -24,6 +26,7 @@ type ResolverQueueEnvelope = {
     item?: unknown;
     review?: unknown;
     rebindReview?: unknown;
+    subjectContext?: unknown;
   };
 };
 
@@ -77,6 +80,15 @@ const normalizeStringArray = (value: unknown): string[] => {
   return value
     .map((entry) => normalizeOptionalString(entry))
     .filter((entry): entry is string => Boolean(entry));
+};
+
+const normalizeSubjectIdentityState = (
+  value: unknown,
+): SubjectContext['identityState'] | undefined => {
+  const normalized = normalizeOptionalString(value);
+  return normalized === 'confirmed' || normalized === 'provisional'
+    ? normalized
+    : undefined;
 };
 
 const parseEnvelopeMessage = (payload: unknown, fallback: string): string => {
@@ -210,6 +222,36 @@ const parseRebindReviewContext = (payload: unknown): ConnectShyftRebindReviewCon
   };
 };
 
+const parseSubjectContext = (payload: unknown): SubjectContext | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  const orgUnitId = normalizeString(candidate.orgUnitId);
+  if (!orgUnitId) {
+    return null;
+  }
+
+  const subjectContext: SubjectContext = {
+    orgUnitId,
+    personId: normalizeOptionalString(candidate.personId) ?? undefined,
+    provisionalPersonId: normalizeOptionalString(candidate.provisionalPersonId) ?? undefined,
+    candidatePersonIds: normalizeStringArray(candidate.candidatePersonIds ?? candidate.candidate_person_ids),
+    conversationId: normalizeOptionalString(candidate.conversationId ?? candidate.conversation_id) ?? undefined,
+    contactPointId: normalizeOptionalString(candidate.contactPointId ?? candidate.contact_point_id) ?? undefined,
+    threadId: normalizeOptionalString(candidate.threadId ?? candidate.thread_id) ?? undefined,
+    identityState: normalizeSubjectIdentityState(candidate.identityState ?? candidate.identity_state),
+  };
+
+  if (!subjectContext.candidatePersonIds?.length) {
+    delete subjectContext.candidatePersonIds;
+  }
+
+  validateSubjectContext(subjectContext);
+  return subjectContext;
+};
+
 const parseResolverQueueDetail = (payload: unknown): ConnectShyftResolverQueueDetailData | null => {
   if (!payload || typeof payload !== 'object') {
     return null;
@@ -221,10 +263,16 @@ const parseResolverQueueDetail = (payload: unknown): ConnectShyftResolverQueueDe
     return null;
   }
 
+  const subjectContext = parseSubjectContext(envelope.data?.subjectContext);
+  if (!subjectContext) {
+    return null;
+  }
+
   return {
     item,
     review: parseResolverReviewRecord(envelope.data?.review),
     rebindReview: parseRebindReviewContext(envelope.data?.rebindReview),
+    subjectContext,
   };
 };
 

--- a/apps/connectshyft-web/src/features/connectshyft/settingsNavigation.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/settingsNavigation.ts
@@ -29,6 +29,24 @@ export type ShellSettingsNavigationItem = {
   path: string;
 };
 
+export type ShellSettingsNavigationState = {
+  items: ShellSettingsNavigationItem[];
+  allowedPaths: string[];
+};
+
+const DEFAULT_SETTINGS_NAVIGATION_STATE: ShellSettingsNavigationState = {
+  items: [
+    {
+      key: 'settings',
+      label: 'Call routing',
+      path: SHELL_ROUTE_PATHS.settings,
+    },
+  ],
+  allowedPaths: [
+    SHELL_ROUTE_PATHS.settings,
+  ],
+};
+
 const SETTINGS_PATH_TRANSLATIONS: Record<string, string> = {
   '/app/connectshyft/settings': SHELL_ROUTE_PATHS.settings,
   '/app/connectshyft/settings/availability': SHELL_ROUTE_PATHS.settingsAvailability,
@@ -65,6 +83,10 @@ const normalizeOption = (
 };
 
 export const fetchConnectShyftSettingsNavigation = async (): Promise<ShellSettingsNavigationItem[]> => {
+  return (await fetchConnectShyftSettingsNavigationState()).items;
+};
+
+export const fetchConnectShyftSettingsNavigationState = async (): Promise<ShellSettingsNavigationState> => {
   try {
     const response = await api.get('/connectshyft/settings/navigation', {
       headers: buildConnectShyftTestOverrideHeaders(),
@@ -87,22 +109,23 @@ export const fetchConnectShyftSettingsNavigation = async (): Promise<ShellSettin
       .map((option) => normalizeOption(option, allowedPaths))
       .filter((option): option is ShellSettingsNavigationItem => option !== null);
 
-    return items.length > 0
-      ? items
-      : [
-        {
-          key: 'settings',
-          label: 'Call routing',
-          path: SHELL_ROUTE_PATHS.settings,
-        },
-      ];
+    return {
+      items: items.length > 0
+        ? items
+        : [...DEFAULT_SETTINGS_NAVIGATION_STATE.items],
+      allowedPaths: allowedPaths.size > 0
+        ? [...allowedPaths]
+        : [...DEFAULT_SETTINGS_NAVIGATION_STATE.allowedPaths],
+    };
   } catch (_error) {
-    return [
-      {
-        key: 'settings',
-        label: 'Call routing',
-        path: SHELL_ROUTE_PATHS.settings,
-      },
-    ];
+    return {
+      items: [...DEFAULT_SETTINGS_NAVIGATION_STATE.items],
+      allowedPaths: [...DEFAULT_SETTINGS_NAVIGATION_STATE.allowedPaths],
+    };
   }
+};
+
+export const canAccessConnectShyftSettingsPath = async (path: string): Promise<boolean> => {
+  const navigationState = await fetchConnectShyftSettingsNavigationState();
+  return navigationState.allowedPaths.includes(path);
 };

--- a/apps/connectshyft-web/src/features/connectshyft/settingsNavigation.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/settingsNavigation.ts
@@ -1,0 +1,108 @@
+import api from '@/services/api';
+import { SHELL_ROUTE_PATHS } from '@/shell/routes';
+import { buildConnectShyftTestOverrideHeaders } from './flags';
+
+type SettingsNavigationOption = {
+  key?: string;
+  label?: string;
+  path?: string;
+};
+
+type SettingsNavigationPathway = {
+  path?: string;
+  allowed?: boolean;
+};
+
+type SettingsNavigationEnvelope = {
+  ok?: boolean;
+  message?: string;
+  data?: {
+    primaryOptions?: SettingsNavigationOption[];
+    adminOptions?: SettingsNavigationOption[];
+    pathways?: SettingsNavigationPathway[];
+  };
+};
+
+export type ShellSettingsNavigationItem = {
+  key: string;
+  label: string;
+  path: string;
+};
+
+const SETTINGS_PATH_TRANSLATIONS: Record<string, string> = {
+  '/app/connectshyft/settings': SHELL_ROUTE_PATHS.settings,
+  '/app/connectshyft/settings/availability': SHELL_ROUTE_PATHS.settingsAvailability,
+  '/app/connectshyft/settings/numbers': SHELL_ROUTE_PATHS.settingsNumbers,
+  '/app/connectshyft/settings/escalation': SHELL_ROUTE_PATHS.settingsEscalation,
+};
+
+const translateLegacySettingsPath = (path: string | undefined): string | null => {
+  if (!path) {
+    return null;
+  }
+
+  return SETTINGS_PATH_TRANSLATIONS[path] || null;
+};
+
+const normalizeOption = (
+  option: SettingsNavigationOption,
+  allowedPaths: Set<string>,
+): ShellSettingsNavigationItem | null => {
+  if (typeof option.key !== 'string' || typeof option.label !== 'string') {
+    return null;
+  }
+
+  const translatedPath = translateLegacySettingsPath(option.path);
+  if (!translatedPath || !allowedPaths.has(translatedPath)) {
+    return null;
+  }
+
+  return {
+    key: option.key,
+    label: option.label,
+    path: translatedPath,
+  };
+};
+
+export const fetchConnectShyftSettingsNavigation = async (): Promise<ShellSettingsNavigationItem[]> => {
+  try {
+    const response = await api.get('/connectshyft/settings/navigation', {
+      headers: buildConnectShyftTestOverrideHeaders(),
+    });
+    const envelope = response.data as SettingsNavigationEnvelope;
+    const pathways = Array.isArray(envelope?.data?.pathways)
+      ? envelope.data.pathways
+      : [];
+    const allowedPaths = new Set(
+      pathways
+        .filter((pathway) => pathway.allowed === true)
+        .map((pathway) => translateLegacySettingsPath(pathway.path))
+        .filter((path): path is string => path !== null),
+    );
+    const options = [
+      ...(Array.isArray(envelope?.data?.primaryOptions) ? envelope.data.primaryOptions : []),
+      ...(Array.isArray(envelope?.data?.adminOptions) ? envelope.data.adminOptions : []),
+    ];
+    const items = options
+      .map((option) => normalizeOption(option, allowedPaths))
+      .filter((option): option is ShellSettingsNavigationItem => option !== null);
+
+    return items.length > 0
+      ? items
+      : [
+        {
+          key: 'settings',
+          label: 'Call routing',
+          path: SHELL_ROUTE_PATHS.settings,
+        },
+      ];
+  } catch (_error) {
+    return [
+      {
+        key: 'settings',
+        label: 'Call routing',
+        path: SHELL_ROUTE_PATHS.settings,
+      },
+    ];
+  }
+};

--- a/apps/connectshyft-web/src/router/__tests__/shellBackbone.test.ts
+++ b/apps/connectshyft-web/src/router/__tests__/shellBackbone.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import router from '../index';
+import api from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+const apiGetMock = vi.mocked(api.get);
+
+beforeEach(() => {
+  apiGetMock.mockResolvedValue({
+    data: {
+      user: {
+        id: 'user-shell-backbone-1',
+      },
+    },
+  });
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await router.push('/login');
+});
+
+describe('shell backbone router', () => {
+  it('routes People, ConnectShyft, and Settings through the shared shell parent', async () => {
+    for (const path of ['/people', '/connect', '/settings']) {
+      await router.push(path);
+
+      expect(router.currentRoute.value.fullPath).toBe(path);
+      expect(router.currentRoute.value.matched[0]?.path).toBe('/');
+    }
+  });
+
+  it('supports the shell-safe fallback route inside the shell parent', async () => {
+    await router.push('/route-that-does-not-exist');
+
+    expect(router.currentRoute.value.name).toBe('shell-route-fallback');
+    expect(router.currentRoute.value.matched[0]?.path).toBe('/');
+  });
+
+  it('keeps legacy paths inside the shell route tree', async () => {
+    await router.push('/app/connectshyft/inbox');
+
+    expect(router.currentRoute.value.name).toBe('connectshyft-inbox');
+    expect(router.currentRoute.value.matched[0]?.path).toBe('/');
+  });
+});

--- a/apps/connectshyft-web/src/router/__tests__/shellBackbone.test.ts
+++ b/apps/connectshyft-web/src/router/__tests__/shellBackbone.test.ts
@@ -11,12 +11,52 @@ vi.mock('@/services/api', () => ({
 const apiGetMock = vi.mocked(api.get);
 
 beforeEach(() => {
-  apiGetMock.mockResolvedValue({
-    data: {
-      user: {
-        id: 'user-shell-backbone-1',
-      },
-    },
+  apiGetMock.mockImplementation(async (path: string) => {
+    if (path === '/auth/me') {
+      return {
+        data: {
+          user: {
+            id: 'user-shell-backbone-1',
+          },
+        },
+      };
+    }
+
+    if (path === '/connectshyft/settings/navigation') {
+      return {
+        data: {
+          ok: true,
+          data: {
+            primaryOptions: [
+              {
+                key: 'settings',
+                label: 'Call routing',
+                path: '/app/connectshyft/settings',
+              },
+            ],
+            adminOptions: [
+              {
+                key: 'availability',
+                label: 'Availability',
+                path: '/app/connectshyft/settings/availability',
+              },
+            ],
+            pathways: [
+              {
+                path: '/app/connectshyft/settings',
+                allowed: true,
+              },
+              {
+                path: '/app/connectshyft/settings/availability',
+                allowed: true,
+              },
+            ],
+          },
+        },
+      };
+    }
+
+    throw new Error(`Unexpected api.get call for ${path}`);
   });
 });
 
@@ -47,5 +87,54 @@ describe('shell backbone router', () => {
 
     expect(router.currentRoute.value.name).toBe('connectshyft-inbox');
     expect(router.currentRoute.value.matched[0]?.path).toBe('/');
+  });
+
+  it('redirects admin-only settings routes when backend navigation denies access', async () => {
+    apiGetMock.mockImplementation(async (path: string) => {
+      if (path === '/auth/me') {
+        return {
+          data: {
+            user: {
+              id: 'user-shell-backbone-1',
+            },
+          },
+        };
+      }
+
+      if (path === '/connectshyft/settings/navigation') {
+        return {
+          data: {
+            ok: true,
+            data: {
+              primaryOptions: [
+                {
+                  key: 'settings',
+                  label: 'Call routing',
+                  path: '/app/connectshyft/settings',
+                },
+              ],
+              adminOptions: [],
+              pathways: [
+                {
+                  path: '/app/connectshyft/settings',
+                  allowed: true,
+                },
+                {
+                  path: '/app/connectshyft/settings/availability',
+                  allowed: false,
+                },
+              ],
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected api.get call for ${path}`);
+    });
+
+    await router.push('/settings/availability');
+
+    expect(router.currentRoute.value.path).toBe('/settings');
+    expect(router.currentRoute.value.query.refusedPath).toBe('/settings/availability');
   });
 });

--- a/apps/connectshyft-web/src/router/index.ts
+++ b/apps/connectshyft-web/src/router/index.ts
@@ -100,6 +100,7 @@ const router = createRouter({
           meta: {
             shellModule: 'people',
             shellTitle: 'People',
+            shellOrgUnitFallback: 'people',
           },
         },
         {
@@ -109,6 +110,7 @@ const router = createRouter({
           meta: {
             shellModule: 'connect',
             shellTitle: 'ConnectShyft',
+            shellOrgUnitFallback: 'communication',
           },
           children: [
             {
@@ -136,6 +138,7 @@ const router = createRouter({
               component: ConnectShyftThreadDetailView,
               meta: {
                 shellTitle: 'ConnectShyft',
+                shellOrgUnitSwitchMode: 'destructive',
               },
             },
             {
@@ -154,6 +157,7 @@ const router = createRouter({
               component: ConnectShyftNeighborCreateView,
               meta: {
                 shellTitle: 'ConnectShyft',
+                shellOrgUnitSwitchMode: 'destructive',
               },
             },
             {
@@ -163,6 +167,7 @@ const router = createRouter({
               component: ConnectShyftNeighborProfileView,
               meta: {
                 shellTitle: 'ConnectShyft',
+                shellOrgUnitSwitchMode: 'destructive',
               },
             },
           ],
@@ -174,6 +179,7 @@ const router = createRouter({
           meta: {
             shellModule: 'settings',
             shellTitle: 'Settings',
+            shellOrgUnitFallback: 'shell',
           },
           children: [
             {

--- a/apps/connectshyft-web/src/router/index.ts
+++ b/apps/connectshyft-web/src/router/index.ts
@@ -1,11 +1,12 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import api from '@/services/api';
-
+import { beginShellNavigation, endShellNavigation } from '@/shell/navigationState';
+import { SHELL_ROUTE_PATHS } from '@/shell/routes';
+import { resolveConnectShyftAdminAccessFromQuery } from '@/features/connectshyft/settingsAccess';
 import ConnectShyftLoginView from '../views/Auth/ConnectShyftLoginView.vue';
 import ForgotPasswordView from '../views/Auth/ForgotPasswordView.vue';
 import ResetPasswordView from '../views/Auth/ResetPasswordView.vue';
 import ConnectShyftInboxView from '../views/ConnectShyft/ConnectShyftInboxView.vue';
-import ConnectShyftMoreView from '../views/ConnectShyft/ConnectShyftMoreView.vue';
 import ConnectShyftSettingsView from '../views/ConnectShyft/ConnectShyftSettingsView.vue';
 import ConnectShyftThreadDetailView from '../views/ConnectShyft/ConnectShyftThreadDetailView.vue';
 import ConnectShyftNeighborProfileView from '../views/ConnectShyft/ConnectShyftNeighborProfileView.vue';
@@ -14,17 +15,11 @@ import ConnectShyftDirectoryView from '../views/ConnectShyft/ConnectShyftDirecto
 import ConnectShyftAvailabilityView from '../views/ConnectShyft/ConnectShyftAvailabilityView.vue';
 import ConnectShyftNumberMappingsView from '../views/ConnectShyft/ConnectShyftNumberMappingsView.vue';
 import ConnectShyftEscalationSettingsView from '../views/ConnectShyft/ConnectShyftEscalationSettingsView.vue';
+import AppShellView from '../views/Shell/AppShellView.vue';
 import ConnectView from '../views/Shell/ConnectView.vue';
 import PeopleView from '../views/Shell/PeopleView.vue';
+import ShellRouteFallbackView from '../views/Shell/ShellRouteFallbackView.vue';
 import WorkView from '../views/Shell/WorkView.vue';
-import { resolveConnectShyftAdminAccessFromQuery } from '@/features/connectshyft/settingsAccess';
-
-const CONNECTSHYFT_APP_PREFIX = '/app/connectshyft';
-const CONNECTSHYFT_ADMIN_SETTINGS_PATHS = new Set([
-  '/app/connectshyft/settings/availability',
-  '/app/connectshyft/settings/numbers',
-  '/app/connectshyft/settings/escalation',
-]);
 
 const extractCurrentUser = (payload: unknown): Record<string, unknown> | null => {
   if (!payload || typeof payload !== 'object') {
@@ -72,114 +67,192 @@ const router = createRouter({
   history: createWebHistory(),
   routes: [
     {
-      path: '/login',
+      path: SHELL_ROUTE_PATHS.login,
       name: 'connectshyft-login',
       component: ConnectShyftLoginView,
     },
     {
-      path: '/auth/password/forgot',
+      path: SHELL_ROUTE_PATHS.forgotPassword,
       name: 'connectshyft-forgot-password',
       component: ForgotPasswordView,
     },
     {
-      path: '/auth/password/reset',
+      path: SHELL_ROUTE_PATHS.resetPassword,
       name: 'connectshyft-reset-password',
       component: ResetPasswordView,
     },
     {
       path: '/',
-      redirect: '/app/connectshyft/inbox',
-    },
-    {
-      path: '/app/connect',
-      name: 'shell-connect',
-      component: ConnectView,
-    },
-    {
-      path: '/app/people',
-      name: 'shell-people',
-      component: PeopleView,
-    },
-    {
-      path: '/app/work',
-      name: 'shell-work',
-      component: WorkView,
-    },
-    {
-      path: '/app/connectshyft/inbox',
-      name: 'connectshyft-inbox',
-      component: ConnectShyftInboxView,
-    },
-    {
-      path: '/app/connectshyft/mine',
-      name: 'connectshyft-mine',
-      component: ConnectShyftInboxView,
-    },
-    {
-      path: '/app/connectshyft/more',
-      name: 'connectshyft-more',
-      component: ConnectShyftMoreView,
-    },
-    {
-      path: '/app/connectshyft/settings',
-      name: 'connectshyft-settings',
-      component: ConnectShyftSettingsView,
-    },
-    {
-      path: '/app/connectshyft/threads/:threadId',
-      name: 'connectshyft-thread',
-      component: ConnectShyftThreadDetailView,
-    },
-    {
-      path: '/app/connectshyft/directory',
-      name: 'connectshyft-directory',
-      component: ConnectShyftDirectoryView,
-    },
-    {
-      path: '/app/connectshyft/neighbors/new',
-      name: 'connectshyft-neighbor-new',
-      component: ConnectShyftNeighborCreateView,
-    },
-    {
-      path: '/app/connectshyft/neighbors/:neighborId',
-      name: 'connectshyft-neighbor',
-      component: ConnectShyftNeighborProfileView,
-    },
-    {
-      path: '/app/connectshyft/settings/availability',
-      name: 'connectshyft-availability',
-      component: ConnectShyftAvailabilityView,
-    },
-    {
-      path: '/app/connectshyft/settings/numbers',
-      name: 'connectshyft-number-mappings',
-      component: ConnectShyftNumberMappingsView,
-    },
-    {
-      path: '/app/connectshyft/settings/escalation',
-      name: 'connectshyft-escalation',
-      component: ConnectShyftEscalationSettingsView,
+      component: AppShellView,
+      meta: {
+        requiresAuth: true,
+      },
+      children: [
+        {
+          path: '',
+          redirect: SHELL_ROUTE_PATHS.people,
+        },
+        {
+          path: 'people',
+          alias: ['/app/people'],
+          name: 'shell-people',
+          component: PeopleView,
+          meta: {
+            shellModule: 'people',
+            shellTitle: 'People',
+          },
+        },
+        {
+          path: 'connect',
+          alias: ['/app/connect'],
+          component: ConnectView,
+          meta: {
+            shellModule: 'connect',
+            shellTitle: 'ConnectShyft',
+          },
+          children: [
+            {
+              path: '',
+              alias: ['/app/connectshyft/inbox'],
+              name: 'connectshyft-inbox',
+              component: ConnectShyftInboxView,
+              meta: {
+                shellTitle: 'ConnectShyft',
+              },
+            },
+            {
+              path: 'mine',
+              alias: ['/app/connectshyft/mine'],
+              name: 'connectshyft-mine',
+              component: ConnectShyftInboxView,
+              meta: {
+                shellTitle: 'ConnectShyft',
+              },
+            },
+            {
+              path: 'threads/:threadId',
+              alias: ['/app/connectshyft/threads/:threadId'],
+              name: 'connectshyft-thread',
+              component: ConnectShyftThreadDetailView,
+              meta: {
+                shellTitle: 'ConnectShyft',
+              },
+            },
+            {
+              path: 'directory',
+              alias: ['/app/connectshyft/directory'],
+              name: 'connectshyft-directory',
+              component: ConnectShyftDirectoryView,
+              meta: {
+                shellTitle: 'ConnectShyft',
+              },
+            },
+            {
+              path: 'neighbors/new',
+              alias: ['/app/connectshyft/neighbors/new'],
+              name: 'connectshyft-neighbor-new',
+              component: ConnectShyftNeighborCreateView,
+              meta: {
+                shellTitle: 'ConnectShyft',
+              },
+            },
+            {
+              path: 'neighbors/:neighborId',
+              alias: ['/app/connectshyft/neighbors/:neighborId'],
+              name: 'connectshyft-neighbor',
+              component: ConnectShyftNeighborProfileView,
+              meta: {
+                shellTitle: 'ConnectShyft',
+              },
+            },
+          ],
+        },
+        {
+          path: 'settings',
+          alias: ['/app/work', '/app/connectshyft/more'],
+          component: WorkView,
+          meta: {
+            shellModule: 'settings',
+            shellTitle: 'Settings',
+          },
+          children: [
+            {
+              path: '',
+              alias: ['/app/connectshyft/settings'],
+              name: 'connectshyft-settings',
+              component: ConnectShyftSettingsView,
+              meta: {
+                shellTitle: 'Settings',
+              },
+            },
+            {
+              path: 'availability',
+              alias: ['/app/connectshyft/settings/availability'],
+              name: 'connectshyft-availability',
+              component: ConnectShyftAvailabilityView,
+              meta: {
+                shellTitle: 'Settings',
+                requiresConnectShyftAdminSettings: true,
+              },
+            },
+            {
+              path: 'numbers',
+              alias: ['/app/connectshyft/settings/numbers'],
+              name: 'connectshyft-number-mappings',
+              component: ConnectShyftNumberMappingsView,
+              meta: {
+                shellTitle: 'Settings',
+                requiresConnectShyftAdminSettings: true,
+              },
+            },
+            {
+              path: 'escalation',
+              alias: ['/app/connectshyft/settings/escalation'],
+              name: 'connectshyft-escalation',
+              component: ConnectShyftEscalationSettingsView,
+              meta: {
+                shellTitle: 'Settings',
+                requiresConnectShyftAdminSettings: true,
+              },
+            },
+          ],
+        },
+        {
+          path: ':pathMatch(.*)*',
+          name: 'shell-route-fallback',
+          component: ShellRouteFallbackView,
+          meta: {
+            shellTitle: 'Workspace unavailable',
+          },
+        },
+      ],
     },
   ],
 });
 
 router.beforeEach(async (to) => {
-  if (to.path === '/login' || to.path === '/auth/password/forgot' || to.path === '/auth/password/reset') {
+  beginShellNavigation();
+
+  if (
+    to.path === SHELL_ROUTE_PATHS.login
+    || to.path === SHELL_ROUTE_PATHS.forgotPassword
+    || to.path === SHELL_ROUTE_PATHS.resetPassword
+  ) {
     const authenticated = await refreshSessionState();
-    return authenticated ? '/app/connectshyft/inbox' : true;
+    return authenticated ? SHELL_ROUTE_PATHS.people : true;
   }
 
-  if (!to.path.startsWith(CONNECTSHYFT_APP_PREFIX)) {
+  if (!to.matched.some((record) => record.meta.requiresAuth === true)) {
     return true;
   }
 
   const authenticated = await refreshSessionState();
   if (authenticated) {
-    if (CONNECTSHYFT_ADMIN_SETTINGS_PATHS.has(to.path)) {
+    if (to.matched.some((record) => record.meta.requiresConnectShyftAdminSettings === true)) {
       const canAccessAdminSettings = resolveConnectShyftAdminAccessFromQuery(to.query);
       if (canAccessAdminSettings === false) {
         return {
-          path: '/app/connectshyft/settings',
+          path: SHELL_ROUTE_PATHS.settings,
           query: {
             ...to.query,
             refusedPath: to.path,
@@ -192,11 +265,19 @@ router.beforeEach(async (to) => {
   }
 
   return {
-    path: '/login',
+    path: SHELL_ROUTE_PATHS.login,
     query: {
       redirect: to.fullPath,
     },
   };
+});
+
+router.afterEach(() => {
+  endShellNavigation();
+});
+
+router.onError(() => {
+  endShellNavigation();
 });
 
 export default router;

--- a/apps/connectshyft-web/src/router/index.ts
+++ b/apps/connectshyft-web/src/router/index.ts
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router';
 import api from '@/services/api';
 import { beginShellNavigation, endShellNavigation } from '@/shell/navigationState';
 import { SHELL_ROUTE_PATHS } from '@/shell/routes';
-import { resolveConnectShyftAdminAccessFromQuery } from '@/features/connectshyft/settingsAccess';
+import { canAccessConnectShyftSettingsPath } from '@/features/connectshyft/settingsNavigation';
 import ConnectShyftLoginView from '../views/Auth/ConnectShyftLoginView.vue';
 import ForgotPasswordView from '../views/Auth/ForgotPasswordView.vue';
 import ResetPasswordView from '../views/Auth/ResetPasswordView.vue';
@@ -255,8 +255,8 @@ router.beforeEach(async (to) => {
   const authenticated = await refreshSessionState();
   if (authenticated) {
     if (to.matched.some((record) => record.meta.requiresConnectShyftAdminSettings === true)) {
-      const canAccessAdminSettings = resolveConnectShyftAdminAccessFromQuery(to.query);
-      if (canAccessAdminSettings === false) {
+      const canAccessAdminSettings = await canAccessConnectShyftSettingsPath(to.path);
+      if (!canAccessAdminSettings) {
         return {
           path: SHELL_ROUTE_PATHS.settings,
           query: {

--- a/apps/connectshyft-web/src/services/api.ts
+++ b/apps/connectshyft-web/src/services/api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type { AxiosInstance, AxiosError, InternalAxiosRequestConfig } from 'axios';
+import { readActiveShellOrgUnitId } from '@/shell/orgUnitState';
 
 const api: AxiosInstance = axios.create({
   baseURL: '/api/v1',
@@ -45,6 +46,14 @@ api.interceptors.request.use((config) => {
     const csrfToken = getCookieValue('csrf_token');
     if (csrfToken) {
       (config.headers as Record<string, string>)['X-CSRF-Token'] = csrfToken;
+    }
+  }
+
+  const existingOrgUnitHeader = (config.headers as Record<string, string>)['x-org-unit-id'];
+  if (!existingOrgUnitHeader) {
+    const activeOrgUnitId = readActiveShellOrgUnitId();
+    if (activeOrgUnitId) {
+      (config.headers as Record<string, string>)['x-org-unit-id'] = activeOrgUnitId;
     }
   }
 

--- a/apps/connectshyft-web/src/shell/__tests__/SubjectContext.test.ts
+++ b/apps/connectshyft-web/src/shell/__tests__/SubjectContext.test.ts
@@ -1,5 +1,9 @@
 import { validateSubjectContext } from '@shyft/contracts';
 import { describe, expect, it } from 'vitest';
+import {
+  resolveShellSubjectSummary,
+  subjectContextHasActiveSubject,
+} from '../subjectContext';
 
 describe('SubjectContext', () => {
   it('rejects contexts that carry both confirmed and provisional ids', () => {
@@ -10,5 +14,34 @@ describe('SubjectContext', () => {
         provisionalPersonId: 'person-connectshyft-web-2',
       }),
     ).toThrow('SubjectContext cannot include both personId and provisionalPersonId');
+  });
+
+  it('treats thread and candidate person context as active shared subject state', () => {
+    expect(subjectContextHasActiveSubject({
+      orgUnitId: 'org-connectshyft-web-1',
+      threadId: 'thread-connectshyft-web-1',
+      candidatePersonIds: ['person-connectshyft-web-1'],
+    })).toBe(true);
+  });
+
+  it('builds a stable summary shape for future shell subject presentation', () => {
+    expect(resolveShellSubjectSummary({
+      orgUnitId: 'org-connectshyft-web-1',
+      provisionalPersonId: 'person-connectshyft-web-1',
+      candidatePersonIds: ['person-connectshyft-web-1', 'person-connectshyft-web-2'],
+      conversationId: 'conversation-connectshyft-web-1',
+      contactPointId: 'contact-point-connectshyft-web-1',
+      threadId: 'thread-connectshyft-web-1',
+      identityState: 'provisional',
+    })).toEqual({
+      orgUnitId: 'org-connectshyft-web-1',
+      hasSubject: true,
+      hasPersonContext: true,
+      hasConversationContext: true,
+      hasContactPointContext: true,
+      hasThreadContext: true,
+      candidatePersonCount: 2,
+      identityState: 'provisional',
+    });
   });
 });

--- a/apps/connectshyft-web/src/shell/__tests__/featureFlags.test.ts
+++ b/apps/connectshyft-web/src/shell/__tests__/featureFlags.test.ts
@@ -1,10 +1,43 @@
 import { describe, expect, it } from 'vitest';
-import { defaultFeatureFlags, isFeatureEnabled } from '../featureFlags';
+import {
+  DEFAULT_SHELL_MODULE_AVAILABILITY,
+  isShellModuleAvailable,
+  resolveShellModuleAvailability,
+} from '../featureFlags';
 
 describe('featureFlags', () => {
-  it('returns true for enabled default flags', () => {
-    expect(isFeatureEnabled(defaultFeatureFlags, 'people.enabled')).toBe(true);
-    expect(isFeatureEnabled(defaultFeatureFlags, 'people.identityDecision.enabled')).toBe(true);
-    expect(isFeatureEnabled(defaultFeatureFlags, 'people.disabled')).toBe(false);
+  it('defaults the shell to People when no orgUnit context is loaded yet', () => {
+    expect(DEFAULT_SHELL_MODULE_AVAILABILITY).toEqual({
+      people: true,
+      connect: false,
+      settings: false,
+    });
+  });
+
+  it('resolves module visibility from the active orgUnit', () => {
+    const availability = resolveShellModuleAvailability([
+      {
+        id: 'org-east',
+        label: 'East Campus',
+        availableModules: {
+          people: true,
+          connect: true,
+          settings: true,
+        },
+      },
+      {
+        id: 'org-west',
+        label: 'West Campus',
+        availableModules: {
+          people: true,
+          connect: false,
+          settings: false,
+        },
+      },
+    ], 'org-west');
+
+    expect(isShellModuleAvailable(availability, 'people')).toBe(true);
+    expect(isShellModuleAvailable(availability, 'connect')).toBe(false);
+    expect(isShellModuleAvailable(availability, 'settings')).toBe(false);
   });
 });

--- a/apps/connectshyft-web/src/shell/__tests__/orgUnitRouteSafety.test.ts
+++ b/apps/connectshyft-web/src/shell/__tests__/orgUnitRouteSafety.test.ts
@@ -1,0 +1,161 @@
+import type { RouteLocationNormalizedLoaded } from 'vue-router';
+import { describe, expect, it } from 'vitest';
+import { evaluateShellOrgUnitSwitch, isShellRouteCompatibleWithOrgUnit } from '../orgUnitRouteSafety';
+
+const buildRoute = (input: {
+  path: string;
+  matched: Array<{
+    shellModule?: 'people' | 'connect' | 'settings';
+    shellOrgUnitFallback?: 'people' | 'communication' | 'shell';
+    shellOrgUnitSwitchMode?: 'safe' | 'destructive';
+  }>;
+}): RouteLocationNormalizedLoaded => ({
+  path: input.path,
+  fullPath: input.path,
+  name: null,
+  params: {},
+  query: {},
+  hash: '',
+  matched: input.matched.map((meta) => ({ meta })),
+  redirectedFrom: undefined,
+  meta: {},
+  href: input.path,
+} as unknown as RouteLocationNormalizedLoaded);
+
+const eastOrgUnit = {
+  id: 'org-east',
+  label: 'East Campus',
+  availableModules: {
+    people: true,
+    connect: true,
+    settings: true,
+  },
+};
+
+const westOrgUnit = {
+  id: 'org-west',
+  label: 'West Campus',
+  availableModules: {
+    people: true,
+    connect: true,
+    settings: true,
+  },
+};
+
+describe('orgUnit route safety', () => {
+  it('treats a module-safe route without an active subject as a safe switch', () => {
+    const route = buildRoute({
+      path: '/people',
+      matched: [
+        {
+          shellModule: 'people',
+          shellOrgUnitFallback: 'people',
+        },
+      ],
+    });
+
+    expect(evaluateShellOrgUnitSwitch({
+      route,
+      subjectContext: {
+        orgUnitId: 'org-east',
+      },
+      targetOrgUnit: westOrgUnit,
+    })).toEqual({
+      kind: 'safe',
+      requiredModule: 'people',
+      targetOrgUnit: westOrgUnit,
+    });
+  });
+
+  it('requires confirmation when the current route carries conversation context', () => {
+    const route = buildRoute({
+      path: '/connect/threads/thread-1',
+      matched: [
+        {
+          shellModule: 'connect',
+          shellOrgUnitFallback: 'communication',
+        },
+        {
+          shellOrgUnitSwitchMode: 'destructive',
+        },
+      ],
+    });
+
+    expect(evaluateShellOrgUnitSwitch({
+      route,
+      subjectContext: {
+        orgUnitId: 'org-east',
+        conversationId: 'conversation-1',
+      },
+      targetOrgUnit: westOrgUnit,
+    })).toEqual({
+      kind: 'destructive',
+      requiredModule: 'connect',
+      redirectPath: '/connect',
+      targetOrgUnit: westOrgUnit,
+    });
+  });
+
+  it('redirects to People when the current module is unavailable in the target orgUnit', () => {
+    const route = buildRoute({
+      path: '/connect/directory',
+      matched: [
+        {
+          shellModule: 'connect',
+          shellOrgUnitFallback: 'communication',
+        },
+      ],
+    });
+
+    expect(evaluateShellOrgUnitSwitch({
+      route,
+      subjectContext: {
+        orgUnitId: 'org-east',
+      },
+      targetOrgUnit: {
+        ...westOrgUnit,
+        availableModules: {
+          people: true,
+          connect: false,
+          settings: false,
+        },
+      },
+    })).toEqual({
+      kind: 'destructive',
+      requiredModule: 'connect',
+      redirectPath: '/people',
+      targetOrgUnit: {
+        ...westOrgUnit,
+        availableModules: {
+          people: true,
+          connect: false,
+          settings: false,
+        },
+      },
+    });
+  });
+
+  it('keeps a thread route valid when the current orgUnit and subject still match', () => {
+    const route = buildRoute({
+      path: '/connect/threads/thread-1',
+      matched: [
+        {
+          shellModule: 'connect',
+          shellOrgUnitFallback: 'communication',
+        },
+        {
+          shellOrgUnitSwitchMode: 'destructive',
+        },
+      ],
+    });
+
+    expect(isShellRouteCompatibleWithOrgUnit({
+      route,
+      subjectContext: {
+        orgUnitId: 'org-east',
+        conversationId: 'conversation-1',
+      },
+      targetOrgUnit: eastOrgUnit,
+    })).toBe(true);
+  });
+});

--- a/apps/connectshyft-web/src/shell/featureFlags.ts
+++ b/apps/connectshyft-web/src/shell/featureFlags.ts
@@ -1,10 +1,36 @@
-export type FeatureFlagMap = Record<string, boolean>;
+import type {
+  ConnectShyftShellModuleAvailability,
+  ConnectShyftShellOrgUnitOption,
+  ShyftUnityShellModuleKey,
+} from '@shyft/contracts';
 
-export const defaultFeatureFlags: FeatureFlagMap = {
-  'people.enabled': true,
-  'people.identityDecision.enabled': true,
+export const DEFAULT_SHELL_MODULE_AVAILABILITY: ConnectShyftShellModuleAvailability = {
+  people: true,
+  connect: false,
+  settings: false,
 };
 
-export function isFeatureEnabled(flags: FeatureFlagMap, key: string) {
-  return Boolean(flags[key]);
-}
+export const normalizeShellModuleAvailability = (
+  value: Partial<ConnectShyftShellModuleAvailability> | null | undefined,
+): ConnectShyftShellModuleAvailability => ({
+  people: value?.people !== false,
+  connect: value?.connect === true,
+  settings: value?.settings === true,
+});
+
+export const resolveShellModuleAvailability = (
+  orgUnits: readonly ConnectShyftShellOrgUnitOption[],
+  currentOrgUnitId: string,
+): ConnectShyftShellModuleAvailability => {
+  if (!currentOrgUnitId) {
+    return DEFAULT_SHELL_MODULE_AVAILABILITY;
+  }
+
+  const matchedOrgUnit = orgUnits.find((orgUnit) => orgUnit.id === currentOrgUnitId);
+  return normalizeShellModuleAvailability(matchedOrgUnit?.availableModules);
+};
+
+export const isShellModuleAvailable = (
+  availability: ConnectShyftShellModuleAvailability,
+  module: ShyftUnityShellModuleKey,
+): boolean => availability[module] === true;

--- a/apps/connectshyft-web/src/shell/navigationState.ts
+++ b/apps/connectshyft-web/src/shell/navigationState.ts
@@ -1,0 +1,13 @@
+import { readonly, ref } from 'vue';
+
+const shellNavigationPending = ref(false);
+
+export const beginShellNavigation = (): void => {
+  shellNavigationPending.value = true;
+};
+
+export const endShellNavigation = (): void => {
+  shellNavigationPending.value = false;
+};
+
+export const useShellNavigationState = () => readonly(shellNavigationPending);

--- a/apps/connectshyft-web/src/shell/orgUnitContext.ts
+++ b/apps/connectshyft-web/src/shell/orgUnitContext.ts
@@ -1,0 +1,187 @@
+import { readonly, ref } from 'vue';
+import type {
+  ConnectShyftShellContext,
+  ConnectShyftShellModuleAvailability,
+  ConnectShyftShellOrgUnitOption,
+} from '@shyft/contracts';
+import api from '@/services/api';
+import { buildConnectShyftTestOverrideHeaders } from '@/features/connectshyft/flags';
+import { setActiveShellOrgUnitId } from './orgUnitState';
+
+type ConnectShyftContextEnvelope = {
+  ok?: boolean;
+  message?: string;
+  data?: {
+    context?: unknown;
+  };
+};
+
+const availableShellOrgUnits = ref<ConnectShyftShellOrgUnitOption[]>([]);
+const shellOrgUnitLoading = ref(false);
+const shellOrgUnitError = ref('');
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const parseShellModuleAvailability = (
+  value: unknown,
+): ConnectShyftShellModuleAvailability => {
+  const candidate = value && typeof value === 'object'
+    ? value as Record<string, unknown>
+    : {};
+
+  return {
+    people: candidate.people !== false,
+    connect: candidate.connect === true,
+    settings: candidate.settings === true,
+  };
+};
+
+const parseShellOrgUnitOption = (value: unknown): ConnectShyftShellOrgUnitOption | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const id = normalizeString(candidate.id);
+  const label = normalizeString(candidate.label);
+
+  if (!id || !label) {
+    return null;
+  }
+
+  return {
+    id,
+    label,
+    availableModules: parseShellModuleAvailability(candidate.availableModules),
+  };
+};
+
+const parseShellContext = (value: unknown): ConnectShyftShellContext | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const tenantId = normalizeString(candidate.tenantId);
+  const orgUnitId = normalizeString(candidate.orgUnitId);
+
+  if (!tenantId || !orgUnitId) {
+    return null;
+  }
+
+  const rawOrgUnits = Array.isArray(candidate.orgUnits) ? candidate.orgUnits : [];
+  const orgUnits = rawOrgUnits
+    .map((entry) => parseShellOrgUnitOption(entry))
+    .filter((entry): entry is ConnectShyftShellOrgUnitOption => entry !== null);
+  const normalizedOrgUnits = orgUnits.some((orgUnit) => orgUnit.id === orgUnitId)
+    ? orgUnits
+    : [
+      {
+        id: orgUnitId,
+        label: 'Current org unit',
+        availableModules: parseShellModuleAvailability(null),
+      },
+      ...orgUnits,
+    ];
+
+  const telephonyCandidate = candidate.telephony && typeof candidate.telephony === 'object'
+    ? candidate.telephony as Record<string, unknown>
+    : {};
+
+  return {
+    tenantId,
+    orgUnitId,
+    bypassedOrgUnitMembership: candidate.bypassedOrgUnitMembership === true,
+    orgUnits: normalizedOrgUnits,
+    telephony: {
+      operatorPhoneSource: normalizeString(telephonyCandidate.operatorPhoneSource) || null,
+      voiceReady: telephonyCandidate.voiceReady === true,
+      smsReady: telephonyCandidate.smsReady === true,
+      degradedMode: telephonyCandidate.degradedMode === true,
+    },
+  };
+};
+
+const extractContextFromEnvelope = (payload: unknown): ConnectShyftShellContext | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const envelope = payload as ConnectShyftContextEnvelope;
+  return parseShellContext(envelope.data?.context);
+};
+
+const extractEnvelopeMessage = (payload: unknown, fallback: string): string => {
+  if (!payload || typeof payload !== 'object') {
+    return fallback;
+  }
+
+  const envelope = payload as ConnectShyftContextEnvelope;
+  return normalizeString(envelope.message) || fallback;
+};
+
+export const useShellAvailableOrgUnits = () => readonly(availableShellOrgUnits);
+
+export const useShellOrgUnitLoading = () => readonly(shellOrgUnitLoading);
+
+export const useShellOrgUnitError = () => readonly(shellOrgUnitError);
+
+export const findShellOrgUnit = (orgUnitId: string): ConnectShyftShellOrgUnitOption | null => (
+  availableShellOrgUnits.value.find((orgUnit) => orgUnit.id === orgUnitId) || null
+);
+
+export const applyShellContext = (context: ConnectShyftShellContext): void => {
+  availableShellOrgUnits.value = context.orgUnits;
+  shellOrgUnitError.value = '';
+  setActiveShellOrgUnitId(context.orgUnitId);
+};
+
+export const selectShellOrgUnit = (orgUnitId: string): ConnectShyftShellOrgUnitOption | null => {
+  const matchedOrgUnit = findShellOrgUnit(orgUnitId);
+  if (!matchedOrgUnit) {
+    return null;
+  }
+
+  setActiveShellOrgUnitId(matchedOrgUnit.id);
+  return matchedOrgUnit;
+};
+
+export const loadShellOrgUnitContext = async (): Promise<ConnectShyftShellContext | null> => {
+  shellOrgUnitLoading.value = true;
+
+  try {
+    const response = await api.get('/connectshyft/context', {
+      headers: buildConnectShyftTestOverrideHeaders(),
+    });
+    const context = extractContextFromEnvelope(response.data);
+    if (!context) {
+      shellOrgUnitError.value = 'Unable to load org unit access.';
+      return null;
+    }
+
+    applyShellContext(context);
+    return context;
+  } catch (error: unknown) {
+    const responseData = (error as { response?: { data?: unknown } })?.response?.data;
+    shellOrgUnitError.value = extractEnvelopeMessage(
+      responseData,
+      'Unable to load org unit access.',
+    );
+    return null;
+  } finally {
+    shellOrgUnitLoading.value = false;
+  }
+};
+
+export const resetShellOrgUnitContextForTests = (): void => {
+  availableShellOrgUnits.value = [];
+  shellOrgUnitLoading.value = false;
+  shellOrgUnitError.value = '';
+  setActiveShellOrgUnitId('');
+};

--- a/apps/connectshyft-web/src/shell/orgUnitRouteSafety.ts
+++ b/apps/connectshyft-web/src/shell/orgUnitRouteSafety.ts
@@ -1,0 +1,140 @@
+import type {
+  ConnectShyftShellOrgUnitOption,
+  SubjectContext,
+  ShyftUnityShellModuleKey,
+} from '@shyft/contracts';
+import type { RouteLocationNormalizedLoaded } from 'vue-router';
+import { SHELL_ROUTE_PATHS } from './routes';
+import { subjectContextHasActiveSubject } from './subjectContext';
+
+type ShellOrgUnitFallbackScope = 'people' | 'communication' | 'shell';
+
+export type ShellOrgUnitSwitchEvaluation =
+  | {
+    kind: 'safe';
+    targetOrgUnit: ConnectShyftShellOrgUnitOption;
+    requiredModule: ShyftUnityShellModuleKey;
+  }
+  | {
+    kind: 'destructive';
+    targetOrgUnit: ConnectShyftShellOrgUnitOption;
+    requiredModule: ShyftUnityShellModuleKey;
+    redirectPath: string;
+  };
+
+export const resolveShellRouteRequiredModule = (
+  route: RouteLocationNormalizedLoaded,
+): ShyftUnityShellModuleKey => {
+  const resolvedModule = [...route.matched]
+    .reverse()
+    .find((record) => typeof record.meta.shellModule === 'string')
+    ?.meta.shellModule;
+
+  if (resolvedModule === 'connect' || resolvedModule === 'settings') {
+    return resolvedModule;
+  }
+
+  return 'people';
+};
+
+const resolveFallbackScope = (
+  route: RouteLocationNormalizedLoaded,
+  requiredModule: ShyftUnityShellModuleKey,
+): ShellOrgUnitFallbackScope => {
+  const matchedScope = [...route.matched]
+    .reverse()
+    .find((record) => typeof record.meta.shellOrgUnitFallback === 'string')
+    ?.meta.shellOrgUnitFallback;
+
+  if (
+    matchedScope === 'people'
+    || matchedScope === 'communication'
+    || matchedScope === 'shell'
+  ) {
+    return matchedScope;
+  }
+
+  if (requiredModule === 'connect') {
+    return 'communication';
+  }
+
+  if (requiredModule === 'settings') {
+    return 'shell';
+  }
+
+  return 'people';
+};
+
+const resolveSwitchMode = (route: RouteLocationNormalizedLoaded): 'safe' | 'destructive' => {
+  const explicitMode = [...route.matched]
+    .reverse()
+    .find((record) => typeof record.meta.shellOrgUnitSwitchMode === 'string')
+    ?.meta.shellOrgUnitSwitchMode;
+
+  return explicitMode === 'destructive' ? 'destructive' : 'safe';
+};
+
+export const shellRouteModuleRemainsAvailable = (
+  targetOrgUnit: ConnectShyftShellOrgUnitOption,
+  requiredModule: ShyftUnityShellModuleKey,
+): boolean => targetOrgUnit.availableModules[requiredModule] === true;
+
+export const shellSubjectContextRemainsValid = (
+  subjectContext: SubjectContext,
+  targetOrgUnit: ConnectShyftShellOrgUnitOption,
+): boolean => (
+  !subjectContextHasActiveSubject(subjectContext)
+  || subjectContext.orgUnitId === targetOrgUnit.id
+);
+
+export const isShellRouteCompatibleWithOrgUnit = (input: {
+  route: RouteLocationNormalizedLoaded;
+  subjectContext: SubjectContext;
+  targetOrgUnit: ConnectShyftShellOrgUnitOption;
+}): boolean => {
+  const requiredModule = resolveShellRouteRequiredModule(input.route);
+  return (
+    shellRouteModuleRemainsAvailable(input.targetOrgUnit, requiredModule)
+    && shellSubjectContextRemainsValid(input.subjectContext, input.targetOrgUnit)
+  );
+};
+
+const resolveNearestValidLanding = (
+  scope: ShellOrgUnitFallbackScope,
+  targetOrgUnit: ConnectShyftShellOrgUnitOption,
+): string => {
+  if (scope === 'communication' && targetOrgUnit.availableModules.connect) {
+    return SHELL_ROUTE_PATHS.connect;
+  }
+
+  return SHELL_ROUTE_PATHS.people;
+};
+
+export const evaluateShellOrgUnitSwitch = (input: {
+  route: RouteLocationNormalizedLoaded;
+  subjectContext: SubjectContext;
+  targetOrgUnit: ConnectShyftShellOrgUnitOption;
+}): ShellOrgUnitSwitchEvaluation => {
+  const requiredModule = resolveShellRouteRequiredModule(input.route);
+  const switchMode = resolveSwitchMode(input.route);
+  const fallbackScope = resolveFallbackScope(input.route, requiredModule);
+  const canPreserveRoute =
+    switchMode === 'safe'
+    && shellRouteModuleRemainsAvailable(input.targetOrgUnit, requiredModule)
+    && shellSubjectContextRemainsValid(input.subjectContext, input.targetOrgUnit);
+
+  if (canPreserveRoute) {
+    return {
+      kind: 'safe',
+      targetOrgUnit: input.targetOrgUnit,
+      requiredModule,
+    };
+  }
+
+  return {
+    kind: 'destructive',
+    targetOrgUnit: input.targetOrgUnit,
+    requiredModule,
+    redirectPath: resolveNearestValidLanding(fallbackScope, input.targetOrgUnit),
+  };
+};

--- a/apps/connectshyft-web/src/shell/orgUnitState.ts
+++ b/apps/connectshyft-web/src/shell/orgUnitState.ts
@@ -1,0 +1,15 @@
+import { readonly, ref } from 'vue';
+
+const activeShellOrgUnitId = ref('');
+
+export const useActiveShellOrgUnitId = () => readonly(activeShellOrgUnitId);
+
+export const readActiveShellOrgUnitId = (): string => activeShellOrgUnitId.value;
+
+export const setActiveShellOrgUnitId = (orgUnitId: string): void => {
+  activeShellOrgUnitId.value = orgUnitId.trim();
+};
+
+export const resetActiveShellOrgUnitIdForTests = (): void => {
+  activeShellOrgUnitId.value = '';
+};

--- a/apps/connectshyft-web/src/shell/routes.ts
+++ b/apps/connectshyft-web/src/shell/routes.ts
@@ -1,0 +1,48 @@
+export type ShellModuleKey = 'people' | 'connect' | 'settings';
+
+export const SHELL_CANONICAL_HOST = 'app.shyftunity.com';
+
+export const SHELL_ROUTE_PATHS = {
+  people: '/people',
+  connect: '/connect',
+  connectMine: '/connect/mine',
+  connectDirectory: '/connect/directory',
+  settings: '/settings',
+  settingsAvailability: '/settings/availability',
+  settingsNumbers: '/settings/numbers',
+  settingsEscalation: '/settings/escalation',
+  login: '/login',
+  forgotPassword: '/auth/password/forgot',
+  resetPassword: '/auth/password/reset',
+} as const;
+
+export const SHELL_PRIMARY_NAV_ITEMS: Array<{
+  label: string;
+  path: string;
+  module: ShellModuleKey;
+}> = [
+  {
+    label: 'People',
+    path: SHELL_ROUTE_PATHS.people,
+    module: 'people',
+  },
+  {
+    label: 'ConnectShyft',
+    path: SHELL_ROUTE_PATHS.connect,
+    module: 'connect',
+  },
+  {
+    label: 'Settings',
+    path: SHELL_ROUTE_PATHS.settings,
+    module: 'settings',
+  },
+];
+
+export const buildConnectThreadPath = (threadId: string): string =>
+  `${SHELL_ROUTE_PATHS.connect}/threads/${encodeURIComponent(threadId)}`;
+
+export const buildConnectNeighborCreatePath = (): string =>
+  `${SHELL_ROUTE_PATHS.connect}/neighbors/new`;
+
+export const buildConnectNeighborPath = (neighborId: string): string =>
+  `${SHELL_ROUTE_PATHS.connect}/neighbors/${encodeURIComponent(neighborId)}`;

--- a/apps/connectshyft-web/src/shell/subjectContext.ts
+++ b/apps/connectshyft-web/src/shell/subjectContext.ts
@@ -3,14 +3,31 @@ import { InjectionKey, Ref, inject, ref } from 'vue';
 
 export const SUBJECT_CONTEXT_KEY: InjectionKey<Ref<SubjectContext>> = Symbol('subject-context');
 
-const DEFAULT_SUBJECT_CONTEXT: SubjectContext = {
-  orgUnitId: 'demo-org',
+export const createEmptySubjectContext = (orgUnitId = ''): SubjectContext => ({
+  orgUnitId,
+});
+
+export const subjectContextHasActiveSubject = (
+  subjectContext: SubjectContext | null | undefined,
+): boolean => Boolean(
+  subjectContext
+  && (
+    subjectContext.personId
+    || subjectContext.provisionalPersonId
+    || subjectContext.conversationId
+    || subjectContext.contactPointId
+  ),
+);
+
+export const clearSubjectContext = (
+  subjectContext: Ref<SubjectContext>,
+  orgUnitId = '',
+): void => {
+  subjectContext.value = createEmptySubjectContext(orgUnitId);
 };
 
 export function createSubjectContext(): Ref<SubjectContext> {
-  return ref<SubjectContext>({
-    ...DEFAULT_SUBJECT_CONTEXT,
-  });
+  return ref<SubjectContext>(createEmptySubjectContext());
 }
 
 export function useSubjectContext(): Ref<SubjectContext> {

--- a/apps/connectshyft-web/src/shell/subjectContext.ts
+++ b/apps/connectshyft-web/src/shell/subjectContext.ts
@@ -1,10 +1,32 @@
-import type { SubjectContext } from '@shyft/contracts';
+import type {
+  SubjectContext,
+  SubjectIdentityState,
+} from '@shyft/contracts';
+import { validateSubjectContext } from '@shyft/contracts';
 import { InjectionKey, Ref, inject, ref } from 'vue';
 
 export const SUBJECT_CONTEXT_KEY: InjectionKey<Ref<SubjectContext>> = Symbol('subject-context');
 
 export const createEmptySubjectContext = (orgUnitId = ''): SubjectContext => ({
   orgUnitId,
+});
+
+export type ShellSubjectSummary = {
+  orgUnitId: string;
+  hasSubject: boolean;
+  hasPersonContext: boolean;
+  hasConversationContext: boolean;
+  hasContactPointContext: boolean;
+  hasThreadContext: boolean;
+  candidatePersonCount: number;
+  identityState: SubjectIdentityState | null;
+};
+
+const cloneSubjectContext = (subjectContext: SubjectContext): SubjectContext => ({
+  ...subjectContext,
+  candidatePersonIds: subjectContext.candidatePersonIds
+    ? [...subjectContext.candidatePersonIds]
+    : undefined,
 });
 
 export const subjectContextHasActiveSubject = (
@@ -14,8 +36,10 @@ export const subjectContextHasActiveSubject = (
   && (
     subjectContext.personId
     || subjectContext.provisionalPersonId
+    || subjectContext.threadId
     || subjectContext.conversationId
     || subjectContext.contactPointId
+    || subjectContext.candidatePersonIds?.length
   ),
 );
 
@@ -25,6 +49,28 @@ export const clearSubjectContext = (
 ): void => {
   subjectContext.value = createEmptySubjectContext(orgUnitId);
 };
+
+export const replaceSubjectContext = (
+  subjectContext: Ref<SubjectContext>,
+  nextSubjectContext: SubjectContext,
+): void => {
+  const clonedSubjectContext = cloneSubjectContext(nextSubjectContext);
+  validateSubjectContext(clonedSubjectContext);
+  subjectContext.value = clonedSubjectContext;
+};
+
+export const resolveShellSubjectSummary = (
+  subjectContext: SubjectContext | null | undefined,
+): ShellSubjectSummary => ({
+  orgUnitId: subjectContext?.orgUnitId || '',
+  hasSubject: subjectContextHasActiveSubject(subjectContext),
+  hasPersonContext: Boolean(subjectContext?.personId || subjectContext?.provisionalPersonId),
+  hasConversationContext: Boolean(subjectContext?.conversationId),
+  hasContactPointContext: Boolean(subjectContext?.contactPointId),
+  hasThreadContext: Boolean(subjectContext?.threadId),
+  candidatePersonCount: subjectContext?.candidatePersonIds?.length || 0,
+  identityState: subjectContext?.identityState || null,
+});
 
 export function createSubjectContext(): Ref<SubjectContext> {
   return ref<SubjectContext>(createEmptySubjectContext());

--- a/apps/connectshyft-web/src/views/Auth/ConnectShyftLoginView.vue
+++ b/apps/connectshyft-web/src/views/Auth/ConnectShyftLoginView.vue
@@ -70,6 +70,7 @@
 import { ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import api from '@/services/api';
+import { SHELL_ROUTE_PATHS } from '@/shell/routes';
 
 const route = useRoute();
 const router = useRouter();
@@ -103,12 +104,12 @@ const resolveLoginErrorMessage = (error: unknown): string => {
 
 const resolveRedirectPath = (): string => {
   if (typeof route.query.redirect !== 'string') {
-    return '/app/connectshyft/inbox';
+    return SHELL_ROUTE_PATHS.people;
   }
 
   const trimmed = route.query.redirect.trim();
   if (!trimmed.startsWith('/')) {
-    return '/app/connectshyft/inbox';
+    return SHELL_ROUTE_PATHS.people;
   }
 
   return trimmed;

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftAvailabilityView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftAvailabilityView.vue
@@ -99,13 +99,11 @@
       </button>
     </section>
 
-    <ConnectShyftPrimaryNav />
   </main>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
-import ConnectShyftPrimaryNav from '@/components/connectshyft/ConnectShyftPrimaryNav.vue';
 import {
   DEFAULT_CONNECTSHYFT_AVAILABILITY,
   fetchConnectShyftAvailability,

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftDirectoryView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftDirectoryView.vue
@@ -140,6 +140,7 @@ import {
   CONNECTSHYFT_RESPONSIVE_BREAKPOINTS,
   sanitizeConnectShyftOperatorCopy,
 } from '@/features/connectshyft/uiContracts';
+import { buildConnectThreadPath } from '@/shell/routes';
 
 const DEFAULT_THREAD_INBOUND_NUMBER_ID = 'cs-number-default-inbound';
 const DEFAULT_THREAD_OUTBOUND_NUMBER_ID = 'cs-number-default-outbound';
@@ -357,7 +358,7 @@ const startConversation = async (neighborId: string): Promise<void> => {
   };
 
   await router.push({
-    path: `/app/connectshyft/threads/${encodeURIComponent(ensureResult.thread.threadId)}`,
+    path: buildConnectThreadPath(ensureResult.thread.threadId),
     query: nextQuery,
   });
 };

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftEscalationSettingsView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftEscalationSettingsView.vue
@@ -166,13 +166,11 @@
       </form>
     </section>
 
-    <ConnectShyftPrimaryNav />
   </main>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
-import ConnectShyftPrimaryNav from '@/components/connectshyft/ConnectShyftPrimaryNav.vue';
 import {
   connectShyftEscalationRecipientScopes,
   fetchConnectShyftEscalationRecipientOptions,

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftInboxView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftInboxView.vue
@@ -504,7 +504,6 @@
       </p>
     </section>
 
-    <ConnectShyftPrimaryNav />
   </main>
 </template>
 
@@ -514,7 +513,6 @@ import { RouterLink, useRoute, useRouter, type LocationQueryRaw } from 'vue-rout
 import ConnectShyftComposer from '@/components/connectshyft/ConnectShyftComposer.vue';
 import ConnectShyftMessageBubble from '@/components/connectshyft/ConnectShyftMessageBubble.vue';
 import ConnectShyftNeighborSnapshot from '@/components/connectshyft/ConnectShyftNeighborSnapshot.vue';
-import ConnectShyftPrimaryNav from '@/components/connectshyft/ConnectShyftPrimaryNav.vue';
 import ConnectShyftQueueCard from '@/components/connectshyft/ConnectShyftQueueCard.vue';
 import ConnectShyftThreadActionBar from '@/components/connectshyft/ConnectShyftThreadActionBar.vue';
 import ConnectShyftVoicemailCard from '@/components/connectshyft/ConnectShyftVoicemailCard.vue';
@@ -553,6 +551,10 @@ import {
   sanitizeConnectShyftOperatorCopy,
   type ConnectShyftFeedback,
 } from '@/features/connectshyft/uiContracts';
+import {
+  buildConnectNeighborCreatePath,
+  buildConnectThreadPath,
+} from '@/shell/routes';
 
 const DEFAULT_THREAD_NEIGHBOR_ID = 'neighbor-connectshyft-c1-1001';
 const DEFAULT_THREAD_INBOUND_NUMBER_ID = 'cs-inbound-c1-001';
@@ -580,7 +582,7 @@ const inboxActionPending = ref(false);
 const viewportWidth = ref(typeof window === 'undefined' ? 1280 : window.innerWidth);
 
 const bucket = computed<'inbox' | 'mine'>(() => {
-  return route.path.includes('/app/connectshyft/mine') ? 'mine' : 'inbox';
+  return route.name === 'connectshyft-mine' ? 'mine' : 'inbox';
 });
 
 const bucketTitle = computed(() => (bucket.value === 'mine' ? 'Mine' : 'Inbox'));
@@ -1124,12 +1126,12 @@ const threadActionPreferencePolicyState = computed(() => {
 
 const buildThreadDetailPath = (threadId: string): string => {
   if (typeof window === 'undefined') {
-    return `/app/connectshyft/threads/${encodeURIComponent(threadId)}`;
+    return buildConnectThreadPath(threadId);
   }
 
   const currentQuery = new URLSearchParams(window.location.search);
   const queryString = currentQuery.toString();
-  const basePath = `/app/connectshyft/threads/${encodeURIComponent(threadId)}`;
+  const basePath = buildConnectThreadPath(threadId);
 
   return queryString.length > 0
     ? `${basePath}?${queryString}`
@@ -1138,12 +1140,12 @@ const buildThreadDetailPath = (threadId: string): string => {
 
 const buildNeighborCreatePath = (): string => {
   if (typeof window === 'undefined') {
-    return '/app/connectshyft/neighbors/new';
+    return buildConnectNeighborCreatePath();
   }
 
   const currentQuery = new URLSearchParams(window.location.search);
   const queryString = currentQuery.toString();
-  const basePath = '/app/connectshyft/neighbors/new';
+  const basePath = buildConnectNeighborCreatePath();
 
   return queryString.length > 0
     ? `${basePath}?${queryString}`

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftMoreView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftMoreView.vue
@@ -102,14 +102,12 @@
       </div>
     </section>
 
-    <ConnectShyftPrimaryNav />
   </main>
 </template>
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import ConnectShyftPrimaryNav from '@/components/connectshyft/ConnectShyftPrimaryNav.vue';
 import { CONNECTSHYFT_RESPONSIVE_BREAKPOINTS } from '@/features/connectshyft/uiContracts';
 import {
   hasConnectShyftAdminSettingsCapability,

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNumberMappingsView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftNumberMappingsView.vue
@@ -113,13 +113,11 @@
       </section>
     </section>
 
-    <ConnectShyftPrimaryNav />
   </main>
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import ConnectShyftPrimaryNav from '@/components/connectshyft/ConnectShyftPrimaryNav.vue';
 import {
   fetchConnectShyftNumberMappings,
   saveConnectShyftNumberMapping,

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftSettingsView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftSettingsView.vue
@@ -214,14 +214,12 @@
       </section>
     </section>
 
-    <ConnectShyftPrimaryNav />
   </main>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
-import ConnectShyftPrimaryNav from '@/components/connectshyft/ConnectShyftPrimaryNav.vue';
 import {
   DEFAULT_CONNECTSHYFT_OPERATOR_CALLBACK_NUMBER,
   DEFAULT_CONNECTSHYFT_TELEPHONY_READINESS,

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
@@ -527,7 +527,6 @@
       </section>
     </section>
 
-    <ConnectShyftPrimaryNav />
   </main>
 </template>
 
@@ -538,7 +537,6 @@ import { RouterLink, useRoute } from 'vue-router';
 import ConnectShyftComposer from '@/components/connectshyft/ConnectShyftComposer.vue';
 import ConnectShyftMessageBubble from '@/components/connectshyft/ConnectShyftMessageBubble.vue';
 import ConnectShyftNeighborSnapshot from '@/components/connectshyft/ConnectShyftNeighborSnapshot.vue';
-import ConnectShyftPrimaryNav from '@/components/connectshyft/ConnectShyftPrimaryNav.vue';
 import ConnectShyftThreadActionBar from '@/components/connectshyft/ConnectShyftThreadActionBar.vue';
 import ConnectShyftThreadHeader from '@/components/connectshyft/ConnectShyftThreadHeader.vue';
 import ConnectShyftVoicemailCard from '@/components/connectshyft/ConnectShyftVoicemailCard.vue';
@@ -576,6 +574,7 @@ import {
   type ConnectShyftFeedback,
   type ConnectShyftFeedbackTaxonomy,
 } from '@/features/connectshyft/uiContracts';
+import { SHELL_ROUTE_PATHS } from '@/shell/routes';
 import { useSubjectContext } from '@/shell/subjectContext';
 
 const route = useRoute();
@@ -712,7 +711,7 @@ const threadSubjectImpactPresentation = computed(() => {
 });
 
 const peopleWorkspaceLink = computed(() => ({
-  path: '/app/people',
+  path: SHELL_ROUTE_PATHS.people,
   query: {
     ...route.query,
     ...(activeOrgUnitId.value ? { orgUnitId: activeOrgUnitId.value } : {}),

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
@@ -575,7 +575,10 @@ import {
   type ConnectShyftFeedbackTaxonomy,
 } from '@/features/connectshyft/uiContracts';
 import { SHELL_ROUTE_PATHS } from '@/shell/routes';
-import { useSubjectContext } from '@/shell/subjectContext';
+import {
+  replaceSubjectContext,
+  useSubjectContext,
+} from '@/shell/subjectContext';
 
 const route = useRoute();
 const subjectContext = useSubjectContext();
@@ -692,10 +695,7 @@ const activeOrgUnitId = computed<string>(() => {
   return queryOrgUnitId || subjectContext.value.orgUnitId || '';
 });
 
-const threadSubjectContext = computed<SubjectContext>(() => {
-  const subject = threadDetail.value?.subjectContext;
-  return subject && subject.orgUnitId ? subject : { orgUnitId: activeOrgUnitId.value };
-});
+const threadSubjectContext = computed<SubjectContext | null>(() => threadDetail.value?.subjectContext || null);
 
 const threadSubjectImpact = computed(() => threadDetail.value?.subjectImpact || null);
 
@@ -1812,9 +1812,11 @@ watch(closeModalOpen, (isOpen) => {
 watch(
   threadSubjectContext,
   (nextSubjectContext) => {
-    subjectContext.value = {
-      ...nextSubjectContext,
-    };
+    if (!nextSubjectContext) {
+      return;
+    }
+
+    replaceSubjectContext(subjectContext, nextSubjectContext);
   },
   {
     immediate: true,

--- a/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftThreadDetailView.test.ts
+++ b/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftThreadDetailView.test.ts
@@ -309,7 +309,7 @@ describe('ConnectShyftThreadDetailView', () => {
       'Review in People',
     );
     expect(wrapper.get('[data-testid="connectshyft-thread-subject-impact-people-link"]').attributes('href')).toContain(
-      '/app/people',
+      '/people',
     );
   });
 

--- a/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftThreadDetailView.test.ts
+++ b/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftThreadDetailView.test.ts
@@ -76,6 +76,8 @@ const buildThreadDetail = (overrides: Record<string, unknown> = {}) => ({
   subjectContext: {
     orgUnitId: 'org-connectshyft-ui-east',
     personId: 'person-detail-view-1001',
+    threadId: 'thread-detail-view-1001',
+    identityState: 'confirmed',
   },
   actions: ['Call', 'Text', 'Close'],
   timeline: [],
@@ -207,6 +209,8 @@ describe('ConnectShyftThreadDetailView', () => {
         subjectContext: {
           orgUnitId: 'org-connectshyft-ui-east',
           provisionalPersonId: 'person-detail-view-provisional-2005',
+          threadId: 'thread-detail-view-1001',
+          identityState: 'provisional',
         },
       }),
     });
@@ -225,6 +229,8 @@ describe('ConnectShyftThreadDetailView', () => {
     expect(shellSubjectContext.value).toEqual({
       orgUnitId: 'org-connectshyft-ui-east',
       provisionalPersonId: 'person-detail-view-provisional-2005',
+      threadId: 'thread-detail-view-1001',
+      identityState: 'provisional',
     });
     expect(shellSubjectContext.value).not.toHaveProperty('personId');
   });
@@ -239,6 +245,8 @@ describe('ConnectShyftThreadDetailView', () => {
     expect(shellSubjectContext.value).toEqual({
       orgUnitId: 'org-connectshyft-ui-east',
       personId: 'person-detail-view-1001',
+      threadId: 'thread-detail-view-1001',
+      identityState: 'confirmed',
     });
     expect(shellSubjectContext.value).not.toHaveProperty('provisionalPersonId');
   });
@@ -260,6 +268,8 @@ describe('ConnectShyftThreadDetailView', () => {
         subjectContext: {
           orgUnitId: 'org-connectshyft-ui-east',
           provisionalPersonId: 'person-detail-view-provisional-2006',
+          threadId: 'thread-detail-view-1001',
+          identityState: 'provisional',
         },
       }),
     });
@@ -294,6 +304,8 @@ describe('ConnectShyftThreadDetailView', () => {
         subjectContext: {
           orgUnitId: 'org-connectshyft-ui-east',
           provisionalPersonId: 'person-detail-view-resolver-2007',
+          threadId: 'thread-detail-view-1001',
+          identityState: 'provisional',
         },
       }),
     });
@@ -332,6 +344,8 @@ describe('ConnectShyftThreadDetailView', () => {
           subjectContext: {
             orgUnitId: 'org-connectshyft-ui-east',
             provisionalPersonId: 'person-detail-view-provisional-2008',
+            threadId: 'thread-detail-view-1001',
+            identityState: 'provisional',
           },
         }),
       })
@@ -346,6 +360,8 @@ describe('ConnectShyftThreadDetailView', () => {
           subjectContext: {
             orgUnitId: 'org-connectshyft-ui-east',
             personId: 'person-detail-view-confirmed-2008',
+            threadId: 'thread-detail-view-1001',
+            identityState: 'confirmed',
           },
         }),
       })
@@ -360,6 +376,8 @@ describe('ConnectShyftThreadDetailView', () => {
           subjectContext: {
             orgUnitId: 'org-connectshyft-ui-east',
             personId: 'person-detail-view-confirmed-2008',
+            threadId: 'thread-detail-view-1001',
+            identityState: 'confirmed',
           },
         }),
       });
@@ -383,6 +401,8 @@ describe('ConnectShyftThreadDetailView', () => {
     expect(shellSubjectContext.value).toEqual({
       orgUnitId: 'org-connectshyft-ui-east',
       personId: 'person-detail-view-confirmed-2008',
+      threadId: 'thread-detail-view-1001',
+      identityState: 'confirmed',
     });
   });
 });

--- a/apps/connectshyft-web/src/views/Shell/AppShellView.vue
+++ b/apps/connectshyft-web/src/views/Shell/AppShellView.vue
@@ -1,0 +1,88 @@
+<template>
+  <div data-testid="app-shell-root" class="min-h-screen bg-slate-100 text-slate-900">
+    <header class="border-b border-slate-200 bg-white/95 backdrop-blur">
+      <div class="mx-auto max-w-7xl px-4 py-5 sm:px-6">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div class="space-y-1">
+            <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+              ShyftUnity
+            </p>
+            <div class="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3">
+              <h1 class="text-2xl font-semibold tracking-tight text-slate-900">
+                {{ currentTitle }}
+              </h1>
+              <p class="text-sm text-slate-500">
+                {{ currentSummary }}
+              </p>
+            </div>
+          </div>
+
+          <div
+            data-testid="shell-orgunit-slot"
+            class="hidden min-h-[44px] min-w-[12rem] rounded-full border border-dashed border-slate-200 px-4 py-2 sm:block"
+            aria-hidden="true"
+          />
+        </div>
+
+        <div class="mt-4">
+          <ShellPrimaryNav />
+        </div>
+
+        <p
+          v-if="isNavigating"
+          data-testid="shell-loading-state"
+          class="mt-4 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600"
+        >
+          Loading workspace...
+        </p>
+
+        <div
+          data-testid="shell-subject-slot"
+          class="mt-4"
+          aria-hidden="true"
+        />
+      </div>
+    </header>
+
+    <div class="py-6">
+      <RouterView />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import ShellPrimaryNav from '@/components/shell/ShellPrimaryNav.vue';
+import { useShellNavigationState } from '@/shell/navigationState';
+
+const route = useRoute();
+const isNavigating = useShellNavigationState();
+
+const currentTitle = computed(() => {
+  const titledRecord = [...route.matched]
+    .reverse()
+    .find((record) => typeof record.meta.shellTitle === 'string');
+
+  return typeof titledRecord?.meta.shellTitle === 'string'
+    ? titledRecord.meta.shellTitle
+    : 'ShyftUnity';
+});
+
+const currentSummary = computed(() => {
+  const moduleRecord = [...route.matched]
+    .reverse()
+    .find((record) => typeof record.meta.shellModule === 'string');
+
+  switch (moduleRecord?.meta.shellModule) {
+    case 'people':
+      return 'Identity and resolver work stays inside one shared workspace.';
+    case 'connect':
+      return 'Inbox, directory, and thread work stay inside the shared shell.';
+    case 'settings':
+      return 'Callback setup and operational settings stay inside the same app frame.';
+    default:
+      return 'One shared shell for People and ConnectShyft.';
+  }
+});
+</script>

--- a/apps/connectshyft-web/src/views/Shell/AppShellView.vue
+++ b/apps/connectshyft-web/src/views/Shell/AppShellView.vue
@@ -60,7 +60,51 @@
     </header>
 
     <div class="py-6">
-      <RouterView v-slot="{ Component }">
+      <section
+        v-if="shellSurfaceState === 'error'"
+        data-testid="shell-surface-error"
+        class="mx-auto max-w-3xl px-4 sm:px-6"
+      >
+        <div class="rounded-[32px] border border-amber-200 bg-amber-50 p-8 text-amber-950 shadow-[0_24px_70px_-52px_rgba(15,23,42,0.2)]">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-amber-700">
+            Workspace unavailable
+          </p>
+          <h2 class="mt-3 text-2xl font-semibold tracking-tight">
+            We couldn’t load this workspace.
+          </h2>
+          <p class="mt-3 text-base text-amber-900/80">
+            {{ orgUnitError || 'Try again to reload your current access and workspace context.' }}
+          </p>
+          <button
+            type="button"
+            data-testid="shell-surface-retry"
+            class="mt-6 inline-flex min-h-[44px] items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700"
+            @click="retryShellSurface"
+          >
+            Retry
+          </button>
+        </div>
+      </section>
+
+      <section
+        v-else-if="shellSurfaceState !== 'ready'"
+        data-testid="shell-surface-loading"
+        class="mx-auto max-w-3xl px-4 sm:px-6"
+      >
+        <div class="rounded-[32px] border border-slate-200 bg-white p-8 text-slate-700 shadow-[0_24px_70px_-52px_rgba(15,23,42,0.2)]">
+          <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+            Loading
+          </p>
+          <h2 class="mt-3 text-2xl font-semibold tracking-tight text-slate-900">
+            Preparing your workspace
+          </h2>
+          <p class="mt-3 text-base text-slate-600">
+            We’re checking your current access and loading the right page.
+          </p>
+        </div>
+      </section>
+
+      <RouterView v-else v-slot="{ Component }">
         <component
           :is="Component"
           :key="shellRouteViewKey"
@@ -146,6 +190,7 @@ const currentOrgUnitId = useActiveShellOrgUnitId();
 const orgUnitLoading = useShellOrgUnitLoading();
 const orgUnitError = useShellOrgUnitError();
 const subjectContext = useSubjectContext();
+const shellSurfaceState = ref<'loading' | 'ready' | 'error'>('loading');
 const pendingOrgUnitSwitch = ref<{
   targetOrgUnit: ConnectShyftShellOrgUnitOption;
   redirectPath: string;
@@ -175,13 +220,13 @@ const currentTitle = computed(() => {
 const currentSummary = computed(() => {
   switch (currentShellModule.value) {
     case 'people':
-      return 'Identity and resolver work stays inside one shared workspace.';
+      return 'People records and review work stay together here.';
     case 'connect':
-      return 'Inbox, directory, and thread work stay inside the shared shell.';
+      return 'Inbox, directory, and conversations stay close at hand.';
     case 'settings':
-      return 'Callback setup and operational settings stay inside the same app frame.';
+      return 'Call routing and workspace settings stay in one place.';
     default:
-      return 'One shared shell for People and ConnectShyft.';
+      return 'One home for People and ConnectShyft.';
   }
 });
 
@@ -351,23 +396,38 @@ const confirmPendingOrgUnitSwitch = async (): Promise<void> => {
   });
 };
 
-onMounted(async () => {
-  const context = await loadShellOrgUnitContext();
-  if (!context) {
+const synchronizeShellSurface = async (reloadContext = false): Promise<void> => {
+  shellSurfaceState.value = 'loading';
+
+  if (reloadContext || !currentOrgUnitId.value) {
+    const context = await loadShellOrgUnitContext();
+    if (!context) {
+      shellSurfaceState.value = 'error';
+      return;
+    }
+  }
+
+  if (!currentOrgUnitId.value) {
+    shellSurfaceState.value = 'error';
     return;
   }
 
   await normalizeShellRoute();
+  shellSurfaceState.value = 'ready';
+};
+
+const retryShellSurface = async (): Promise<void> => {
+  await synchronizeShellSurface(true);
+};
+
+onMounted(() => {
+  void synchronizeShellSurface(true);
 });
 
 watch(
   () => route.fullPath,
   () => {
-    if (!currentOrgUnitId.value) {
-      return;
-    }
-
-    void normalizeShellRoute();
+    void synchronizeShellSurface(false);
   },
 );
 
@@ -375,6 +435,7 @@ defineExpose({
   handleOrgUnitSelection,
   confirmPendingOrgUnitSwitch,
   cancelPendingOrgUnitSwitch,
+  retryShellSurface,
   shellSubjectSummary,
 });
 </script>

--- a/apps/connectshyft-web/src/views/Shell/AppShellView.vue
+++ b/apps/connectshyft-web/src/views/Shell/AppShellView.vue
@@ -53,6 +53,8 @@
           data-testid="shell-subject-slot"
           class="mt-4"
           aria-hidden="true"
+          :data-subject-active="shellSubjectSummary.hasSubject ? 'true' : 'false'"
+          :data-subject-identity-state="shellSubjectSummary.identityState || undefined"
         />
       </div>
     </header>
@@ -130,6 +132,8 @@ import {
 import { useActiveShellOrgUnitId } from '@/shell/orgUnitState';
 import {
   clearSubjectContext,
+  replaceSubjectContext,
+  resolveShellSubjectSummary,
   subjectContextHasActiveSubject,
   useSubjectContext,
 } from '@/shell/subjectContext';
@@ -146,6 +150,17 @@ const pendingOrgUnitSwitch = ref<{
   targetOrgUnit: ConnectShyftShellOrgUnitOption;
   redirectPath: string;
 } | null>(null);
+const currentShellModule = computed<'people' | 'connect' | 'settings' | null>(() => {
+  const matchedModule = [...route.matched]
+    .reverse()
+    .find((record) => typeof record.meta.shellModule === 'string')
+    ?.meta.shellModule;
+
+  return matchedModule === 'people' || matchedModule === 'connect' || matchedModule === 'settings'
+    ? matchedModule
+    : null;
+});
+const shellSubjectSummary = computed(() => resolveShellSubjectSummary(subjectContext.value));
 
 const currentTitle = computed(() => {
   const titledRecord = [...route.matched]
@@ -158,11 +173,7 @@ const currentTitle = computed(() => {
 });
 
 const currentSummary = computed(() => {
-  const moduleRecord = [...route.matched]
-    .reverse()
-    .find((record) => typeof record.meta.shellModule === 'string');
-
-  switch (moduleRecord?.meta.shellModule) {
+  switch (currentShellModule.value) {
     case 'people':
       return 'Identity and resolver work stays inside one shared workspace.';
     case 'connect':
@@ -181,6 +192,10 @@ const buildRouteQueryWithOrgUnit = (orgUnitId: string): LocationQueryRaw => ({
   orgUnitId,
 });
 
+const routeSupportsShellSubjectContext = computed(() => (
+  currentShellModule.value === 'people' || currentShellModule.value === 'connect'
+));
+
 const syncSubjectOrgUnit = (orgUnitId: string): void => {
   if (!orgUnitId || subjectContextHasActiveSubject(subjectContext.value)) {
     return;
@@ -190,10 +205,19 @@ const syncSubjectOrgUnit = (orgUnitId: string): void => {
     return;
   }
 
-  subjectContext.value = {
+  replaceSubjectContext(subjectContext, {
     ...subjectContext.value,
     orgUnitId,
-  };
+  });
+};
+
+const normalizeSubjectContextForRoute = (orgUnitId: string): void => {
+  if (!routeSupportsShellSubjectContext.value) {
+    clearSubjectContext(subjectContext, orgUnitId);
+    return;
+  }
+
+  syncSubjectOrgUnit(orgUnitId);
 };
 
 const preserveCurrentRouteForOrgUnit = async (orgUnitId: string): Promise<void> => {
@@ -255,7 +279,7 @@ const normalizeShellRoute = async (): Promise<void> => {
   });
 
   if (routeIsCompatible) {
-    syncSubjectOrgUnit(resolvedOrgUnit.id);
+    normalizeSubjectContextForRoute(resolvedOrgUnit.id);
     const currentQueryOrgUnitId = typeof route.query.orgUnitId === 'string'
       ? route.query.orgUnitId.trim()
       : '';
@@ -351,5 +375,6 @@ defineExpose({
   handleOrgUnitSelection,
   confirmPendingOrgUnitSwitch,
   cancelPendingOrgUnitSwitch,
+  shellSubjectSummary,
 });
 </script>

--- a/apps/connectshyft-web/src/views/Shell/AppShellView.vue
+++ b/apps/connectshyft-web/src/views/Shell/AppShellView.vue
@@ -19,9 +19,22 @@
 
           <div
             data-testid="shell-orgunit-slot"
-            class="hidden min-h-[44px] min-w-[12rem] rounded-full border border-dashed border-slate-200 px-4 py-2 sm:block"
-            aria-hidden="true"
-          />
+            class="sm:min-w-[14rem]"
+          >
+            <ShellOrgUnitSelector
+              :current-org-unit-id="currentOrgUnitId"
+              :options="availableOrgUnits"
+              :loading="orgUnitLoading"
+              @request-switch="handleOrgUnitSelection"
+            />
+            <p
+              v-if="orgUnitError"
+              data-testid="shell-orgunit-error"
+              class="mt-2 text-xs text-rose-600"
+            >
+              {{ orgUnitError }}
+            </p>
+          </div>
         </div>
 
         <div class="mt-4">
@@ -45,19 +58,94 @@
     </header>
 
     <div class="py-6">
-      <RouterView />
+      <RouterView v-slot="{ Component }">
+        <component
+          :is="Component"
+          :key="shellRouteViewKey"
+        />
+      </RouterView>
+    </div>
+
+    <div
+      v-if="pendingOrgUnitSwitch"
+      data-testid="shell-orgunit-confirmation"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/35 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="shell-orgunit-confirmation-title"
+    >
+      <div class="w-full max-w-md rounded-3xl bg-white p-6 shadow-2xl">
+        <h2
+          id="shell-orgunit-confirmation-title"
+          class="text-lg font-semibold text-slate-900"
+        >
+          Switch orgUnit?
+        </h2>
+        <p class="mt-3 text-sm leading-6 text-slate-600">
+          This will clear the current person or conversation and take you to the nearest available page in the selected orgUnit.
+        </p>
+        <div class="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            data-testid="shell-orgunit-cancel"
+            class="rounded-2xl border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+            @click="cancelPendingOrgUnitSwitch"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="shell-orgunit-confirm-switch"
+            class="rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700"
+            @click="confirmPendingOrgUnitSwitch"
+          >
+            Switch orgUnit
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-import { useRoute } from 'vue-router';
+import type { ConnectShyftShellOrgUnitOption } from '@shyft/contracts';
+import { computed, onMounted, ref, watch } from 'vue';
+import type { LocationQueryRaw } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
+import ShellOrgUnitSelector from '@/components/shell/ShellOrgUnitSelector.vue';
 import ShellPrimaryNav from '@/components/shell/ShellPrimaryNav.vue';
 import { useShellNavigationState } from '@/shell/navigationState';
+import {
+  evaluateShellOrgUnitSwitch,
+  isShellRouteCompatibleWithOrgUnit,
+} from '@/shell/orgUnitRouteSafety';
+import {
+  findShellOrgUnit,
+  loadShellOrgUnitContext,
+  selectShellOrgUnit,
+  useShellAvailableOrgUnits,
+  useShellOrgUnitError,
+  useShellOrgUnitLoading,
+} from '@/shell/orgUnitContext';
+import { useActiveShellOrgUnitId } from '@/shell/orgUnitState';
+import {
+  clearSubjectContext,
+  subjectContextHasActiveSubject,
+  useSubjectContext,
+} from '@/shell/subjectContext';
 
 const route = useRoute();
+const router = useRouter();
 const isNavigating = useShellNavigationState();
+const availableOrgUnits = useShellAvailableOrgUnits();
+const currentOrgUnitId = useActiveShellOrgUnitId();
+const orgUnitLoading = useShellOrgUnitLoading();
+const orgUnitError = useShellOrgUnitError();
+const subjectContext = useSubjectContext();
+const pendingOrgUnitSwitch = ref<{
+  targetOrgUnit: ConnectShyftShellOrgUnitOption;
+  redirectPath: string;
+} | null>(null);
 
 const currentTitle = computed(() => {
   const titledRecord = [...route.matched]
@@ -84,5 +172,184 @@ const currentSummary = computed(() => {
     default:
       return 'One shared shell for People and ConnectShyft.';
   }
+});
+
+const shellRouteViewKey = computed(() => `${route.fullPath}::${currentOrgUnitId.value}`);
+
+const buildRouteQueryWithOrgUnit = (orgUnitId: string): LocationQueryRaw => ({
+  ...route.query,
+  orgUnitId,
+});
+
+const syncSubjectOrgUnit = (orgUnitId: string): void => {
+  if (!orgUnitId || subjectContextHasActiveSubject(subjectContext.value)) {
+    return;
+  }
+
+  if (subjectContext.value.orgUnitId === orgUnitId) {
+    return;
+  }
+
+  subjectContext.value = {
+    ...subjectContext.value,
+    orgUnitId,
+  };
+};
+
+const preserveCurrentRouteForOrgUnit = async (orgUnitId: string): Promise<void> => {
+  await router.replace({
+    path: route.path,
+    query: buildRouteQueryWithOrgUnit(orgUnitId),
+    hash: route.hash,
+  });
+};
+
+const redirectToLandingForOrgUnit = async (
+  orgUnitId: string,
+  redirectPath: string,
+): Promise<void> => {
+  await router.replace({
+    path: redirectPath,
+    query: buildRouteQueryWithOrgUnit(orgUnitId),
+  });
+};
+
+const applyOrgUnitSwitch = async (input: {
+  orgUnitId: string;
+  redirectPath?: string;
+  clearSubject: boolean;
+}): Promise<void> => {
+  const resolvedOrgUnit = selectShellOrgUnit(input.orgUnitId);
+  if (!resolvedOrgUnit) {
+    return;
+  }
+
+  if (input.clearSubject) {
+    clearSubjectContext(subjectContext, resolvedOrgUnit.id);
+  } else {
+    syncSubjectOrgUnit(resolvedOrgUnit.id);
+  }
+
+  if (input.redirectPath) {
+    await redirectToLandingForOrgUnit(resolvedOrgUnit.id, input.redirectPath);
+    return;
+  }
+
+  await preserveCurrentRouteForOrgUnit(resolvedOrgUnit.id);
+};
+
+const normalizeShellRoute = async (): Promise<void> => {
+  if (!currentOrgUnitId.value) {
+    return;
+  }
+
+  const resolvedOrgUnit = findShellOrgUnit(currentOrgUnitId.value);
+  if (!resolvedOrgUnit) {
+    return;
+  }
+
+  const routeIsCompatible = isShellRouteCompatibleWithOrgUnit({
+    route,
+    subjectContext: subjectContext.value,
+    targetOrgUnit: resolvedOrgUnit,
+  });
+
+  if (routeIsCompatible) {
+    syncSubjectOrgUnit(resolvedOrgUnit.id);
+    const currentQueryOrgUnitId = typeof route.query.orgUnitId === 'string'
+      ? route.query.orgUnitId.trim()
+      : '';
+    if (currentQueryOrgUnitId !== resolvedOrgUnit.id) {
+      await preserveCurrentRouteForOrgUnit(resolvedOrgUnit.id);
+    }
+    return;
+  }
+
+  clearSubjectContext(subjectContext, resolvedOrgUnit.id);
+  const fallbackEvaluation = evaluateShellOrgUnitSwitch({
+    route,
+    subjectContext: subjectContext.value,
+    targetOrgUnit: resolvedOrgUnit,
+  });
+  if (
+    fallbackEvaluation.kind === 'destructive'
+    && route.path !== fallbackEvaluation.redirectPath
+  ) {
+    await redirectToLandingForOrgUnit(resolvedOrgUnit.id, fallbackEvaluation.redirectPath);
+    return;
+  }
+
+  await preserveCurrentRouteForOrgUnit(resolvedOrgUnit.id);
+};
+
+const handleOrgUnitSelection = async (targetOrgUnitId: string): Promise<void> => {
+  const targetOrgUnit = findShellOrgUnit(targetOrgUnitId);
+  if (!targetOrgUnit || targetOrgUnit.id === currentOrgUnitId.value) {
+    return;
+  }
+
+  const evaluation = evaluateShellOrgUnitSwitch({
+    route,
+    subjectContext: subjectContext.value,
+    targetOrgUnit,
+  });
+
+  if (evaluation.kind === 'safe') {
+    await applyOrgUnitSwitch({
+      orgUnitId: targetOrgUnit.id,
+      clearSubject: false,
+    });
+    return;
+  }
+
+  pendingOrgUnitSwitch.value = {
+    targetOrgUnit,
+    redirectPath: evaluation.redirectPath,
+  };
+};
+
+const cancelPendingOrgUnitSwitch = (): void => {
+  pendingOrgUnitSwitch.value = null;
+};
+
+const confirmPendingOrgUnitSwitch = async (): Promise<void> => {
+  const pendingSwitch = pendingOrgUnitSwitch.value;
+  pendingOrgUnitSwitch.value = null;
+
+  if (!pendingSwitch) {
+    return;
+  }
+
+  await applyOrgUnitSwitch({
+    orgUnitId: pendingSwitch.targetOrgUnit.id,
+    redirectPath: pendingSwitch.redirectPath,
+    clearSubject: true,
+  });
+};
+
+onMounted(async () => {
+  const context = await loadShellOrgUnitContext();
+  if (!context) {
+    return;
+  }
+
+  await normalizeShellRoute();
+});
+
+watch(
+  () => route.fullPath,
+  () => {
+    if (!currentOrgUnitId.value) {
+      return;
+    }
+
+    void normalizeShellRoute();
+  },
+);
+
+defineExpose({
+  handleOrgUnitSelection,
+  confirmPendingOrgUnitSwitch,
+  cancelPendingOrgUnitSwitch,
 });
 </script>

--- a/apps/connectshyft-web/src/views/Shell/ConnectView.vue
+++ b/apps/connectshyft-web/src/views/Shell/ConnectView.vue
@@ -1,3 +1,24 @@
 <template>
-  <div>Connect shell view coming soon</div>
+  <div class="space-y-4">
+    <section class="mx-auto max-w-7xl px-4 sm:px-6">
+      <div class="rounded-[28px] border border-slate-200 bg-white/90 p-4 shadow-[0_20px_60px_-48px_rgba(15,23,42,0.24)]">
+        <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+          ConnectShyft workspace
+        </p>
+        <p class="mt-2 text-sm text-slate-600">
+          Inbox, directory, and conversation work stay inside the shared shell.
+        </p>
+      </div>
+
+      <div class="mt-4">
+        <ConnectShyftPrimaryNav />
+      </div>
+    </section>
+
+    <RouterView />
+  </div>
 </template>
+
+<script setup lang="ts">
+import ConnectShyftPrimaryNav from '@/components/connectshyft/ConnectShyftPrimaryNav.vue';
+</script>

--- a/apps/connectshyft-web/src/views/Shell/ConnectView.vue
+++ b/apps/connectshyft-web/src/views/Shell/ConnectView.vue
@@ -3,10 +3,10 @@
     <section class="mx-auto max-w-7xl px-4 sm:px-6">
       <div class="rounded-[28px] border border-slate-200 bg-white/90 p-4 shadow-[0_20px_60px_-48px_rgba(15,23,42,0.24)]">
         <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
-          ConnectShyft workspace
+          ConnectShyft
         </p>
         <p class="mt-2 text-sm text-slate-600">
-          Inbox, directory, and conversation work stay inside the shared shell.
+          Inbox, directory, and conversations stay together here.
         </p>
       </div>
 

--- a/apps/connectshyft-web/src/views/Shell/PeopleView.vue
+++ b/apps/connectshyft-web/src/views/Shell/PeopleView.vue
@@ -22,7 +22,11 @@ import {
   type ConnectShyftIdentityResolutionCandidate,
   type ConnectShyftIdentityResolutionResponse,
 } from '@/features/connectshyft/identityResolution';
-import { useSubjectContext } from '../../shell/subjectContext';
+import {
+  clearSubjectContext,
+  replaceSubjectContext,
+  useSubjectContext,
+} from '../../shell/subjectContext';
 
 type ResolverWorkspaceFilter =
   | 'all_active'
@@ -53,6 +57,7 @@ const selectedResolverQueueKey = ref('');
 const selectedResolverQueueDetail = ref<ConnectShyftResolverQueueDetailData | null>(null);
 const resolverDetailLoading = ref(false);
 const resolverDetailError = ref('');
+const manuallySelectedResolverQueueKey = ref('');
 
 const SAMPLE_CANDIDATES: ConnectShyftIdentityResolutionCandidate[] = [
   {
@@ -433,6 +438,15 @@ const clearSelectedResolverQueueDetail = () => {
   resolverDetailError.value = '';
 };
 
+const clearManualResolverSubjectSelection = (orgUnitId = '') => {
+  if (!manuallySelectedResolverQueueKey.value) {
+    return;
+  }
+
+  manuallySelectedResolverQueueKey.value = '';
+  clearSubjectContext(subjectContext, orgUnitId || subjectContext.value.orgUnitId);
+};
+
 const loadResolverQueue = async () => {
   resolverQueueLoading.value = true;
   resolverQueueError.value = '';
@@ -480,6 +494,7 @@ const loadResolverQueueDetail = async (
     if (result.unauthorized) {
       resolverQueueAuthorized.value = false;
       setResolverQueueItems([]);
+      clearManualResolverSubjectSelection(item.orgUnitId || subjectContext.value.orgUnitId);
       clearSelectedResolverQueueDetail();
       return;
     }
@@ -490,6 +505,9 @@ const loadResolverQueueDetail = async (
       setResolverQueueItems(resolverQueueItems.value.filter((queueItem) =>
         buildResolverQueueKey(queueItem.itemType, queueItem.id) !== requestKey));
       selectedResolverQueueDetail.value = null;
+      if (manuallySelectedResolverQueueKey.value === requestKey) {
+        clearManualResolverSubjectSelection(item.orgUnitId || subjectContext.value.orgUnitId);
+      }
       return;
     }
 
@@ -504,7 +522,19 @@ const loadResolverQueueDetail = async (
 };
 
 const selectResolverQueueItem = (item: ConnectShyftResolverQueueItemRecord) => {
-  selectedResolverQueueKey.value = buildResolverQueueKey(item.itemType, item.id);
+  const requestKey = buildResolverQueueKey(item.itemType, item.id);
+  manuallySelectedResolverQueueKey.value = requestKey;
+  selectedResolverQueueKey.value = requestKey;
+
+  if (selectedResolverQueueDetail.value) {
+    const detailKey = buildResolverQueueKey(
+      selectedResolverQueueDetail.value.item.itemType,
+      selectedResolverQueueDetail.value.item.id,
+    );
+    if (detailKey === requestKey) {
+      replaceSubjectContext(subjectContext, selectedResolverQueueDetail.value.subjectContext);
+    }
+  }
 };
 
 const runResolverQueueMutation = async (
@@ -528,6 +558,7 @@ const runResolverQueueMutation = async (
       resolverQueueAuthorized.value = false;
       setResolverQueueItems([]);
       selectedResolverQueueKey.value = '';
+      clearManualResolverSubjectSelection(item.orgUnitId || subjectContext.value.orgUnitId);
       clearSelectedResolverQueueDetail();
       return;
     }
@@ -538,6 +569,9 @@ const runResolverQueueMutation = async (
         buildResolverQueueKey(queueItem.itemType, queueItem.id) !== actionKey));
       selectedResolverQueueDetail.value = null;
       selectedResolverQueueKey.value = '';
+      if (manuallySelectedResolverQueueKey.value === actionKey) {
+        clearManualResolverSubjectSelection(item.orgUnitId || subjectContext.value.orgUnitId);
+      }
       return;
     }
 
@@ -577,6 +611,7 @@ const releaseSelectedResolverQueueItem = async () => {
 
 watch(filteredResolverQueueItems, (items) => {
   if (items.length === 0) {
+    clearManualResolverSubjectSelection(subjectContext.value.orgUnitId);
     selectedResolverQueueKey.value = '';
     clearSelectedResolverQueueDetail();
     return;
@@ -585,6 +620,13 @@ watch(filteredResolverQueueItems, (items) => {
   const hasSelectedItem = items.some((item) =>
     buildResolverQueueKey(item.itemType, item.id) === selectedResolverQueueKey.value);
   if (!hasSelectedItem) {
+    if (manuallySelectedResolverQueueKey.value) {
+      const hasManualSelection = items.some((item) =>
+        buildResolverQueueKey(item.itemType, item.id) === manuallySelectedResolverQueueKey.value);
+      if (!hasManualSelection) {
+        clearManualResolverSubjectSelection(subjectContext.value.orgUnitId);
+      }
+    }
     selectedResolverQueueKey.value = buildResolverQueueKey(items[0].itemType, items[0].id);
   }
 }, { immediate: true });
@@ -598,6 +640,19 @@ watch(selectedResolverQueueKey, (nextKey) => {
   }
 
   void loadResolverQueueDetail(item);
+});
+
+watch(selectedResolverQueueDetail, (nextDetail) => {
+  if (!nextDetail) {
+    return;
+  }
+
+  const detailKey = buildResolverQueueKey(nextDetail.item.itemType, nextDetail.item.id);
+  if (!manuallySelectedResolverQueueKey.value || detailKey !== manuallySelectedResolverQueueKey.value) {
+    return;
+  }
+
+  replaceSubjectContext(subjectContext, nextDetail.subjectContext);
 });
 
 onMounted(() => {

--- a/apps/connectshyft-web/src/views/Shell/PeopleView.vue
+++ b/apps/connectshyft-web/src/views/Shell/PeopleView.vue
@@ -3,8 +3,6 @@ import type {
   ConnectShyftResolverQueueDetailData,
   ConnectShyftResolverQueueItemRecord,
   ConnectShyftResolverQueueItemType,
-  ContactPoint,
-  ContactPointStatus,
   ResolverActionType,
   ResolverRiskFlag,
   ResolverReviewStatus,
@@ -18,15 +16,11 @@ import {
   releaseConnectShyftResolverQueueItem,
 } from '@/features/connectshyft/resolverQueue';
 import {
-  resolveConnectShyftIdentityResolutionPresentation,
-  type ConnectShyftIdentityResolutionCandidate,
-  type ConnectShyftIdentityResolutionResponse,
-} from '@/features/connectshyft/identityResolution';
-import {
   clearSubjectContext,
   replaceSubjectContext,
   useSubjectContext,
 } from '../../shell/subjectContext';
+import { useShellAvailableOrgUnits } from '../../shell/orgUnitContext';
 
 type ResolverWorkspaceFilter =
   | 'all_active'
@@ -42,10 +36,7 @@ type ResolverFilterDefinition = {
 };
 
 const subjectContext = useSubjectContext();
-const contactPoints = ref<ContactPoint[]>([]);
-const contactPointError = ref('');
-const decisionResult = ref<ConnectShyftIdentityResolutionResponse | null>(null);
-const decisionError = ref('');
+const availableOrgUnits = useShellAvailableOrgUnits();
 const resolverQueueItems = ref<ConnectShyftResolverQueueItemRecord[]>([]);
 const resolverQueueLoading = ref(false);
 const resolverQueueError = ref('');
@@ -58,21 +49,6 @@ const selectedResolverQueueDetail = ref<ConnectShyftResolverQueueDetailData | nu
 const resolverDetailLoading = ref(false);
 const resolverDetailError = ref('');
 const manuallySelectedResolverQueueKey = ref('');
-
-const SAMPLE_CANDIDATES: ConnectShyftIdentityResolutionCandidate[] = [
-  {
-    personId: 'person_very_high',
-    score: 140,
-    reasons: ['Exact phone match'],
-    contactPointStatus: 'reassignment_suspected',
-  },
-  {
-    personId: 'person_medium',
-    score: 60,
-    reasons: ['Name similarity'],
-    contactPointStatus: 'active_shared_possible',
-  },
-];
 
 const RESOLVER_FILTERS: ResolverFilterDefinition[] = [
   {
@@ -88,7 +64,7 @@ const RESOLVER_FILTERS: ResolverFilterDefinition[] = [
   {
     id: 'rebind_review',
     label: 'Rebind reviews',
-    description: 'Sensitive reassignment work that needs tenant-admin review.',
+    description: 'Sensitive reassignment work that needs review before it moves forward.',
   },
   {
     id: 'claimed_by_me',
@@ -98,42 +74,14 @@ const RESOLVER_FILTERS: ResolverFilterDefinition[] = [
   {
     id: 'unclaimed',
     label: 'Unclaimed',
-    description: 'Queue items ready for a tenant-admin to pick up.',
+    description: 'Queue items ready for someone to pick up.',
   },
 ];
 
-const isSharedStatus = (status: ContactPointStatus | null | undefined): boolean =>
-  status === 'active_shared_possible' || status === 'active_shared_confirmed';
-
-const isStaleStatus = (status: ContactPointStatus | null | undefined): boolean =>
-  status === 'stale';
-
-const isReassignmentStatus = (status: ContactPointStatus | null | undefined): boolean =>
-  status === 'reassignment_suspected';
-
-const warnMissingDecisionStatus = (payload: {
-  contactPointStatus?: ContactPointStatus;
-  candidates?: ConnectShyftIdentityResolutionCandidate[];
-}) => {
-  if (!payload.contactPointStatus) {
-    console.warn('ConnectShyft identity resolution response is missing contactPointStatus.');
-  }
-
-  (payload.candidates || []).forEach((candidate) => {
-    if (!candidate.contactPointStatus) {
-      console.warn('ConnectShyft identity resolution candidate is missing contactPointStatus.', {
-        personId: candidate.personId,
-      });
-    }
-  });
-};
-
-const decisionPresentation = computed(() => (
-  decisionResult.value
-    ? resolveConnectShyftIdentityResolutionPresentation(decisionResult.value)
-    : null
+const currentOrgUnitLabel = computed(() => (
+  availableOrgUnits.value.find((orgUnit) => orgUnit.id === subjectContext.value.orgUnitId)?.label
+  || 'Current workspace'
 ));
-const decisionCandidates = computed(() => decisionResult.value?.candidates || []);
 
 const buildResolverQueueKey = (itemType: ConnectShyftResolverQueueItemType, itemId: string): string =>
   `${itemType}:${itemId}`;
@@ -192,15 +140,15 @@ const selectedResolverQueueItem = computed(() => filteredResolverQueueItems.valu
 const resolverQueueSummary = computed(() => {
   const total = resolverQueueCounts.value.all_active;
   if (!resolverWorkspaceAccessible.value) {
-    return 'Resolver queue actions stay tenant-admin only. Read-safe PeopleCore identity context remains available below.';
+    return 'Review queue actions are not available for your access in this workspace.';
   }
 
   if (resolverQueueLoading.value && total === 0) {
-    return 'Loading backend-authored resolver work for this org unit.';
+    return 'Loading current review work for this workspace.';
   }
 
   if (total === 0) {
-    return 'No active resolver work is waiting right now. Identity and rebind reviews will appear here when backend truth requires action.';
+    return 'No review work is waiting right now. Identity and reassignment reviews will appear here when they need attention.';
   }
 
   const identityCount = resolverQueueCounts.value.identity_review;
@@ -258,7 +206,7 @@ const formatClaimStateLabel = (item: ConnectShyftResolverQueueItemRecord): strin
     case 'claimed_by_current_user':
       return 'Claimed by me';
     case 'claimed_by_other':
-      return 'Claimed by another resolver';
+      return 'Claimed elsewhere';
     default:
       return 'Unclaimed';
   }
@@ -317,7 +265,7 @@ const formatResolverRiskFlag = (flag: ResolverRiskFlag): string => {
 
 const formatResolverActionType = (value: ResolverActionType | null | undefined): string => {
   if (!value) {
-    return 'Tenant-admin review';
+    return 'Review required';
   }
 
   switch (value) {
@@ -342,14 +290,14 @@ const formatResolverActionType = (value: ResolverActionType | null | undefined):
 
 const buildQueueItemSummary = (item: ConnectShyftResolverQueueItemRecord): string => {
   if (item.itemType === 'rebind_review') {
-    return 'Sensitive reassignment work is waiting for tenant-admin review before historical ConnectShyft context moves with the new subject truth.';
+    return 'Sensitive record updates are waiting for review before conversation history moves to the right person.';
   }
 
   if (item.status === 'waiting_for_more_info') {
-    return 'Identity review is blocked until more information is available, but it stays in the active resolver workspace.';
+    return 'This review is waiting for more information before it can continue.';
   }
 
-  return 'Identity evidence requires tenant-admin confirmation before subject truth can be applied safely across PeopleCore and ConnectShyft.';
+  return 'Identity evidence needs review before People and ConnectShyft update together.';
 };
 
 const buildQueueItemContext = (item: ConnectShyftResolverQueueItemRecord): string[] => {
@@ -377,30 +325,30 @@ const buildIdentityReviewReason = (
   riskFlags: ResolverRiskFlag[],
 ): string => {
   if (reviewType === 'contact_point_reassignment') {
-    return 'This contact point may have moved between people, so tenant-admin review is required before identity truth changes.';
+    return 'This contact point may have moved between people, so review is required before identity updates.';
   }
 
   if (reviewType === 'shared_contact_ambiguity' || riskFlags.includes('shared_contact_possible')) {
-    return 'This contact point may belong to more than one person, so tenant-admin review is required before assignment is confirmed.';
+    return 'This contact point may belong to more than one person, so review is required before it is confirmed.';
   }
 
   if (riskFlags.includes('conflicting_name_dob')) {
-    return 'The current identity evidence conflicts, so a tenant admin needs to confirm the correct person before the workspace updates.';
+    return 'The current identity evidence conflicts, so the correct person needs review before the workspace updates.';
   }
 
-  return 'Tenant-admin review is required before PeopleCore and ConnectShyft can rely on this identity outcome.';
+  return 'Review is required before People and ConnectShyft can rely on this identity outcome.';
 };
 
 const buildRebindReviewReason = (resolutionType: ResolverActionType | null | undefined): string => {
   if (resolutionType === 'reassign_contact_point') {
-    return 'A contact-point reassignment created sensitive follow-up work, so tenant-admin review is required before historical context is rebound.';
+    return 'A contact-point reassignment created sensitive follow-up work, so review is required before history is rebound.';
   }
 
   if (resolutionType === 'merge_people') {
-    return 'A person merge created sensitive follow-up work, so tenant-admin review is required before historical context is rebound.';
+    return 'A person merge created sensitive follow-up work, so review is required before history is rebound.';
   }
 
-  return 'This reassignment affects sensitive ConnectShyft context, so tenant-admin review is required before the new subject truth is fully applied.';
+  return 'This reassignment affects sensitive ConnectShyft context, so review is required before the new person record is fully applied.';
 };
 
 const formatIdentityReviewStatus = (value: ResolverReviewStatus | undefined): string => {
@@ -658,57 +606,15 @@ watch(selectedResolverQueueDetail, (nextDetail) => {
 onMounted(() => {
   void loadResolverQueue();
 });
-
-async function loadContactPoints() {
-  contactPointError.value = '';
-
-  try {
-    const response = await fetch('/people/contact-points');
-    if (!response.ok) {
-      throw new Error(`Failed to load contact points (${response.status})`);
-    }
-
-    contactPoints.value = (await response.json()) as ContactPoint[];
-  } catch (error) {
-    contactPointError.value = error instanceof Error ? error.message : 'Failed to load contact points';
-  }
-}
-
-async function runSampleDecision() {
-  decisionError.value = '';
-
-  try {
-    const response = await fetch('/people/identity/decision', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        candidates: SAMPLE_CANDIDATES,
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to run identity decision (${response.status})`);
-    }
-
-    const payload = (await response.json()) as ConnectShyftIdentityResolutionResponse;
-    warnMissingDecisionStatus(payload);
-    decisionResult.value = payload;
-  } catch (error) {
-    decisionError.value = error instanceof Error ? error.message : 'Failed to run identity decision';
-  }
-}
 </script>
 
 <template>
   <section class="space-y-6 p-4">
     <div class="space-y-1">
-      <h1 class="text-xl font-semibold text-slate-900">People shell</h1>
-      <p class="text-sm text-slate-600">Org unit: {{ subjectContext.orgUnitId }}</p>
+      <h1 class="text-xl font-semibold text-slate-900">People</h1>
+      <p class="text-sm text-slate-600">Current workspace: {{ currentOrgUnitLabel }}</p>
       <p class="text-sm text-slate-500">
-        Tenant-admin resolvers work the shared identity and rebind queue here. Existing PeopleCore
-        identity scaffolds stay available below for compatibility.
+        Identity review and record updates stay grounded here while current conversation context stays connected.
       </p>
     </div>
 
@@ -747,8 +653,7 @@ async function runSampleDecision() {
         data-test="resolver-workspace-locked"
         class="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
       >
-        Resolver queue actions are available only to tenant-admin resolvers. People identity status
-        remains visible below where it is safe to show.
+        Review queue actions are not available for your current access in this workspace.
       </p>
 
       <div v-else class="mt-4 grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(20rem,0.82fr)]">
@@ -975,7 +880,7 @@ async function runSampleDecision() {
                     disabled
                     class="inline-flex min-h-[44px] items-center justify-center rounded-full border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 disabled:cursor-not-allowed"
                   >
-                    Claimed by another resolver
+                    Already in progress
                   </button>
                 </div>
               </div>
@@ -992,7 +897,7 @@ async function runSampleDecision() {
                 data-test="resolver-detail-claimed-by-other"
                 class="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900"
               >
-                Another tenant-admin resolver is currently working this item, so it is not actionable here.
+                Someone else is currently working this item, so it is not actionable here.
               </p>
               <p
                 v-else-if="selectedResolverQueueItem.status === 'waiting_for_more_info'"
@@ -1172,7 +1077,7 @@ async function runSampleDecision() {
               v-else
               class="rounded-2xl border border-slate-200 bg-white px-4 py-6 text-sm text-slate-600"
             >
-              Select a resolver item to inspect its backend-authored context.
+              Select a review item to inspect its current context.
             </p>
           </div>
 
@@ -1181,164 +1086,10 @@ async function runSampleDecision() {
             data-test="resolver-detail-empty"
             class="rounded-2xl border border-dashed border-slate-200 px-4 py-8 text-center text-sm text-slate-500"
           >
-            Select a resolver item to inspect its context and claim state.
+            Select a review item to inspect its context and action state.
           </p>
         </section>
       </div>
     </section>
-
-    <div class="space-y-2">
-      <button
-        data-test="load-contact-points"
-        type="button"
-        class="rounded-full border border-slate-300 px-3 py-2 text-sm text-slate-700"
-        @click="loadContactPoints"
-      >
-        Load contact points
-      </button>
-
-      <p
-        v-if="contactPointError"
-        class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
-      >
-        {{ contactPointError }}
-      </p>
-
-      <ul v-if="contactPoints.length > 0" class="space-y-2 pl-5">
-        <li
-          v-for="contactPoint in contactPoints"
-          :key="contactPoint.id"
-          class="flex flex-wrap items-center gap-2 text-sm text-slate-700"
-        >
-          <span>{{ contactPoint.type }} | {{ contactPoint.normalizedValue }} | {{ contactPoint.status }}</span>
-          <span
-            v-if="isSharedStatus(contactPoint.status)"
-            data-test="contact-point-shared-indicator"
-            role="status"
-            aria-label="Shared contact point indicator"
-            class="border border-amber-400 px-2 py-0.5 text-xs"
-          >
-            Shared
-          </span>
-          <span
-            v-if="isStaleStatus(contactPoint.status)"
-            data-test="contact-point-stale-indicator"
-            role="status"
-            aria-label="Stale contact point indicator"
-            class="border border-slate-400 px-2 py-0.5 text-xs"
-          >
-            Stale
-          </span>
-          <span
-            v-if="isReassignmentStatus(contactPoint.status)"
-            data-test="contact-point-reassignment-indicator"
-            role="status"
-            aria-label="Reassignment risk indicator"
-            class="border border-rose-400 px-2 py-0.5 text-xs"
-          >
-            Reassignment risk
-          </span>
-        </li>
-      </ul>
-      <p v-else class="text-sm text-slate-500">No contact points loaded yet.</p>
-    </div>
-
-    <div class="space-y-2">
-      <button
-        data-test="run-sample-decision"
-        type="button"
-        class="rounded-full border border-slate-300 px-3 py-2 text-sm text-slate-700"
-        @click="runSampleDecision"
-      >
-        Run sample identity decision
-      </button>
-
-      <p
-        v-if="decisionError"
-        class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
-      >
-        {{ decisionError }}
-      </p>
-
-      <div v-if="decisionResult && decisionPresentation" data-test="decision-result" class="space-y-2">
-        <p class="text-sm text-slate-700">Confidence band: {{ decisionResult.confidenceBand }}</p>
-        <p class="text-sm text-slate-700">Resolution state: {{ decisionPresentation.resolvedState }}</p>
-        <p class="text-sm text-slate-700">Default action: {{ decisionPresentation.defaultAction }}</p>
-        <p data-test="decision-guidance" class="text-sm text-slate-600">{{ decisionPresentation.guidance }}</p>
-        <p v-if="decisionResult.resolverReviewId" data-test="resolver-review-id" class="text-sm text-slate-700">
-          Resolver review: {{ decisionResult.resolverReviewId }}
-        </p>
-        <ul
-          v-if="decisionPresentation.showCandidates && decisionCandidates.length > 0"
-          data-test="decision-candidates"
-          class="space-y-2 pl-5"
-        >
-          <li
-            v-for="candidate in decisionCandidates"
-            :key="candidate.personId"
-            class="flex flex-wrap items-center gap-2 text-sm text-slate-700"
-          >
-            <span>{{ candidate.personId }} (score {{ candidate.score }})</span>
-            <span data-test="decision-candidate-status">
-              {{ candidate.contactPointStatus }}
-            </span>
-            <span
-              v-if="isSharedStatus(candidate.contactPointStatus)"
-              data-test="decision-candidate-shared-indicator"
-              role="status"
-              aria-label="Shared decision candidate indicator"
-              class="border border-amber-400 px-2 py-0.5 text-xs"
-            >
-              Shared
-            </span>
-            <span
-              v-if="isStaleStatus(candidate.contactPointStatus)"
-              data-test="decision-candidate-stale-indicator"
-              role="status"
-              aria-label="Stale decision candidate indicator"
-              class="border border-slate-400 px-2 py-0.5 text-xs"
-            >
-              Stale
-            </span>
-            <span
-              v-if="isReassignmentStatus(candidate.contactPointStatus)"
-              data-test="decision-candidate-reassignment-indicator"
-              role="status"
-              aria-label="Reassignment risk decision candidate indicator"
-              class="border border-rose-400 px-2 py-0.5 text-xs"
-            >
-              Reassignment risk
-            </span>
-          </li>
-        </ul>
-        <div class="flex flex-wrap gap-2">
-          <button
-            v-if="decisionPresentation.showAttachAction"
-            data-test="attach-existing"
-            type="button"
-            class="rounded-full border border-slate-300 px-3 py-2 text-sm text-slate-700"
-          >
-            Attach to suggested match
-          </button>
-          <button
-            v-if="decisionPresentation.showCreateNewAction"
-            data-test="create-new"
-            type="button"
-            class="rounded-full border border-slate-300 px-3 py-2 text-sm text-slate-700 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
-            :disabled="!decisionPresentation.createNewAllowed"
-          >
-            Create new person
-          </button>
-        </div>
-        <p
-          v-if="decisionPresentation.mode === 'resolver_required'"
-          data-test="resolver-required-message"
-          class="text-sm text-slate-600"
-        >
-          Resolver review is required before creating a new person.
-        </p>
-      </div>
-      <p v-else class="text-sm text-slate-500">No identity decision run yet.</p>
-    </div>
   </section>
 </template>

--- a/apps/connectshyft-web/src/views/Shell/ShellRouteFallbackView.vue
+++ b/apps/connectshyft-web/src/views/Shell/ShellRouteFallbackView.vue
@@ -11,21 +11,18 @@
         We couldn’t open that page.
       </h2>
       <p class="mt-3 text-base text-slate-600">
-        Return to People or ConnectShyft to keep working inside the shared shell.
+        Return to an available workspace to keep moving.
       </p>
 
       <div class="mt-6 flex flex-wrap gap-3">
         <RouterLink
-          :to="SHELL_ROUTE_PATHS.people"
+          v-for="action in fallbackActions"
+          :key="action.path"
+          :to="{ path: action.path, query: navigationQuery }"
+          :data-testid="`shell-route-fallback-${action.module}`"
           class="inline-flex min-h-[44px] items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
         >
-          Open People
-        </RouterLink>
-        <RouterLink
-          :to="SHELL_ROUTE_PATHS.connect"
-          class="inline-flex min-h-[44px] items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700"
-        >
-          Open ConnectShyft
+          {{ action.label }}
         </RouterLink>
       </div>
     </div>
@@ -33,5 +30,41 @@
 </template>
 
 <script setup lang="ts">
-import { SHELL_ROUTE_PATHS } from '@/shell/routes';
+import type { LocationQueryRaw } from 'vue-router';
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { useShellAvailableOrgUnits } from '@/shell/orgUnitContext';
+import { useActiveShellOrgUnitId } from '@/shell/orgUnitState';
+import { isShellModuleAvailable, resolveShellModuleAvailability } from '@/shell/featureFlags';
+import { SHELL_PRIMARY_NAV_ITEMS } from '@/shell/routes';
+
+const route = useRoute();
+const availableOrgUnits = useShellAvailableOrgUnits();
+const currentOrgUnitId = useActiveShellOrgUnitId();
+
+const navigationQuery = computed<LocationQueryRaw>(() => {
+  const {
+    refusedPath: _refusedPath,
+    settingsRefusal: _settingsRefusal,
+    settingsRefusedPath: _settingsRefusedPath,
+    ...rest
+  } = route.query;
+
+  return rest as LocationQueryRaw;
+});
+
+const fallbackActions = computed(() => {
+  const moduleAvailability = resolveShellModuleAvailability(
+    availableOrgUnits.value,
+    currentOrgUnitId.value,
+  );
+
+  return SHELL_PRIMARY_NAV_ITEMS
+    .filter((item) => item.module !== 'settings')
+    .filter((item) => isShellModuleAvailable(moduleAvailability, item.module))
+    .map((item) => ({
+      ...item,
+      label: `Open ${item.label}`,
+    }));
+});
 </script>

--- a/apps/connectshyft-web/src/views/Shell/ShellRouteFallbackView.vue
+++ b/apps/connectshyft-web/src/views/Shell/ShellRouteFallbackView.vue
@@ -1,0 +1,37 @@
+<template>
+  <section class="mx-auto max-w-3xl px-4 sm:px-6">
+    <div
+      data-testid="shell-route-fallback"
+      class="rounded-[32px] border border-slate-200 bg-white p-8 shadow-[0_24px_70px_-52px_rgba(15,23,42,0.2)]"
+    >
+      <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+        Route unavailable
+      </p>
+      <h2 class="mt-3 text-2xl font-semibold tracking-tight text-slate-900">
+        We couldn’t open that page.
+      </h2>
+      <p class="mt-3 text-base text-slate-600">
+        Return to People or ConnectShyft to keep working inside the shared shell.
+      </p>
+
+      <div class="mt-6 flex flex-wrap gap-3">
+        <RouterLink
+          :to="SHELL_ROUTE_PATHS.people"
+          class="inline-flex min-h-[44px] items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+        >
+          Open People
+        </RouterLink>
+        <RouterLink
+          :to="SHELL_ROUTE_PATHS.connect"
+          class="inline-flex min-h-[44px] items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700"
+        >
+          Open ConnectShyft
+        </RouterLink>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { SHELL_ROUTE_PATHS } from '@/shell/routes';
+</script>

--- a/apps/connectshyft-web/src/views/Shell/WorkView.vue
+++ b/apps/connectshyft-web/src/views/Shell/WorkView.vue
@@ -1,3 +1,70 @@
 <template>
-  <div>Work shell view coming soon</div>
+  <div class="space-y-4">
+    <section class="mx-auto max-w-7xl px-4 sm:px-6">
+      <div class="rounded-[28px] border border-slate-200 bg-white/90 p-4 shadow-[0_20px_60px_-48px_rgba(15,23,42,0.24)]">
+        <p class="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+          Settings
+        </p>
+        <p class="mt-2 text-sm text-slate-600">
+          Callback setup and operational settings stay in the same shared application frame.
+        </p>
+      </div>
+
+      <nav
+        v-if="navigationItems.length > 0"
+        data-testid="shell-settings-nav"
+        class="mt-4 flex flex-wrap gap-2"
+      >
+        <RouterLink
+          v-for="item in navigationItems"
+          :key="item.path"
+          :to="{ path: item.path, query: navigationQuery }"
+          :data-testid="`shell-settings-nav-${item.key}`"
+          class="inline-flex min-h-[44px] items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition"
+          :class="isActive(item.path)
+            ? 'bg-slate-900 text-white shadow-sm'
+            : 'bg-slate-100 text-slate-700 hover:bg-slate-200'"
+        >
+          {{ item.label }}
+        </RouterLink>
+      </nav>
+    </section>
+
+    <RouterView />
+  </div>
 </template>
+
+<script setup lang="ts">
+import type { LocationQueryRaw } from 'vue-router';
+import { computed, onMounted, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import type { ShellSettingsNavigationItem } from '@/features/connectshyft/settingsNavigation';
+import { fetchConnectShyftSettingsNavigation } from '@/features/connectshyft/settingsNavigation';
+import { SHELL_ROUTE_PATHS } from '@/shell/routes';
+
+const route = useRoute();
+const navigationItems = ref<ShellSettingsNavigationItem[]>([
+  {
+    key: 'settings',
+    label: 'Call routing',
+    path: SHELL_ROUTE_PATHS.settings,
+  },
+]);
+
+const navigationQuery = computed<LocationQueryRaw>(() => {
+  const {
+    refusedPath: _refusedPath,
+    settingsRefusal: _settingsRefusal,
+    settingsRefusedPath: _settingsRefusedPath,
+    ...rest
+  } = route.query;
+
+  return rest as LocationQueryRaw;
+});
+
+const isActive = (path: string): boolean => route.path === path || route.path.startsWith(`${path}/`);
+
+onMounted(async () => {
+  navigationItems.value = await fetchConnectShyftSettingsNavigation();
+});
+</script>

--- a/apps/connectshyft-web/src/views/Shell/WorkView.vue
+++ b/apps/connectshyft-web/src/views/Shell/WorkView.vue
@@ -6,7 +6,14 @@
           Settings
         </p>
         <p class="mt-2 text-sm text-slate-600">
-          Callback setup and operational settings stay in the same shared application frame.
+          Call routing and workspace settings live here.
+        </p>
+        <p
+          v-if="settingsRefusalGuidance"
+          data-testid="shell-settings-refusal-guidance"
+          class="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+        >
+          {{ settingsRefusalGuidance }}
         </p>
       </div>
 
@@ -61,6 +68,12 @@ const navigationQuery = computed<LocationQueryRaw>(() => {
 
   return rest as LocationQueryRaw;
 });
+
+const settingsRefusalGuidance = computed(() => (
+  typeof route.query.refusedPath === 'string' && route.query.refusedPath.trim().length > 0
+    ? 'That settings page is not available for your current access in this workspace.'
+    : ''
+));
 
 const isActive = (path: string): boolean => route.path === path || route.path.startsWith(`${path}/`);
 

--- a/apps/connectshyft-web/src/views/Shell/__tests__/AppShellView.test.ts
+++ b/apps/connectshyft-web/src/views/Shell/__tests__/AppShellView.test.ts
@@ -175,8 +175,13 @@ const renderShell = async (input?: {
   initialPath?: string;
   subjectContext?: SubjectContext;
   contextResponse?: ReturnType<typeof buildShellContextResponse>;
+  contextError?: unknown;
 }) => {
-  apiGetMock.mockResolvedValueOnce(input?.contextResponse || buildShellContextResponse());
+  if (input?.contextError) {
+    apiGetMock.mockRejectedValueOnce(input.contextError);
+  } else {
+    apiGetMock.mockResolvedValueOnce(input?.contextResponse || buildShellContextResponse());
+  }
   const router = await buildRouter(input?.initialPath || '/people?orgUnitId=org-east');
   const shellSubjectContext = ref<SubjectContext>(input?.subjectContext || {
     orgUnitId: 'org-east',
@@ -221,6 +226,30 @@ describe('AppShellView', () => {
       'Settings',
     ]);
     expect(wrapper.get('[data-testid="shell-orgunit-selector"]').exists()).toBe(true);
+  });
+
+  it('hides backend-disabled modules from the shell nav', async () => {
+    const { wrapper } = await renderShell({
+      contextResponse: buildShellContextResponse({
+        orgUnits: [
+          {
+            id: 'org-east',
+            label: 'East Campus',
+            availableModules: {
+              people: true,
+              connect: false,
+              settings: false,
+            },
+          },
+        ],
+      }),
+    });
+
+    const navItems = wrapper.findAll('[data-testid^="shell-primary-nav-"]');
+    expect(navItems).toHaveLength(1);
+    expect(navItems[0]?.text()).toBe('People');
+    expect(wrapper.find('[data-testid="shell-primary-nav-connect"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="shell-primary-nav-settings"]').exists()).toBe(false);
   });
 
   it('executes a safe orgUnit switch immediately and preserves the current route', async () => {
@@ -370,5 +399,22 @@ describe('AppShellView', () => {
     expect(shellSubjectContext.value).toEqual({
       orgUnitId: 'org-west',
     });
+  });
+
+  it('shows a shell-level error state when orgUnit access fails to load', async () => {
+    const { wrapper } = await renderShell({
+      contextError: {
+        response: {
+          data: {
+            message: 'Unable to load org unit access.',
+          },
+        },
+      },
+    });
+
+    expect(wrapper.find('[data-testid="people-surface"]').exists()).toBe(false);
+    expect(wrapper.get('[data-testid="shell-surface-error"]').text()).toContain(
+      'We couldn’t load this workspace.',
+    );
   });
 });

--- a/apps/connectshyft-web/src/views/Shell/__tests__/AppShellView.test.ts
+++ b/apps/connectshyft-web/src/views/Shell/__tests__/AppShellView.test.ts
@@ -243,6 +243,22 @@ describe('AppShellView', () => {
     });
   });
 
+  it('clears active subject context on routes that do not support shared subject continuity', async () => {
+    const { wrapper, shellSubjectContext } = await renderShell({
+      initialPath: '/settings?orgUnitId=org-east',
+      subjectContext: {
+        orgUnitId: 'org-east',
+        conversationId: 'conversation-1',
+        threadId: 'thread-1',
+      },
+    });
+
+    expect(shellSubjectContext.value).toEqual({
+      orgUnitId: 'org-east',
+    });
+    expect(wrapper.get('[data-testid="shell-subject-slot"]').attributes('data-subject-active')).toBe('false');
+  });
+
   it('shows confirmation before a destructive orgUnit switch', async () => {
     const { wrapper, router, shellSubjectContext } = await renderShell({
       initialPath: '/connect/threads/thread-1?orgUnitId=org-east',

--- a/apps/connectshyft-web/src/views/Shell/__tests__/AppShellView.test.ts
+++ b/apps/connectshyft-web/src/views/Shell/__tests__/AppShellView.test.ts
@@ -1,0 +1,126 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createMemoryHistory, createRouter } from 'vue-router';
+import { nextTick } from 'vue';
+import AppShellView from '../AppShellView.vue';
+
+const TestApp = {
+  template: '<RouterView />',
+};
+
+const buildRouter = async (initialPath: string) => {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: '/',
+        component: AppShellView,
+        children: [
+          {
+            path: '',
+            redirect: '/people',
+          },
+          {
+            path: 'people',
+            component: {
+              template: '<div data-testid="people-surface">People content</div>',
+            },
+            meta: {
+              shellModule: 'people',
+              shellTitle: 'People',
+            },
+          },
+          {
+            path: 'connect',
+            component: {
+              template: '<div data-testid="connect-surface">Connect content</div>',
+            },
+            meta: {
+              shellModule: 'connect',
+              shellTitle: 'ConnectShyft',
+            },
+          },
+          {
+            path: 'settings',
+            component: {
+              template: '<div data-testid="settings-surface">Settings content</div>',
+            },
+            meta: {
+              shellModule: 'settings',
+              shellTitle: 'Settings',
+            },
+          },
+          {
+            path: ':pathMatch(.*)*',
+            component: {
+              template: '<div data-testid="shell-route-fallback">Fallback content</div>',
+            },
+            meta: {
+              shellTitle: 'Workspace unavailable',
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  await router.push(initialPath);
+  await router.isReady();
+  return router;
+};
+
+const renderShell = async (initialPath: string) => {
+  const router = await buildRouter(initialPath);
+  const wrapper = mount(TestApp, {
+    global: {
+      plugins: [router],
+    },
+  });
+
+  await nextTick();
+  return { wrapper, router };
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('AppShellView', () => {
+  it('renders exactly the MVP shell nav items', async () => {
+    const { wrapper } = await renderShell('/people');
+    const navItems = wrapper.findAll('[data-testid^="shell-primary-nav-"]');
+
+    expect(navItems).toHaveLength(3);
+    expect(navItems.map((item) => item.text())).toEqual([
+      'People',
+      'ConnectShyft',
+      'Settings',
+    ]);
+  });
+
+  it('keeps one shell frame while navigating between primary modules', async () => {
+    const { wrapper, router } = await renderShell('/people');
+
+    expect(wrapper.get('[data-testid="app-shell-root"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="people-surface"]').text()).toContain('People content');
+
+    await router.push('/connect');
+    await nextTick();
+
+    expect(wrapper.get('[data-testid="app-shell-root"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="connect-surface"]').text()).toContain('Connect content');
+
+    await router.push('/settings');
+    await nextTick();
+
+    expect(wrapper.get('[data-testid="app-shell-root"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="settings-surface"]').text()).toContain('Settings content');
+  });
+
+  it('renders a shell-safe fallback for invalid routes', async () => {
+    const { wrapper } = await renderShell('/not-a-real-route');
+
+    expect(wrapper.get('[data-testid="app-shell-root"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="shell-route-fallback"]').text()).toContain('Fallback content');
+  });
+});

--- a/apps/connectshyft-web/src/views/Shell/__tests__/AppShellView.test.ts
+++ b/apps/connectshyft-web/src/views/Shell/__tests__/AppShellView.test.ts
@@ -1,11 +1,80 @@
 import { mount } from '@vue/test-utils';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMemoryHistory, createRouter } from 'vue-router';
-import { nextTick } from 'vue';
+import { nextTick, ref } from 'vue';
+import type { SubjectContext } from '@shyft/contracts';
+import api from '@/services/api';
+import { SUBJECT_CONTEXT_KEY } from '@/shell/subjectContext';
+import { resetActiveShellOrgUnitIdForTests } from '@/shell/orgUnitState';
+import { resetShellOrgUnitContextForTests } from '@/shell/orgUnitContext';
 import AppShellView from '../AppShellView.vue';
+
+vi.mock('@/services/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
 
 const TestApp = {
   template: '<RouterView />',
+};
+
+const apiGetMock = vi.mocked(api.get);
+
+const buildShellContextResponse = (input?: {
+  currentOrgUnitId?: string;
+  orgUnits?: Array<{
+    id: string;
+    label: string;
+    availableModules: {
+      people: boolean;
+      connect: boolean;
+      settings: boolean;
+    };
+  }>;
+}) => ({
+  data: {
+    ok: true,
+    code: 'CONNECTSHYFT_CONTEXT_RESOLVED',
+    data: {
+      context: {
+        tenantId: 'tenant-shell-test',
+        orgUnitId: input?.currentOrgUnitId || 'org-east',
+        bypassedOrgUnitMembership: false,
+        orgUnits: input?.orgUnits || [
+          {
+            id: 'org-east',
+            label: 'East Campus',
+            availableModules: {
+              people: true,
+              connect: true,
+              settings: true,
+            },
+          },
+          {
+            id: 'org-west',
+            label: 'West Campus',
+            availableModules: {
+              people: true,
+              connect: true,
+              settings: true,
+            },
+          },
+        ],
+        telephony: {
+          operatorPhoneSource: 'callback_number',
+          voiceReady: true,
+          smsReady: true,
+          degradedMode: false,
+        },
+      },
+    },
+  },
+});
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
 };
 
 const buildRouter = async (initialPath: string) => {
@@ -28,17 +97,49 @@ const buildRouter = async (initialPath: string) => {
             meta: {
               shellModule: 'people',
               shellTitle: 'People',
+              shellOrgUnitFallback: 'people',
             },
           },
           {
             path: 'connect',
             component: {
-              template: '<div data-testid="connect-surface">Connect content</div>',
+              template: '<RouterView />',
             },
             meta: {
               shellModule: 'connect',
               shellTitle: 'ConnectShyft',
+              shellOrgUnitFallback: 'communication',
             },
+            children: [
+              {
+                path: '',
+                component: {
+                  template: '<div data-testid="connect-surface">Connect content</div>',
+                },
+                meta: {
+                  shellTitle: 'ConnectShyft',
+                },
+              },
+              {
+                path: 'directory',
+                component: {
+                  template: '<div data-testid="connect-directory-surface">Directory content</div>',
+                },
+                meta: {
+                  shellTitle: 'ConnectShyft',
+                },
+              },
+              {
+                path: 'threads/:threadId',
+                component: {
+                  template: '<div data-testid="connect-thread-surface">Thread content</div>',
+                },
+                meta: {
+                  shellTitle: 'ConnectShyft',
+                  shellOrgUnitSwitchMode: 'destructive',
+                },
+              },
+            ],
           },
           {
             path: 'settings',
@@ -48,6 +149,7 @@ const buildRouter = async (initialPath: string) => {
             meta: {
               shellModule: 'settings',
               shellTitle: 'Settings',
+              shellOrgUnitFallback: 'shell',
             },
           },
           {
@@ -69,25 +171,47 @@ const buildRouter = async (initialPath: string) => {
   return router;
 };
 
-const renderShell = async (initialPath: string) => {
-  const router = await buildRouter(initialPath);
+const renderShell = async (input?: {
+  initialPath?: string;
+  subjectContext?: SubjectContext;
+  contextResponse?: ReturnType<typeof buildShellContextResponse>;
+}) => {
+  apiGetMock.mockResolvedValueOnce(input?.contextResponse || buildShellContextResponse());
+  const router = await buildRouter(input?.initialPath || '/people?orgUnitId=org-east');
+  const shellSubjectContext = ref<SubjectContext>(input?.subjectContext || {
+    orgUnitId: 'org-east',
+  });
+
   const wrapper = mount(TestApp, {
     global: {
       plugins: [router],
+      provide: {
+        [SUBJECT_CONTEXT_KEY as symbol]: shellSubjectContext,
+      },
     },
   });
 
+  await flushPromises();
   await nextTick();
-  return { wrapper, router };
+
+  return { wrapper, router, shellSubjectContext };
 };
+
+beforeEach(() => {
+  apiGetMock.mockReset();
+  resetShellOrgUnitContextForTests();
+  resetActiveShellOrgUnitIdForTests();
+});
 
 afterEach(() => {
   document.body.innerHTML = '';
+  resetShellOrgUnitContextForTests();
+  resetActiveShellOrgUnitIdForTests();
 });
 
 describe('AppShellView', () => {
   it('renders exactly the MVP shell nav items', async () => {
-    const { wrapper } = await renderShell('/people');
+    const { wrapper } = await renderShell();
     const navItems = wrapper.findAll('[data-testid^="shell-primary-nav-"]');
 
     expect(navItems).toHaveLength(3);
@@ -96,31 +220,139 @@ describe('AppShellView', () => {
       'ConnectShyft',
       'Settings',
     ]);
+    expect(wrapper.get('[data-testid="shell-orgunit-selector"]').exists()).toBe(true);
   });
 
-  it('keeps one shell frame while navigating between primary modules', async () => {
-    const { wrapper, router } = await renderShell('/people');
+  it('executes a safe orgUnit switch immediately and preserves the current route', async () => {
+    const { wrapper, router, shellSubjectContext } = await renderShell({
+      initialPath: '/people?orgUnitId=org-east',
+      subjectContext: {
+        orgUnitId: 'org-east',
+      },
+    });
 
-    expect(wrapper.get('[data-testid="app-shell-root"]').exists()).toBe(true);
-    expect(wrapper.get('[data-testid="people-surface"]').text()).toContain('People content');
-
-    await router.push('/connect');
+    expect(wrapper.findAll('option')).toHaveLength(2);
+    await wrapper.findComponent(AppShellView).vm.handleOrgUnitSelection('org-west');
+    await flushPromises();
     await nextTick();
 
-    expect(wrapper.get('[data-testid="app-shell-root"]').exists()).toBe(true);
-    expect(wrapper.get('[data-testid="connect-surface"]').text()).toContain('Connect content');
-
-    await router.push('/settings');
-    await nextTick();
-
-    expect(wrapper.get('[data-testid="app-shell-root"]').exists()).toBe(true);
-    expect(wrapper.get('[data-testid="settings-surface"]').text()).toContain('Settings content');
+    expect(wrapper.find('[data-testid="shell-orgunit-confirmation"]').exists()).toBe(false);
+    expect(router.currentRoute.value.fullPath).toBe('/people?orgUnitId=org-west');
+    expect(shellSubjectContext.value).toEqual({
+      orgUnitId: 'org-west',
+    });
   });
 
-  it('renders a shell-safe fallback for invalid routes', async () => {
-    const { wrapper } = await renderShell('/not-a-real-route');
+  it('shows confirmation before a destructive orgUnit switch', async () => {
+    const { wrapper, router, shellSubjectContext } = await renderShell({
+      initialPath: '/connect/threads/thread-1?orgUnitId=org-east',
+      subjectContext: {
+        orgUnitId: 'org-east',
+        conversationId: 'conversation-1',
+      },
+    });
 
-    expect(wrapper.get('[data-testid="app-shell-root"]').exists()).toBe(true);
-    expect(wrapper.get('[data-testid="shell-route-fallback"]').text()).toContain('Fallback content');
+    await wrapper.findComponent(AppShellView).vm.handleOrgUnitSelection('org-west');
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.get('[data-testid="shell-orgunit-confirmation"]').text()).toContain(
+      'This will clear the current person or conversation and take you to the nearest available page in the selected orgUnit.',
+    );
+    expect(router.currentRoute.value.fullPath).toBe('/connect/threads/thread-1?orgUnitId=org-east');
+    expect(shellSubjectContext.value).toEqual({
+      orgUnitId: 'org-east',
+      conversationId: 'conversation-1',
+    });
+  });
+
+  it('keeps the current route and subject context when the destructive switch is canceled', async () => {
+    const { wrapper, router, shellSubjectContext } = await renderShell({
+      initialPath: '/connect/threads/thread-1?orgUnitId=org-east',
+      subjectContext: {
+        orgUnitId: 'org-east',
+        conversationId: 'conversation-1',
+      },
+    });
+
+    await wrapper.findComponent(AppShellView).vm.handleOrgUnitSelection('org-west');
+    await flushPromises();
+    await nextTick();
+    await wrapper.get('[data-testid="shell-orgunit-cancel"]').trigger('click');
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="shell-orgunit-confirmation"]').exists()).toBe(false);
+    expect(router.currentRoute.value.fullPath).toBe('/connect/threads/thread-1?orgUnitId=org-east');
+    expect(shellSubjectContext.value).toEqual({
+      orgUnitId: 'org-east',
+      conversationId: 'conversation-1',
+    });
+  });
+
+  it('clears subject context and redirects after confirming a destructive switch', async () => {
+    const { wrapper, router, shellSubjectContext } = await renderShell({
+      initialPath: '/connect/threads/thread-1?orgUnitId=org-east',
+      subjectContext: {
+        orgUnitId: 'org-east',
+        conversationId: 'conversation-1',
+      },
+    });
+
+    await wrapper.findComponent(AppShellView).vm.handleOrgUnitSelection('org-west');
+    await flushPromises();
+    await nextTick();
+    expect(wrapper.find('[data-testid="shell-orgunit-confirmation"]').exists()).toBe(true);
+    await wrapper.findComponent(AppShellView).vm.confirmPendingOrgUnitSwitch();
+    await flushPromises();
+    await nextTick();
+
+    expect(router.currentRoute.value.fullPath).toBe('/connect?orgUnitId=org-west');
+    expect(shellSubjectContext.value).toEqual({
+      orgUnitId: 'org-west',
+    });
+  });
+
+  it('corrects invalid routes by redirecting to People when the target orgUnit disables the current module', async () => {
+    const { wrapper, router, shellSubjectContext } = await renderShell({
+      initialPath: '/connect/directory?orgUnitId=org-east',
+      subjectContext: {
+        orgUnitId: 'org-east',
+      },
+      contextResponse: buildShellContextResponse({
+        orgUnits: [
+          {
+            id: 'org-east',
+            label: 'East Campus',
+            availableModules: {
+              people: true,
+              connect: true,
+              settings: true,
+            },
+          },
+          {
+            id: 'org-west',
+            label: 'West Campus',
+            availableModules: {
+              people: true,
+              connect: false,
+              settings: false,
+            },
+          },
+        ],
+      }),
+    });
+
+    await wrapper.findComponent(AppShellView).vm.handleOrgUnitSelection('org-west');
+    await flushPromises();
+    await nextTick();
+    expect(wrapper.find('[data-testid="shell-orgunit-confirmation"]').exists()).toBe(true);
+    await wrapper.findComponent(AppShellView).vm.confirmPendingOrgUnitSwitch();
+    await flushPromises();
+    await nextTick();
+
+    expect(router.currentRoute.value.fullPath).toBe('/people?orgUnitId=org-west');
+    expect(shellSubjectContext.value).toEqual({
+      orgUnitId: 'org-west',
+    });
   });
 });

--- a/apps/connectshyft-web/src/views/Shell/__tests__/PeopleView.test.ts
+++ b/apps/connectshyft-web/src/views/Shell/__tests__/PeopleView.test.ts
@@ -224,8 +224,9 @@ describe('PeopleView', () => {
     const { wrapper } = await renderPeopleView();
 
     expect(fetchResolverQueueMock).toHaveBeenCalledTimes(1);
-    expect(wrapper.text()).toContain('People shell');
-    expect(wrapper.text()).toContain('Org unit: test-org');
+    expect(wrapper.text()).toContain('People');
+    expect(wrapper.text()).toContain('Current workspace: Current workspace');
+    expect(wrapper.text()).not.toContain('test-org');
     expect(wrapper.get('[data-test="resolver-workspace"]').text()).toContain(
       'Primary queue for identity and rebind reviews',
     );
@@ -247,7 +248,7 @@ describe('PeopleView', () => {
     const { wrapper } = await renderPeopleView();
 
     expect(wrapper.get('[data-test="resolver-workspace-locked"]').text()).toContain(
-      'available only to tenant-admin resolvers',
+      'not available for your current access',
     );
     expect(wrapper.find('[data-test="resolver-filter-all_active"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="resolver-detail-claim"]').exists()).toBe(false);
@@ -290,7 +291,7 @@ describe('PeopleView', () => {
       'Claimed by me',
     );
     expect(wrapper.get('[data-test="resolver-queue-item-claim-rebind-item"]').text()).toContain(
-      'Claimed by another resolver',
+      'Claimed elsewhere',
     );
   });
 
@@ -465,102 +466,12 @@ describe('PeopleView', () => {
     expect(wrapper.find('[data-test="resolver-queue-item-identity-other"]').exists()).toBe(false);
   });
 
-  it('renders shared, stale, and reassignment indicators for contact points', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ([
-        {
-          id: 'contact-shared',
-          tenantId: 'tenant-1',
-          type: 'phone',
-          normalizedValue: '+12605551212',
-          status: 'active_shared_possible',
-          firstSeenAt: '2026-03-24T10:00:00.000Z',
-          lastSeenAt: '2026-03-24T10:00:00.000Z',
-          suspectedShared: true,
-          confirmedShared: false,
-          reassignmentSuspected: false,
-          createdAt: '2026-03-24T10:00:00.000Z',
-          updatedAt: '2026-03-24T10:00:00.000Z',
-        },
-        {
-          id: 'contact-stale',
-          tenantId: 'tenant-1',
-          type: 'phone',
-          normalizedValue: '+12605551213',
-          status: 'stale',
-          firstSeenAt: '2026-03-24T10:00:00.000Z',
-          lastSeenAt: '2026-03-24T10:00:00.000Z',
-          suspectedShared: false,
-          confirmedShared: false,
-          reassignmentSuspected: false,
-          createdAt: '2026-03-24T10:00:00.000Z',
-          updatedAt: '2026-03-24T10:00:00.000Z',
-        },
-        {
-          id: 'contact-reassigned',
-          tenantId: 'tenant-1',
-          type: 'phone',
-          normalizedValue: '+12605551214',
-          status: 'reassignment_suspected',
-          firstSeenAt: '2026-03-24T10:00:00.000Z',
-          lastSeenAt: '2026-03-24T10:00:00.000Z',
-          suspectedShared: false,
-          confirmedShared: false,
-          reassignmentSuspected: true,
-          createdAt: '2026-03-24T10:00:00.000Z',
-          updatedAt: '2026-03-24T10:00:00.000Z',
-        },
-      ]),
-    });
-
-    vi.stubGlobal('fetch', fetchMock);
-
+  it('removes sample tooling and raw identifiers from the cleaned People shell', async () => {
     const { wrapper } = await renderPeopleView();
 
-    await wrapper.get('[data-test="load-contact-points"]').trigger('click');
-    await flushPromises();
-
-    expect(wrapper.findAll('[data-test="contact-point-shared-indicator"]')).toHaveLength(1);
-    expect(wrapper.findAll('[data-test="contact-point-stale-indicator"]')).toHaveLength(1);
-    expect(wrapper.findAll('[data-test="contact-point-reassignment-indicator"]')).toHaveLength(1);
-  });
-
-  it('runs the sample identity decision and keeps resolver-required guidance compatible', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        confidenceBand: 'very_high',
-        contactPointStatus: 'reassignment_suspected',
-        outcome: 'resolver_required',
-        resolverReviewId: 'review-1',
-        candidates: [],
-      }),
-    });
-
-    vi.stubGlobal('fetch', fetchMock);
-
-    const { wrapper } = await renderPeopleView();
-
-    await wrapper.get('[data-test="run-sample-decision"]').trigger('click');
-    await flushPromises();
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      '/people/identity/decision',
-      expect.objectContaining({
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }),
-    );
-    expect(wrapper.text()).toContain('Confidence band: very_high');
-    expect(wrapper.text()).toContain('Resolution state: resolver_required');
-    expect(wrapper.text()).toContain('Default action: resolver_review');
-    expect(wrapper.get('[data-test="resolver-review-id"]').text()).toContain('review-1');
-    expect(wrapper.find('[data-test="create-new"]').exists()).toBe(false);
-    expect(wrapper.get('[data-test="resolver-required-message"]').text()).toContain(
-      'Resolver review is required before creating a new person.',
-    );
+    expect(wrapper.find('[data-test="load-contact-points"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="run-sample-decision"]').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('resolver-item-1');
+    expect(wrapper.text()).not.toContain('person-a');
   });
 });

--- a/apps/connectshyft-web/src/views/Shell/__tests__/PeopleView.test.ts
+++ b/apps/connectshyft-web/src/views/Shell/__tests__/PeopleView.test.ts
@@ -90,6 +90,15 @@ const buildQueueDetail = (
     terminal: item.terminal,
     decisionStatus: null,
   },
+  subjectContext: {
+    orgUnitId: item.orgUnitId || 'test-org',
+    provisionalPersonId: item.personIds[0],
+    candidatePersonIds: item.personIds,
+    conversationId: item.conversationId || undefined,
+    contactPointId: item.contactPointId || undefined,
+    threadId: item.threadId || undefined,
+    identityState: item.personIds[0] ? 'provisional' : undefined,
+  },
   rebindReview: item.itemType === 'rebind_review'
     ? {
       rebindHistoryId: `rebind-${item.id}`,
@@ -142,18 +151,19 @@ const setupResolverQueue = (items: ConnectShyftResolverQueueItemRecord[]) => {
 };
 
 const renderPeopleView = async () => {
+  const shellSubjectContext = ref({
+    orgUnitId: 'test-org',
+  });
   const wrapper = mount(PeopleView, {
     global: {
       provide: {
-        [SUBJECT_CONTEXT_KEY as symbol]: ref({
-          orgUnitId: 'test-org',
-        }),
+        [SUBJECT_CONTEXT_KEY as symbol]: shellSubjectContext,
       },
     },
   });
 
   await flushPromises();
-  return wrapper;
+  return { wrapper, shellSubjectContext };
 };
 
 beforeEach(() => {
@@ -211,7 +221,7 @@ describe('PeopleView', () => {
     });
     setupResolverQueue([identityItem, rebindItem]);
 
-    const wrapper = await renderPeopleView();
+    const { wrapper } = await renderPeopleView();
 
     expect(fetchResolverQueueMock).toHaveBeenCalledTimes(1);
     expect(wrapper.text()).toContain('People shell');
@@ -234,7 +244,7 @@ describe('PeopleView', () => {
       unauthorized: true,
     });
 
-    const wrapper = await renderPeopleView();
+    const { wrapper } = await renderPeopleView();
 
     expect(wrapper.get('[data-test="resolver-workspace-locked"]').text()).toContain(
       'available only to tenant-admin resolvers',
@@ -268,7 +278,7 @@ describe('PeopleView', () => {
     });
     setupResolverQueue([identityItem, rebindItem]);
 
-    const wrapper = await renderPeopleView();
+    const { wrapper } = await renderPeopleView();
 
     expect(wrapper.get('[data-test="resolver-queue-item-type-identity-item"]').text()).toContain(
       'Identity review',
@@ -282,6 +292,43 @@ describe('PeopleView', () => {
     expect(wrapper.get('[data-test="resolver-queue-item-claim-rebind-item"]').text()).toContain(
       'Claimed by another resolver',
     );
+  });
+
+  it('does not overwrite shell subject context from the auto-selected resolver detail', async () => {
+    const identityItem = buildQueueItem({
+      id: 'identity-item',
+      itemType: 'identity_review',
+    });
+    setupResolverQueue([identityItem]);
+
+    const { shellSubjectContext } = await renderPeopleView();
+
+    expect(shellSubjectContext.value).toEqual({
+      orgUnitId: 'test-org',
+    });
+  });
+
+  it('syncs shell subject context only after a resolver item is explicitly selected', async () => {
+    const identityItem = buildQueueItem({
+      id: 'identity-item',
+      itemType: 'identity_review',
+    });
+    setupResolverQueue([identityItem]);
+
+    const { wrapper, shellSubjectContext } = await renderPeopleView();
+
+    await wrapper.get('[data-test="resolver-queue-item-identity-item"]').trigger('click');
+    await flushPromises();
+
+    expect(shellSubjectContext.value).toEqual({
+      orgUnitId: 'test-org',
+      provisionalPersonId: 'person-a',
+      candidatePersonIds: ['person-a', 'person-b'],
+      conversationId: 'conversation-1',
+      contactPointId: 'contact-point-1',
+      threadId: 'thread-1',
+      identityState: 'provisional',
+    });
   });
 
   it('claims and releases resolver work through backend-backed operations', async () => {
@@ -321,7 +368,7 @@ describe('PeopleView', () => {
       detail: buildQueueDetail(queueItem),
     });
 
-    const wrapper = await renderPeopleView();
+    const { wrapper } = await renderPeopleView();
 
     await wrapper.get('[data-test="resolver-detail-claim"]').trigger('click');
     await flushPromises();
@@ -357,7 +404,7 @@ describe('PeopleView', () => {
     });
     setupResolverQueue([queueItem]);
 
-    const wrapper = await renderPeopleView();
+    const { wrapper } = await renderPeopleView();
 
     expect(wrapper.get('[data-test="resolver-detail-claim-disabled"]').attributes('disabled')).toBeDefined();
     expect(wrapper.get('[data-test="resolver-detail-claimed-by-other"]').text()).toContain(
@@ -398,7 +445,7 @@ describe('PeopleView', () => {
     });
     setupResolverQueue([unclaimedIdentity, claimedRebind, claimedByOtherIdentity]);
 
-    const wrapper = await renderPeopleView();
+    const { wrapper } = await renderPeopleView();
 
     await wrapper.get('[data-test="resolver-filter-rebind_review"]').trigger('click');
     await flushPromises();
@@ -469,7 +516,7 @@ describe('PeopleView', () => {
 
     vi.stubGlobal('fetch', fetchMock);
 
-    const wrapper = await renderPeopleView();
+    const { wrapper } = await renderPeopleView();
 
     await wrapper.get('[data-test="load-contact-points"]').trigger('click');
     await flushPromises();
@@ -493,7 +540,7 @@ describe('PeopleView', () => {
 
     vi.stubGlobal('fetch', fetchMock);
 
-    const wrapper = await renderPeopleView();
+    const { wrapper } = await renderPeopleView();
 
     await wrapper.get('[data-test="run-sample-decision"]').trigger('click');
     await flushPromises();

--- a/libs/contracts/src/connectshyft.ts
+++ b/libs/contracts/src/connectshyft.ts
@@ -7,6 +7,7 @@ import type {
   ResolverReview,
   ResolverReviewStatus,
 } from './people';
+import type { SubjectContext } from './subject-context';
 
 export type ConnectShyftIdentityResolutionCandidate = {
   personId: string;
@@ -210,6 +211,7 @@ export type ConnectShyftResolverQueueDetailData = {
   item: ConnectShyftResolverQueueItemRecord;
   review: ConnectShyftResolverReviewRecord | null;
   rebindReview: ConnectShyftRebindReviewContext | null;
+  subjectContext: SubjectContext;
 };
 
 export type ConnectShyftResolverDecisionData = {

--- a/libs/contracts/src/connectshyft.ts
+++ b/libs/contracts/src/connectshyft.ts
@@ -267,3 +267,38 @@ export type ConnectShyftIdentityResolutionResponse = {
   resolverReviewId?: string | null;
   candidates?: ConnectShyftIdentityResolutionCandidate[];
 };
+
+export const SHYFTUNITY_SHELL_MODULE_KEYS = [
+  'people',
+  'connect',
+  'settings',
+] as const;
+
+export type ShyftUnityShellModuleKey = typeof SHYFTUNITY_SHELL_MODULE_KEYS[number];
+
+export type ConnectShyftShellModuleAvailability = {
+  people: boolean;
+  connect: boolean;
+  settings: boolean;
+};
+
+export type ConnectShyftShellOrgUnitOption = {
+  id: string;
+  label: string;
+  availableModules: ConnectShyftShellModuleAvailability;
+};
+
+export type ConnectShyftContextTelephonySummary = {
+  operatorPhoneSource: string | null;
+  voiceReady: boolean;
+  smsReady: boolean;
+  degradedMode: boolean;
+};
+
+export type ConnectShyftShellContext = {
+  tenantId: string;
+  orgUnitId: string;
+  bypassedOrgUnitMembership: boolean;
+  orgUnits: ConnectShyftShellOrgUnitOption[];
+  telephony: ConnectShyftContextTelephonySummary;
+};

--- a/libs/contracts/src/subject-context.ts
+++ b/libs/contracts/src/subject-context.ts
@@ -2,12 +2,30 @@ export type SubjectContext = {
   orgUnitId: string;
   personId?: string;
   provisionalPersonId?: string;
+  candidatePersonIds?: string[];
   conversationId?: string;
   contactPointId?: string;
+  threadId?: string;
+  identityState?: SubjectIdentityState;
 };
+
+export const SUBJECT_IDENTITY_STATES = [
+  'confirmed',
+  'provisional',
+] as const;
+
+export type SubjectIdentityState = typeof SUBJECT_IDENTITY_STATES[number];
 
 export function validateSubjectContext(subject: SubjectContext): void {
   if (subject.personId && subject.provisionalPersonId) {
     throw new Error('SubjectContext cannot include both personId and provisionalPersonId');
+  }
+
+  if (subject.identityState === 'confirmed' && subject.provisionalPersonId) {
+    throw new Error('Confirmed SubjectContext cannot include provisionalPersonId');
+  }
+
+  if (subject.identityState === 'provisional' && subject.personId) {
+    throw new Error('Provisional SubjectContext cannot include personId');
   }
 }

--- a/libs/contracts/tests/connectshyft.test.ts
+++ b/libs/contracts/tests/connectshyft.test.ts
@@ -60,11 +60,19 @@ describe('connectshyft contracts', () => {
       item: rebindItem,
       review: null,
       rebindReview,
+      subjectContext: {
+        orgUnitId: rebindItem.orgUnitId || 'org-1',
+        personId: rebindReview.targetPersonId,
+        conversationId: rebindItem.conversationId || undefined,
+        contactPointId: rebindItem.contactPointId || undefined,
+        identityState: 'confirmed',
+      },
     };
 
     expect(identityItem.itemType).toBe('identity_review');
     expect(rebindItem.itemType).toBe('rebind_review');
     expect(detail.rebindReview?.rebindHistoryId).toBe('rebind-history-1');
+    expect(detail.subjectContext.orgUnitId).toBe('org-1');
     expect(isConnectShyftResolverQueueItemType(identityItem.itemType)).toBe(true);
     expect(isConnectShyftResolverQueueItemType(rebindItem.itemType)).toBe(true);
     expect(isConnectShyftResolverQueueClaimState(identityItem.claimState)).toBe(true);

--- a/libs/platform/src/middleware/authContext.ts
+++ b/libs/platform/src/middleware/authContext.ts
@@ -23,7 +23,7 @@ export const authContext = (req: RequestLike, res: ResponseLike, next: NextLike)
       role: request.user.role,
       householdId: request.user.householdId || null,
       activeTenantId: request.user.activeTenantId || request.tenantId || null,
-      orgUnitId: request.user.activeOrgUnitId || request.orgUnitId || null,
+      orgUnitId: request.orgUnitId || request.user.activeOrgUnitId || null,
       scopeMode: request.scopeMode || 'TENANT',
     }
     : null;

--- a/libs/platform/src/tenancy/requestContext.ts
+++ b/libs/platform/src/tenancy/requestContext.ts
@@ -30,9 +30,14 @@ export const resolveTenantRequestContext = (req: RequestLike): TenantRequestCont
   const request = req as RequestWithTenantUser;
   const userTenant = normalizeValue(request.user?.activeTenantId || request.user?.householdId || null);
   const userOrgUnit = normalizeValue(request.user?.activeOrgUnitId || null);
+  const requestedOrgUnit = normalizeValue(
+    request.header('x-org-unit-id')
+    || request.header('x-orgunit-id')
+    || null,
+  );
   const tenantId = userTenant || 'public';
 
-  const orgUnitId = tenantId === 'public' ? null : userOrgUnit;
+  const orgUnitId = tenantId === 'public' ? null : (requestedOrgUnit || userOrgUnit);
   const scopeMode: ScopeMode = orgUnitId ? 'ORG_UNIT' : 'TENANT';
 
   return {

--- a/libs/platform/tsconfig.json
+++ b/libs/platform/tsconfig.json
@@ -10,7 +10,9 @@
       "../../apps/moneyshyft-api/node_modules/@types",
       "../../apps/admin-api/node_modules/@types",
       "../../apps/moneyshyft-web/node_modules/@types",
-      "../../apps/admin-web/node_modules/@types"
+      "../../apps/admin-web/node_modules/@types",
+      "../../apps/connectshyft-api/node_modules/@types",
+      "../../apps/connectshyft-web/node_modules/@types"
     ],
     "rootDir": "./src",
     "outDir": "./dist",

--- a/specs/prep_step_3_checkpoint_1_shell_backbone.md
+++ b/specs/prep_step_3_checkpoint_1_shell_backbone.md
@@ -1,0 +1,297 @@
+# CHECKPOINT 1 — SHELL BACKBONE, TOP-LEVEL ROUTING, AND MVP-SCOPED MODULE CHROME
+**Slice:** Prep Step 3  
+**Objective:** Establish the unified application shell at `app.shyftunity.com` with one shared layout, stable top-level routing, MVP-scoped navigation, and domain-aware deployment assumptions
+
+---
+
+## 1. Goal
+
+Create the shell backbone so that:
+
+- the app runs under **`app.shyftunity.com`** as the canonical host
+- People and ConnectShyft render inside a single shared shell frame
+- top-level navigation is unified and MVP-scoped
+- module visibility is controlled and not implementation-leaky
+- shell-level layout replaces fragmented per-module chrome
+- the system is ready for orgUnit and subject-context layering in later checkpoints
+
+This checkpoint is about **structure and containment**, not deep feature work.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-web/src/main.ts
+apps/connectshyft-web/src/App.vue
+apps/connectshyft-web/src/router/index.ts (or equivalent)
+apps/connectshyft-web/src/routes.ts (or equivalent)
+apps/connectshyft-web/src/shell/*
+apps/connectshyft-web/src/views/Shell/*
+apps/connectshyft-web/src/components/*Nav*.vue
+apps/connectshyft-web/src/components/*Layout*.vue
+libs/contracts/src/connectshyft.ts
+libs/contracts/src/people/*
+```
+
+Include adjacent shell/layout/router helpers only as needed. Do not refactor unrelated feature modules.
+
+---
+
+## 3. Required Changes
+
+### 3.1 Establish canonical shell root
+
+The app must have a single shell root that:
+
+- wraps all primary routes
+- owns:
+  - top-level navigation
+  - layout frame
+  - module switching
+  - shell-level loading/empty states
+- renders People and ConnectShyft as children
+
+If multiple competing layout roots exist:
+- consolidate to one shell root
+- remove duplicated top-level chrome from child modules
+
+---
+
+### 3.2 Route everything under the shell
+
+All primary routes must render inside the shell:
+
+Required top-level route grouping:
+
+```text
+/
+  ├── /people
+  ├── /connect
+  └── /settings (or /more)
+```
+
+Rules:
+- no standalone People or ConnectShyft routes outside the shell
+- no “bypass” routes that skip shell layout
+- shell must be the consistent parent for all MVP surfaces
+
+---
+
+### 3.3 Lock MVP navigation model
+
+Shell must render exactly:
+
+- **People**
+- **ConnectShyft**
+- **Settings / More**
+
+Required behavior:
+- no additional modules shown
+- no placeholder/coming-soon modules
+- no resolver queue top-level nav
+
+Resolver Queue remains inside People.
+
+---
+
+### 3.4 Remove fragmented module-level chrome
+
+If People or ConnectShyft currently render their own:
+
+- top nav
+- headers
+- app frame
+- module switchers
+
+Then:
+
+- remove or demote those elements
+- move ownership to shell where appropriate
+
+Child views should assume:
+- they are inside a shell
+- they do not own global layout
+
+---
+
+### 3.5 Enforce MVP module visibility
+
+Shell must:
+
+- show only People, ConnectShyft, Settings
+- hide all unfinished modules completely
+- not rely on frontend-only flags to guess availability
+
+If feature flags exist:
+- use them as backend-authoritative inputs
+- do not invent visibility rules in the UI
+
+---
+
+### 3.6 Domain-aware routing assumptions
+
+The shell must be designed to run at:
+
+**`https://app.shyftunity.com`**
+
+Required implications:
+
+- no hardcoded localhost-only assumptions
+- no pathing assumptions tied to legacy hosts
+- routing must work correctly when served from root `/`
+- SPA fallback must be assumed (handled by Nginx)
+
+---
+
+### 3.7 Nginx + Cloudflare awareness (design-level)
+
+This checkpoint must assume:
+
+#### Nginx
+- server block for `app.shyftunity.com`
+- reverse proxy to app service
+- SPA fallback (`try_files $uri /index.html`)
+- correct forwarded headers
+
+#### Cloudflare
+- DNS entry for `app.shyftunity.com`
+- proxied or DNS-only depending on environment
+
+You are **not** implementing infra here, but:
+- routing must be compatible with this setup
+- no code should assume a different host
+
+---
+
+### 3.8 Shell-level loading and error states
+
+Shell must provide consistent:
+
+- loading state when switching modules
+- fallback UI when route is invalid
+- guard against blank screens during route transitions
+
+Do not leave loading/error behavior fragmented per module.
+
+---
+
+### 3.9 Preserve existing module internals
+
+Do not:
+
+- rewrite People internals
+- rewrite ConnectShyft internals
+- move business logic into shell
+
+Shell only:
+- contains
+- routes
+- frames
+
+---
+
+### 3.10 Prepare for next checkpoints
+
+Shell must expose extension points for:
+
+- orgUnit selector (Checkpoint 2)
+- subject/context bar (Checkpoint 3)
+- feature flags cleanup (Checkpoint 4)
+
+Do not implement those yet, but ensure layout supports them.
+
+---
+
+## 4. Explicit Non-Changes
+
+Do not:
+
+- implement orgUnit switching yet
+- implement subject/context bar yet
+- redesign ConnectShyft or People UI
+- expose resolver queue in nav
+- add placeholder modules
+- redesign auth/session system
+- introduce frontend-only routing logic that conflicts with backend truth
+
+---
+
+## 5. Tests Required
+
+### Unit / Component
+
+- shell renders nav with exactly People, ConnectShyft, Settings
+- shell wraps all routes
+- module-level chrome is not duplicated
+- hidden modules do not render
+
+### Integration
+
+- navigating between People and ConnectShyft stays within one shell
+- direct navigation to `/people` or `/connect` loads inside shell
+- invalid routes fall back to shell-safe state
+- routing works without reload loops under SPA assumptions
+
+### Regression
+
+- existing PeopleView behavior still works inside shell
+- existing ConnectShyft thread/detail behavior still works
+- Slice 2B resolver behavior is unaffected
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- all primary routes render inside one shared shell
+- nav shows only People, ConnectShyft, Settings
+- no duplicate top-level chrome exists in child modules
+- routing works cleanly under `app.shyftunity.com` assumptions
+- shell-level layout is stable and consistent
+
+---
+
+## 7. Commit Boundary
+
+```text
+feat(connectshyft-web): establish unified shell backbone and routing at app.shyftunity.com
+```
+
+---
+
+## 8. Verification Commands
+
+```bash
+rg "Shell|Layout|Nav|router|routes|People|ConnectShyft" apps/connectshyft-web
+```
+
+Confirm:
+- single shell root
+- unified routing
+
+```bash
+rg "People|ConnectShyft|Settings|More" apps/connectshyft-web
+```
+
+Confirm:
+- nav is MVP-scoped
+
+```bash
+rg "localhost|127.0.0.1" apps/connectshyft-web
+```
+
+Confirm:
+- no hardcoded host assumptions
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- the app has a real, unified shell
+- People and ConnectShyft feel like one application
+- routing and layout are stable
+- the system is ready for orgUnit and subject/context layering in subsequent checkpoints

--- a/specs/prep_step_3_checkpoint_2_orgunit_context.md
+++ b/specs/prep_step_3_checkpoint_2_orgunit_context.md
@@ -1,0 +1,238 @@
+# CHECKPOINT 2 — ORGUNIT CONTEXT AND ROUTE SAFETY
+**Slice:** Prep Step 3  
+**Objective:** Implement a persistent orgUnit context in the shared shell with safe switching behavior, including confirmation when switching would drop current subject/context or invalidate the current route
+
+---
+
+## 1. Goal
+
+Enable orgUnit to function as a first-class shell control so that:
+
+- orgUnit is always visible and switchable from the shell
+- switching orgUnit is safe, predictable, and does not silently break context
+- destructive switches (those that drop subject/context or invalidate route) require confirmation
+- non-destructive switches happen immediately
+- routing always resolves to a valid state after orgUnit change
+
+This checkpoint establishes **context safety**, not feature expansion.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-web/src/shell/*
+apps/connectshyft-web/src/components/*OrgUnit*.vue
+apps/connectshyft-web/src/router/index.ts
+apps/connectshyft-web/src/views/Shell/*
+apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+apps/connectshyft-api/src/modules/peoplecore/service.ts
+libs/contracts/src/connectshyft.ts
+libs/contracts/src/people/*
+```
+
+---
+
+## 3. Required Changes
+
+### 3.1 Persistent orgUnit selector
+
+The shell must expose a persistent orgUnit selector:
+
+- visible across all primary routes
+- reflects current orgUnit from backend/session
+- updates shell state when changed
+
+---
+
+### 3.2 Shell-owned orgUnit state
+
+Frontend must maintain:
+
+- current orgUnit id
+- available orgUnits (from backend)
+- derived “safe route” evaluation state
+
+Backend remains authoritative for:
+- which orgUnits are available
+- access permissions
+
+---
+
+### 3.3 Safe vs destructive switch evaluation
+
+Before switching orgUnit, evaluate:
+
+#### SAFE switch (no confirmation)
+- current route is valid in target orgUnit
+- subject/context (if present) still valid
+- module remains available
+
+#### DESTRUCTIVE switch (confirmation required)
+- subject/context will be cleared
+- current person/thread not available in new orgUnit
+- module not available in new orgUnit
+- route cannot be preserved
+
+---
+
+### 3.4 Confirmation behavior (locked)
+
+If switch is destructive:
+
+Show modal:
+
+**Title:** Switch orgUnit?  
+**Body:** This will clear the current person or conversation and take you to the nearest available page in the selected orgUnit.
+
+Buttons:
+- Switch orgUnit (primary)
+- Cancel
+
+Rules:
+- no engineering terms
+- no IDs or debug language
+- no silent destructive switches
+
+---
+
+### 3.5 Switch execution rules
+
+#### Safe switch
+- apply immediately
+- preserve route
+- preserve subject/context
+
+#### Destructive switch (after confirmation)
+- clear subject/context
+- redirect to nearest valid landing route:
+  - `/people` if person-related
+  - `/connect` if communication-related
+  - fallback to `/people` if uncertain
+
+---
+
+### 3.6 Route safety enforcement
+
+After switching:
+
+- ensure route is valid for:
+  - orgUnit
+  - module visibility
+  - subject/context
+
+If invalid:
+- redirect to nearest valid route
+- never leave user on broken route
+
+---
+
+### 3.7 Subject/context clearing rules
+
+On destructive switch:
+
+- clear subject/context immediately
+- do not carry stale identity state
+- do not attempt partial reuse
+
+---
+
+### 3.8 No backend leakage
+
+Frontend must not infer orgUnit safety via:
+- string matching
+- missing data heuristics
+
+Use contract-backed data only.
+
+---
+
+### 3.9 Preserve shell authority
+
+OrgUnit switching must remain:
+
+- shell-controlled
+- backend-authorized
+- not duplicated inside modules
+
+---
+
+## 4. Explicit Non-Changes
+
+Do not:
+
+- implement subject/context bar yet
+- redesign People or ConnectShyft
+- add feature flags logic here
+- expose resolver controls
+- change backend permission model
+
+---
+
+## 5. Tests Required
+
+### Unit
+
+- orgUnit selector renders correctly
+- safe switch executes immediately
+- destructive switch triggers confirmation
+- cancel prevents switch
+- confirm executes switch
+
+### Integration
+
+- safe switch preserves route and subject/context
+- destructive switch clears subject/context and redirects
+- invalid routes after switch are corrected
+- switching orgUnit does not produce inconsistent state
+
+### Regression
+
+- Slice 2B behavior remains intact
+- shell routing remains stable
+- no silent context loss occurs
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- orgUnit selector is persistent and functional
+- safe vs destructive switch logic is enforced
+- destructive switches require confirmation
+- subject/context is cleared correctly when required
+- routing remains valid after switch
+- no silent context loss occurs
+
+---
+
+## 7. Commit Boundary
+
+```text
+feat(connectshyft-web): add orgUnit context with safe switching and confirmation
+```
+
+---
+
+## 8. Verification Commands
+
+```bash
+rg "orgUnit|switch|selector|context|route safety|confirmation" apps/connectshyft-web
+```
+
+```bash
+rg "orgUnit|tenant|permission" apps/connectshyft-api libs/contracts
+```
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- orgUnit is a stable shell-level concept
+- switching orgUnit is safe and predictable
+- users are protected from accidental context loss
+- system is ready for subject/context unification

--- a/specs/prep_step_3_checkpoint_3_subject_context.md
+++ b/specs/prep_step_3_checkpoint_3_subject_context.md
@@ -1,0 +1,249 @@
+# CHECKPOINT 3 — SUBJECT/CONTEXT UNIFICATION ACROSS PEOPLE ↔ CONNECTSHYFT
+**Slice:** Prep Step 3  
+**Objective:** Establish a persistent, shell-owned subject/context model that unifies People and ConnectShyft so users can move between surfaces without losing context, while ensuring stale or invalid context is safely cleared
+
+---
+
+## 1. Goal
+
+Create a unified subject/context system so that:
+
+- the shell owns the current subject (person/contact/thread context)
+- subject/context persists across People ↔ ConnectShyft when valid
+- subject/context is cleared when invalid or unsafe
+- ConnectShyft and People consume the same context source
+- no module invents its own subject state independently
+- final identity truth is always reflected (no stale provisional context)
+
+This checkpoint establishes **continuity and correctness of subject context**.
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-web/src/shell/*
+apps/connectshyft-web/src/views/Shell/*
+apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue
+apps/connectshyft-web/src/views/Shell/PeopleView.vue
+apps/connectshyft-web/src/features/connectshyft/identityResolution.ts
+apps/connectshyft-web/src/router/index.ts
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+apps/connectshyft-api/src/modules/connectshyft/*
+apps/connectshyft-api/src/modules/peoplecore/*
+libs/contracts/src/connectshyft.ts
+libs/contracts/src/people/*
+```
+
+---
+
+## 3. Required Changes
+
+### 3.1 Shell-owned subject/context state
+
+The shell must maintain a single authoritative subject/context state:
+
+Includes (as available from contracts):
+- person identity
+- contact point
+- thread context (if in ConnectShyft)
+- identity state (resolved/provisional when relevant)
+
+Rules:
+- no duplicate subject stores in People or ConnectShyft
+- modules must read from shell context
+
+---
+
+### 3.2 Subject/context entry points
+
+Subject/context can be set from:
+
+- selecting a person in People
+- opening a thread in ConnectShyft
+- navigating directly to a route with subject params
+
+When set:
+- shell updates subject/context
+- downstream modules receive updated context
+
+---
+
+### 3.3 Cross-module continuity
+
+When moving between:
+
+- People → ConnectShyft
+- ConnectShyft → People
+
+If subject remains valid:
+- preserve subject/context
+- do not reset or re-fetch unnecessarily
+
+---
+
+### 3.4 Context validation rules
+
+Before preserving subject/context, validate:
+
+- subject exists in current orgUnit
+- subject is still accessible
+- module supports subject type
+- identity is not invalidated by backend truth
+
+If invalid:
+- clear subject/context
+- route safely
+
+---
+
+### 3.5 Clearing rules (mandatory)
+
+Subject/context must be cleared when:
+
+- orgUnit switch invalidates subject
+- route change no longer supports subject
+- backend truth changes (merge/rebind removes or changes identity)
+- thread no longer maps to valid subject
+
+No stale subject state allowed.
+
+---
+
+### 3.6 Backend truth synchronization
+
+Subject/context must always reflect:
+
+- latest identity resolution
+- latest rebind results
+- current thread-to-person mapping
+
+If backend changes:
+- invalidate/refetch context
+- update shell state
+- remove stale UI indicators
+
+---
+
+### 3.7 No frontend inference
+
+Do not derive subject validity from:
+- missing fields
+- string parsing
+- UI heuristics
+
+Use contract-backed data only.
+
+---
+
+### 3.8 Interaction with ConnectShyft
+
+When a thread is opened:
+
+- shell sets subject/context from thread
+- thread detail uses shell context
+- context updates when identity/rebind changes
+
+When leaving thread:
+- context persists if still valid
+
+---
+
+### 3.9 Interaction with People
+
+When a person is selected:
+
+- shell sets subject/context
+- People and ConnectShyft can both consume it
+
+---
+
+### 3.10 Preparation for subject/context bar
+
+Shell must expose:
+
+- subject summary data
+- identity state indicators
+- stable data shape
+
+Do not implement visual bar yet (comes later if needed refinement).
+
+---
+
+## 4. Explicit Non-Changes
+
+Do not:
+
+- redesign People UI
+- redesign ConnectShyft UI
+- add new subject UI components beyond minimal needs
+- expose debug/internal identity details
+- implement advanced caching or offline logic
+
+---
+
+## 5. Tests Required
+
+### Unit
+
+- subject/context sets correctly from People selection
+- subject/context sets correctly from thread open
+- subject/context clears when invalid
+- subject/context persists across safe navigation
+
+### Integration
+
+- People → ConnectShyft retains subject
+- ConnectShyft → People retains subject
+- orgUnit switch clears invalid subject
+- backend identity change updates subject correctly
+- stale subject is never displayed
+
+### Regression
+
+- Slice 2B identity resolution still works
+- thread behavior remains intact
+- resolver flows unaffected
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+This checkpoint is complete only when:
+
+- shell owns subject/context state
+- People and ConnectShyft use the same context
+- subject persists across modules when valid
+- subject clears when invalid
+- backend truth always wins over cached state
+
+---
+
+## 7. Commit Boundary
+
+```text
+feat(connectshyft-web): unify subject context across People and ConnectShyft
+```
+
+---
+
+## 8. Verification Commands
+
+```bash
+rg "subject|context|personId|threadId|identity" apps/connectshyft-web
+```
+
+```bash
+rg "subject|context|identity|thread|person" apps/connectshyft-api libs/contracts
+```
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- subject/context is unified across the app
+- navigation feels continuous
+- identity truth remains accurate
+- system is ready for final shell cleanup and polish

--- a/specs/prep_step_3_checkpoint_4_shell_cleanup.md
+++ b/specs/prep_step_3_checkpoint_4_shell_cleanup.md
@@ -1,0 +1,208 @@
+# CHECKPOINT 4 — FEATURE FLAGS, ROLE VISIBILITY, AND SHELL CLEANUP
+**Slice:** Prep Step 3  
+**Objective:** Finalize MVP shell coherence by enforcing backend-driven feature/module visibility, role-based access at the shell layer, and removing engineering artifacts from user-facing UI
+
+---
+
+## 1. Goal
+
+- Shell shows only MVP-allowed modules (People, ConnectShyft, Settings/More)
+- Visibility is **backend-authoritative** (feature flags / entitlements)
+- Role-restricted surfaces are hidden or disabled appropriately
+- All engineering artifacts are removed from user-facing shell chrome
+- Loading/empty/error states are consistent at the shell level
+- The app feels like one product at `app.shyftunity.com`
+
+---
+
+## 2. Files in Scope (REQUIRED)
+
+```text
+apps/connectshyft-web/src/shell/*
+apps/connectshyft-web/src/views/Shell/*
+apps/connectshyft-web/src/components/*Nav*.vue
+apps/connectshyft-web/src/components/*Layout*.vue
+apps/connectshyft-web/src/router/index.ts
+apps/connectshyft-web/src/features/* (feature flags / permissions)
+apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+apps/connectshyft-api/src/modules/* (feature flags / permissions)
+libs/contracts/src/connectshyft.ts
+libs/contracts/src/people/*
+```
+
+---
+
+## 3. Required Changes
+
+### 3.1 Backend-authoritative feature flags
+
+- Consume feature flags / entitlements from backend
+- Do not invent visibility rules in frontend
+- Normalize into a single shell-consumable shape
+
+---
+
+### 3.2 MVP module visibility enforcement
+
+Shell must render exactly:
+- People
+- ConnectShyft
+- Settings / More
+
+Rules:
+- hide all other modules completely
+- no “coming soon” placeholders
+- no dev-only routes exposed in UI
+
+---
+
+### 3.3 Role-based visibility
+
+- Tenant-admin-only controls remain hidden for non-admin users
+- Resolver-only affordances stay inside People (and only when applicable)
+- Do not expose role internals in UI
+
+---
+
+### 3.4 Route gating
+
+Before rendering a route, validate:
+- module is enabled
+- user has access
+- orgUnit allows it
+
+If invalid:
+- redirect to nearest valid landing page
+- never render a broken or unauthorized surface
+
+---
+
+### 3.5 Shell cleanup — remove engineering artifacts
+
+Remove from all shell-level UI:
+- IDs (tenant_id, person_id, thread_id)
+- debug labels
+- internal notes (e.g., “mapped outbound number configured”)
+- instructional or placeholder text intended for developers
+
+Replace with:
+- plain-language labels
+- clean status indicators
+- no leakage of internal system concepts
+
+---
+
+### 3.6 Consistent shell states
+
+Shell must own:
+
+- loading states between module transitions
+- empty states when no data
+- error states when routes or data fail
+
+Rules:
+- no blank screens
+- no raw error dumps
+- no module-specific inconsistent patterns at top level
+
+---
+
+### 3.7 Navigation polish
+
+- active module clearly indicated
+- nav is visually consistent across all routes
+- no duplication between modules
+- no shifting layout between People and ConnectShyft
+
+---
+
+### 3.8 Subject/context compatibility
+
+- subject/context continues to work
+- no visual conflicts with shell cleanup
+- no stale identity labels after resolution
+
+---
+
+### 3.9 Accessibility and clarity
+
+- buttons and nav items clearly labeled
+- consistent interaction patterns
+- no ambiguous actions
+
+---
+
+## 4. Explicit Non-Changes
+
+Do not:
+
+- redesign People or ConnectShyft internals
+- add new modules
+- introduce notification systems
+- add visible resolution history
+- change backend permission model
+
+---
+
+## 5. Tests Required
+
+### Unit
+
+- only allowed nav items render
+- hidden modules do not appear
+- role-based controls hidden correctly
+- no debug/ID strings in UI output
+
+### Integration
+
+- unauthorized routes redirect safely
+- feature flags control visibility correctly
+- switching modules maintains shell consistency
+- no engineering artifacts appear anywhere in shell
+
+### Regression
+
+- Slice 2B behavior intact
+- subject/context behavior intact
+- routing and orgUnit switching intact
+
+---
+
+## 6. Stop Condition (MANDATORY)
+
+- shell shows only MVP modules
+- role visibility enforced
+- no engineering artifacts visible
+- routing gated correctly
+- shell UI is clean, consistent, and user-safe
+
+---
+
+## 7. Commit Boundary
+
+```text
+feat(connectshyft-web): enforce feature flags, role visibility, and clean shell UI for MVP
+```
+
+---
+
+## 8. Verification Commands
+
+```bash
+rg "tenant_id|thread_id|person_id|debug|placeholder" apps/connectshyft-web
+```
+
+```bash
+rg "feature|flag|permission|role" apps/connectshyft-web apps/connectshyft-api libs/contracts
+```
+
+---
+
+## 9. Outcome
+
+After this checkpoint:
+
+- shell is production-safe
+- no internal artifacts leak to users
+- module visibility is correct
+- app feels cohesive and complete at MVP level

--- a/specs/prep_step_3_implementation_brief.md
+++ b/specs/prep_step_3_implementation_brief.md
@@ -1,0 +1,492 @@
+# PREP STEP 3 — IMPLEMENTATION BRIEF
+**Title:** Build the Shared Application Shell and Context Unification Layer at `app.shyftunity.com`
+
+## 1. Objective
+
+Deliver the unified ShyftUnity application shell at **`app.shyftunity.com`** so that:
+
+- People and ConnectShyft live inside one coherent application frame
+- the shell becomes the authoritative top-level experience for MVP
+- app-level routing, navigation, orgUnit context, subject context, and module visibility are unified
+- People and ConnectShyft stop feeling like adjacent tools and start feeling like one product
+- shell-level polish improves coherence without forcing premature deep per-view redesign
+- the system is ready for later THE_GOAL-level polish and future CaseShyft readiness work
+
+**Done =** a user can log into `app.shyftunity.com`, move between People and ConnectShyft inside one stable shell, keep orgUnit and subject context when appropriate, and never see fragmented app chrome or engineering-artifact framing.
+
+---
+
+## 2. Locked Product Decisions
+
+The following decisions are already locked and are authoritative for Prep Step 3:
+
+### Shell scope
+- MVP shell includes **People + ConnectShyft only**
+- unfinished modules are hidden entirely
+- no fake modules or placeholder destinations in MVP
+
+### Domain / deployment target
+- the unified application shell is served from **`app.shyftunity.com`**
+- deployment work will require:
+  - **Nginx** configuration for the application host
+  - **Cloudflare DNS** configuration for `app.shyftunity.com`
+- Prep Step 3 should account for this deployment target explicitly in architecture and routing assumptions
+
+### Navigation
+- top-level nav for MVP:
+  - **People**
+  - **ConnectShyft**
+  - **Settings / More**
+- **Resolver Queue remains inside People**, not as a top-level nav item
+
+### OrgUnit context
+- orgUnit selector is a persistent shell-level control
+- users may switch orgUnit from anywhere in the shell
+- orgUnit changes should preserve current page only when safe
+- otherwise, route to the nearest valid landing state for the new orgUnit
+
+### Subject/context bar
+- the shell includes a persistent subject/context bar whenever a specific subject is active
+- subject/context persists across People ↔ ConnectShyft when the same subject remains active
+- subject/context should not persist across obviously incompatible routes or orgUnit switches
+
+### Feature/module visibility
+- unfinished modules are hidden entirely
+- role-restricted surfaces are hidden unless visibility is operationally necessary
+
+### Polish boundary
+- Prep Step 3 includes **shell-level polish**
+- Prep Step 3 does **not** include deep per-view redesign
+- shell coherence comes first; detailed surface polish follows in a later prep step
+
+---
+
+## 3. Architectural Position (Locked)
+
+Prep Step 3 is **not** a new app and **not** a full redesign of People or ConnectShyft.
+
+The repo already contains:
+
+- real shell-oriented routing structure
+- real People and ConnectShyft views
+- subject-context primitives
+- orgUnit and feature-flag seams
+- role-aware and module-aware behavior
+- resolver work already centered in PeopleView
+- contextual identity/rebind state already present in ConnectShyft thread detail
+
+Prep Step 3 completes the missing top-level coherence layer:
+
+> **one shared shell, one navigation model, one orgUnit model, one subject/context model, one visible application experience**
+
+### Ownership model
+
+- **Shell** owns top-level routing, nav, orgUnit control, subject/context continuity, and module visibility
+- **People** remains the primary workspace for identity/resolver work
+- **ConnectShyft** remains the communications workspace with contextual identity state
+- **Feature flags / entitlements** continue to be backend-authoritative and frontend-consumed
+- **Per-view business logic** stays in its existing modules; the shell must not absorb domain behavior
+
+---
+
+## 4. Problem This Slice Solves
+
+Current repo state already has the core product logic, but the MVP still lacks a unified product container.
+
+Without Prep Step 3:
+
+- People and ConnectShyft still risk feeling like separate app surfaces
+- top-level navigation and context continuity remain fragmented
+- subject context can exist, but the shell is not yet the explicit home for it
+- orgUnit switching lacks fully unified shell behavior
+- feature/module visibility may still feel implementation-driven rather than product-driven
+- further visual polish would risk being done inside the wrong frame
+
+Prep Step 3 solves that by making the shell the authoritative top-level experience.
+
+---
+
+## 5. Domain and Deployment Target
+
+### 5.1 Canonical MVP host
+
+The unified application shell must be accessed via:
+
+**`app.shyftunity.com`**
+
+This host is the canonical entry point for the MVP shell.
+
+### 5.2 Infrastructure implications
+
+This requires real deployment coordination beyond repo code:
+
+- **Cloudflare DNS**
+  - create/update DNS for `app.shyftunity.com`
+  - ensure it targets the correct origin/service
+- **Nginx**
+  - create/update server block / reverse proxy config for `app.shyftunity.com`
+  - route the host to the correct application service
+  - preserve SPA routing behavior if applicable
+  - ensure TLS / forwarded headers / upstream behavior remain correct
+
+### 5.3 Scope handling
+
+Prep Step 3 implementation specs may include:
+- deployment assumptions
+- shell host expectations
+- route/path assumptions based on the `app.shyftunity.com` domain
+
+But this prep step is not a full ops runbook by default.  
+If needed, deployment/server configuration work can be captured in a dedicated checkpoint or implementation companion.
+
+---
+
+## 6. Shared Shell Backbone (Locked)
+
+### 6.1 One shell frame
+
+The shell must provide one shared application frame for:
+- top-level nav
+- orgUnit selector
+- subject/context bar
+- page title / shell chrome
+- role-aware module visibility
+- consistent loading / empty / error framing at the shell layer
+
+### 6.2 No fragmented local chrome
+
+Prep Step 3 must reduce or eliminate duplicated top-level app chrome across People and ConnectShyft where that chrome belongs in the shared shell.
+
+Examples of shell-owned concerns:
+- top nav
+- active module state
+- orgUnit switcher
+- shell-level headers
+- cross-surface subject context
+- shell-level empty/loading framing
+
+Examples that remain local:
+- People workspace internals
+- ConnectShyft inbox/thread internals
+- resolver queue details inside People
+- thread-level communication tools inside ConnectShyft
+
+### 6.3 Stable shell routing
+
+The shell must unify route framing so that:
+- People routes feel like one module inside the shell
+- ConnectShyft routes feel like one module inside the shell
+- moving between them does not feel like switching apps
+
+---
+
+## 7. Navigation Model (Locked)
+
+### 7.1 Top-level nav
+
+MVP top-level nav must include:
+- **People**
+- **ConnectShyft**
+- **Settings / More**
+
+### 7.2 Resolver Queue placement
+
+Resolver Queue remains inside **People**, not top-level nav.
+
+Reason:
+- identity/resolver work belongs in People
+- top-level nav should stay compact and product-clear
+- a dedicated resolver top-level destination would prematurely flatten domain boundaries
+
+### 7.3 Hidden unfinished modules
+
+Modules that are not ready for MVP must be hidden entirely.
+Do not show unavailable destinations just to hint at future scope.
+
+### 7.4 Role-aware nav visibility
+
+Shell nav must respect backend-authoritative role/entitlement truth.
+Role-restricted items should be hidden unless their visibility is operationally necessary.
+
+---
+
+## 8. OrgUnit Context Model (Locked)
+
+### 8.1 Persistent orgUnit control
+
+The shell must provide a persistent orgUnit selector visible throughout the app where appropriate.
+
+### 8.2 Shell-owned orgUnit truth
+
+The shell owns the active orgUnit context for navigation and route framing, while backend services remain authoritative for what orgUnits the user may access.
+
+### 8.3 Safe switch behavior
+
+When orgUnit changes:
+- preserve current page **only when safe**
+- otherwise redirect to the nearest valid landing page for the new orgUnit/module
+
+### 8.4 Safety rules
+
+Examples of “not safe”:
+- current person/thread does not exist or is not visible in the new orgUnit
+- current route depends on subject context bound to the prior orgUnit
+- current module is not enabled in the new orgUnit
+
+In those cases, route to the closest valid destination rather than preserving broken context.
+
+### 8.5 No stale orgUnit bleed
+
+Subject context, module visibility, and page state must not continue to imply the old orgUnit after switch.
+
+---
+
+## 9. Subject/Context Unification (Locked)
+
+### 9.1 Persistent subject/context bar
+
+When a specific subject is in focus, the shell must show a subject/context bar.
+
+At minimum, the bar should be able to reflect contract-backed context such as:
+- subject identity summary
+- identity state where relevant
+- orgUnit context
+- current linkage between People and ConnectShyft when the same subject is active
+
+Exact displayed fields may follow repo capabilities, but the semantic role is locked.
+
+### 9.2 Cross-module continuity
+
+If the same subject remains active while moving between:
+- People
+- ConnectShyft
+
+the shell should preserve subject/context continuity.
+
+### 9.3 Safe clearing rules
+
+The shell must clear or reset subject/context when:
+- route changes to a non-subject page
+- orgUnit switches invalidate current subject
+- current subject is no longer valid for the destination surface
+- backend truth indicates the previous subject context is stale or incompatible
+
+### 9.4 Final truth, not stale identity
+
+Subject/context bar must reflect current backend truth and must not preserve stale provisional or outdated subject assumptions after identity resolution/rebind.
+
+---
+
+## 10. Feature Flags and Module Visibility
+
+### 10.1 Backend-authoritative visibility
+
+Feature flags / entitlements remain backend-authoritative.
+The shell consumes them and enforces product visibility accordingly.
+
+### 10.2 MVP module rule
+
+For MVP:
+- show only modules that are live and intentionally available
+- hide unfinished modules completely
+
+### 10.3 Role-restricted surface rule
+
+Hide role-restricted surfaces unless visibility itself is operationally necessary.
+
+For example:
+- normal users should not see resolver-only entry points if those belong inside People and are not relevant
+- tenant-admin-only controls should appear only where needed and where backend authorization supports them
+
+### 10.4 No fake “coming soon” destinations
+
+Prep Step 3 should not introduce fake shell destinations for future product plans.
+
+---
+
+## 11. Shell-Level UX and Polish
+
+### 11.1 Allowed polish
+
+Prep Step 3 may improve:
+- shell chrome consistency
+- top-level nav clarity
+- orgUnit selector clarity
+- subject/context bar clarity
+- shell-level loading / empty / error states
+- removal of engineering-artifact framing from the top-level shell experience
+
+### 11.2 Not yet in scope
+
+Prep Step 3 does not deep-redesign:
+- ConnectShyft inbox
+- ConnectShyft thread detail internals
+- People workspace internals
+- resolver queue detail internals
+- other future module views
+
+### 11.3 THE_GOAL boundary
+
+Prep Step 3 should move the app meaningfully closer to THE_GOAL at the shell level only.
+
+---
+
+## 12. Backend/API Requirements
+
+Prep Step 3 must expose or finalize backend support for shell needs where not already stable, including as needed:
+
+- current-user/session summary
+- available orgUnits
+- active feature/module visibility
+- subject/context-safe summary payloads already used by People and ConnectShyft
+- route-safe validation inputs for orgUnit and subject transitions
+
+### API rule
+
+Route handlers remain thin:
+- authenticate/authorize
+- validate transport shape
+- call backend service
+- return normalized result
+
+The shell must not invent backend capability or visibility rules.
+
+---
+
+## 13. Frontend Requirements
+
+### 13.1 Shell root and routing
+
+The frontend must have one stable shell root that hosts:
+- People routes
+- ConnectShyft routes
+- Settings / More routes
+
+### 13.2 Shared shell state
+
+The frontend must maintain shell-level state for:
+- current module
+- current orgUnit
+- current subject/context when applicable
+- module visibility / entitlement-backed nav
+
+### 13.3 Route safety
+
+The shell must guard against invalid transitions when:
+- orgUnit changes
+- subject becomes invalid
+- module visibility changes
+- backend truth invalidates current route assumptions
+
+### 13.4 No duplicate local shell logic
+
+People and ConnectShyft should not each continue owning their own top-level app-shell logic once the shared shell exists.
+
+---
+
+## 14. Tests (Required)
+
+### Unit / Component tests
+
+- shell nav shows only allowed MVP modules
+- orgUnit selector renders and updates shell state correctly
+- subject/context bar appears when valid subject is active
+- subject/context bar clears when route/orgUnit invalidates it
+- hidden modules do not appear
+- role-restricted shell controls remain hidden when not allowed
+
+### Integration tests
+
+- user can navigate between People and ConnectShyft inside one shared shell
+- orgUnit switch preserves current page when safe
+- orgUnit switch redirects to nearest valid landing page when not safe
+- subject/context persists across People ↔ ConnectShyft when same subject remains active
+- subject/context is cleared or refreshed when backend truth invalidates it
+- feature/module visibility correctly hides unfinished surfaces
+- `app.shyftunity.com` assumptions are reflected in shell route/deployment expectations where applicable
+
+### Regression / characterization
+
+- Slice 2A and Slice 2B behavior remain intact inside the shell
+- People remains the primary resolver workspace
+- ConnectShyft remains the communications workspace with contextual identity state
+- shell changes do not break resolver queue behavior, subject snapshot behavior, or thread contextual banners
+
+---
+
+## 15. Explicit Non-Goals
+
+The following are out of scope for Prep Step 3:
+
+- deep redesign of People or ConnectShyft local views
+- CaseShyft readiness handoff work
+- visible “coming soon” module stubs
+- broad ops runbook beyond what is necessary to target `app.shyftunity.com`
+- non-MVP modules in shell nav
+- notifications/escalations unrelated to shell behavior
+- global application redesign beyond shell/context unification
+
+---
+
+## 16. Done Criteria
+
+Prep Step 3 is done only when:
+
+- the unified application shell is designed around **`app.shyftunity.com`**
+- People and ConnectShyft run inside one coherent shell
+- shell navigation is stable and MVP-scoped
+- orgUnit is a persistent shell control
+- orgUnit switching is safe and route-aware
+- subject/context persists across People ↔ ConnectShyft when appropriate
+- subject/context clears when invalid
+- hidden/unready modules are not exposed
+- role-restricted shell surfaces remain appropriately hidden
+- shell-level polish improves coherence without forcing deep per-view redesign
+
+---
+
+## 17. Recommended Checkpoint Shape
+
+Prep Step 3 should likely be broken into these checkpoints:
+
+1. **Shell backbone + top-level routing/chrome**
+   - shell root
+   - top-level nav
+   - MVP-scoped module visibility
+   - shell framing
+
+2. **OrgUnit context + route safety**
+   - persistent orgUnit selector
+   - orgUnit switch logic
+   - safe route preservation/reset behavior
+
+3. **Subject/context unification across People ↔ ConnectShyft**
+   - persistent subject/context bar
+   - cross-module continuity
+   - stale-context clearing and backend-truth refresh
+
+4. **Feature flags / role visibility / shell cleanup**
+   - hidden unfinished modules
+   - role-aware shell surfaces
+   - shell-level cleanup of engineering artifacts
+   - shell-level tests and polish
+
+Checkpoint count may be adjusted slightly if repo implementation suggests combining 1 and 4, but this is the recommended shape.
+
+---
+
+## 18. Locked Recommendation
+
+Proceed next with:
+
+> **Prep Step 3 — Checkpoint 1: shell backbone, top-level routing, and MVP-scoped module chrome**
+
+Do not start with deep visual redesign of ConnectShyft or People internals before the shell itself is stable.
+
+---
+
+## 19. Implementation Intent
+
+This is a **completion and hardening slice**, not a redesign.
+
+Use the repo’s existing route structure, shell primitives, subject-context seams, feature-flag seams, and People/ConnectShyft module boundaries. Extend them into one coherent MVP shell at `app.shyftunity.com`. Do not introduce fake modules, a second shell model, or frontend-owned entitlement/context truth.

--- a/tests/navigation/connectshyft-shell.smoke.spec.ts
+++ b/tests/navigation/connectshyft-shell.smoke.spec.ts
@@ -1,16 +1,283 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
-const shellRoutes = [
-  ['/app/connect', 'Connect shell view coming soon'],
-  ['/app/people', 'Load contact points'],
-  ['/app/work', 'Work shell view coming soon'],
-] as const;
+const mockUnifiedShellApis = async (page: Page) => {
+  await page.route('**/api/v1/**', async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname.replace(/^\/api\/v1/, '');
+
+    if (path === '/auth/me') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user: {
+            id: 'user-shell-smoke-1',
+          },
+        }),
+      });
+      return;
+    }
+
+    if (path === '/connectshyft/context') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            context: {
+              tenantId: 'tenant-shell-smoke-1',
+              orgUnitId: 'org-east',
+              orgUnits: [
+                {
+                  id: 'org-east',
+                  label: 'East Campus',
+                  availableModules: {
+                    people: true,
+                    connect: true,
+                    settings: true,
+                  },
+                },
+              ],
+              telephony: {
+                operatorPhoneSource: 'callback_number',
+                voiceReady: true,
+                smsReady: true,
+                degradedMode: false,
+              },
+            },
+          },
+        }),
+      });
+      return;
+    }
+
+    if (path === '/connectshyft/resolver-queue') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          code: 'CONNECTSHYFT_RESOLVER_QUEUE_LISTED',
+          message: 'ConnectShyft resolver queue listed',
+          data: {
+            items: [],
+          },
+        }),
+      });
+      return;
+    }
+
+    if (path === '/connectshyft/availability') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            flags: {
+              connectshyft_enabled: true,
+              connectshyft_inbox_enabled: true,
+              connectshyft_escalation_enabled: true,
+              connectshyft_webhooks_enabled: true,
+            },
+            capabilities: {
+              module: true,
+              inbox: true,
+              escalation: true,
+              webhooks: true,
+            },
+          },
+        }),
+      });
+      return;
+    }
+
+    if (path === '/connectshyft/inbox') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          code: 'CONNECTSHYFT_INBOX_LISTED',
+          message: 'ConnectShyft threads loaded',
+          data: {
+            items: [],
+            actions: {
+              claim: false,
+              takeover: false,
+            },
+            context: {
+              tenantId: 'tenant-shell-smoke-1',
+              orgUnitId: 'org-east',
+              bypassedOrgUnitMembership: false,
+            },
+          },
+        }),
+      });
+      return;
+    }
+
+    if (path === '/connectshyft/neighbors') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          code: 'CONNECTSHYFT_NEIGHBORS_RESOLVED',
+          data: {
+            scope: {
+              tenantId: 'tenant-shell-smoke-1',
+              orgUnitId: 'org-east',
+            },
+            neighbors: [
+              {
+                neighborId: 'neighbor-1',
+                tenantId: 'tenant-shell-smoke-1',
+                orgUnitId: 'org-east',
+                firstName: 'Ava',
+                lastName: 'Neighbor',
+                prefersTexting: 'YES',
+                phones: [
+                  {
+                    phoneId: 'phone-1',
+                    label: 'Mobile',
+                    value: '(555) 123-4567',
+                    sortOrder: 0,
+                    isPrimary: true,
+                    isShared: false,
+                    verificationStatus: 'verified',
+                    status: 'active_personal',
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      });
+      return;
+    }
+
+    if (path === '/connectshyft/settings/navigation') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            primaryOptions: [
+              {
+                key: 'settings',
+                label: 'Call routing',
+                path: '/app/connectshyft/settings',
+              },
+            ],
+            adminOptions: [],
+            pathways: [
+              {
+                path: '/app/connectshyft/settings',
+                allowed: true,
+              },
+            ],
+          },
+        }),
+      });
+      return;
+    }
+
+    if (path === '/connectshyft/operator/callback-number') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            callbackNumber: {
+              value: '+15551234567',
+              rawInput: '+1 (555) 123-4567',
+              createdAtUtc: '2026-03-24T10:00:00.000Z',
+              updatedAtUtc: '2026-03-24T10:00:00.000Z',
+            },
+          },
+        }),
+      });
+      return;
+    }
+
+    if (path === '/connectshyft/telephony-readiness') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            providerReady: true,
+            providerSelectionPathActive: true,
+            webhookSignatureConfigured: true,
+            orgUnitNumberMappingReady: true,
+            voiceSupported: true,
+            callbackNumberConfigured: true,
+            callbackNumberNormalized: true,
+            voiceReady: true,
+            bridgeCallRunnable: true,
+            smsReady: true,
+            messageDispatchRunnable: true,
+            operatorPhoneSource: 'callback_number',
+            degradedMode: false,
+            callbackNumber: {
+              value: '+15551234567',
+              rawInput: '+1 (555) 123-4567',
+              createdAtUtc: '2026-03-24T10:00:00.000Z',
+              updatedAtUtc: '2026-03-24T10:00:00.000Z',
+              persistenceAvailable: true,
+            },
+            blockingReasons: [],
+            nextActions: [],
+          },
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: false,
+        message: `Unhandled shell smoke API route: ${path}`,
+      }),
+    });
+  });
+};
 
 test.describe('ConnectShyft shell smoke', () => {
-  test('loads placeholder shell routes @P1', async ({ page }) => {
-    for (const [path, text] of shellRoutes) {
-      await page.goto(path);
-      await expect(page.getByText(text)).toBeVisible();
-    }
+  test.beforeEach(async ({ page }) => {
+    await mockUnifiedShellApis(page);
+  });
+
+  test('loads the unified shell routes @P1', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByTestId('app-shell-root')).toBeVisible();
+    await expect(page.getByTestId('shell-primary-nav')).toBeVisible();
+    await expect(page.getByTestId('shell-primary-nav-people')).toBeVisible();
+    await expect(page.getByTestId('shell-primary-nav-connect')).toBeVisible();
+    await expect(page.getByTestId('shell-primary-nav-settings')).toBeVisible();
+    await expect(page.getByText('Resolver workspace')).toBeVisible();
+    await expect(page.getByText('Primary queue for identity and rebind reviews')).toBeVisible();
+
+    await page.getByTestId('shell-primary-nav-connect').click();
+    await expect(page.getByTestId('connectshyft-inbox-surface')).toBeVisible();
+    await expect(page.getByText('1 neighbor is ready to reach out')).toBeVisible();
+    await page.getByTestId('connectshyft-section-nav-directory').click();
+    await expect(page.getByTestId('connectshyft-section-nav')).toBeVisible();
+    await expect(page.getByTestId('connectshyft-directory-surface')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Neighbor Directory' })).toBeVisible();
+    await expect(page.getByText('Ava Neighbor')).toBeVisible();
+
+    await page.getByTestId('shell-primary-nav-settings').click();
+    await expect(page.getByTestId('shell-settings-nav')).toBeVisible();
+    await expect(page.getByTestId('connectshyft-settings-surface')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'ConnectShyft Settings' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Callback / forwarding number' })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- establish the unified shell backbone and routing for People, ConnectShyft, and Settings
- add persistent orgUnit context with safe switching and confirmation for destructive changes
- unify shell-owned subject context across People and ConnectShyft
- enforce backend-driven module visibility, backend settings route gating, and clean shell-facing MVP copy
- add the Prep Step 3 implementation brief and checkpoint specs under `specs/`

## Testing
- `cd apps/connectshyft-web && npm test`
- `cd apps/connectshyft-web && npm run build`
- `cd apps/connectshyft-api && npx jest --runInBand --runTestsByPath src/modules/peoplecore/__tests__/service.test.ts src/routes/api/v1/__tests__/connectshyft.identity-ambiguity-ops.test.ts src/routes/api/v1/__tests__/connectshyft.thread-detail.characterization.test.ts`
- `cd apps/connectshyft-api && npx jest --runInBand --runTestsByPath src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts`

## Notes
- branch includes the four required Prep Step 3 checkpoint commits plus a docs commit for the implementation specs