### PR TITLE
fix(connectshyft): repair thread claim persistence path

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/threads.test.ts
@@ -586,6 +586,44 @@ describe('connectshyft async thread service persistence guards', () => {
 
     loggerErrorSpy.mockRestore();
   });
+
+  it('classifies database claim write failures as thread persistence refusals', async () => {
+    const invalidUuidError = Object.assign(new Error('invalid input syntax for type uuid'), {
+      code: '22P02',
+    });
+    const store = {
+      ensureActiveThread: jest.fn(),
+      listDueThreads: jest.fn(),
+      transitionThreadState: jest.fn().mockRejectedValue(invalidUuidError),
+    } as any;
+    const loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation(() => logger);
+    const service = new AsyncConnectShyftThreadService(store);
+
+    const result = await service.transitionThreadState({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: 'tenant-connectshyft-c1',
+      threadId: 'f3fe1191-f90a-4c7d-82ef-f77ce5dff8ba',
+      nextState: 'CLAIMED',
+      actorUserId: 'f3bb331f-8adb-4664-926b-66e01c1881a7',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'CONNECTSHYFT_THREAD_PERSISTENCE_UNAVAILABLE',
+    });
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'connectshyft thread transition persistence failed',
+      expect.objectContaining({
+        tenantId: 'tenant-connectshyft-c1',
+        threadId: 'f3fe1191-f90a-4c7d-82ef-f77ce5dff8ba',
+        nextState: 'CLAIMED',
+        actorUserId: 'f3bb331f-8adb-4664-926b-66e01c1881a7',
+        error: invalidUuidError,
+      }),
+    );
+
+    loggerErrorSpy.mockRestore();
+  });
 });
 
 describe('connectshyft knex thread persistence', () => {
@@ -668,6 +706,95 @@ describe('connectshyft knex thread persistence', () => {
       updated_by_user_id: 'operator-text-id',
       updated_at_utc: 'db-now',
     }));
+  });
+
+  it('logs the exact claim update payload when persistence fails inside transitionThreadState', async () => {
+    const actorUserId = 'f3bb331f-8adb-4664-926b-66e01c1881a7';
+    const threadId = 'f3fe1191-f90a-4c7d-82ef-f77ce5dff8ba';
+    const updateError = Object.assign(new Error('insert or update on table "cs_threads" violates foreign key constraint'), {
+      code: '23503',
+    });
+    const existingRow = {
+      id: threadId,
+      tenant_id: 'tenant-connectshyft-c1',
+      org_unit_id: 'org-connectshyft-c1-east',
+      neighbor_id: 'neighbor-connectshyft-c1-9001',
+      person_id: 'person-connectshyft-c1-9001',
+      origin_person_id: null,
+      activity_id: null,
+      source: 'VOICE',
+      state: 'UNCLAIMED',
+      escalation_stage: 2,
+      next_evaluation_at_utc: '2026-03-01T00:00:00.000Z',
+      last_inbound_cs_number_id: '+12605550191',
+      preferred_outbound_cs_number_id: '+12605550191',
+      claimed_by_user_id: null,
+      claimed_at_utc: null,
+      closed_by_user_id: null,
+      closed_at_utc: null,
+      created_at_utc: '2026-03-01T00:00:00.000Z',
+      updated_at_utc: '2026-03-01T00:00:00.000Z',
+    };
+    const capturedUpdates: Array<Record<string, unknown>> = [];
+    const loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    const createBuilder = () => ({
+      where: jest.fn().mockReturnThis(),
+      first: jest.fn().mockResolvedValue(existingRow),
+      update: jest.fn((payload: Record<string, unknown>) => {
+        capturedUpdates.push(payload);
+        return {
+          returning: jest.fn().mockRejectedValue(updateError),
+        };
+      }),
+    });
+
+    const trx = {
+      fn: {
+        now: jest.fn(() => 'db-now'),
+      },
+      withSchema: jest.fn().mockReturnValue({
+        table: jest.fn(() => createBuilder()),
+      }),
+    };
+    const knexClient = {
+      transaction: jest.fn(async (handler: (transaction: typeof trx) => Promise<unknown>) => handler(trx)),
+    } as any;
+    const store = new KnexConnectShyftThreadStore(knexClient);
+
+    await expect(store.transitionThreadState({
+      tenantId: 'tenant-connectshyft-c1',
+      threadId,
+      nextState: 'CLAIMED',
+      actorUserId,
+    } as any)).rejects.toBe(updateError);
+
+    expect(capturedUpdates).toContainEqual(expect.objectContaining({
+      state: 'CLAIMED',
+      claimed_by_user_id: actorUserId,
+      claimed_at_utc: 'db-now',
+      updated_by_user_id: actorUserId,
+      updated_at_utc: 'db-now',
+    }));
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'connectshyft thread transition persistence failed',
+      expect.objectContaining({
+        tenantId: 'tenant-connectshyft-c1',
+        threadId,
+        nextState: 'CLAIMED',
+        actorUserId,
+        updatePayload: expect.objectContaining({
+          state: 'CLAIMED',
+          claimed_by_user_id: actorUserId,
+          claimed_at_utc: 'db-now',
+          updated_by_user_id: actorUserId,
+          updated_at_utc: 'db-now',
+        }),
+        error: updateError,
+      }),
+    );
+
+    loggerErrorSpy.mockRestore();
   });
 });
 

--- a/apps/connectshyft-api/src/modules/connectshyft/threads.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/threads.ts
@@ -21,6 +21,18 @@ const MAX_ESCALATION_STAGE = 3;
 const HOUR_MS = 60 * 60 * 1000;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const E164_PROVIDER_NUMBER_PATTERN = /^\+[1-9]\d{1,14}$/;
+const CONNECTSHYFT_PERSISTENCE_ERROR_CODES = new Set([
+  '3F000',
+  '22P02',
+  '22007',
+  '23502',
+  '23503',
+  '23505',
+  '23514',
+  '42703',
+  '42804',
+  '42P01',
+]);
 
 export type ConnectShyftThreadState = (typeof CONNECTSHYFT_CANONICAL_THREAD_STATES)[number];
 export type ConnectShyftLifecycleAction = 'claim' | 'takeover' | 'close';
@@ -650,15 +662,14 @@ const hasThreadTransitionCapability = (actorRoles: Array<string | null | undefin
     || hasCapability(actorRoles, CAPABILITIES.THREAD_TAKEOVER_ALL);
 };
 
-const isMissingPersistenceError = (error: unknown): boolean => {
+const isClassifiedPersistenceError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {
     return false;
   }
 
   const candidate = error as { code?: string };
-  return candidate.code === '42P01'
-    || candidate.code === '3F000'
-    || candidate.code === '42703';
+  return typeof candidate.code === 'string'
+    && CONNECTSHYFT_PERSISTENCE_ERROR_CODES.has(candidate.code);
 };
 
 const buildThreadViewCapabilityRefusal = (): ThreadRefusalResult => ({
@@ -1399,20 +1410,32 @@ export class KnexConnectShyftThreadStore {
         updatePayload.next_evaluation_at_utc = null;
       }
 
-      const [updated] = await trx
-        .withSchema('connectshyft')
-        .table('cs_threads')
-        .where({
-          tenant_id: input.tenantId,
-          id: input.threadId,
-        })
-        .update(updatePayload)
-        .returning<DbThreadRow[]>(this.threadColumns());
+      try {
+        const [updated] = await trx
+          .withSchema('connectshyft')
+          .table('cs_threads')
+          .where({
+            tenant_id: input.tenantId,
+            id: input.threadId,
+          })
+          .update(updatePayload)
+          .returning<DbThreadRow[]>(this.threadColumns());
 
-      return {
-        ok: true,
-        thread: mapDbRowToThread(updated),
-      };
+        return {
+          ok: true,
+          thread: mapDbRowToThread(updated),
+        };
+      } catch (errorCaught) {
+        logger.error('connectshyft thread transition persistence failed', {
+          tenantId: input.tenantId,
+          threadId: input.threadId,
+          nextState: input.nextState,
+          actorUserId: input.actorUserId,
+          updatePayload,
+          error: errorCaught,
+        });
+        throw errorCaught;
+      }
     });
   }
 
@@ -1823,7 +1846,7 @@ export class AsyncConnectShyftThreadService {
         },
       };
     } catch (error) {
-      if (!isMissingPersistenceError(error)) {
+      if (!isClassifiedPersistenceError(error)) {
         throw error;
       }
 
@@ -1854,7 +1877,7 @@ export class AsyncConnectShyftThreadService {
         },
       };
     } catch (error) {
-      if (!isMissingPersistenceError(error)) {
+      if (!isClassifiedPersistenceError(error)) {
         throw error;
       }
 
@@ -1905,7 +1928,7 @@ export class AsyncConnectShyftThreadService {
         },
       };
     } catch (error) {
-      if (!isMissingPersistenceError(error)) {
+      if (!isClassifiedPersistenceError(error)) {
         throw error;
       }
 
@@ -1944,7 +1967,7 @@ export class AsyncConnectShyftThreadService {
         },
       };
     } catch (error) {
-      if (!isMissingPersistenceError(error)) {
+      if (!isClassifiedPersistenceError(error)) {
         throw error;
       }
 
@@ -1967,7 +1990,7 @@ export class AsyncConnectShyftThreadService {
     try {
       return await this.store.findThreadById(input);
     } catch (error) {
-      if (!isMissingPersistenceError(error)) {
+      if (!isClassifiedPersistenceError(error)) {
         throw error;
       }
 
@@ -1981,7 +2004,7 @@ export class AsyncConnectShyftThreadService {
     try {
       return await this.store.listThreadsByPersonIds(input);
     } catch (error) {
-      if (!isMissingPersistenceError(error)) {
+      if (!isClassifiedPersistenceError(error)) {
         throw error;
       }
 
@@ -1995,7 +2018,7 @@ export class AsyncConnectShyftThreadService {
     try {
       return await this.store.rebindPersonThreads(input);
     } catch (error) {
-      if (!isMissingPersistenceError(error)) {
+      if (!isClassifiedPersistenceError(error)) {
         throw error;
       }
 

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts
@@ -2,6 +2,8 @@
 import express from 'express';
 import request from 'supertest';
 import { responseEnvelope } from '../../../../platform/middleware/responseEnvelope';
+import * as readContractsModule from '../../../../modules/connectshyft/readContracts';
+import * as threadsModule from '../../../../modules/connectshyft/threads';
 import connectShyftRouter from '../connectshyft';
 import {
   buildApp,
@@ -12,8 +14,10 @@ import {
 const TEST_TENANT_ID = 'tenant-connectshyft-c5';
 const TEST_ORG_UNIT_ID = 'org-connectshyft-c5-east';
 const TEST_ACTOR_USER_ID = 'user-connectshyft-c5-operator';
+const UUID_ACTOR_USER_ID = 'f3bb331f-8adb-4664-926b-66e01c1881a7';
 const CLAIM_SUCCESS_THREAD_ID = 'thread-c5-unclaimed-claim-characterization-success-1001';
 const CLAIM_INVALID_STATE_THREAD_ID = 'thread-c5-unclaimed-claim-characterization-invalid-state-1001';
+const CLAIM_UUID_THREAD_ID = 'f3fe1191-f90a-4c7d-82ef-f77ce5dff8ba';
 const NOT_FOUND_THREAD_ID = '11111111-1111-4111-8111-111111111111';
 
 const buildLifecycleHeaders = (
@@ -211,6 +215,102 @@ describe('connectshyft thread claim route characterization', () => {
       'updatedAtUtc',
     ].sort());
     expect(response.body.data.audit).toEqual(response.body.data.outbox);
+  });
+
+  it('routes UUID-backed claim requests through the async thread transition write path', async () => {
+    const app = buildApp();
+    const detailSpy = jest.spyOn(
+      readContractsModule,
+      'resolveConnectShyftThreadDetailContractAsync',
+    ).mockResolvedValue({
+      threadId: CLAIM_UUID_THREAD_ID,
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      state: 'UNCLAIMED',
+      claimedByUserId: null,
+      claimed_by_user_id: null,
+    } as any);
+    const transitionSpy = jest.spyOn(
+      threadsModule.connectShyftThreadServiceAsync,
+      'transitionThreadState',
+    ).mockResolvedValue({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_TRANSITIONED',
+      httpStatus: 200,
+      data: {
+        thread: {
+          threadId: CLAIM_UUID_THREAD_ID,
+          tenantId: TEST_TENANT_ID,
+          orgUnitId: TEST_ORG_UNIT_ID,
+          neighborId: `neighbor-${CLAIM_UUID_THREAD_ID}`,
+          source: 'VOICE',
+          state: 'CLAIMED',
+          lastInboundCsNumberId: '+12605550179',
+          preferredOutboundCsNumberId: '+12605550179',
+          claimedByUserId: UUID_ACTOR_USER_ID,
+          claimedAtUtc: '2026-03-26T12:00:00.000Z',
+          closedByUserId: null,
+          closedAtUtc: null,
+          createdAtUtc: '2026-03-25T12:00:00.000Z',
+          updatedAtUtc: '2026-03-26T12:00:00.000Z',
+          escalation: {
+            stage: 0,
+            nextEvaluationAtUtc: null,
+          },
+        },
+      },
+    } as any);
+
+    const response = await postClaim(
+      app,
+      CLAIM_UUID_THREAD_ID,
+      buildLifecycleHeaders({
+        'x-test-connectshyft-user-id': UUID_ACTOR_USER_ID,
+      }),
+      {
+        reason: 'Operator accepted ownership',
+        resolution: 'needs_follow_up',
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(detailSpy).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      threadId: CLAIM_UUID_THREAD_ID,
+      actorUserId: UUID_ACTOR_USER_ID,
+    }));
+    expect(transitionSpy).toHaveBeenCalledWith({
+      actorRoles: ['ORGUNIT_MEMBER'],
+      tenantId: TEST_TENANT_ID,
+      threadId: CLAIM_UUID_THREAD_ID,
+      nextState: 'CLAIMED',
+      actorUserId: UUID_ACTOR_USER_ID,
+    });
+    expect(response.body).toMatchObject({
+      ok: true,
+      code: 'CONNECTSHYFT_THREAD_CLAIMED',
+      message: 'ConnectShyft claim action accepted',
+      data: {
+        threadId: CLAIM_UUID_THREAD_ID,
+        sideEffectsPersisted: false,
+        thread: {
+          threadId: CLAIM_UUID_THREAD_ID,
+          state: 'CLAIMED',
+          claimedByUserId: UUID_ACTOR_USER_ID,
+          claimedAtUtc: '2026-03-26T12:00:00.000Z',
+        },
+        audit: {
+          eventName: 'connectshyft.thread.claimed',
+          metadata: expect.objectContaining({
+            actor_user_id: UUID_ACTOR_USER_ID,
+            thread_id: CLAIM_UUID_THREAD_ID,
+            new_state: 'CLAIMED',
+            action: 'claim',
+          }),
+        },
+      },
+    });
   });
 
   it('returns the current invalid-state refusal when claim is retried on an already claimed thread', async () => {


### PR DESCRIPTION
## Summary
- repair ConnectShyft claim-transition persistence classification so real DB write failures return CONNECTSHYFT_THREAD_PERSISTENCE_UNAVAILABLE
- log the exact claim updatePayload inside transitionThreadState() to surface failing persistence inputs
- add checkpoint 4.6C coverage for store-level claim failures and the UUID-backed claim route write path

## Testing
- ./node_modules/.bin/jest --config jest.config.js --runInBand --runTestsByPath src/modules/connectshyft/__tests__/threads.test.ts
- ./node_modules/.bin/jest --config jest.config.js --runInBand --runTestsByPath src/routes/api/v1/__tests__/connectshyft.thread-claim.characterization.test.ts

## Notes
- repo-root npm test -- --runTestsByPath ... still fans into unrelated Nx projects in this workspace, so verification was run from apps/connectshyft-api with app-local Jest