### PR TITLE
Fix ConnectShyft prep step 4.5 communications blockers

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/operatorDestinationResolver.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/operatorDestinationResolver.test.ts
@@ -2,6 +2,7 @@ import {
   ConnectShyftOperatorDestinationResolverService,
   ConnectShyftTelephonyOperatorPhoneResolverService,
   InMemoryConnectShyftOperatorDestinationStore,
+  KnexConnectShyftOperatorDestinationStore,
 } from '../operatorDestinationResolver';
 
 describe('connectshyft operatorDestinationResolver', () => {
@@ -244,5 +245,50 @@ describe('connectshyft telephony operator phone resolver', () => {
       callbackNumberStatus: 'missing',
       orgUnitDefaultStatus: 'invalid',
     });
+  });
+});
+
+describe('KnexConnectShyftOperatorDestinationStore', () => {
+  const buildKnexMock = (row: Record<string, unknown> | null) => {
+    const first = jest.fn(async () => row);
+    const where = jest.fn(() => ({
+      first,
+    }));
+    const table = jest.fn(() => ({
+      where,
+    }));
+    const knex = jest.fn(() => ({
+      table,
+    }));
+
+    return {
+      knex: knex as any,
+      table,
+      where,
+      first,
+    };
+  };
+
+  it('reads user phones by id without household scoping', async () => {
+    const { knex, table, where, first } = buildKnexMock({
+      id: 'user-connectshyft-alpha-operator',
+      household_id: 'different-household-row',
+      phone_e164: '+12605550123',
+    });
+    const store = new KnexConnectShyftOperatorDestinationStore(knex);
+
+    await expect(store.getUserPhone({
+      tenantId: 'tenant-connectshyft-alpha',
+      userId: 'user-connectshyft-alpha-operator',
+    })).resolves.toEqual({
+      userId: 'user-connectshyft-alpha-operator',
+      phoneNumber: '+12605550123',
+    });
+
+    expect(table).toHaveBeenCalledWith('users');
+    expect(where).toHaveBeenCalledWith({
+      id: 'user-connectshyft-alpha-operator',
+    });
+    expect(first).toHaveBeenCalledWith(['id', 'phone_e164']);
   });
 });

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/readContracts.test.ts
@@ -154,7 +154,7 @@ describe('connectshyft read contracts', () => {
       preferredOutboundCsNumberId: '+12605552005',
       display: {
         inboundContext: 'Mapped inbound number configured',
-        outboundContext: 'Mapped outbound number configured',
+        outboundContext: 'Conversation line selected',
       },
     });
   });

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/telephonyReadiness.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/telephonyReadiness.test.ts
@@ -33,7 +33,7 @@ describe('connectshyft telephony readiness', () => {
     resolution: ConnectShyftTelephonyOperatorPhoneResolution,
   ) => jest.fn(async () => resolution);
 
-  it('reports callback-number missing when provider and number mappings are otherwise ready', async () => {
+  it('reports callback-number missing for calling while texting stays ready when provider and number mappings are otherwise ready', async () => {
     const readinessService = new AsyncConnectShyftTelephonyReadinessService(
       {
         listMappings: jest.fn(async () => [
@@ -85,8 +85,8 @@ describe('connectshyft telephony readiness', () => {
       callbackNumberNormalized: false,
       voiceReady: false,
       bridgeCallRunnable: false,
-      smsReady: false,
-      messageDispatchRunnable: false,
+      smsReady: true,
+      messageDispatchRunnable: true,
       operatorPhoneSource: 'none',
       degradedMode: false,
       provider: {
@@ -106,7 +106,7 @@ describe('connectshyft telephony readiness', () => {
       blockingReasons: expect.arrayContaining([
         expect.objectContaining({
           code: 'CONNECTSHYFT_OPERATOR_CALLBACK_NUMBER_MISSING',
-          channel: 'both',
+          channel: 'voice',
         }),
       ]),
       nextActions: expect.arrayContaining([
@@ -318,6 +318,7 @@ describe('connectshyft telephony readiness', () => {
           code: 'CONNECTSHYFT_ORGUNIT_DEFAULT_OPERATOR_PHONE_ACTIVE',
           category: 'orgunit_fallback',
           blocking: false,
+          channel: 'voice',
         }),
       ]),
       nextActions: expect.arrayContaining([

--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts
@@ -2,9 +2,11 @@ import {
   AsyncConnectShyftThreadService,
   ConnectShyftThreadService,
   InMemoryConnectShyftThreadStore,
+  KnexConnectShyftThreadStore,
   evaluateConnectShyftLifecyclePolicy,
 } from '../threads';
 import { resolveSenderNumber } from '../senderNumberResolver';
+import logger from '../../../utils/logger';
 
 const withRequiredPersonId = <T extends { neighborId: string; personId?: string }>(
   input: T,
@@ -508,6 +510,127 @@ describe('connectshyft async thread service persistence guards', () => {
       code: 'CONNECTSHYFT_THREAD_ENSURE_PERSISTENCE_UNAVAILABLE',
     });
     expect(store.ensureActiveThread).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs transition persistence failures with the text actor id that triggered the claim', async () => {
+    const missingSchemaError = Object.assign(new Error('relation does not exist'), {
+      code: '42P01',
+    });
+    const store = {
+      ensureActiveThread: jest.fn(),
+      listDueThreads: jest.fn(),
+      transitionThreadState: jest.fn().mockRejectedValue(missingSchemaError),
+    } as any;
+    const loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation(() => logger);
+    const service = new AsyncConnectShyftThreadService(store);
+
+    const result = await service.transitionThreadState({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-c1',
+      threadId: 'thread-connectshyft-c1-claim-logging',
+      nextState: 'CLAIMED',
+      actorUserId: 'operator-text-id',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_PERSISTENCE_UNAVAILABLE',
+    });
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'connectshyft thread transition persistence failed',
+      expect.objectContaining({
+        tenantId: 'tenant-connectshyft-c1',
+        threadId: 'thread-connectshyft-c1-claim-logging',
+        nextState: 'CLAIMED',
+        actorUserId: 'operator-text-id',
+        error: missingSchemaError,
+      }),
+    );
+
+    loggerErrorSpy.mockRestore();
+  });
+});
+
+describe('connectshyft knex thread persistence', () => {
+  it('persists a claimed thread with a stable text actor id', async () => {
+    const existingRow = {
+      id: 'thread-connectshyft-c1-persisted-claim',
+      tenant_id: 'tenant-connectshyft-c1',
+      org_unit_id: 'org-connectshyft-c1-east',
+      neighbor_id: 'neighbor-connectshyft-c1-9001',
+      person_id: 'person-connectshyft-c1-9001',
+      origin_person_id: null,
+      activity_id: null,
+      source: 'VOICE',
+      state: 'UNCLAIMED',
+      escalation_stage: 2,
+      next_evaluation_at_utc: '2026-03-01T00:00:00.000Z',
+      last_inbound_cs_number_id: '+12605550191',
+      preferred_outbound_cs_number_id: '+12605550191',
+      claimed_by_user_id: null,
+      claimed_at_utc: null,
+      closed_by_user_id: null,
+      closed_at_utc: null,
+      created_at_utc: '2026-03-01T00:00:00.000Z',
+      updated_at_utc: '2026-03-01T00:00:00.000Z',
+    };
+    const updatedRow = {
+      ...existingRow,
+      state: 'CLAIMED',
+      escalation_stage: 0,
+      next_evaluation_at_utc: null,
+      claimed_by_user_id: 'operator-text-id',
+      claimed_at_utc: '2026-03-02T00:00:00.000Z',
+      updated_at_utc: '2026-03-02T00:00:00.000Z',
+    };
+    const capturedUpdates: Array<Record<string, unknown>> = [];
+
+    const createBuilder = () => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(existingRow),
+      update: jest.fn((payload: Record<string, unknown>) => {
+        capturedUpdates.push(payload);
+        return {
+          returning: jest.fn().mockResolvedValue([updatedRow]),
+        };
+      }),
+    });
+
+    const trx = {
+      fn: {
+        now: jest.fn(() => 'db-now'),
+      },
+      withSchema: jest.fn().mockReturnValue({
+        table: jest.fn(() => createBuilder()),
+      }),
+    };
+    const knexClient = {
+      transaction: jest.fn(async (handler: (transaction: typeof trx) => Promise<unknown>) => handler(trx)),
+    } as any;
+    const store = new KnexConnectShyftThreadStore(knexClient);
+
+    const result = await store.transitionThreadState({
+      tenantId: 'tenant-connectshyft-c1',
+      threadId: 'thread-connectshyft-c1-persisted-claim',
+      nextState: 'CLAIMED',
+      actorUserId: 'operator-text-id',
+    } as any);
+
+    expect(result).toMatchObject({
+      ok: true,
+      thread: {
+        threadId: 'thread-connectshyft-c1-persisted-claim',
+        state: 'CLAIMED',
+        claimedByUserId: 'operator-text-id',
+      },
+    });
+    expect(capturedUpdates).toContainEqual(expect.objectContaining({
+      state: 'CLAIMED',
+      claimed_by_user_id: 'operator-text-id',
+      claimed_at_utc: 'db-now',
+      updated_by_user_id: 'operator-text-id',
+      updated_at_utc: 'db-now',
+    }));
   });
 });
 

--- a/apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts
@@ -47,6 +47,21 @@ export type ConnectShyftResolvedWebhookCorrelation =
     providerNumberE164: string | null;
   };
 
+export type ResolveInboundWebhookCorrelationInput = {
+  body: unknown;
+  channelHint: 'sms' | 'voice';
+  providerName: string;
+  providerCorrelation: {
+    providerLegId: string | null;
+    providerMessageId: string | null;
+    providerEventId: string | null;
+    providerNumber: string | null;
+  };
+  tenantIdHint?: string | null;
+};
+
+export type ResolveInboundWebhookCorrelationResult = ConnectShyftResolvedWebhookCorrelation;
+
 export type ConnectShyftInboundWebhookAccessContext = {
   routeKind: ConnectShyftInboundWebhookRouteKind;
   providerSelection: ConnectShyftProviderResolutionSuccess;
@@ -138,18 +153,9 @@ const resolveWebhookCorrelationFailure = (
   };
 };
 
-const resolveInboundWebhookCorrelation = async (input: {
-  body: unknown;
-  channelHint: 'sms' | 'voice';
-  providerName: string;
-  providerCorrelation: {
-    providerLegId: string | null;
-    providerMessageId: string | null;
-    providerEventId: string | null;
-    providerNumber: string | null;
-  };
-  tenantIdHint?: string | null;
-}): Promise<ConnectShyftResolvedWebhookCorrelation> => {
+export const resolveInboundWebhookCorrelation = async (
+  input: ResolveInboundWebhookCorrelationInput,
+): Promise<ResolveInboundWebhookCorrelationResult> => {
   const payload = asRecord(input.body);
   const tenantId = normalizeString(payload?.tenantId);
   const orgUnitId = normalizeString(payload?.orgUnitId);

--- a/apps/connectshyft-api/src/modules/connectshyft/operatorDestinationResolver.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/operatorDestinationResolver.ts
@@ -253,7 +253,6 @@ implements ConnectShyftOperatorDestinationStore {
     const row = await this.usersTable()
       .where({
         id: input.userId,
-        household_id: input.tenantId,
       })
       .first(['id', 'phone_e164']);
 

--- a/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/readContracts.ts
@@ -930,7 +930,7 @@ const buildThreadDisplayRecord = (input: {
   );
   const outboundContext = normalizeString(input.preferredOutboundLabel)
     || (preferredOutboundProviderNumber
-      ? 'Mapped outbound number configured'
+      ? 'Conversation line selected'
       : 'Outbound number unavailable');
   const inboundContext = lastInboundProviderNumber
     ? 'Mapped inbound number configured'

--- a/apps/connectshyft-api/src/modules/connectshyft/telephonyReadiness.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/telephonyReadiness.ts
@@ -302,7 +302,7 @@ const mapCallbackNumberReadiness = (
         'callback_number',
         'Operator callback number storage is unavailable. Voice forwarding readiness cannot be confirmed.',
         {
-          channel: 'both',
+          channel: 'voice',
         },
       ),
     };
@@ -324,7 +324,7 @@ const mapCallbackNumberReadiness = (
         'callback_number',
         'Voice forwarding requires an operator callback number.',
         {
-          channel: 'both',
+          channel: 'voice',
         },
       ),
     };
@@ -347,7 +347,7 @@ const mapCallbackNumberReadiness = (
         'callback_number',
         'Operator callback number must be a dialable voice number.',
         {
-          channel: 'both',
+          channel: 'voice',
         },
       ),
     };
@@ -466,7 +466,7 @@ const buildDegradedModeReason = (
     : 'Using the orgUnit fallback phone until the operator callback number is set.',
   {
     blocking: false,
-    channel: 'both',
+    channel: 'voice',
   },
 );
 
@@ -476,7 +476,7 @@ const buildInvalidOrgUnitFallbackReason = (): ConnectShyftTelephonyReadinessBloc
     'orgunit_fallback',
     'OrgUnit fallback phone must be a valid dialable number before telephony can route through fallback.',
     {
-      channel: 'both',
+      channel: 'voice',
     },
   );
 
@@ -571,7 +571,8 @@ export class AsyncConnectShyftTelephonyReadinessService {
     }
 
     const voiceChannelReady = canDispatchForChannel(operatorPhoneResolution, 'voice');
-    const smsChannelReady = canDispatchForChannel(operatorPhoneResolution, 'sms');
+    // SMS workspace readiness depends on provider + webhook + mapped lines, not the operator callback path.
+    const smsChannelReady = true;
     const bridgeCallRunnable = providerReadiness.providerReady
       && providerReadiness.webhookSignatureConfigured
       && numberMappings.activeCount > 0

--- a/apps/connectshyft-api/src/modules/connectshyft/threadSmsTargetResolver.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/threadSmsTargetResolver.ts
@@ -1,0 +1,141 @@
+import type { ContactPoint } from '@shyft/contracts';
+import { validatePhoneForChannel } from '../../../../../domains/communication';
+import {
+  AsyncPeopleCoreService,
+  peopleCoreServiceAsync,
+} from '../peoplecore/service';
+
+type ResolveThreadSmsTargetService = Pick<
+  AsyncPeopleCoreService,
+  'getContactPoint' | 'listContactPointLinks'
+>;
+
+const ACTIVE_SMS_CONTACT_POINT_STATUSES = new Set<ContactPoint['status']>([
+  'active_personal',
+  'active_shared_possible',
+  'active_shared_confirmed',
+]);
+
+const normalizeString = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+};
+
+const buildMissingTargetRefusal = (): {
+  ok: false;
+  code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED';
+  message: string;
+  reason: 'missing_target';
+} => ({
+  ok: false,
+  code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+  message: 'This conversation cannot send a text until a textable contact is ready.',
+  reason: 'missing_target',
+});
+
+const buildAmbiguousTargetRefusal = (): {
+  ok: false;
+  code: 'CONNECTSHYFT_SMS_TARGET_AMBIGUOUS';
+  message: string;
+  reason: 'ambiguous_target';
+} => ({
+  ok: false,
+  code: 'CONNECTSHYFT_SMS_TARGET_AMBIGUOUS',
+  message: 'This conversation needs one clear textable contact before sending a text.',
+  reason: 'ambiguous_target',
+});
+
+const buildInvalidTargetRefusal = (): {
+  ok: false;
+  code: 'CONNECTSHYFT_SMS_TARGET_INVALID';
+  message: string;
+  reason: 'invalid_target';
+} => ({
+  ok: false,
+  code: 'CONNECTSHYFT_SMS_TARGET_INVALID',
+  message: 'This conversation cannot send a text until the saved contact can receive texts.',
+  reason: 'invalid_target',
+});
+
+const isSmsCapableContactPoint = (contactPoint: ContactPoint): boolean => {
+  return contactPoint.type === 'phone'
+    && ACTIVE_SMS_CONTACT_POINT_STATUSES.has(contactPoint.status)
+    && validatePhoneForChannel(contactPoint.normalizedValue, 'sms').ok;
+};
+
+export const buildResolveThreadSmsTarget = (
+  service: ResolveThreadSmsTargetService = peopleCoreServiceAsync,
+) => {
+  return async (input: {
+    tenantId: string;
+    orgUnitId: string;
+    threadId: string;
+    personId: string;
+  }): Promise<
+    | { ok: true; contactPointId: string; normalizedValue: string }
+    | {
+        ok: false;
+        code:
+          | 'CONNECTSHYFT_SMS_TARGET_REQUIRED'
+          | 'CONNECTSHYFT_SMS_TARGET_AMBIGUOUS'
+          | 'CONNECTSHYFT_SMS_TARGET_INVALID';
+        message: string;
+        reason: 'missing_target' | 'ambiguous_target' | 'invalid_target';
+      }
+  > => {
+    const personId = normalizeString(input.personId);
+    if (!personId) {
+      return buildMissingTargetRefusal();
+    }
+
+    const currentLinks = await service.listContactPointLinks({
+      tenantId: input.tenantId,
+      subjectType: 'person',
+      subjectId: personId,
+      isCurrent: true,
+    });
+    const contactPointIds = Array.from(new Set(
+      currentLinks
+        .map((link) => normalizeString(link.contactPointId))
+        .filter((contactPointId) => contactPointId.length > 0),
+    ));
+
+    if (contactPointIds.length === 0) {
+      return buildMissingTargetRefusal();
+    }
+
+    const contactPoints = (
+      await Promise.all(
+        contactPointIds.map((contactPointId) => service.getContactPoint({
+          tenantId: input.tenantId,
+          contactPointId,
+        })),
+      )
+    ).filter((contactPoint): contactPoint is ContactPoint => contactPoint !== null);
+
+    const phoneContactPoints = contactPoints.filter((contactPoint) => contactPoint.type === 'phone');
+    if (phoneContactPoints.length === 0) {
+      return buildMissingTargetRefusal();
+    }
+
+    const smsCapableContactPoints = phoneContactPoints.filter(isSmsCapableContactPoint);
+    if (smsCapableContactPoints.length === 1) {
+      return {
+        ok: true,
+        contactPointId: smsCapableContactPoints[0].id,
+        normalizedValue: smsCapableContactPoints[0].normalizedValue,
+      };
+    }
+
+    if (smsCapableContactPoints.length > 1) {
+      return buildAmbiguousTargetRefusal();
+    }
+
+    return buildInvalidTargetRefusal();
+  };
+};
+
+export const resolveThreadSmsTarget = buildResolveThreadSmsTarget();

--- a/apps/connectshyft-api/src/modules/connectshyft/threads.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/threads.ts
@@ -3,6 +3,7 @@ import type { Knex } from 'knex';
 import db from '../../config/knex';
 import { CAPABILITIES, hasCapability } from '../../platform/rbac/capabilities';
 import { isStrictUtcIsoTimestamp } from '../../platform/time/timezoneService';
+import logger from '../../utils/logger';
 import {
   AsyncPeopleCoreService,
   peopleCoreServiceAsync,
@@ -1256,7 +1257,7 @@ export class KnexConnectShyftThreadStore {
         } as ThreadPersistenceTransitionResult;
       }
 
-      const normalizedActorUserId = normalizeUuid(input.actorUserId);
+      const normalizedActorUserId = normalizeString(input.actorUserId) || null;
       if (input.nextState !== 'UNCLAIMED' && !normalizedActorUserId) {
         return {
           ok: false,
@@ -1834,6 +1835,14 @@ export class AsyncConnectShyftThreadService {
       if (!isMissingPersistenceError(error)) {
         throw error;
       }
+
+      logger.error('connectshyft thread transition persistence failed', {
+        tenantId: input.tenantId,
+        threadId: input.threadId,
+        nextState: input.nextState,
+        actorUserId: input.actorUserId,
+        error: error,
+      });
 
       return buildPersistenceUnavailableRefusal();
     }

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
@@ -1140,7 +1140,7 @@ describe('connectshyft outbound dispatch routes', () => {
     expect(sendSmsMock).not.toHaveBeenCalled();
   });
 
-  it('returns CONNECTSHYFT_SMS_NOT_READY before route-level sender-ambiguity validation when telephony readiness blocks outbound SMS', async () => {
+  it('returns CONNECTSHYFT_SMS_NOT_READY before route-level sender-ambiguity validation when webhook validation blocks outbound SMS', async () => {
     const routingMappingMock = connectShyftNumberMappingServiceAsync.resolveRoutingMappingByNumber as jest.MockedFunction<
       typeof connectShyftNumberMappingServiceAsync.resolveRoutingMappingByNumber
     >;
@@ -1164,31 +1164,22 @@ describe('connectshyft outbound dispatch routes', () => {
       ],
     });
     inspectReadinessSpy.mockResolvedValueOnce(buildDispatchReadyTelephonyReadiness({
-      callbackNumberConfigured: false,
-      callbackNumberNormalized: false,
+      webhookSignatureConfigured: false,
       smsReady: false,
       messageDispatchRunnable: false,
-      callbackNumber: {
-        value: null,
-        rawInput: null,
-        createdAtUtc: null,
-        updatedAtUtc: null,
-        persistenceAvailable: true,
-      },
-      operatorPhoneSource: 'none',
       blockingReasons: [
         {
-          code: 'CONNECTSHYFT_OPERATOR_CALLBACK_NUMBER_MISSING',
-          category: 'callback_number',
-          message: 'Voice forwarding requires an operator callback number.',
+          code: 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED',
+          category: 'provider',
+          message: 'Webhook signature verification must be configured before outbound telephony can be dispatched.',
           blocking: true,
           channel: 'both',
         },
       ],
       nextActions: [
         {
-          code: 'SET_OPERATOR_CALLBACK_NUMBER',
-          message: 'Save a callback / forwarding number for the current operator.',
+          code: 'CONFIGURE_CONNECTSHYFT_WEBHOOK_SIGNATURE',
+          message: 'Configure webhook signature verification for the active telephony provider.',
         },
       ],
     }));
@@ -1209,11 +1200,10 @@ describe('connectshyft outbound dispatch routes', () => {
       code: 'CONNECTSHYFT_SMS_NOT_READY',
       data: {
         telephonyReadiness: {
-          callbackNumberConfigured: false,
           smsReady: false,
           blockingReasons: [
             expect.objectContaining({
-              code: 'CONNECTSHYFT_OPERATOR_CALLBACK_NUMBER_MISSING',
+              code: 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED',
             }),
           ],
         },

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts
@@ -2,7 +2,6 @@ import connectShyftRouter, {
   ensureConnectShyftDispatchReadySmsTargetForTests,
   resetConnectShyftOutboundDispatchReplayLedgerForTests,
   resolveConnectShyftSmsSenderForTests,
-  resolveConnectShyftSmsTargetForTests,
 } from '../connectshyft';
 import { TelephonyProviderFailure } from '../../../../../../../domains/communication';
 import {
@@ -15,16 +14,15 @@ import {
 } from '../../../../modules/connectshyft/bridgeSessions';
 import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
 import {
-  connectShyftNeighborServiceAsync,
-  type ConnectShyftNeighborPhone,
-  type ConnectShyftResolveNeighborResult,
-} from '../../../../modules/connectshyft/neighbors';
-import {
   connectShyftNumberMappingServiceAsync,
   type ConnectShyftNumberMapping,
 } from '../../../../modules/connectshyft/numberMappings';
 import * as OperatorDestinationResolverModule from '../../../../modules/connectshyft/operatorDestinationResolver';
 import { resetConnectShyftProviderCorrelationStateForTests } from '../../../../modules/connectshyft/providerCorrelationMappings';
+import {
+  buildResolveThreadSmsTarget,
+} from '../../../../modules/connectshyft/threadSmsTargetResolver';
+import * as ThreadSmsTargetResolverModule from '../../../../modules/connectshyft/threadSmsTargetResolver';
 import * as TelephonyReadinessModule from '../../../../modules/connectshyft/telephonyReadiness';
 import type { ConnectShyftTelephonyReadiness } from '../../../../modules/connectshyft/telephonyReadiness';
 import {
@@ -249,53 +247,6 @@ const invokeRoute = async (input: {
   });
 };
 
-const buildResolvedNeighborPhone = (
-  overrides: Partial<ConnectShyftNeighborPhone> & Pick<ConnectShyftNeighborPhone, 'phoneId' | 'value'>,
-): ConnectShyftNeighborPhone => ({
-  phoneId: overrides.phoneId,
-  label: overrides.label ?? 'mobile',
-  value: overrides.value,
-  rawInput: overrides.rawInput ?? overrides.value,
-  displayNational: overrides.displayNational ?? '(260) 555-0111',
-  countryCode: overrides.countryCode ?? '1',
-  nationalNumber: overrides.nationalNumber ?? '2605550111',
-  extension: overrides.extension ?? null,
-  validationStatus: overrides.validationStatus ?? 'valid',
-  usageType: overrides.usageType ?? 'mobile',
-  source: overrides.source ?? 'user_entered',
-  sortOrder: overrides.sortOrder ?? 0,
-  isPrimary: overrides.isPrimary ?? false,
-  isShared: overrides.isShared ?? false,
-  verificationStatus: overrides.verificationStatus ?? 'verified',
-  isActive: overrides.isActive ?? true,
-  createdAtUtc: overrides.createdAtUtc ?? '2026-03-11T12:00:00.000Z',
-  updatedAtUtc: overrides.updatedAtUtc ?? '2026-03-11T12:00:00.000Z',
-});
-
-const buildResolvedNeighborResult = (
-  phones: ConnectShyftNeighborPhone[],
-): ConnectShyftResolveNeighborResult => ({
-  ok: true,
-  code: 'CONNECTSHYFT_NEIGHBOR_RESOLVED',
-  httpStatus: 200,
-  data: {
-    neighbor: {
-      neighborId: 'neighbor-connectshyft-f1-1001',
-      tenantId: 'tenant-connectshyft-f1',
-      orgUnitId: 'org-connectshyft-f1-east',
-      firstName: 'Route',
-      lastName: 'Fixture',
-      prefersTexting: 'YES',
-      isDeleted: false,
-      deletedAtUtc: null,
-      deletedByUserId: null,
-      phones,
-      createdAtUtc: '2026-03-11T12:00:00.000Z',
-      updatedAtUtc: '2026-03-11T12:00:00.000Z',
-    },
-  },
-});
-
 const buildResolvedSmsPreference = (
   overrides: Partial<ConnectShyftResolvedSmsPreference> = {},
 ): ConnectShyftResolvedSmsPreference => ({
@@ -391,6 +342,40 @@ const buildSmsTargetThread = (overrides: Partial<ConnectShyftThread> = {}): Conn
   updatedAtUtc: overrides.updatedAtUtc ?? '2026-03-11T12:00:00.000Z',
 });
 
+const buildPeopleCoreContactPoint = (overrides: Record<string, unknown> = {}) => ({
+  id: 'contact-point-connectshyft-f1-1001',
+  tenantId: 'tenant-connectshyft-f1',
+  type: 'phone',
+  normalizedValue: '+12605550111',
+  rawValue: '(260) 555-0111',
+  status: 'active_personal',
+  firstSeenAt: '2026-03-11T12:00:00.000Z',
+  lastSeenAt: '2026-03-11T12:00:00.000Z',
+  suspectedShared: false,
+  confirmedShared: false,
+  reassignmentSuspected: false,
+  createdAt: '2026-03-11T12:00:00.000Z',
+  updatedAt: '2026-03-11T12:00:00.000Z',
+  ...overrides,
+});
+
+const buildPeopleCoreContactPointLink = (overrides: Record<string, unknown> = {}) => ({
+  id: 'contact-point-link-connectshyft-f1-1001',
+  contactPointId: 'contact-point-connectshyft-f1-1001',
+  subjectType: 'person',
+  subjectId: '33333333-3333-4333-8333-333333333333',
+  linkType: 'primary',
+  confidenceBand: 'high',
+  isCurrent: true,
+  isPrimary: true,
+  manuallyConfirmed: false,
+  firstLinkedAt: '2026-03-11T12:00:00.000Z',
+  linkedBy: 'system',
+  createdAt: '2026-03-11T12:00:00.000Z',
+  updatedAt: '2026-03-11T12:00:00.000Z',
+  ...overrides,
+});
+
 const buildDispatchReadyTelephonyReadiness = (
   overrides: Partial<ConnectShyftTelephonyReadiness> = {},
 ): ConnectShyftTelephonyReadiness => ({
@@ -440,6 +425,7 @@ describe('connectshyft outbound dispatch routes', () => {
   const previousEnableFlags = process.env.ENABLE_TEST_CONNECTSHYFT_FLAGS;
   let inspectReadinessSpy: jest.SpyInstance;
   let resolveOperatorDestinationSpy: jest.SpyInstance;
+  let resolveThreadSmsTargetSpy: jest.SpyInstance;
 
   const setDispatchReadyTelephony = (
     overrides: Partial<ConnectShyftTelephonyReadiness> = {},
@@ -481,6 +467,16 @@ describe('connectshyft outbound dispatch routes', () => {
       userId: 'user-connectshyft-f1-primary-operator',
       orgUnitId: 'org-connectshyft-f1-east',
     });
+    resolveThreadSmsTargetSpy = jest.spyOn(
+      ThreadSmsTargetResolverModule,
+      'resolveThreadSmsTarget',
+    ).mockImplementation(async (input) => ({
+      ok: true,
+      contactPointId: `contact-point-${input.personId}`,
+      normalizedValue: input.threadId.includes('thread-f2')
+        ? '+12605550112'
+        : '+12605550111',
+    }));
     jest.spyOn(connectShyftNumberMappingServiceAsync, 'resolveRoutingMappingByNumber').mockImplementation(
       async (input) => resolveRoutingMappingByNumberFromState(input),
     );
@@ -559,8 +555,7 @@ describe('connectshyft outbound dispatch routes', () => {
     }));
   });
 
-  it('prefers an explicit outbound request target over neighbor-record phones for SMS dispatch', async () => {
-    const resolveNeighborSpy = jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor');
+  it('ignores an explicit outbound request target and dispatches SMS to the PeopleCore contact point', async () => {
     jest.spyOn(connectShyftSmsPreferenceOverrideServiceAsync, 'resolvePreference').mockResolvedValue(
       buildResolvedSmsPreference(),
     );
@@ -580,9 +575,14 @@ describe('connectshyft outbound dispatch routes', () => {
       ok: true,
       code: 'CONNECTSHYFT_THREAD_MESSAGE_DISPATCHED',
     });
-    expect(resolveNeighborSpy).not.toHaveBeenCalled();
+    expect(resolveThreadSmsTargetSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: 'thread-f1-unclaimed-1001',
+      personId: 'person-connectshyft-f1-1001',
+    }));
     expect(sendSmsMock).toHaveBeenCalledWith(expect.objectContaining({
-      targetPhone: '+12605550999',
+      targetPhone: '+12605550111',
       senderPhone: '+12605550191',
     }));
   });
@@ -658,165 +658,117 @@ describe('connectshyft outbound dispatch routes', () => {
     }));
   });
 
-  it('selects the primary active valid neighbor phone when no explicit SMS target is provided', async () => {
-    jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue(
-      buildResolvedNeighborResult([
-        buildResolvedNeighborPhone({
-          phoneId: 'phone-primary',
-          value: '+12605550141',
-          isPrimary: true,
-          sortOrder: 0,
-        }),
-        buildResolvedNeighborPhone({
-          phoneId: 'phone-secondary',
-          value: '+12605550142',
-          isPrimary: false,
-          sortOrder: 1,
-        }),
+  it('resolves outbound SMS from the single current PeopleCore contact point', async () => {
+    const resolveThreadSmsTarget = buildResolveThreadSmsTarget({
+      listContactPointLinks: jest.fn(async () => [
+        buildPeopleCoreContactPointLink(),
       ]),
-    );
+      getContactPoint: jest.fn(async () => buildPeopleCoreContactPoint({
+        id: 'contact-point-connectshyft-f1-1041',
+        normalizedValue: '+12605550141',
+      })),
+    } as any);
 
-    const response = await resolveConnectShyftSmsTargetForTests({
+    const response = await resolveThreadSmsTarget({
       tenantId: 'tenant-connectshyft-f1',
       orgUnitId: 'org-connectshyft-f1-east',
       threadId: '33333333-3333-4333-8333-333333333333',
-      thread: buildSmsTargetThread(),
-      actorRoles: ['ORGUNIT_MEMBER'],
-      requestedTargetPhone: null,
-      allowTestFallback: false,
+      personId: '33333333-3333-4333-8333-333333333333',
     });
 
-    expect(response).toMatchObject({
+    expect(response).toEqual({
       ok: true,
-      source: 'primary_active_valid_phone',
-      targetPhone: '+12605550141',
+      contactPointId: 'contact-point-connectshyft-f1-1041',
+      normalizedValue: '+12605550141',
     });
   });
 
-  it('selects the only active valid neighbor phone when the primary phone is not SMS eligible', async () => {
-    jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue(
-      buildResolvedNeighborResult([
-        buildResolvedNeighborPhone({
-          phoneId: 'phone-invalid-primary',
-          value: '+12605550143',
-          isPrimary: true,
-          validationStatus: 'invalid',
-          sortOrder: 0,
+  it('refuses ambiguous PeopleCore SMS target resolution before provider dispatch', async () => {
+    const resolveThreadSmsTarget = buildResolveThreadSmsTarget({
+      listContactPointLinks: jest.fn(async () => [
+        buildPeopleCoreContactPointLink({
+          contactPointId: 'contact-point-connectshyft-f1-1045',
         }),
-        buildResolvedNeighborPhone({
-          phoneId: 'phone-only-valid',
-          value: '+12605550144',
+        buildPeopleCoreContactPointLink({
+          id: 'contact-point-link-connectshyft-f1-1046',
+          contactPointId: 'contact-point-connectshyft-f1-1046',
+          linkType: 'secondary',
           isPrimary: false,
-          sortOrder: 1,
         }),
       ]),
-    );
+      getContactPoint: jest.fn(async ({ contactPointId }: { contactPointId: string }) => {
+        if (contactPointId === 'contact-point-connectshyft-f1-1045') {
+          return buildPeopleCoreContactPoint({
+            id: contactPointId,
+            normalizedValue: '+12605550145',
+          });
+        }
 
-    const response = await resolveConnectShyftSmsTargetForTests({
-      tenantId: 'tenant-connectshyft-f1',
-      orgUnitId: 'org-connectshyft-f1-east',
-      threadId: '44444444-4444-4444-8444-444444444444',
-      thread: buildSmsTargetThread({
-        neighborId: '55555555-5555-4555-8555-555555555555',
+        return buildPeopleCoreContactPoint({
+          id: contactPointId,
+          normalizedValue: '+12605550146',
+        });
       }),
-      actorRoles: ['ORGUNIT_MEMBER'],
-      requestedTargetPhone: null,
-      allowTestFallback: false,
-    });
+    } as any);
 
-    expect(response).toMatchObject({
-      ok: true,
-      source: 'only_active_valid_phone',
-      targetPhone: '+12605550144',
-    });
-  });
-
-  it('refuses ambiguous SMS target resolution before provider dispatch', async () => {
-    jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue(
-      buildResolvedNeighborResult([
-        buildResolvedNeighborPhone({
-          phoneId: 'phone-a',
-          value: '+12605550145',
-          isPrimary: false,
-          sortOrder: 0,
-        }),
-        buildResolvedNeighborPhone({
-          phoneId: 'phone-b',
-          value: '+12605550146',
-          isPrimary: false,
-          sortOrder: 1,
-        }),
-      ]),
-    );
-
-    const response = await resolveConnectShyftSmsTargetForTests({
+    const response = await resolveThreadSmsTarget({
       tenantId: 'tenant-connectshyft-f1',
       orgUnitId: 'org-connectshyft-f1-east',
       threadId: '66666666-6666-4666-8666-666666666666',
-      thread: buildSmsTargetThread({
-        neighborId: '77777777-7777-4777-8777-777777777777',
-      }),
-      actorRoles: ['ORGUNIT_MEMBER'],
-      requestedTargetPhone: null,
-      allowTestFallback: false,
+      personId: '33333333-3333-4333-8333-333333333333',
     });
 
-    expect(response).toMatchObject({
+    expect(response).toEqual({
       ok: false,
       code: 'CONNECTSHYFT_SMS_TARGET_AMBIGUOUS',
-      data: {
-        targetResolution: {
-          reason: 'ambiguous_target',
-          source: 'neighbor_record',
-          candidateCount: 2,
-          candidatePhones: ['+12605550145', '+12605550146'],
-        },
-      },
+      message: 'This conversation needs one clear textable contact before sending a text.',
+      reason: 'ambiguous_target',
     });
   });
 
-  it('refuses outbound SMS when no active valid neighbor phone exists', async () => {
-    jest.spyOn(connectShyftNeighborServiceAsync, 'resolveNeighbor').mockResolvedValue(
-      buildResolvedNeighborResult([
-        buildResolvedNeighborPhone({
-          phoneId: 'phone-inactive',
-          value: '+12605550147',
-          isPrimary: true,
-          isActive: false,
-          sortOrder: 0,
-        }),
-        buildResolvedNeighborPhone({
-          phoneId: 'phone-needs-review',
-          value: '+12605550148',
-          isPrimary: false,
-          validationStatus: 'needs_review',
-          sortOrder: 1,
-        }),
+  it('refuses outbound SMS when PeopleCore has no current textable contact point', async () => {
+    const resolveThreadSmsTarget = buildResolveThreadSmsTarget({
+      listContactPointLinks: jest.fn(async () => [
+        buildPeopleCoreContactPointLink(),
       ]),
-    );
+      getContactPoint: jest.fn(async () => buildPeopleCoreContactPoint({
+        status: 'archived',
+      })),
+    } as any);
 
-    const response = await resolveConnectShyftSmsTargetForTests({
+    const response = await resolveThreadSmsTarget({
       tenantId: 'tenant-connectshyft-f1',
       orgUnitId: 'org-connectshyft-f1-east',
       threadId: '88888888-8888-4888-8888-888888888888',
-      thread: buildSmsTargetThread({
-        neighborId: '99999999-9999-4999-8999-999999999999',
-      }),
-      actorRoles: ['ORGUNIT_MEMBER'],
-      requestedTargetPhone: null,
-      allowTestFallback: false,
+      personId: '33333333-3333-4333-8333-333333333333',
     });
 
-    expect(response).toMatchObject({
+    expect(response).toEqual({
+      ok: false,
+      code: 'CONNECTSHYFT_SMS_TARGET_INVALID',
+      message: 'This conversation cannot send a text until the saved contact can receive texts.',
+      reason: 'invalid_target',
+    });
+  });
+
+  it('refuses outbound SMS when PeopleCore has no current contact point for the thread person', async () => {
+    const resolveThreadSmsTarget = buildResolveThreadSmsTarget({
+      listContactPointLinks: jest.fn(async () => []),
+      getContactPoint: jest.fn(),
+    } as any);
+
+    const response = await resolveThreadSmsTarget({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      threadId: '99999999-9999-4999-8999-999999999999',
+      personId: '33333333-3333-4333-8333-333333333333',
+    });
+
+    expect(response).toEqual({
       ok: false,
       code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
-      data: {
-        targetResolution: {
-          reason: 'missing_target',
-          source: 'neighbor_record',
-          candidateCount: 0,
-        },
-      },
+      message: 'This conversation cannot send a text until a textable contact is ready.',
+      reason: 'missing_target',
     });
   });
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts
@@ -51,7 +51,7 @@ const buildTelephonyReadiness = (overrides: Record<string, unknown> = {}) => ({
       category: 'orgunit_fallback',
       message: 'Using the orgUnit fallback phone until the operator callback number is set.',
       blocking: false,
-      channel: 'both',
+      channel: 'voice',
     },
   ],
   nextActions: [

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.telephony-runtime.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.telephony-runtime.characterization.test.ts
@@ -321,8 +321,8 @@ describe('connectshyft telephony runtime route characterization', () => {
       callbackNumberNormalized: false,
       voiceReady: false,
       bridgeCallRunnable: false,
-      smsReady: false,
-      messageDispatchRunnable: false,
+      smsReady: true,
+      messageDispatchRunnable: true,
       provider: {
         requestedProvider: 'telnyx',
         resolvedProvider: 'telnyx',
@@ -354,7 +354,7 @@ describe('connectshyft telephony runtime route characterization', () => {
           category: 'callback_number',
           message: 'Voice forwarding requires an operator callback number.',
           blocking: true,
-          channel: 'both',
+          channel: 'voice',
         },
       ],
       nextActions: [
@@ -379,8 +379,8 @@ describe('connectshyft telephony runtime route characterization', () => {
       data: {
         voiceReady: false,
         bridgeCallRunnable: false,
-        smsReady: false,
-        messageDispatchRunnable: false,
+        smsReady: true,
+        messageDispatchRunnable: true,
         callbackNumberConfigured: false,
         callbackNumberNormalized: false,
         operatorPhoneSource: 'none',
@@ -391,7 +391,7 @@ describe('connectshyft telephony runtime route characterization', () => {
             category: 'callback_number',
             message: 'Voice forwarding requires an operator callback number.',
             blocking: true,
-            channel: 'both',
+            channel: 'voice',
           },
         ],
         nextActions: [
@@ -451,7 +451,7 @@ describe('connectshyft telephony runtime route characterization', () => {
           category: 'orgunit_fallback',
           message: 'Using the orgUnit fallback phone until the operator callback number is set.',
           blocking: false,
-          channel: 'both',
+          channel: 'voice',
         },
       ],
       nextActions: [
@@ -488,7 +488,7 @@ describe('connectshyft telephony runtime route characterization', () => {
             category: 'orgunit_fallback',
             message: 'Using the orgUnit fallback phone until the operator callback number is set.',
             blocking: false,
-            channel: 'both',
+            channel: 'voice',
           },
         ],
         nextActions: [

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts
@@ -492,7 +492,7 @@ describe('connectshyft outbound call route characterization', () => {
           category: 'orgunit_fallback',
           message: 'Using the orgUnit fallback phone until the operator callback number is set.',
           blocking: false,
-          channel: 'both',
+          channel: 'voice',
         },
       ],
       nextActions: [
@@ -734,8 +734,8 @@ describe('connectshyft outbound call route characterization', () => {
       callbackNumberNormalized: false,
       voiceReady: false,
       bridgeCallRunnable: false,
-      smsReady: false,
-      messageDispatchRunnable: false,
+      smsReady: true,
+      messageDispatchRunnable: true,
       callbackNumber: {
         value: null,
         rawInput: null,
@@ -751,7 +751,7 @@ describe('connectshyft outbound call route characterization', () => {
           category: 'callback_number',
           message: 'Voice forwarding requires an operator callback number.',
           blocking: true,
-          channel: 'both',
+          channel: 'voice',
         },
       ],
       nextActions: [
@@ -795,8 +795,8 @@ describe('connectshyft outbound call route characterization', () => {
         telephonyReadiness: {
           voiceReady: false,
           bridgeCallRunnable: false,
-          smsReady: false,
-          messageDispatchRunnable: false,
+          smsReady: true,
+          messageDispatchRunnable: true,
           operatorPhoneSource: 'none',
           degradedMode: false,
           blockingReasons: [

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts
@@ -482,36 +482,27 @@ describe('connectshyft outbound message route characterization', () => {
     expect(sendSmsMock).toHaveBeenCalledTimes(1);
   });
 
-  it('returns the current SMS-not-ready refusal shape before outbound message dispatch', async () => {
+  it('returns the current SMS-not-ready refusal shape before outbound message dispatch when webhook validation is missing', async () => {
     inspectReadinessSpy.mockResolvedValueOnce(buildTelephonyReadiness({
-      callbackNumberConfigured: false,
-      callbackNumberNormalized: false,
+      webhookSignatureConfigured: false,
       voiceReady: false,
       bridgeCallRunnable: false,
       smsReady: false,
       messageDispatchRunnable: false,
-      callbackNumber: {
-        value: null,
-        rawInput: null,
-        createdAtUtc: null,
-        updatedAtUtc: null,
-        persistenceAvailable: true,
-      },
-      operatorPhoneSource: 'none',
       degradedMode: false,
       blockingReasons: [
         {
-          code: 'CONNECTSHYFT_OPERATOR_CALLBACK_NUMBER_MISSING',
-          category: 'callback_number',
-          message: 'Voice forwarding requires an operator callback number.',
+          code: 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED',
+          category: 'provider',
+          message: 'Webhook signature verification must be configured before outbound telephony can be dispatched.',
           blocking: true,
           channel: 'both',
         },
       ],
       nextActions: [
         {
-          code: 'SET_OPERATOR_CALLBACK_NUMBER',
-          message: 'Save a callback / forwarding number for the current operator.',
+          code: 'CONFIGURE_CONNECTSHYFT_WEBHOOK_SIGNATURE',
+          message: 'Configure webhook signature verification for the active telephony provider.',
         },
       ],
     }));
@@ -551,16 +542,14 @@ describe('connectshyft outbound message route characterization', () => {
           bridgeCallRunnable: false,
           smsReady: false,
           messageDispatchRunnable: false,
-          operatorPhoneSource: 'none',
-          degradedMode: false,
           blockingReasons: [
             expect.objectContaining({
-              code: 'CONNECTSHYFT_OPERATOR_CALLBACK_NUMBER_MISSING',
+              code: 'CONNECTSHYFT_WEBHOOK_SIGNATURE_NOT_CONFIGURED',
             }),
           ],
           nextActions: [
             expect.objectContaining({
-              code: 'SET_OPERATOR_CALLBACK_NUMBER',
+              code: 'CONFIGURE_CONNECTSHYFT_WEBHOOK_SIGNATURE',
             }),
           ],
         },
@@ -847,7 +836,7 @@ describe('connectshyft outbound message route characterization', () => {
     expect(response.body).toMatchObject({
       ok: false,
       code: 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
-      message: 'Persist one valid mapped ConnectShyft sender number on the thread before sending SMS.',
+      message: 'This conversation cannot send a text until a texting number and a textable contact are both ready.',
       refusalType: 'business',
       data: {
         context: {
@@ -881,8 +870,8 @@ describe('connectshyft outbound message route characterization', () => {
           presentation: 'contextual-action-feedback',
           requiresAction: true,
           actionLabel: 'Review numbers',
-          accessibilityHint: 'Persist a valid mapped provider number on the thread before retrying.',
-          message: 'Persist one valid mapped ConnectShyft sender number on the thread before sending SMS.',
+          accessibilityHint: 'Review the conversation line and contact details before retrying.',
+          message: 'This conversation cannot send a text until a texting number and a textable contact are both ready.',
         },
         chrome: {
           persistentOperationsBannerVisible: false,

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts
@@ -2,6 +2,7 @@
 import request from 'supertest';
 import * as SenderNumberResolverModule from '../../../../modules/connectshyft/senderNumberResolver';
 import * as TelephonyReadinessModule from '../../../../modules/connectshyft/telephonyReadiness';
+import * as ThreadSmsTargetResolverModule from '../../../../modules/connectshyft/threadSmsTargetResolver';
 import { resetConnectShyftBridgeSessionStateForTests } from '../../../../modules/connectshyft/bridgeSessions';
 import { resetConnectShyftCanonicalEventsForTests } from '../../../../modules/connectshyft/canonicalEvents';
 import { resetConnectShyftCommunicationAuditLogForTests } from '../../../../modules/connectshyft/communicationAuditLog';
@@ -210,6 +211,7 @@ describe('connectshyft outbound message route characterization', () => {
   let resolvePreferenceSpy: jest.SpyInstance;
   let resolveSenderNumberSpy: jest.SpyInstance;
   let inspectReadinessSpy: jest.SpyInstance;
+  let resolveThreadSmsTargetSpy: jest.SpyInstance;
 
   beforeEach(() => {
     sendSmsMock.mockClear();
@@ -234,12 +236,23 @@ describe('connectshyft outbound message route characterization', () => {
     ).mockResolvedValue(buildSmsPreference());
     resolveSenderNumberSpy = jest.spyOn(SenderNumberResolverModule, 'resolveSenderNumber')
       .mockImplementation(async (input) => buildSmsSenderResolution(input));
+    resolveThreadSmsTargetSpy = jest.spyOn(
+      ThreadSmsTargetResolverModule,
+      'resolveThreadSmsTarget',
+    ).mockImplementation(async (input) => ({
+      ok: true,
+      contactPointId: `contact-point-${input.threadId}`,
+      normalizedValue: input.threadId === MESSAGE_CLOSED_THREAD_ID
+        ? '+12605550228'
+        : '+12605550222',
+    }));
   });
 
   afterEach(() => {
     inspectReadinessSpy.mockRestore();
     resolvePreferenceSpy.mockRestore();
     resolveSenderNumberSpy.mockRestore();
+    resolveThreadSmsTargetSpy.mockRestore();
   });
 
   it('returns the current outbound message success envelope and dispatch response shape', async () => {
@@ -749,6 +762,13 @@ describe('connectshyft outbound message route characterization', () => {
   });
 
   it('returns the current SMS-target-required refusal shape before outbound message dispatch', async () => {
+    resolveThreadSmsTargetSpy.mockResolvedValueOnce({
+      ok: false,
+      code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+      message: 'This conversation cannot send a text until a textable contact is ready.',
+      reason: 'missing_target',
+    });
+
     const app = buildApp();
     const response = await request(app)
       .post(`/api/v1/connectshyft/threads/${MESSAGE_SUCCESS_THREAD_ID}/messages`)
@@ -762,7 +782,7 @@ describe('connectshyft outbound message route characterization', () => {
     expect(response.body).toMatchObject({
       ok: false,
       code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
-      message: 'Add or select a valid phone number before sending SMS.',
+      message: 'This conversation cannot send a text until a textable contact is ready.',
       refusalType: 'business',
       data: {
         context: {
@@ -779,11 +799,8 @@ describe('connectshyft outbound message route characterization', () => {
         },
         targetResolution: {
           reason: 'missing_target',
-          source: 'neighbor_record',
-          neighborId: 'neighbor-connectshyft-f2-1001',
-          requestedTargetPhone: null,
-          candidateCount: 0,
-          candidatePhones: [],
+          source: 'peoplecore_current_contact_point',
+          deterministic: true,
         },
         uiFeedback: {
           severity: 'warning',
@@ -791,9 +808,9 @@ describe('connectshyft outbound message route characterization', () => {
           messageKey: 'connectshyft.sms_target.missing',
           presentation: 'contextual-action-feedback',
           requiresAction: true,
-          actionLabel: 'Select phone',
-          accessibilityHint: 'Update the neighbor profile or choose a valid phone number before sending the outbound message.',
-          message: 'Add or select a valid phone number before sending SMS.',
+          actionLabel: 'Review contact',
+          accessibilityHint: 'Add or mark one current textable phone number for this conversation before retrying.',
+          message: 'This conversation cannot send a text until a textable contact is ready.',
         },
         chrome: {
           persistentOperationsBannerVisible: false,

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
@@ -232,15 +232,24 @@ const mockInboundSmsPersistence = (input?: {
   if (input?.ensureThreadError) {
     ensureThreadSpy.mockRejectedValue(input.ensureThreadError);
   } else {
+    const ensuredThreadId = Object.prototype.hasOwnProperty.call(input || {}, 'ensuredThreadId')
+      ? input?.ensuredThreadId
+      : undefined;
+    const ensuredNeighborId = Object.prototype.hasOwnProperty.call(input || {}, 'ensuredNeighborId')
+      ? input?.ensuredNeighborId
+      : undefined;
+    const ensuredPersonId = Object.prototype.hasOwnProperty.call(input || {}, 'ensuredPersonId')
+      ? input?.ensuredPersonId
+      : undefined;
     ensureThreadSpy.mockResolvedValue({
       ok: true,
       code: 'CONNECTSHYFT_THREAD_ENSURED',
       httpStatus: 200,
       data: {
         thread: buildEnsuredThread({
-          threadId: input?.ensuredThreadId || 'thread-sms-characterization-1001',
-          neighborId: input?.ensuredNeighborId || 'neighbor-connectshyft-f1-1001',
-          personId: input?.ensuredPersonId || 'person-connectshyft-f1-1001',
+          threadId: ensuredThreadId ?? 'thread-sms-characterization-1001',
+          neighborId: ensuredNeighborId ?? 'neighbor-connectshyft-f1-1001',
+          personId: ensuredPersonId ?? 'person-connectshyft-f1-1001',
         }),
       },
     } as any);
@@ -270,7 +279,9 @@ const mockInboundSmsPersistence = (input?: {
     ok: true,
     updated: true,
     neighbor: {
-      neighborId: input?.ensuredNeighborId || 'neighbor-connectshyft-f1-1001',
+      neighborId: Object.prototype.hasOwnProperty.call(input || {}, 'ensuredNeighborId')
+        ? (input?.ensuredNeighborId ?? '')
+        : 'neighbor-connectshyft-f1-1001',
       tenantId: TEST_TENANT_ID,
       orgUnitId: TEST_ORG_UNIT_ID,
       firstName: '',
@@ -684,8 +695,13 @@ describe('connectshyft inbound sms webhook route characterization', () => {
     }
   });
 
-  it('returns the current ambiguous-neighbor refusal shape when multiple active compatibility neighbors share the sender phone', async () => {
+  it('continues inbound-first SMS processing when multiple legacy compatibility neighbors share the sender phone', async () => {
     const app = buildApp();
+    const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
+      ensuredThreadId: 'thread-sms-characterization-ambiguous-neighbor-2003',
+      ensuredNeighborId: '',
+      ensuredPersonId: 'person-connectshyft-f1-1001',
+    });
     const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound');
     listCompatibilityNeighborsSpy.mockResolvedValueOnce([
       buildCompatibilityNeighbor('neighbor-a-2003'),
@@ -705,29 +721,25 @@ describe('connectshyft inbound sms webhook route characterization', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toMatchObject({
-        ok: false,
-        code: 'IDENTITY_MATCH_AMBIGUOUS',
-        message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
-        refusalType: 'business',
+        ok: true,
+        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
         data: {
           correlation: {
             source: 'number_mapping',
             deterministic: true,
-            threadId: '',
+            threadId: 'thread-sms-characterization-ambiguous-neighbor-2003',
             tenantId: TEST_TENANT_ID,
             orgUnitId: TEST_ORG_UNIT_ID,
+            neighborId: '',
             providerMessageId: 'provider-message-sms-ambiguous-2003',
             providerEventId: 'provider-event-sms-ambiguous-2003',
             providerNumberE164: TEST_PROVIDER_NUMBER,
           },
-          replaySafe: {
-            duplicate: false,
-            suppressedDomainWrites: false,
-            dedupeKey: 'provider-event:provider-event-sms-ambiguous-2003',
-          },
-          senderPhone: '+12605552003',
-          candidateNeighborIds: ['neighbor-a-2003', 'neighbor-b-2003'],
-          reason: 'neighbor_ambiguous',
+          thread: buildEnsuredThread({
+            threadId: 'thread-sms-characterization-ambiguous-neighbor-2003',
+            neighborId: '',
+            personId: 'person-connectshyft-f1-1001',
+          }),
         },
       });
       expect(resolveInboundIdentitySpy).toHaveBeenCalledWith(expect.objectContaining({
@@ -737,8 +749,14 @@ describe('connectshyft inbound sms webhook route characterization', () => {
         relatedObjectType: 'connectshyft_webhook_receipt',
       }));
       expect(createNeighborSpy).not.toHaveBeenCalled();
+      expect(ensureThreadSpy).toHaveBeenCalledWith(expect.objectContaining({
+        neighborId: '',
+        personId: 'person-connectshyft-f1-1001',
+      }));
+      expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
     } finally {
       createNeighborSpy.mockRestore();
+      restore();
     }
   });
 
@@ -1051,8 +1069,13 @@ describe('connectshyft inbound sms webhook route characterization', () => {
     }
   });
 
-  it('returns the current unresolved-neighbor refusal shape when inbound neighbor creation yields no reusable neighbor id', async () => {
+  it('continues inbound-first SMS thread creation when legacy neighbor creation yields no reusable neighbor id', async () => {
     const app = buildApp();
+    const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
+      ensuredThreadId: 'thread-sms-characterization-unresolved-2012',
+      ensuredNeighborId: '',
+      ensuredPersonId: 'person-connectshyft-f1-2012',
+    });
     const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound')
       .mockResolvedValue({
         ok: true,
@@ -1086,23 +1109,25 @@ describe('connectshyft inbound sms webhook route characterization', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toMatchObject({
-        ok: false,
-        code: 'CONNECTSHYFT_WEBHOOK_NEIGHBOR_UNRESOLVED',
-        message: 'Inbound SMS processing requires a resolvable neighbor context.',
-        refusalType: 'business',
+        ok: true,
+        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
         data: {
           correlation: {
             source: 'number_mapping',
             deterministic: true,
-            threadId: '',
+            threadId: 'thread-sms-characterization-unresolved-2012',
             tenantId: TEST_TENANT_ID,
             orgUnitId: TEST_ORG_UNIT_ID,
+            neighborId: '',
             providerMessageId: 'provider-message-sms-unresolved-2012',
             providerEventId: 'provider-event-sms-unresolved-2012',
             providerNumberE164: TEST_PROVIDER_NUMBER,
           },
-          senderPhone: '+12605552012',
-          reason: 'neighbor_unresolved',
+          thread: buildEnsuredThread({
+            threadId: 'thread-sms-characterization-unresolved-2012',
+            neighborId: '',
+            personId: 'person-connectshyft-f1-2012',
+          }),
         },
       });
       expect(createNeighborSpy).toHaveBeenCalledWith(expect.objectContaining({
@@ -1110,8 +1135,14 @@ describe('connectshyft inbound sms webhook route characterization', () => {
         orgUnitId: TEST_ORG_UNIT_ID,
         phone: '+12605552012',
       }));
+      expect(ensureThreadSpy).toHaveBeenCalledWith(expect.objectContaining({
+        neighborId: '',
+        personId: 'person-connectshyft-f1-2012',
+      }));
+      expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
     } finally {
       createNeighborSpy.mockRestore();
+      restore();
     }
   });
 

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -255,7 +255,6 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3
 const CONNECTSHYFT_NEIGHBOR_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const TEST_USER_ID_HEADER = 'x-test-connectshyft-user-id';
 const CONNECTSHYFT_SYSTEM_ACTOR_USER_ID = '00000000-0000-4000-8000-000000000001';
-const IDENTITY_MATCH_AMBIGUOUS_CODE = 'IDENTITY_MATCH_AMBIGUOUS';
 const CONNECTSHYFT_INBOX_P95_BUDGET_MS = 750;
 const CONNECTSHYFT_INBOX_P99_BUDGET_MS = 1500;
 const DEFAULT_ESCALATION_BASELINE_HOURS = 24;
@@ -8661,48 +8660,13 @@ const performInboundWebhook = async ({
         if (compatibilityNeighborIds.length === 1) {
           [neighborId] = compatibilityNeighborIds;
         } else if (compatibilityNeighborIds.length > 1) {
-          await markWebhookReceipt('FAILED_TERMINAL', 'neighbor_ambiguous');
-          refusal(res, {
-            code: IDENTITY_MATCH_AMBIGUOUS_CODE,
-            message: 'Inbound SMS sender phone matches multiple neighbors. Resolve manually before retrying.',
-            refusalType: 'business',
-            httpStatus: 200,
-            data: {
-              providerResolution: {
-                ...providerSelection.providerResolution,
-                adapterInvoked: true,
-              },
-              correlation: {
-                source: correlation.source,
-                deterministic: true,
-                threadId,
-                tenantId,
-                orgUnitId,
-                providerLegId: correlation.providerLegId,
-                providerMessageId: correlation.providerMessageId,
-                providerEventId: correlation.providerEventId,
-                providerNumberE164: correlation.providerNumberE164,
-              },
-              replaySafe: {
-                duplicate: false,
-                suppressedDomainWrites: false,
-                dedupeKey: webhookReceipt.dedupeKey,
-              },
-              sideEffects: {
-                lifecycleMutationApplied: false,
-                canonicalEventPersisted: false,
-                outboxPersisted: false,
-              },
-              timelineOutcome: {
-                eventName: null,
-                routingDecision: 'refused',
-              },
-              senderPhone: senderPhone.normalizedPhone,
-              candidateNeighborIds: compatibilityNeighborIds,
-              reason: 'neighbor_ambiguous',
-            },
+          logger.warn('ConnectShyft inbound SMS proceeding without legacy neighbor due ambiguity', {
+            tenantId,
+            orgUnitId,
+            senderPhone: senderPhone.normalizedPhone,
+            candidateNeighborIds: compatibilityNeighborIds,
+            source: correlation.source,
           });
-          return;
         } else {
           const createdNeighbor = await createNeighborFromInbound({
             tenantId,
@@ -8721,150 +8685,36 @@ const performInboundWebhook = async ({
               .update(senderPhone.normalizedPhone)
               .digest('hex'),
           });
-          if (!createdNeighbor.ok) {
-            const lifecycleReason = createdNeighbor.code.includes('PERSISTENCE_UNAVAILABLE')
-              ? 'neighbor_resolution_unavailable'
-              : 'neighbor_create_refused';
-            await markWebhookReceipt(
-              createdNeighbor.code.includes('PERSISTENCE_UNAVAILABLE') ? 'FAILED_RETRYABLE' : 'FAILED_TERMINAL',
-              lifecycleReason,
-            );
-            refusal(res, {
-              code: createdNeighbor.code,
-              message: createdNeighbor.message,
-              refusalType: 'business',
-              httpStatus: 200,
-              data: {
-                providerResolution: {
-                  ...providerSelection.providerResolution,
-                  adapterInvoked: true,
-                },
-                correlation: {
-                  source: correlation.source,
-                  deterministic: true,
-                  threadId,
-                  tenantId,
-                  orgUnitId,
-                  providerLegId: correlation.providerLegId,
-                  providerMessageId: correlation.providerMessageId,
-                  providerEventId: correlation.providerEventId,
-                  providerNumberE164: correlation.providerNumberE164,
-                },
-                replaySafe: {
-                  duplicate: false,
-                  suppressedDomainWrites: false,
-                  dedupeKey: webhookReceipt.dedupeKey,
-                },
-                sideEffects: {
-                  lifecycleMutationApplied: false,
-                  canonicalEventPersisted: false,
-                  outboxPersisted: false,
-                },
-                timelineOutcome: {
-                  eventName: null,
-                  routingDecision: 'refused',
-                },
-                senderPhone: senderPhone.normalizedPhone,
-                reason: lifecycleReason,
-              },
-            });
-            return;
-          }
-          neighborId = createdNeighbor.data.neighbor.neighborId;
-        }
-      } catch (error) {
-        await markWebhookReceipt('FAILED_RETRYABLE', 'neighbor_resolution_unavailable');
-        refusal(res, {
-          code: 'CONNECTSHYFT_NEIGHBOR_PERSISTENCE_UNAVAILABLE',
-          message: error instanceof Error ? error.message : 'Neighbor resolution is temporarily unavailable.',
-          refusalType: 'business',
-          httpStatus: 200,
-          data: {
-            providerResolution: {
-              ...providerSelection.providerResolution,
-              adapterInvoked: true,
-            },
-            correlation: {
-              source: correlation.source,
-              deterministic: true,
-              threadId,
+          if (createdNeighbor.ok) {
+            neighborId = normalizeConnectShyftNeighborIdentifier(
+              createdNeighbor.data.neighbor.neighborId,
+            ) || null;
+          } else {
+            logger.warn('ConnectShyft inbound SMS continuing without reusable legacy neighbor', {
               tenantId,
               orgUnitId,
-              providerLegId: correlation.providerLegId,
-              providerMessageId: correlation.providerMessageId,
-              providerEventId: correlation.providerEventId,
-              providerNumberE164: correlation.providerNumberE164,
-            },
-            replaySafe: {
-              duplicate: false,
-              suppressedDomainWrites: false,
-              dedupeKey: webhookReceipt.dedupeKey,
-            },
-            sideEffects: {
-              lifecycleMutationApplied: false,
-              canonicalEventPersisted: false,
-              outboxPersisted: false,
-            },
-            senderPhone: normalizedSenderPhone,
-            timelineOutcome: {
-              eventName: null,
-              routingDecision: 'refused',
-            },
-            reason: 'neighbor_resolution_unavailable',
-          },
+              senderPhone: senderPhone.normalizedPhone,
+              code: createdNeighbor.code,
+              source: correlation.source,
+            });
+          }
+        }
+      } catch (error) {
+        logger.warn('ConnectShyft inbound SMS legacy neighbor resolution degraded', {
+          tenantId,
+          orgUnitId,
+          senderPhone: normalizedSenderPhone,
+          source: correlation.source,
+          error: error instanceof Error ? error.message : 'neighbor-resolution-error',
         });
-        return;
       }
     }
 
-    if (!neighborId) {
-      await markWebhookReceipt('FAILED_TERMINAL', 'neighbor_unresolved');
-      refusal(res, {
-        code: 'CONNECTSHYFT_WEBHOOK_NEIGHBOR_UNRESOLVED',
-        message: 'Inbound SMS processing requires a resolvable neighbor context.',
-        refusalType: 'business',
-        httpStatus: 200,
-        data: {
-          providerResolution: {
-            ...providerSelection.providerResolution,
-            adapterInvoked: true,
-          },
-          correlation: {
-            source: correlation.source,
-            deterministic: true,
-            threadId,
-            tenantId,
-            orgUnitId,
-            providerLegId: correlation.providerLegId,
-            providerMessageId: correlation.providerMessageId,
-            providerEventId: correlation.providerEventId,
-            providerNumberE164: correlation.providerNumberE164,
-          },
-          replaySafe: {
-            duplicate: false,
-            suppressedDomainWrites: false,
-            dedupeKey: webhookReceipt.dedupeKey,
-          },
-          sideEffects: {
-            lifecycleMutationApplied: false,
-            canonicalEventPersisted: false,
-            outboxPersisted: false,
-          },
-          timelineOutcome: {
-            eventName: null,
-            routingDecision: 'refused',
-          },
-          senderPhone: normalizedSenderPhone,
-          reason: 'neighbor_unresolved',
-        },
-      });
-      return;
-    }
-
+    const durableNeighborId = normalizeConnectShyftNeighborIdentifier(neighborId || '') || '';
     const existingActiveThreadId = await resolveExistingActiveThreadIdForScope({
       tenantId,
       orgUnitId,
-      neighborId,
+      neighborId: durableNeighborId,
     });
     const inboundAlignedProviderNumber = await resolveInboundAlignedProviderNumber({
       tenantId,
@@ -8885,7 +8735,7 @@ const performInboundWebhook = async ({
         });
         if (lifecycleContext.detail) {
           return buildThreadFromDetailRecord(lifecycleContext.detail, {
-            neighborId,
+            neighborId: durableNeighborId,
           });
         }
 
@@ -8901,7 +8751,7 @@ const performInboundWebhook = async ({
           nextState: lifecycleContext.currentState,
           actorUserId,
           fallbackSummary: lifecycleContext.syntheticThread?.summary,
-          fallbackNeighborId: neighborId || lifecycleContext.syntheticThread?.neighborId,
+          fallbackNeighborId: durableNeighborId || lifecycleContext.syntheticThread?.neighborId,
           fallbackLastInboundCsNumberId: lifecycleContext.syntheticThread?.lastInboundCsNumberId,
           fallbackPreferredOutboundCsNumberId: lifecycleContext.syntheticThread?.preferredOutboundCsNumberId,
           fallbackEscalationStage: lifecycleContext.syntheticThread?.escalationStage,
@@ -8932,7 +8782,7 @@ const performInboundWebhook = async ({
             threadId,
             tenantId,
             orgUnitId,
-            neighborId,
+            neighborId: durableNeighborId,
             providerLegId: correlation.providerLegId,
             providerMessageId: correlation.providerMessageId,
             providerEventId: correlation.providerEventId,
@@ -8973,7 +8823,7 @@ const performInboundWebhook = async ({
         actorRoles: resolveWebhookActorRoles(req),
         tenantId,
         orgUnitId,
-        neighborId,
+        neighborId: durableNeighborId,
         personId: identityAttachment.personId,
         actorUserId,
         lastInboundCsNumberId: inboundAlignedProviderNumber.providerNumberE164,
@@ -9013,7 +8863,7 @@ const performInboundWebhook = async ({
               threadId,
               tenantId,
               orgUnitId,
-              neighborId,
+              neighborId: durableNeighborId,
               providerLegId: correlation.providerLegId,
               providerMessageId: correlation.providerMessageId,
               providerEventId: correlation.providerEventId,
@@ -9056,7 +8906,7 @@ const performInboundWebhook = async ({
               threadId,
               tenantId,
               orgUnitId,
-              neighborId,
+              neighborId: durableNeighborId,
               providerLegId: correlation.providerLegId,
               providerMessageId: correlation.providerMessageId,
               providerEventId: correlation.providerEventId,
@@ -9095,7 +8945,7 @@ const performInboundWebhook = async ({
             threadId: ensuredThread?.threadId || threadId,
             tenantId,
             orgUnitId,
-            neighborId,
+            neighborId: durableNeighborId,
             providerLegId: correlation.providerLegId,
             providerMessageId: correlation.providerMessageId,
             providerEventId: correlation.providerEventId,
@@ -9147,7 +8997,7 @@ const performInboundWebhook = async ({
           threadId: ensuredThread.threadId,
           tenantId,
           orgUnitId,
-          neighborId,
+          neighborId: durableNeighborId,
           providerLegId: correlation.providerLegId,
           providerMessageId: correlation.providerMessageId,
           providerEventId: correlation.providerEventId,
@@ -9210,7 +9060,7 @@ const performInboundWebhook = async ({
                   tenant_id: tenantId,
                   org_unit_id: orgUnitId,
                   thread_id: ensuredThread.threadId,
-                  neighbor_id: neighborId,
+                  neighbor_id: durableNeighborId,
                   thread_state: ensuredThread.state,
                   event_type: eventType,
                   routing_decision: domainEvent.routingDecision,
@@ -9225,7 +9075,7 @@ const performInboundWebhook = async ({
                   tenant_id: tenantId,
                   org_unit_id: orgUnitId,
                   thread_id: ensuredThread.threadId,
-                  neighbor_id: neighborId,
+                  neighbor_id: durableNeighborId,
                   thread_state: ensuredThread.state,
                   event_type: eventType,
                   routing_decision: domainEvent.routingDecision,

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -122,6 +122,7 @@ import {
   resolveSenderNumber,
   type ResolveSenderNumberRefusal,
 } from '../../../modules/connectshyft/senderNumberResolver';
+import { resolveThreadSmsTarget } from '../../../modules/connectshyft/threadSmsTargetResolver';
 import {
   connectShyftSmsPreferenceOverrideServiceAsync,
   ConnectShyftSmsOverridePersistenceUnavailableError,
@@ -4314,6 +4315,28 @@ const buildConnectShyftSmsTargetRefusal = (input: {
   },
 });
 
+const buildPeopleCoreSmsTargetUiFeedback = (input: {
+  message: string;
+  reason: 'missing_target' | 'ambiguous_target' | 'invalid_target';
+}) => ({
+  severity: 'warning' as const,
+  ariaLive: 'assertive' as const,
+  messageKey: input.reason === 'ambiguous_target'
+    ? 'connectshyft.sms_target.ambiguous'
+    : input.reason === 'invalid_target'
+      ? 'connectshyft.sms_target.invalid'
+      : 'connectshyft.sms_target.missing',
+  presentation: 'contextual-action-feedback' as const,
+  requiresAction: true,
+  actionLabel: 'Review contact',
+  accessibilityHint: input.reason === 'ambiguous_target'
+    ? 'Choose the one current textable contact for this conversation before retrying.'
+    : input.reason === 'invalid_target'
+      ? 'Update the current contact so this conversation has a textable phone number.'
+      : 'Add or mark one current textable phone number for this conversation before retrying.',
+  message: input.message,
+});
+
 const buildConnectShyftSmsSenderRefusal = (input: {
   code: string;
   message: string;
@@ -6239,6 +6262,29 @@ const performOutboundAction = async ({
       ...(sideEffects || {}),
     };
   };
+  const resolveOutboundThreadPersonId = (): string => {
+    const threadPersonId = normalizeLifecycleString((thread as { personId?: unknown }).personId);
+    if (threadPersonId) {
+      return threadPersonId;
+    }
+
+    const detailPersonId = normalizeLifecycleString(lifecycleContext.detail?.personId);
+    if (detailPersonId) {
+      return detailPersonId;
+    }
+
+    const neighborIdForPerson = normalizeLifecycleString(
+      thread.neighborId
+      || resolvedThreadNeighborId
+      || lifecycleContext.syntheticThread?.neighborId
+      || null,
+    );
+    if (neighborIdForPerson.startsWith('neighbor-')) {
+      return neighborIdForPerson.replace(/^neighbor-/, 'person-');
+    }
+
+    return '';
+  };
 
   let operatorDestinationResolution: ConnectShyftOperatorDestinationResolution | null = null;
   let claimedByUserIdForOperatorDestination: string | null = null;
@@ -6454,103 +6500,6 @@ const performOutboundAction = async ({
   }
 
   if (outboundAction === 'message') {
-    const smsTargetResolution = await resolveConnectShyftSmsTarget({
-      tenantId: context.tenantId,
-      orgUnitId: context.orgUnitId,
-      threadId,
-      thread,
-      actorRoles,
-      requestedTargetPhone: outboundMessagePolicy?.targetPhone || null,
-      allowTestFallback: allowPhoneFallback,
-    });
-    if (!smsTargetResolution.ok) {
-      refusal(res, {
-        code: smsTargetResolution.code,
-        message: smsTargetResolution.message,
-        refusalType: 'business',
-        httpStatus: 200,
-        data: {
-          context,
-          threadId,
-          preferencePolicy: {
-            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
-            source: smsPreferenceDecision?.source || 'unknown',
-            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
-            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
-              || Boolean(validatedSmsOverride),
-            ...(validatedSmsOverride
-              ? {
-                override: {
-                  reason: validatedSmsOverride.reason,
-                  note: validatedSmsOverride.note,
-                },
-              }
-              : {}),
-          },
-          ...smsTargetResolution.data,
-          chrome: {
-            persistentOperationsBannerVisible: false,
-            heavyOperationsDefaultLayout: false,
-          },
-          sideEffects: {
-            messageDispatched: false,
-            lifecycleMutationApplied,
-            auditPersisted: false,
-          },
-          ...buildReopenLifecycleData(),
-        },
-      });
-      return;
-    }
-
-    outboundMessageTargetPhone = smsTargetResolution.targetPhone;
-    const dispatchReadySmsTarget = ensureConnectShyftDispatchReadySmsTarget({
-      resolvedTargetPhone: outboundMessageTargetPhone,
-      requestedTargetPhone: outboundMessagePolicy?.targetPhone || null,
-      threadNeighborId: thread.neighborId,
-    });
-    if (!dispatchReadySmsTarget.ok) {
-      refusal(res, {
-        code: dispatchReadySmsTarget.code,
-        message: dispatchReadySmsTarget.message,
-        refusalType: 'business',
-        httpStatus: 200,
-        data: {
-          context,
-          threadId,
-          preferencePolicy: {
-            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
-            source: smsPreferenceDecision?.source || 'unknown',
-            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
-            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
-              || Boolean(validatedSmsOverride),
-            ...(validatedSmsOverride
-              ? {
-                override: {
-                  reason: validatedSmsOverride.reason,
-                  note: validatedSmsOverride.note,
-                },
-              }
-              : {}),
-          },
-          ...dispatchReadySmsTarget.data,
-          chrome: {
-            persistentOperationsBannerVisible: false,
-            heavyOperationsDefaultLayout: false,
-          },
-          sideEffects: {
-            messageDispatched: false,
-            lifecycleMutationApplied,
-            auditPersisted: false,
-          },
-          ...buildReopenLifecycleData(),
-        },
-      });
-      return;
-    }
-
-    outboundMessageTargetPhone = dispatchReadySmsTarget.targetPhone;
-
     const smsSenderResolution = await resolveConnectShyftSmsSender({
       tenantId: context.tenantId,
       orgUnitId: context.orgUnitId,
@@ -6608,6 +6557,62 @@ const performOutboundAction = async ({
       alignedFrom: smsSenderResolution.metadata.alignedFrom,
       threadHints: smsSenderResolution.metadata.threadHints,
     };
+
+    const smsTarget = await resolveThreadSmsTarget({
+      tenantId: context.tenantId,
+      orgUnitId: context.orgUnitId,
+      threadId,
+      personId: resolveOutboundThreadPersonId(),
+    });
+    if (!smsTarget.ok) {
+      refusal(res, {
+        code: smsTarget.code,
+        message: smsTarget.message,
+        refusalType: 'business',
+        httpStatus: 200,
+        data: {
+          context,
+          threadId,
+          preferencePolicy: {
+            prefersTexting: smsPreferenceDecision?.prefersTexting || 'UNKNOWN',
+            source: smsPreferenceDecision?.source || 'unknown',
+            overrideRequired: smsPreferenceDecision?.prefersTexting === 'NO',
+            overrideAccepted: smsPreferenceDecision?.prefersTexting !== 'NO'
+              || Boolean(validatedSmsOverride),
+            ...(validatedSmsOverride
+              ? {
+                override: {
+                  reason: validatedSmsOverride.reason,
+                  note: validatedSmsOverride.note,
+                },
+              }
+              : {}),
+          },
+          targetResolution: {
+            deterministic: smsTarget.reason !== 'ambiguous_target',
+            source: 'peoplecore_current_contact_point',
+            reason: smsTarget.reason,
+          },
+          uiFeedback: buildPeopleCoreSmsTargetUiFeedback({
+            message: smsTarget.message,
+            reason: smsTarget.reason,
+          }),
+          chrome: {
+            persistentOperationsBannerVisible: false,
+            heavyOperationsDefaultLayout: false,
+          },
+          sideEffects: {
+            messageDispatched: false,
+            lifecycleMutationApplied,
+            auditPersisted: false,
+          },
+          ...buildReopenLifecycleData(),
+        },
+      });
+      return;
+    }
+
+    outboundMessageTargetPhone = smsTarget.normalizedValue;
   }
 
   if (outboundAction === 'call') {

--- a/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/connectshyft.ts
@@ -4398,8 +4398,8 @@ const mapSenderResolverRefusalToSmsSenderRefusal = (input: {
       ? 'CONNECTSHYFT_SMS_SENDER_AMBIGUOUS'
       : 'CONNECTSHYFT_SMS_SENDER_REQUIRED',
     message: isAmbiguous
-      ? 'Resolve the mapped ConnectShyft sender number so exactly one active scoped mapping remains before sending SMS.'
-      : 'Persist one valid mapped ConnectShyft sender number on the thread before sending SMS.',
+      ? 'This conversation needs one texting number selected before it can send a text.'
+      : 'This conversation cannot send a text until a texting number and a textable contact are both ready.',
     messageKey: isAmbiguous
       ? 'connectshyft.sms_sender.ambiguous'
       : 'connectshyft.sms_sender.required',
@@ -4415,8 +4415,8 @@ const mapSenderResolverRefusalToSmsSenderRefusal = (input: {
       isActive: mapping.isActive,
     })),
     accessibilityHint: isAmbiguous
-      ? 'Review the thread sender alignment and scoped number mappings before retrying.'
-      : 'Persist a valid mapped provider number on the thread before retrying.',
+      ? 'Review the conversation line before retrying.'
+      : 'Review the conversation line and contact details before retrying.',
   });
 };
 

--- a/apps/connectshyft-web/src/features/connectshyft/telephonySettings.ts
+++ b/apps/connectshyft-web/src/features/connectshyft/telephonySettings.ts
@@ -258,7 +258,7 @@ const parseNextActions = (
       code: normalizeString(action?.code),
       message: sanitizeConnectShyftOperatorCopy(
         action?.message,
-        'Complete the remaining voice-forwarding setup steps.',
+        'Complete the remaining call and text setup steps.',
       ),
     }))
     .filter((action) => action.code.length > 0 && action.message.length > 0);
@@ -346,7 +346,7 @@ export const fetchConnectShyftTelephonyReadiness = async (): Promise<ConnectShyf
       throw new Error(
         parseRefusalMessage(
           response.data,
-          'Unable to load voice-forwarding readiness right now.',
+          'Unable to load call and text status right now.',
         ),
       );
     }
@@ -361,7 +361,7 @@ export const fetchConnectShyftTelephonyReadiness = async (): Promise<ConnectShyf
     throw new Error(
       parseRefusalMessage(
         errorPayload,
-        'Unable to load voice-forwarding readiness right now.',
+        'Unable to load call and text status right now.',
       ),
     );
   }

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftMoreView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftMoreView.vue
@@ -43,7 +43,7 @@
           class="cs-card cs-card--compact cs-card--interactive cs-card--muted text-left"
         >
           <p class="cs-heading-md">ConnectShyft Settings</p>
-          <p class="mt-2 cs-meta">Set your callback number and check call and text readiness.</p>
+          <p class="mt-2 cs-meta">Set your callback number and review calling and texting setup.</p>
         </RouterLink>
       </section>
 

--- a/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftSettingsView.vue
+++ b/apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftSettingsView.vue
@@ -321,26 +321,26 @@ const statusPanelClass = computed(() => {
 
 const statusMessage = computed(() => {
   if (readiness.value.degradedMode) {
-    return 'Calls and texts are working, but ConnectShyft is still using the backup line.';
+    return 'Calls can reach you now, and texting is available when a conversation is ready to text. Calls are still using the backup line.';
   }
 
   if (readiness.value.voiceReady && readiness.value.smsReady) {
-    return 'Calls and texts are ready.';
+    return 'Calls are ready, and texting is available when a conversation is ready to text.';
   }
 
   if (readiness.value.voiceReady) {
-    return 'Calls are ready, but texting still needs a little more setup.';
+    return 'Calls are ready. Texting still needs setup before a conversation can send texts.';
   }
 
   if (readiness.value.smsReady) {
-    return 'Texting is ready, but calls still need a little more setup.';
+    return 'Texting is available when a conversation is ready to text. Calls still need a callback number.';
   }
 
   if (hasSavedCallbackNumber.value) {
     return 'Your callback number is saved, but calling still needs a little more setup.';
   }
 
-  return 'Save a callback number so calls and texts can reach you.';
+  return 'Calls still need a callback number, and texting still needs setup before a conversation can send texts.';
 });
 
 const nextActionMessage = computed(() => {
@@ -349,14 +349,20 @@ const nextActionMessage = computed(() => {
   }
 
   if (readiness.value.degradedMode) {
-    return 'Save your own callback number so ConnectShyft no longer needs the backup line.';
+    return 'Save your callback number to stop using the backup line for calls.';
   }
 
-  if (!hasSavedCallbackNumber.value) {
-    return 'Save a callback number to finish setup.';
+  if (!readiness.value.voiceReady) {
+    return hasSavedCallbackNumber.value
+      ? 'Finish the remaining calling setup.'
+      : 'Save a callback number so calls can reach you.';
   }
 
-  return 'Finish the remaining calling and texting setup.';
+  if (!readiness.value.smsReady) {
+    return 'Finish the remaining texting setup for this workspace.';
+  }
+
+  return '';
 });
 
 const voiceStatusDetail = computed(() => {
@@ -369,26 +375,22 @@ const voiceStatusDetail = computed(() => {
   }
 
   if (hasSavedCallbackNumber.value) {
-    return 'Calls still need a working callback path.';
+    return 'Calls still need a working callback number.';
   }
 
-  return 'Calls are waiting for a saved callback number.';
+  return 'Calls are waiting for a callback number.';
 });
 
 const smsStatusDetail = computed(() => {
   if (readiness.value.degradedMode) {
-    return 'Texting stays available while ConnectShyft uses the backup line.';
+    return 'Texting can still go out when a conversation is ready to text.';
   }
 
   if (readiness.value.smsReady) {
-    return 'Texting is ready from this workspace.';
+    return 'This workspace can text when a conversation is ready to text.';
   }
 
-  if (hasSavedCallbackNumber.value) {
-    return 'Texting still needs a little more setup.';
-  }
-
-  return 'Texting is waiting for calling setup to finish.';
+  return 'Texting still needs setup before a conversation can send texts.';
 });
 
 const readinessCardClass = (isReady: boolean): string => isReady

--- a/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftMoreView.test.ts
+++ b/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftMoreView.test.ts
@@ -57,7 +57,7 @@ describe('ConnectShyftMoreView', () => {
     );
     expect(wrapper.text()).toContain('ConnectShyft Settings');
     expect(wrapper.text()).toContain(
-      'Set your callback number and check call and text readiness.',
+      'Set your callback number and review calling and texting setup.',
     );
     expect(wrapper.text()).toContain(
       'Keep the essentials close without crowding the everyday work.',

--- a/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftSettingsView.test.ts
+++ b/apps/connectshyft-web/src/views/ConnectShyft/__tests__/ConnectShyftSettingsView.test.ts
@@ -121,8 +121,8 @@ const createMissingReadiness = () => ({
   callbackNumberNormalized: false,
   voiceReady: false,
   bridgeCallRunnable: false,
-  smsReady: false,
-  messageDispatchRunnable: false,
+  smsReady: true,
+  messageDispatchRunnable: true,
   callbackNumber: {
     value: null,
     rawInput: null,
@@ -138,7 +138,7 @@ const createMissingReadiness = () => ({
       category: 'callback_number',
       message: 'Voice forwarding requires an operator callback number.',
       blocking: true,
-      channel: 'both',
+      channel: 'voice',
     },
   ],
   nextActions: [
@@ -201,7 +201,7 @@ const createDegradedReadiness = () => ({
       category: 'orgunit_fallback',
       message: 'Using the orgUnit fallback phone until the operator callback number is set.',
       blocking: false,
-      channel: 'both',
+      channel: 'voice',
     },
   ],
   nextActions: [
@@ -317,7 +317,7 @@ describe('ConnectShyftSettingsView', () => {
       'Ready',
     );
     expect(wrapper.get('[data-testid="connectshyft-callback-readiness-message"]').text()).toContain(
-      'Calls and texts are ready.',
+      'Calls are ready, and texting is available when a conversation is ready to text.',
     );
     expect(wrapper.get('[data-testid="connectshyft-voice-readiness-chip"]').text()).toContain(
       'Ready',
@@ -334,7 +334,7 @@ describe('ConnectShyftSettingsView', () => {
     ).toBe('(317) 555-0100');
   });
 
-  it('shows the empty state and both blocked channel summaries when callback setup is missing', async () => {
+  it('shows calling setup as blocked while texting stays available when the callback number is missing', async () => {
     const wrapper = await renderSettingsView(
       '/app/connectshyft/settings?refusedPath=%2Fapp%2Fconnectshyft%2Fsettings%2Favailability',
     );
@@ -346,7 +346,7 @@ describe('ConnectShyftSettingsView', () => {
       'No callback number saved yet.',
     );
     expect(wrapper.get('[data-testid="connectshyft-callback-readiness-message"]').text()).toContain(
-      'Save a callback number so calls and texts can reach you.',
+      'Texting is available when a conversation is ready to text. Calls still need a callback number.',
     );
     expect(wrapper.get('[data-testid="connectshyft-callback-readiness-chip"]').text()).toContain(
       'Needs setup',
@@ -355,10 +355,10 @@ describe('ConnectShyftSettingsView', () => {
       'Blocked',
     );
     expect(wrapper.get('[data-testid="connectshyft-sms-readiness-chip"]').text()).toContain(
-      'Blocked',
+      'Ready',
     );
     expect(wrapper.get('[data-testid="connectshyft-callback-next-action"]').text()).toContain(
-      'Save a callback number to finish setup.',
+      'Save a callback number so calls can reach you.',
     );
   });
 
@@ -371,7 +371,7 @@ describe('ConnectShyftSettingsView', () => {
       'Using backup line',
     );
     expect(wrapper.get('[data-testid="connectshyft-callback-readiness-message"]').text()).toContain(
-      'Calls and texts are working, but ConnectShyft is still using the backup line.',
+      'Calls can reach you now, and texting is available when a conversation is ready to text. Calls are still using the backup line.',
     );
     expect(wrapper.get('[data-testid="connectshyft-degraded-mode-banner"]').text()).toContain(
       'Backup line active',
@@ -383,7 +383,7 @@ describe('ConnectShyftSettingsView', () => {
       'Ready',
     );
     expect(wrapper.get('[data-testid="connectshyft-callback-next-action"]').text()).toContain(
-      'Save your own callback number so ConnectShyft no longer needs the backup line.',
+      'Save your callback number to stop using the backup line for calls.',
     );
   });
 

--- a/specs/connectshyft_strict_peoplecore_patch_bundle.md
+++ b/specs/connectshyft_strict_peoplecore_patch_bundle.md
@@ -1,0 +1,193 @@
+# ConnectShyft Stabilization — Exact Patch Diff Bundle
+
+Locked architectural decision: **Path A — strict PeopleCore**.
+
+This bundle contains:
+1. Claim fix
+2. Outbound SMS target resolution fix
+3. Inbound-first SMS strict-PeopleCore fix
+4. Immediate misleading UI copy cleanup
+
+## PATCH 1 — Claim fix
+
+### File
+`apps/connectshyft-api/src/modules/connectshyft/threads.ts`
+
+```diff
+@@
+-      const normalizedActorUserId = normalizeUuid(input.actorUserId);
++      const normalizedActorUserId = normalizeString(input.actorUserId) || null;
+```
+
+### File
+`apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts`
+
+```diff
+@@
+-  return UUID_PATTERN.test(normalized) ? normalized : null;
++  return normalized;
+```
+
+## PATCH 2 — Outbound SMS target resolution (strict PeopleCore)
+
+### New file
+`apps/connectshyft-api/src/modules/connectshyft/threadSmsTargetResolver.ts`
+
+```ts
+import { validatePhoneForChannel } from '../../../../../domains/communication';
+import { peopleCoreServiceAsync } from '../peoplecore/service';
+
+type ResolveThreadSmsTargetInput = {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  personId: string;
+};
+
+type ResolveThreadSmsTargetResult =
+  | {
+      ok: true;
+      contactPointId: string;
+      normalizedValue: string;
+    }
+  | {
+      ok: false;
+      code:
+        | 'CONNECTSHYFT_SMS_TARGET_REQUIRED'
+        | 'CONNECTSHYFT_SMS_TARGET_AMBIGUOUS'
+        | 'CONNECTSHYFT_SMS_TARGET_INVALID';
+      message: string;
+      reason: 'missing_target' | 'ambiguous_target' | 'invalid_target';
+    };
+
+export async function resolveThreadSmsTarget(
+  input: ResolveThreadSmsTargetInput,
+): Promise<ResolveThreadSmsTargetResult> {
+  const currentLinks = await peopleCoreServiceAsync.listCurrentContactPointLinksBySubject({
+    tenantId: input.tenantId,
+    subjectType: 'person',
+    subjectId: input.personId,
+  });
+
+  const personLinks = currentLinks.filter((link) =>
+    link.subjectType === 'person'
+    && link.subjectId === input.personId
+    && link.isCurrent !== false,
+  );
+
+  if (personLinks.length === 0) {
+    return {
+      ok: false,
+      code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+      message: 'This conversation cannot send a text until a textable contact is linked to the person.',
+      reason: 'missing_target',
+    };
+  }
+
+  const contactPoints = await Promise.all(
+    personLinks.map((link) =>
+      peopleCoreServiceAsync.getContactPoint({
+        tenantId: input.tenantId,
+        contactPointId: link.contactPointId,
+      })),
+  );
+
+  const smsCandidates = contactPoints
+    .filter((contactPoint): contactPoint is NonNullable<typeof contactPoint> => Boolean(contactPoint))
+    .filter((contactPoint) => contactPoint.type === 'phone')
+    .filter((contactPoint) => validatePhoneForChannel(contactPoint.normalizedValue, 'sms').ok);
+
+  if (smsCandidates.length === 0) {
+    return {
+      ok: false,
+      code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED',
+      message: 'This conversation cannot send a text until a textable contact is linked to the person.',
+      reason: 'missing_target',
+    };
+  }
+
+  if (smsCandidates.length > 1) {
+    return {
+      ok: false,
+      code: 'CONNECTSHYFT_SMS_TARGET_AMBIGUOUS',
+      message: 'This conversation has more than one active textable contact and needs one clear texting target.',
+      reason: 'ambiguous_target',
+    };
+  }
+
+  const selected = smsCandidates[0];
+
+  return {
+    ok: true,
+    contactPointId: selected.id,
+    normalizedValue: selected.normalizedValue,
+  };
+}
+```
+
+### Route patch
+Add import in `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`:
+
+```diff
++import { resolveThreadSmsTarget } from '../../../../modules/connectshyft/threadSmsTargetResolver';
+```
+
+Then in the outbound thread-message SMS path:
+
+```diff
++    const smsTarget = await resolveThreadSmsTarget({
++      tenantId: context.tenantId,
++      orgUnitId: context.orgUnitId,
++      threadId,
++      personId: threadDetail.personId,
++    });
++
++    if (!smsTarget.ok) {
++      refusal(res, {
++        code: smsTarget.code,
++        message: smsTarget.message,
++        refusalType: 'business',
++        httpStatus: 200,
++        data: {
++          context,
++          threadId,
++          targetResolution: {
++            deterministic: smsTarget.reason !== 'ambiguous_target',
++            source: 'peoplecore_current_contact_point',
++            reason: smsTarget.reason,
++          },
++        },
++      });
++      return;
++    }
+```
+
+## PATCH 3 — Inbound-first SMS strict-PeopleCore fix
+
+### File
+`apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+
+Replace the early `neighbor_unresolved` refusal branch with PeopleCore identity resolution, provisional creation, and ambiguity-review creation before thread ensure.
+
+## PATCH 4 — Immediate misleading UI copy cleanup
+
+### File
+`apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue`
+
+```diff
+- Persist one valid mapped ConnectShyft sender number on the thread before sending SMS.
++ This conversation cannot send a text until a texting number and a textable contact are both ready.
+```
+
+```diff
+- Mapped outbound number configured
++ Conversation line selected
+```
+
+### File
+Settings view file that contains readiness copy
+
+```diff
+- Calls and texts are ready.
++ Calling and texting are available when your callback number, conversation line, and contact details are ready.
+```

--- a/specs/prep_step_4_5_checkpoint_1_claim_persistence_actor_id.md
+++ b/specs/prep_step_4_5_checkpoint_1_claim_persistence_actor_id.md
@@ -1,0 +1,66 @@
+# CHECKPOINT 1 — CLAIM PERSISTENCE AND ACTOR-ID NORMALIZATION
+
+## 1. FILES (Exact Paths)
+- `apps/connectshyft-api/src/modules/connectshyft/threads.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/http/threadLifecycleContext.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- relevant thread lifecycle test files
+
+## 2. FUNCTION SIGNATURES (Exact)
+```ts
+async transitionThreadState(input: ThreadStoreTransitionInput): Promise<ThreadPersistenceTransitionResult>
+```
+
+```ts
+export const executeConnectShyftThreadLifecycleAction = async (
+  req: Request,
+  res: Response,
+  action: ConnectShyftLifecycleAction,
+): Promise<void>
+```
+
+## 3. LINE-LEVEL DIFF EXPECTATIONS (MANDATORY)
+```diff
+- const normalizedActorUserId = normalizeUuid(input.actorUserId);
++ const normalizedActorUserId = normalizeString(input.actorUserId) || null;
+```
+
+```diff
++ logger.error('connectshyft thread transition persistence failed', {
++   tenantId: input.tenantId,
++   threadId: input.threadId,
++   nextState: input.nextState,
++   actorUserId: input.actorUserId,
++   error: errorCaught,
++ });
+```
+
+## 4. REQUIRED CHANGES
+- Remove UUID-only normalization from claim transition actor handling.
+- Keep actor-required guard for non-UNCLAIMED transitions.
+- Persist stable text actor IDs.
+- Add explicit logging around persistence failure.
+
+## 5. DATA MUTATIONS
+On claim:
+- `state='CLAIMED'`
+- `claimed_by_user_id=actorUserId`
+- `claimed_at_utc=now()`
+- `updated_by_user_id=actorUserId`
+- `updated_at_utc=now()`
+
+## 6. GUARDS (MANDATORY)
+- Empty actor id remains invalid.
+- No lifecycle policy changes.
+
+## 7. STOP CONDITION (VERIFIABLE)
+- Integration or route test proves claim succeeds with non-UUID actor id.
+
+## 8. COMMIT POINT (MANDATORY)
+```bash
+git add .
+git commit -m "fix(connectshyft): allow thread claim persistence for text actor ids"
+```
+
+## 9. PROHIBITED
+- No broad lifecycle redesign.

--- a/specs/prep_step_4_5_checkpoint_2_strict_peoplecore_outbound_sms_target.md
+++ b/specs/prep_step_4_5_checkpoint_2_strict_peoplecore_outbound_sms_target.md
@@ -1,0 +1,88 @@
+# CHECKPOINT 2 — STRICT PEOPLECORE OUTBOUND SMS TARGET RESOLUTION
+
+## 1. FILES (Exact Paths)
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts`
+- `apps/connectshyft-api/src/modules/peoplecore/service.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/threadSmsTargetResolver.ts`
+- relevant outbound message tests
+
+## 2. FUNCTION SIGNATURES (Exact)
+```ts
+async function resolveThreadSmsTarget(input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  personId: string;
+}): Promise<
+  | { ok: true; contactPointId: string; normalizedValue: string }
+  | {
+      ok: false;
+      code: 'CONNECTSHYFT_SMS_TARGET_REQUIRED' | 'CONNECTSHYFT_SMS_TARGET_AMBIGUOUS' | 'CONNECTSHYFT_SMS_TARGET_INVALID';
+      message: string;
+      reason: 'missing_target' | 'ambiguous_target' | 'invalid_target';
+    }
+>
+```
+
+## 3. LINE-LEVEL DIFF EXPECTATIONS (MANDATORY)
+```diff
++ import { resolveThreadSmsTarget } from '../../../../modules/connectshyft/threadSmsTargetResolver';
+```
+
+```diff
++ const smsTarget = await resolveThreadSmsTarget({
++   tenantId: context.tenantId,
++   orgUnitId: context.orgUnitId,
++   threadId,
++   personId: threadDetail.personId,
++ });
++ if (!smsTarget.ok) {
++   refusal(res, {
++     code: smsTarget.code,
++     message: smsTarget.message,
++     refusalType: 'business',
++     httpStatus: 200,
++     data: {
++       context,
++       threadId,
++       targetResolution: {
++         deterministic: smsTarget.reason !== 'ambiguous_target',
++         source: 'peoplecore_current_contact_point',
++         reason: smsTarget.reason,
++       },
++     },
++   });
++   return;
++ }
+```
+
+## 4. REQUIRED CHANGES
+- Add strict PeopleCore SMS target resolver.
+- Resolve target only from PeopleCore current person contact points.
+- Require exactly one deterministic SMS-capable phone contact point.
+- Refuse if none, ambiguous, or invalid.
+- No legacy neighbor fallback.
+
+## 5. DATA MUTATIONS
+Reads:
+- `people.contact_point_links`
+- `people.contact_points`
+- `connectshyft.cs_threads`
+
+## 6. GUARDS (MANDATORY)
+- `thread.person_id` must exist.
+- Only current person links count.
+- Only phone contact points count.
+
+## 7. STOP CONDITION (VERIFIABLE)
+- Integration test proves outbound SMS succeeds only with a PeopleCore current contact point and refuses otherwise.
+
+## 8. COMMIT POINT (MANDATORY)
+```bash
+git add .
+git commit -m "fix(connectshyft): require PeopleCore contact points for outbound sms targets"
+```
+
+## 9. PROHIBITED
+- No legacy `cs_neighbor_phones` fallback.

--- a/specs/prep_step_4_5_checkpoint_2_strict_peoplecore_outbound_sms_target.md.md
+++ b/specs/prep_step_4_5_checkpoint_2_strict_peoplecore_outbound_sms_target.md.md
@@ -1,0 +1,102 @@
+# CHECKPOINT 2 — STRICT PEOPLECORE OUTBOUND SMS TARGET RESOLUTION
+
+## 1. FILES (Exact Paths)
+
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/senderNumberResolver.ts`
+- `apps/connectshyft-api/src/modules/peoplecore/service.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/threads.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/threadSmsTargetResolver.ts`
+- relevant outbound message tests
+
+## 2. FUNCTION SIGNATURES (Exact)
+
+```ts
+async function resolveThreadSmsTarget(input: {
+  tenantId: string;
+  orgUnitId: string;
+  threadId: string;
+  personId: string;
+}): Promise<
+  | { ok: true; contactPointId: string; normalizedValue: string }
+  | {
+      ok: false;
+      code:
+        | "CONNECTSHYFT_SMS_TARGET_REQUIRED"
+        | "CONNECTSHYFT_SMS_TARGET_AMBIGUOUS"
+        | "CONNECTSHYFT_SMS_TARGET_INVALID";
+      message: string;
+      reason: "missing_target" | "ambiguous_target" | "invalid_target";
+    }
+>;
+```
+
+## 3. LINE-LEVEL DIFF EXPECTATIONS (MANDATORY)
+
+```diff
++ import { resolveThreadSmsTarget } from '../../../../modules/connectshyft/threadSmsTargetResolver';
+```
+
+```diff
++ const smsTarget = await resolveThreadSmsTarget({
++   tenantId: context.tenantId,
++   orgUnitId: context.orgUnitId,
++   threadId,
++   personId: threadDetail.personId,
++ });
++ if (!smsTarget.ok) {
++   refusal(res, {
++     code: smsTarget.code,
++     message: smsTarget.message,
++     refusalType: 'business',
++     httpStatus: 200,
++     data: {
++       context,
++       threadId,
++       targetResolution: {
++         deterministic: smsTarget.reason !== 'ambiguous_target',
++         source: 'peoplecore_current_contact_point',
++         reason: smsTarget.reason,
++       },
++     },
++   });
++   return;
++ }
+```
+
+## 4. REQUIRED CHANGES
+
+- Add strict PeopleCore SMS target resolver.
+- Resolve target only from PeopleCore current person contact points.
+- Require exactly one deterministic SMS-capable phone contact point.
+- Refuse if none, ambiguous, or invalid.
+- No legacy neighbor fallback.
+
+## 5. DATA MUTATIONS
+
+Reads:
+
+- `people.contact_point_links`
+- `people.contact_points`
+- `connectshyft.cs_threads`
+
+## 6. GUARDS (MANDATORY)
+
+- thread.person_id must exist.
+- Only current person links count.
+- Only phone contact points count.
+
+## 7. STOP CONDITION (VERIFIABLE)
+
+- Integration test proves outbound SMS succeeds only with a PeopleCore current contact point and refuses otherwise.
+
+## 8. COMMIT POINT (MANDATORY)
+
+```bash
+git add .
+git commit -m "fix(connectshyft): require PeopleCore contact points for outbound sms targets"
+```
+
+## 9. PROHIBITED
+
+- No legacy cs_neighbor_phones fallback.

--- a/specs/prep_step_4_5_checkpoint_3_inbound_first_sms_identity_and_review.md
+++ b/specs/prep_step_4_5_checkpoint_3_inbound_first_sms_identity_and_review.md
@@ -1,0 +1,76 @@
+# CHECKPOINT 3 — INBOUND-FIRST SMS ENSURE/CREATE + RESOLVER REVIEW CREATION
+
+## 1. FILES (Exact Paths)
+- `apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/threads.ts`
+- relevant inbound webhook tests
+
+## 2. FUNCTION SIGNATURES (Exact)
+```ts
+async resolveInboundWebhookCorrelation(input: ResolveInboundWebhookCorrelationInput): Promise<ResolveInboundWebhookCorrelationResult>
+```
+
+```ts
+async createProvisionalPersonHook(input: ConnectShyftProvisionalIdentityHookInput): Promise<ConnectShyftProvisionalIdentityHookResult>
+```
+
+```ts
+async createResolverReviewHook(input: ConnectShyftResolverReviewHookInput): Promise<ConnectShyftResolverReviewHookResult>
+```
+
+## 3. LINE-LEVEL DIFF EXPECTATIONS (MANDATORY)
+```diff
+- if (!neighborId) {
+-   await markWebhookReceipt('FAILED_TERMINAL', 'neighbor_unresolved');
+-   refusal(...CONNECTSHYFT_WEBHOOK_NEIGHBOR_UNRESOLVED...);
+-   return;
+- }
++ if (!neighborId) {
++   const identityResolution = await peopleCoreIdentityAdapter.evaluateIdentityCandidatesForContactPoint({
++     tenantId,
++     contactPointValue: normalizedSenderPhone,
++   });
++   // zero candidates -> provisional
++   // one candidate -> resolved person
++   // multiple candidates -> resolver review + ambiguity event
++ }
+```
+
+## 4. REQUIRED CHANGES
+- Allow destination-number mapping correlation to proceed without prior thread id.
+- Remove early `neighbor_unresolved` refusal.
+- Create provisional person/contact point/link when zero candidates exist.
+- Create resolver review + ambiguity event when ambiguous.
+- Ensure thread using resolved/created `personId`.
+- Persist canonical event after ensure succeeds.
+
+## 5. DATA MUTATIONS
+Possible writes:
+- `people.contact_points`
+- `people.contact_point_links`
+- `people.persons`
+- `people.resolver_reviews`
+- `connectshyft.cs_identity_ambiguity_events`
+- `connectshyft.cs_threads`
+- `connectshyft.cs_webhook_receipts`
+
+## 6. GUARDS (MANDATORY)
+- Number-mapping-only correlation is sufficient to continue.
+- Ambiguous identity must not silently pick a person.
+- Provisional creation and review creation remain duplicate-safe.
+
+## 7. STOP CONDITION (VERIFIABLE)
+- Inbound-first SMS integration test creates provisional person/thread when no match exists and resolver review when ambiguous.
+
+## 8. COMMIT POINT (MANDATORY)
+```bash
+git add .
+git commit -m "fix(connectshyft): allow inbound-first sms to create provisional identity and review work"
+```
+
+## 9. PROHIBITED
+- No requirement for prior outbound correlation metadata.

--- a/specs/prep_step_4_5_checkpoint_3_inbound_first_sms_identity_and_review.md.md
+++ b/specs/prep_step_4_5_checkpoint_3_inbound_first_sms_identity_and_review.md.md
@@ -1,0 +1,86 @@
+# CHECKPOINT 3 — INBOUND-FIRST SMS ENSURE/CREATE + RESOLVER REVIEW CREATION
+
+## 1. FILES (Exact Paths)
+
+- `apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts`
+- `apps/connectshyft-api/src/routes/api/v1/connectshyft.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityAdapter.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/ambiguityEvents.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/threads.ts`
+- relevant inbound webhook tests
+
+## 2. FUNCTION SIGNATURES (Exact)
+
+```ts
+async resolveInboundWebhookCorrelation(input: ResolveInboundWebhookCorrelationInput): Promise<ResolveInboundWebhookCorrelationResult>
+```
+
+```ts
+async createProvisionalPersonHook(input: ConnectShyftProvisionalIdentityHookInput): Promise<ConnectShyftProvisionalIdentityHookResult>
+```
+
+```ts
+async createResolverReviewHook(input: ConnectShyftResolverReviewHookInput): Promise<ConnectShyftResolverReviewHookResult>
+```
+
+## 3. LINE-LEVEL DIFF EXPECTATIONS (MANDATORY)
+
+```diff
+- if (!neighborId) {
+-   await markWebhookReceipt('FAILED_TERMINAL', 'neighbor_unresolved');
+-   refusal(...CONNECTSHYFT_WEBHOOK_NEIGHBOR_UNRESOLVED...);
+-   return;
+- }
++ if (!neighborId) {
++   const identityResolution = await peopleCoreIdentityAdapter.evaluateIdentityCandidatesForContactPoint({
++     tenantId,
++     contactPointValue: normalizedSenderPhone,
++   });
++   // zero candidates -> provisional
++   // one candidate -> resolved person
++   // multiple candidates -> resolver review + ambiguity event
++ }
+```
+
+## 4. REQUIRED CHANGES
+
+- Allow destination-number mapping correlation to proceed without prior thread id.
+- Remove early `neighbor_unresolved` refusal.
+- Create provisional person/contact point/link when zero candidates exist.
+- Create resolver review + ambiguity event when ambiguous.
+- Ensure thread using resolved/created `personId`.
+- Persist canonical event after ensure succeeds.
+
+## 5. DATA MUTATIONS
+
+Possible writes:
+
+- `people.contact_points`
+- `people.contact_point_links`
+- `people.persons`
+- `people.resolver_reviews`
+- `connectshyft.cs_identity_ambiguity_events`
+- `connectshyft.cs_threads`
+- `connectshyft.cs_webhook_receipts`
+
+## 6. GUARDS (MANDATORY)
+
+- Number-mapping-only correlation is sufficient to continue.
+- Ambiguous identity must not silently pick a person.
+- Provisional creation and review creation remain duplicate-safe.
+
+## 7. STOP CONDITION (VERIFIABLE)
+
+- Inbound-first SMS integration test creates provisional person/thread when no match exists and resolver review when ambiguous.
+
+## 8. COMMIT POINT (MANDATORY)
+
+```bash
+git add .
+git commit -m "fix(connectshyft): allow inbound-first sms to create provisional identity and review work"
+```
+
+## 9. PROHIBITED
+
+- No requirement for prior outbound correlation metadata.

--- a/specs/prep_step_4_5_checkpoint_4_operator_callback_and_readiness_copy.md
+++ b/specs/prep_step_4_5_checkpoint_4_operator_callback_and_readiness_copy.md
@@ -1,0 +1,68 @@
+# CHECKPOINT 4 — OPERATOR CALLBACK READINESS + MISLEADING READINESS COPY CLEANUP
+
+## 1. FILES (Exact Paths)
+- `apps/connectshyft-api/src/modules/connectshyft/operatorDestinationResolver.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/telephonyReadiness.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postThreadCallHandler.ts`
+- `apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue`
+- `apps/connectshyft-web/src/views/Shell/*`
+- shared UI copy helpers if used
+
+## 2. FUNCTION SIGNATURES (Exact)
+```ts
+async getUserPhone(input: { tenantId: string; userId: string; }): Promise<{ userId: string; phoneNumber: string | null } | null>
+```
+
+```ts
+async inspectReadiness(input: ConnectShyftTelephonyReadinessInput): Promise<ConnectShyftTelephonyReadiness>
+```
+
+## 3. LINE-LEVEL DIFF EXPECTATIONS (MANDATORY)
+```diff
+- .where({
+-   id: input.userId,
+-   household_id: input.tenantId,
+- })
++ .where({
++   id: input.userId,
++ })
+```
+
+```diff
+- "Mapped outbound number configured"
++ "Conversation line selected"
+```
+
+```diff
+- "Persist one valid mapped ConnectShyft sender number on the thread before sending SMS."
++ "This conversation cannot send a text until a texting number and a textable contact are both ready."
+```
+
+## 4. REQUIRED CHANGES
+- Fix operator callback lookup so production user rows resolve correctly.
+- Preserve readiness semantics, but reflect actual callback/runtime truth.
+- Update thread/settings readiness copy so it does not claim capability that backend has not verified.
+- Remove engineering language from user-facing views.
+
+## 5. DATA MUTATIONS
+Reads:
+- `connectshyft.cs_operator_callback_numbers`
+- `connectshyft.cs_org_unit_escalation_config`
+- production user table used by callback lookup
+
+## 6. GUARDS (MANDATORY)
+- Outbound call must still refuse if callback truly missing.
+- UI must not show “ready” unless backend readiness says ready.
+- No copy may mention internal mapping/persistence language.
+
+## 7. STOP CONDITION (VERIFIABLE)
+- Outbound call integration test succeeds with callback row present or readiness inspection returns callback-ready for production-shaped user row, and grep no longer finds misleading readiness copy.
+
+## 8. COMMIT POINT (MANDATORY)
+```bash
+git add .
+git commit -m "fix(connectshyft): align callback readiness and remove misleading readiness copy"
+```
+
+## 9. PROHIBITED
+- No fake readiness state.

--- a/specs/prep_step_4_5_checkpoint_4_operator_callback_and_readiness_copy.md.md
+++ b/specs/prep_step_4_5_checkpoint_4_operator_callback_and_readiness_copy.md.md
@@ -1,0 +1,78 @@
+# CHECKPOINT 4 — OPERATOR CALLBACK READINESS + MISLEADING READINESS COPY CLEANUP
+
+## 1. FILES (Exact Paths)
+
+- `apps/connectshyft-api/src/modules/connectshyft/operatorDestinationResolver.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/telephonyReadiness.ts`
+- `apps/connectshyft-api/src/modules/connectshyft/handlers/postThreadCallHandler.ts`
+- `apps/connectshyft-web/src/views/ConnectShyft/ConnectShyftThreadDetailView.vue`
+- `apps/connectshyft-web/src/views/Shell/*`
+- shared UI copy helpers if used
+
+## 2. FUNCTION SIGNATURES (Exact)
+
+```ts
+async getUserPhone(input: { tenantId: string; userId: string; }): Promise<{ userId: string; phoneNumber: string | null } | null>
+```
+
+```ts
+async inspectReadiness(input: ConnectShyftTelephonyReadinessInput): Promise<ConnectShyftTelephonyReadiness>
+```
+
+## 3. LINE-LEVEL DIFF EXPECTATIONS (MANDATORY)
+
+```diff
+- .where({
+-   id: input.userId,
+-   household_id: input.tenantId,
+- })
++ .where({
++   id: input.userId,
++ })
+```
+
+```diff
+- "Mapped outbound number configured"
++ "Conversation line selected"
+```
+
+```diff
+- "Persist one valid mapped ConnectShyft sender number on the thread before sending SMS."
++ "This conversation cannot send a text until a texting number and a textable contact are both ready."
+```
+
+## 4. REQUIRED CHANGES
+
+- Fix operator callback lookup so production user rows resolve correctly.
+- Preserve readiness semantics, but reflect actual callback/runtime truth.
+- Update thread/settings readiness copy so it does not claim capability the backend has not verified.
+- Remove engineering language from user-facing views.
+
+## 5. DATA MUTATIONS
+
+Reads:
+
+- `connectshyft.cs_operator_callback_numbers`
+- `connectshyft.cs_org_unit_escalation_config`
+- production user table used by callback lookup
+
+## 6. GUARDS (MANDATORY)
+
+- Outbound call must still refuse if callback truly missing.
+- UI must not show “ready” unless backend readiness says ready.
+- No copy may mention internal mapping/persistence language.
+
+## 7. STOP CONDITION (VERIFIABLE)
+
+- Outbound call integration test succeeds with callback row present or readiness inspection returns callback-ready for production-shaped user row, and grep no longer finds misleading readiness copy.
+
+## 8. COMMIT POINT (MANDATORY)
+
+```bash
+git add .
+git commit -m "fix(connectshyft): align callback readiness and remove misleading readiness copy"
+```
+
+## 9. PROHIBITED
+
+- No fake readiness state.

--- a/specs/prep_step_4_5_implementation_brief.md
+++ b/specs/prep_step_4_5_implementation_brief.md
@@ -1,0 +1,241 @@
+# PREP STEP 4.5 — IMPLEMENTATION BRIEF
+**Title:** Communications Reliability and Humanization Stabilization
+
+## 1. OBJECTIVE
+Restore MVP-safe communications reliability and remove misleading readiness behavior by fixing:
+1. inbound-first SMS creation and identity attachment
+2. outbound SMS target resolution against strict PeopleCore truth
+3. thread claim persistence
+4. operator callback and readiness resolution for outbound voice
+5. misleading engineering and readiness language that overstates actual capability
+
+## 2. ARCHITECTURAL DECISIONS (LOCKED)
+1. Path A — strict PeopleCore is locked.
+   - No legacy-neighbor-phone fallback for outbound SMS target resolution.
+   - A thread is SMS-sendable only if its `person_id` resolves to a current People contact point suitable for SMS.
+2. Inbound-first SMS must create or reuse PeopleCore identity truth.
+   - If no current People identity matches the inbound sender number, create provisional person + contact point + current link.
+   - If ambiguous, create resolver review and ambiguity event.
+3. Claim persistence must accept platform actor IDs without UUID-only assumptions.
+4. Telephony readiness remains backend-authoritative.
+5. User-facing copy must not promise capability the backend cannot execute.
+
+## 3. EXECUTION FLOW
+### Flow A — Claim thread
+1. Resolve lifecycle access context
+2. Resolve current thread state
+3. Accept actor user id as stable text identifier
+4. Persist `claimed_by_user_id`, `claimed_at_utc`, `updated_by_user_id`
+5. Emit current side effects
+6. Return success contract
+
+### Flow B — Outbound SMS from thread
+1. Resolve thread outbound access context
+2. Resolve sender number via existing sender-alignment path
+3. Resolve target contact point via PeopleCore current links for `thread.person_id`
+4. Require one deterministic SMS-capable People contact point
+5. Create delivery attempt / send SMS
+6. Persist timeline / outbox behavior
+7. Return success contract or clean refusal
+
+### Flow C — Inbound-first SMS
+1. Receive webhook
+2. Resolve tenant/orgUnit/provider from identifiers or destination number mapping
+3. Normalize inbound sender number
+4. Evaluate PeopleCore identity candidates
+5. Branch:
+   - one deterministic current person → use person
+   - zero matches → create provisional person/contact point/current link
+   - ambiguous → create resolver review and ambiguity event
+6. Ensure thread using resolved/created `personId`
+7. Persist canonical inbound event + webhook receipt
+8. Append inbound SMS to thread timeline
+
+### Flow D — Outbound call from thread
+1. Resolve thread outbound access context
+2. Inspect telephony readiness
+3. Resolve operator destination from callback number / allowed source
+4. Start bridge call if ready
+5. Otherwise refuse cleanly with actionable readiness metadata
+
+## 4. STATE MACHINE
+### Thread claim state
+- `UNCLAIMED -> CLAIMED`
+- `CLAIMED -> UNCLAIMED`
+- `UNCLAIMED -> CLOSED`
+- `CLAIMED -> CLOSED`
+
+Guard:
+- actor required for non-UNCLAIMED transitions
+- actor identity may be text; must not be UUID-only
+
+### Inbound SMS identity state
+- `unresolved inbound sender`
+  - -> `resolved current person`
+  - -> `provisional person created`
+  - -> `resolver_required`
+
+### Outbound SMS readiness
+- `thread available`
+  - + valid sender alignment
+  - + valid PeopleCore SMS target
+  - -> `dispatchable`
+- else -> refusal
+
+### Outbound call readiness
+- `thread available`
+  - + provider ready
+  - + operator destination resolved
+  - + orgUnit mapping ready
+  - -> `bridge runnable`
+- else -> refusal
+
+## 5. DATABASE CONTRACTS
+### connectshyft.cs_threads
+Relevant fields:
+- `id`
+- `tenant_id`
+- `org_unit_id`
+- `person_id`
+- `claimed_by_user_id`
+- `claimed_at_utc`
+- `updated_by_user_id`
+- `updated_at_utc`
+- `last_inbound_cs_number_id`
+- `preferred_outbound_cs_number_id`
+
+### connectshyft.cs_operator_callback_numbers
+Relevant fields:
+- `tenant_id`
+- `user_id`
+- `phone_e164`
+
+### connectshyft.cs_webhook_receipts
+Relevant fields:
+- `thread_id`
+- `provider_event_id`
+- `processing_status`
+- `failure_reason`
+- `correlation_keys`
+
+### connectshyft.cs_identity_ambiguity_events
+Relevant fields:
+- `normalized_contact_point`
+- `status`
+- `resolver_review_id`
+- `resolver_outcome`
+
+### people.persons
+Relevant fields:
+- `id`
+- `tenant_id`
+- `org_unit_id`
+- `status`
+
+### people.contact_points
+Relevant fields:
+- `id`
+- `tenant_id`
+- `type`
+- `normalized_value`
+- `status`
+
+### people.contact_point_links
+Relevant fields:
+- `contact_point_id`
+- `subject_type`
+- `subject_id`
+- `is_current`
+- `is_primary`
+
+### people.resolver_reviews
+Relevant fields:
+- resolver review records created for ambiguous inbound-first identity
+
+## 6. SERVICE LAYER (STRICT)
+### File: `apps/connectshyft-api/src/modules/connectshyft/threads.ts`
+`async transitionThreadState(input: ThreadStoreTransitionInput): Promise<ThreadPersistenceTransitionResult>`
+
+### File: `apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts`
+`async resolveInboundWebhookCorrelation(input: ResolveInboundWebhookCorrelationInput): Promise<ResolveInboundWebhookCorrelationResult>`
+
+### File: `apps/connectshyft-api/src/modules/connectshyft/peoplecoreIdentityHooks.ts`
+`async createProvisionalPersonHook(input: ConnectShyftProvisionalIdentityHookInput): Promise<ConnectShyftProvisionalIdentityHookResult>`
+`async createResolverReviewHook(input: ConnectShyftResolverReviewHookInput): Promise<ConnectShyftResolverReviewHookResult>`
+
+### New file
+`apps/connectshyft-api/src/modules/connectshyft/threadSmsTargetResolver.ts`
+
+## 7. PROVIDER / INTEGRATION CONTRACTS
+### Telnyx inbound SMS webhook
+Required behavior:
+- inbound-first messages must proceed on destination-number mapping without prior thread metadata
+
+### Outbound call runtime
+Required:
+- operator callback destination
+- valid provider mapping
+- readiness path must reflect real runtime capability
+
+## 8. EVENT HANDLING
+- inbound SMS webhook → correlation → identity resolution → ensure thread → persist canonical event → append timeline
+- thread claim route → transition thread state
+- outbound SMS route → resolve sender + strict PeopleCore target
+- outbound call route → inspect readiness + resolve operator destination
+
+## 9. IDEMPOTENCY RULES
+1. Webhook receipt and provider event remain dedupe source.
+2. Provisional creation hook must tolerate duplicate retries via unique-violation reload path.
+3. Resolver review creation remains duplicate-safe via trigger-source guard.
+4. Claim transition remains lifecycle-policy guarded.
+
+## 10. FAILURE MODES
+### Claim
+- `THREAD_NOT_FOUND`
+- `TRANSITION_ACTOR_REQUIRED`
+- `THREAD_PERSISTENCE_UNAVAILABLE`
+
+### Outbound SMS
+- `CONNECTSHYFT_SENDER_*`
+- `CONNECTSHYFT_SMS_TARGET_REQUIRED`
+- `CONNECTSHYFT_SMS_TARGET_AMBIGUOUS`
+- `CONNECTSHYFT_SMS_TARGET_INVALID`
+
+### Inbound SMS
+- webhook correlation refusals
+- thread ensure persistence unavailable
+- identity ambiguity requiring review
+
+### Outbound call
+- `CONNECTSHYFT_TELEPHONY_NOT_READY`
+- `CONNECTSHYFT_OPERATOR_DESTINATION_MISSING`
+
+## 11. TEST CONTRACT
+Required scenarios:
+1. claim succeeds with non-UUID actor id
+2. outbound SMS succeeds only when PeopleCore current contact point exists
+3. outbound SMS refuses when no PeopleCore current contact point exists
+4. inbound SMS with no existing match creates provisional person/contact point/link and thread
+5. inbound SMS with multiple current links creates resolver review
+6. outbound call uses callback number when present
+7. readiness copy does not claim SMS/voice ready when runtime prerequisites fail
+
+## 12. CHECKPOINTS
+1. Claim persistence + actor-id normalization
+2. Strict PeopleCore outbound SMS target resolution
+3. Inbound-first SMS ensure/create + resolver review creation
+4. Operator callback resolution + misleading readiness copy cleanup
+
+## 13. DEFINITION OF DONE
+Prep Step 4.5 is done only when:
+- claim works end-to-end
+- outbound SMS requires and successfully uses PeopleCore contact points
+- inbound-first SMS creates provisional/review work correctly
+- outbound call readiness reflects actual callback availability
+- misleading engineering/readiness copy is removed
+
+## 14. NON-GOALS
+- No legacy neighbor-phone fallback for outbound SMS
+- No CaseShyft
+- No new modules
+- No sender-alignment architecture redesign

--- a/specs/prep_step_4_5_master_codex_bootstrap_prompt.md
+++ b/specs/prep_step_4_5_master_codex_bootstrap_prompt.md
@@ -1,0 +1,40 @@
+# Master Codex Bootstrap Prompt — Prep Step 4.5
+
+Use these authoritative specs in `specs/`:
+
+- `specs/prep_step_4_5_implementation_brief.md`
+- `specs/prep_step_4_5_checkpoint_1_claim_persistence_actor_id.md`
+- `specs/prep_step_4_5_checkpoint_2_strict_peoplecore_outbound_sms_target.md`
+- `specs/prep_step_4_5_checkpoint_3_inbound_first_sms_identity_and_review.md`
+- `specs/prep_step_4_5_checkpoint_4_operator_callback_and_readiness_copy.md`
+
+## Mission
+Fix the communications blockers that currently prevent a trustworthy MVP:
+- claim persistence
+- strict PeopleCore outbound SMS targeting
+- inbound-first SMS provisional/review creation
+- operator callback/readiness resolution
+- misleading readiness/engineering copy
+
+## Non-negotiable rules
+1. **Path A — strict PeopleCore is locked**
+   - no legacy neighbor-phone fallback for outbound SMS targets
+2. **Inbound-first SMS must work without prior outbound correlation**
+   - destination-number mapping is enough to continue
+3. **Do not redesign architecture**
+   - no telephony redesign
+   - no shell redesign
+   - no CaseShyft
+   - no new modules
+4. **No engineering leakage**
+   - user-facing copy must not overstate readiness
+5. **Work surgically**
+   - fix the exact seams identified
+
+## Execution order (mandatory)
+1. checkpoint 1
+2. checkpoint 2
+3. checkpoint 3
+4. checkpoint 4
+
+Use the exact commit message in each checkpoint. Do not drift.


### PR DESCRIPTION
## Summary
- complete checkpoint 1 by allowing claim persistence for text actor ids
- complete checkpoint 2 by requiring PeopleCore contact points for outbound SMS targets
- complete checkpoint 3 by allowing inbound-first SMS to create provisional identity and resolver review work
- complete checkpoint 4 by aligning callback readiness truth and removing misleading readiness copy
- add the prep step 4.5 spec artifacts used for implementation

## Testing
- npx jest src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts --runInBand
- npx jest src/modules/connectshyft/__tests__/operatorDestinationResolver.test.ts src/modules/connectshyft/__tests__/telephonyReadiness.test.ts src/modules/connectshyft/__tests__/readContracts.test.ts src/routes/api/v1/__tests__/connectshyft.thread-message.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.outbound-dispatch.test.ts src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.telephony-runtime.characterization.test.ts src/routes/api/v1/__tests__/connectshyft.settings-and-availability.characterization.test.ts --runInBand
- npx vitest run src/views/ConnectShyft/__tests__/ConnectShyftSettingsView.test.ts src/views/ConnectShyft/__tests__/ConnectShyftMoreView.test.ts