### PR TITLE
fix(connectshyft): resolve operator destination from callback number store

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/operatorDestinationResolver.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/operatorDestinationResolver.test.ts
@@ -3,6 +3,7 @@ import {
   ConnectShyftTelephonyOperatorPhoneResolverService,
   InMemoryConnectShyftOperatorDestinationStore,
   KnexConnectShyftOperatorDestinationStore,
+  resolveOperatorDestination,
 } from '../operatorDestinationResolver';
 
 describe('connectshyft operatorDestinationResolver', () => {
@@ -14,7 +15,7 @@ describe('connectshyft operatorDestinationResolver', () => {
     service = new ConnectShyftOperatorDestinationResolverService(store);
   });
 
-  it('resolves the claimed thread operator first', async () => {
+  it('resolves the claimed thread operator callback number first', async () => {
     store.seedUserPhone({
       tenantId: 'tenant-connectshyft-f1',
       userId: 'user-connectshyft-claimed',
@@ -44,7 +45,7 @@ describe('connectshyft operatorDestinationResolver', () => {
     });
   });
 
-  it('falls back to the actor user when the claimed operator has no stored phone', async () => {
+  it('falls back to the actor user callback number when the claimed operator has no stored callback', async () => {
     store.seedUserPhone({
       tenantId: 'tenant-connectshyft-f1',
       userId: 'user-connectshyft-claimed',
@@ -69,7 +70,7 @@ describe('connectshyft operatorDestinationResolver', () => {
     });
   });
 
-  it('falls back to the org-unit default when no user phone resolves', async () => {
+  it('falls back to the org-unit default when no callback number resolves', async () => {
     store.seedUserPhone({
       tenantId: 'tenant-connectshyft-f1',
       userId: 'user-connectshyft-claimed',
@@ -151,6 +152,27 @@ describe('connectshyft operatorDestinationResolver', () => {
       actorUserId: 'user-connectshyft-actor',
     })).resolves.toEqual({
       phoneNumber: '+12605550123',
+      source: 'actor_user',
+      userId: 'user-connectshyft-actor',
+      orgUnitId: 'org-connectshyft-f1-east',
+    });
+  });
+
+  it('supports store overrides through resolveOperatorDestination()', async () => {
+    store.seedUserPhone({
+      tenantId: 'tenant-connectshyft-f1',
+      userId: 'user-connectshyft-actor',
+      phoneNumber: '+12605550999',
+    });
+
+    await expect(resolveOperatorDestination({
+      tenantId: 'tenant-connectshyft-f1',
+      orgUnitId: 'org-connectshyft-f1-east',
+      actorUserId: 'user-connectshyft-actor',
+    }, {
+      store,
+    })).resolves.toEqual({
+      phoneNumber: '+12605550999',
       source: 'actor_user',
       userId: 'user-connectshyft-actor',
       orgUnitId: 'org-connectshyft-f1-east',
@@ -257,23 +279,26 @@ describe('KnexConnectShyftOperatorDestinationStore', () => {
     const table = jest.fn(() => ({
       where,
     }));
-    const knex = jest.fn(() => ({
+    const withSchema = jest.fn(() => ({
       table,
+    }));
+    const knex = jest.fn(() => ({
+      withSchema,
     }));
 
     return {
       knex: knex as any,
+      withSchema,
       table,
       where,
       first,
     };
   };
 
-  it('reads user phones by id without household scoping', async () => {
-    const { knex, table, where, first } = buildKnexMock({
-      id: 'user-connectshyft-alpha-operator',
-      household_id: 'different-household-row',
-      phone_e164: '+12605550123',
+  it('reads callback numbers from connectshyft.cs_operator_callback_numbers by tenant and user', async () => {
+    const { knex, withSchema, table, where, first } = buildKnexMock({
+      user_id: 'user-connectshyft-alpha-operator',
+      callback_number_e164: '+12605550123',
     });
     const store = new KnexConnectShyftOperatorDestinationStore(knex);
 
@@ -285,10 +310,12 @@ describe('KnexConnectShyftOperatorDestinationStore', () => {
       phoneNumber: '+12605550123',
     });
 
-    expect(table).toHaveBeenCalledWith('users');
+    expect(withSchema).toHaveBeenCalledWith('connectshyft');
+    expect(table).toHaveBeenCalledWith('cs_operator_callback_numbers');
     expect(where).toHaveBeenCalledWith({
-      id: 'user-connectshyft-alpha-operator',
+      tenant_id: 'tenant-connectshyft-alpha',
+      user_id: 'user-connectshyft-alpha-operator',
     });
-    expect(first).toHaveBeenCalledWith(['id', 'phone_e164']);
+    expect(first).toHaveBeenCalledWith(['user_id', 'callback_number_e164']);
   });
 });

--- a/apps/connectshyft-api/src/modules/connectshyft/operatorDestinationResolver.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/operatorDestinationResolver.ts
@@ -38,7 +38,11 @@ export type ResolveConnectShyftOperatorDestinationInput = {
   claimedByUserId?: string | null;
 };
 
-type ConnectShyftOperatorDestinationStore = {
+export type ResolveOperatorDestinationInput = ResolveConnectShyftOperatorDestinationInput;
+
+export type ResolveOperatorDestinationResult = ConnectShyftOperatorDestinationResolution;
+
+export type OperatorDestinationStore = {
   getUserPhone(input: {
     tenantId: string;
     userId: string;
@@ -46,6 +50,9 @@ type ConnectShyftOperatorDestinationStore = {
     userId: string;
     phoneNumber: string | null;
   } | null>;
+};
+
+type ConnectShyftOperatorDestinationStore = OperatorDestinationStore & {
   getOrgUnitDefaultPhone(input: {
     tenantId: string;
     orgUnitId: string;
@@ -83,10 +90,9 @@ type ResolveNormalizedPhoneResult =
     value: string;
   };
 
-type ConnectShyftUserPhoneRow = {
-  id: string;
-  household_id: string | null;
-  phone_e164: string | null;
+type ConnectShyftOperatorCallbackPhoneRow = {
+  user_id: string;
+  callback_number_e164: string | null;
 };
 
 const normalizeString = (value: unknown): string => {
@@ -242,27 +248,30 @@ implements ConnectShyftOperatorDestinationStore {
     this.escalationConfigStore = new KnexConnectShyftEscalationConfigStore(resolveDb);
   }
 
-  private usersTable() {
-    return this.resolveDb().table<ConnectShyftUserPhoneRow>('users');
+  private operatorCallbackNumbersTable() {
+    return this.resolveDb()
+      .withSchema('connectshyft')
+      .table<ConnectShyftOperatorCallbackPhoneRow>('cs_operator_callback_numbers');
   }
 
   async getUserPhone(input: {
     tenantId: string;
     userId: string;
   }): Promise<{ userId: string; phoneNumber: string | null } | null> {
-    const row = await this.usersTable()
+    const row = await this.operatorCallbackNumbersTable()
       .where({
-        id: input.userId,
+        tenant_id: input.tenantId,
+        user_id: input.userId,
       })
-      .first(['id', 'phone_e164']);
+      .first(['user_id', 'callback_number_e164']);
 
     if (!row) {
       return null;
     }
 
     return {
-      userId: row.id,
-      phoneNumber: normalizeString(row.phone_e164) || null,
+      userId: row.user_id,
+      phoneNumber: normalizeString(row.callback_number_e164) || null,
     };
   }
 
@@ -459,19 +468,50 @@ export class ConnectShyftTelephonyOperatorPhoneResolverService {
   }
 }
 
+const connectShyftOperatorDestinationStore =
+  new KnexConnectShyftOperatorDestinationStore(() => db);
+
 const connectShyftOperatorDestinationResolverService =
   new ConnectShyftOperatorDestinationResolverService(
-    new KnexConnectShyftOperatorDestinationStore(() => db),
+    connectShyftOperatorDestinationStore,
   );
 
 const connectShyftTelephonyOperatorPhoneResolverService =
   new ConnectShyftTelephonyOperatorPhoneResolverService(
-    new KnexConnectShyftOperatorDestinationStore(() => db),
+    connectShyftOperatorDestinationStore,
   );
 
+export type ResolveOperatorDestinationDependencies = {
+  service?: Pick<ConnectShyftOperatorDestinationResolverService, 'resolve'>;
+  store?: OperatorDestinationStore;
+  getOrgUnitDefaultPhone?: ConnectShyftOperatorDestinationStore['getOrgUnitDefaultPhone'];
+};
+
 export async function resolveOperatorDestination(
-  input: ResolveConnectShyftOperatorDestinationInput,
-): Promise<ConnectShyftOperatorDestinationResolution> {
+  input: ResolveOperatorDestinationInput,
+  overrides?: ResolveOperatorDestinationDependencies,
+): Promise<ResolveOperatorDestinationResult> {
+  if (overrides?.service) {
+    return overrides.service.resolve(input);
+  }
+
+  if (overrides?.store || overrides?.getOrgUnitDefaultPhone) {
+    const store: ConnectShyftOperatorDestinationStore = {
+      getUserPhone: async (dependencyInput) => (
+        overrides.store
+          ? overrides.store.getUserPhone(dependencyInput)
+          : connectShyftOperatorDestinationStore.getUserPhone(dependencyInput)
+      ),
+      getOrgUnitDefaultPhone: async (dependencyInput) => (
+        overrides.getOrgUnitDefaultPhone
+          ? overrides.getOrgUnitDefaultPhone(dependencyInput)
+          : connectShyftOperatorDestinationStore.getOrgUnitDefaultPhone(dependencyInput)
+      ),
+    };
+
+    return new ConnectShyftOperatorDestinationResolverService(store).resolve(input);
+  }
+
   return connectShyftOperatorDestinationResolverService.resolve(input);
 }
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts
@@ -243,7 +243,7 @@ describe('connectshyft outbound call route characterization', () => {
     resolveSenderNumberSpy.mockRestore();
   });
 
-  it('returns the current outbound call success envelope and bridge-session response shape', async () => {
+  it('returns the current outbound call success envelope and bridge-session response shape when callback-backed operator resolution succeeds', async () => {
     const app = buildApp();
     const response = await request(app)
       .post(`/api/v1/connectshyft/threads/${CALL_SUCCESS_THREAD_ID}/call`)
@@ -468,9 +468,11 @@ describe('connectshyft outbound call route characterization', () => {
       'createdAtUtc',
       'escalation',
       'lastInboundCsNumberId',
+      'lastInboundProviderNumberE164',
       'neighborId',
       'orgUnitId',
       'preferredOutboundCsNumberId',
+      'preferredOutboundProviderNumberE164',
       'source',
       'state',
       'tenantId',
@@ -479,6 +481,12 @@ describe('connectshyft outbound call route characterization', () => {
     ].sort());
     expect(response.body.data.audit).toEqual(response.body.data.outbox);
     expect(response.body.data.outboundDispatch.audit).toEqual(response.body.data.audit);
+    expect(resolveOperatorDestinationSpy).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      actorUserId: TEST_ACTOR_USER_ID,
+      claimedByUserId: null,
+    });
     expect(startOutboundCallMock).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- Read operator destinations from connectshyft.cs_operator_callback_numbers instead of users.phone_e164.
- Preserve claimed -> actor -> org-unit default fallback ordering for outbound voice resolution.
- Update resolver and characterization coverage for the callback-backed outbound call path.

## Testing
- npm test -- --runTestsByPath src/modules/connectshyft/__tests__/operatorDestinationResolver.test.ts src/modules/connectshyft/__tests__/operatorCallbackNumbers.test.ts src/routes/api/v1/__tests__/connectshyft.thread-call.characterization.test.ts
- npm run build