### PR TITLE
Fix: tighten inbound-first SMS correlation fallback

### DIFF
--- a/apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts
@@ -5,11 +5,13 @@ import {
   executeConnectShyftInboundWebhookRoute,
   registerConnectShyftInboundWebhookCoreExecutor,
   resolveConnectShyftInboundWebhookAccessContext,
+  resolveInboundWebhookCorrelation,
 } from '../http/inboundWebhookContext';
 import * as inboundWebhookContextModule from '../http/inboundWebhookContext';
 import * as accessContextModule from '../http/accessContext';
 import * as providerRegistryModule from '../providerRegistry';
 import * as providerCorrelationMappingsModule from '../providerCorrelationMappings';
+import { connectShyftNumberMappingServiceAsync } from '../numberMappings';
 import * as bridgeSessionsModule from '../bridgeSessions';
 import * as canonicalEventsModule from '../canonicalEvents';
 import * as inboundSmsModule from '../inboundSms';
@@ -295,6 +297,130 @@ describe('connectshyft inbound webhook helper boundary', () => {
         },
       }),
     }));
+  });
+
+  it('continues first-contact correlation on a mapped provider number when provider identifiers are absent', async () => {
+    const correlationLookupSpy = jest.spyOn(
+      providerCorrelationMappingsModule,
+      'resolveConnectShyftProviderCorrelationByIdentifiers',
+    ).mockResolvedValue({
+      ok: false,
+      reason: 'missing-identifiers',
+    } as any);
+    const numberMappingSpy = jest.spyOn(
+      connectShyftNumberMappingServiceAsync,
+      'resolveRoutingMappingByNumber',
+    ).mockResolvedValue({
+      status: 'found',
+      mapping: {
+        mappingId: 'mapping-connectshyft-c9-1001',
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        twilioNumberE164: '+12605550199',
+        label: 'Main',
+        isActive: true,
+        createdAtUtc: '2026-03-26T00:00:00.000Z',
+        updatedAtUtc: '2026-03-26T00:00:00.000Z',
+      },
+    } as any);
+
+    const correlation = await resolveInboundWebhookCorrelation({
+      body: {
+        eventType: 'MessageReceived',
+      },
+      channelHint: 'sms',
+      providerName: 'telnyx',
+      providerCorrelation: {
+        providerLegId: null,
+        providerMessageId: null,
+        providerEventId: null,
+        providerNumber: '+12605550199',
+      },
+      tenantIdHint: TEST_TENANT_ID,
+    });
+
+    expect(correlation).toEqual({
+      ok: true,
+      source: 'number_mapping',
+      tenantId: TEST_TENANT_ID,
+      orgUnitId: TEST_ORG_UNIT_ID,
+      threadId: '',
+      providerLegId: null,
+      providerMessageId: null,
+      providerEventId: null,
+      providerNumberE164: '+12605550199',
+    });
+    expect(correlationLookupSpy).toHaveBeenCalledWith({
+      providerName: 'telnyx',
+      providerLegId: null,
+      providerMessageId: null,
+      tenantId: null,
+      db: { mocked: 'db' },
+    });
+    expect(numberMappingSpy).toHaveBeenCalledWith({
+      tenantId: TEST_TENANT_ID,
+      twilioNumberE164: '+12605550199',
+    });
+  });
+
+  it('preserves ambiguous provider identifier failures instead of falling back to number mapping', async () => {
+    const correlationLookupSpy = jest.spyOn(
+      providerCorrelationMappingsModule,
+      'resolveConnectShyftProviderCorrelationByIdentifiers',
+    ).mockResolvedValue({
+      ok: false,
+      reason: 'ambiguous',
+    } as any);
+    const numberMappingSpy = jest.spyOn(
+      connectShyftNumberMappingServiceAsync,
+      'resolveRoutingMappingByNumber',
+    ).mockResolvedValue({
+      status: 'found',
+      mapping: {
+        mappingId: 'mapping-connectshyft-c9-ambiguous',
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        twilioNumberE164: '+12605550199',
+        label: 'Main',
+        isActive: true,
+        createdAtUtc: '2026-03-26T00:00:00.000Z',
+        updatedAtUtc: '2026-03-26T00:00:00.000Z',
+      },
+    } as any);
+
+    const correlation = await resolveInboundWebhookCorrelation({
+      body: {
+        eventType: 'MessageReceived',
+      },
+      channelHint: 'sms',
+      providerName: 'telnyx',
+      providerCorrelation: {
+        providerLegId: null,
+        providerMessageId: 'provider-message-c9-ambiguous',
+        providerEventId: null,
+        providerNumber: '+12605550199',
+      },
+      tenantIdHint: TEST_TENANT_ID,
+    });
+
+    expect(correlation).toEqual({
+      ok: false,
+      code: 'CONNECTSHYFT_WEBHOOK_CORRELATION_AMBIGUOUS',
+      message: 'Inbound webhook correlation is ambiguous across provider identifiers.',
+      reason: 'ambiguous',
+      providerLegId: null,
+      providerMessageId: 'provider-message-c9-ambiguous',
+      providerEventId: null,
+      providerNumberE164: '+12605550199',
+    });
+    expect(correlationLookupSpy).toHaveBeenCalledWith({
+      providerName: 'telnyx',
+      providerLegId: null,
+      providerMessageId: 'provider-message-c9-ambiguous',
+      tenantId: null,
+      db: { mocked: 'db' },
+    });
+    expect(numberMappingSpy).not.toHaveBeenCalled();
   });
 
   it('stays limited to prerequisite resolution and execution delegation without bridge or canonical side effects', async () => {

--- a/apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts
+++ b/apps/connectshyft-api/src/modules/connectshyft/http/inboundWebhookContext.ts
@@ -222,7 +222,11 @@ export const resolveInboundWebhookCorrelation = async (
     tenantId: tenantId || null,
     db: platformDb,
   });
-  if (!fallback.ok && providerNumberE164) {
+  const shouldAttemptNumberMappingFallback = !fallback.ok
+    && Boolean(providerNumberE164)
+    && (fallback.reason === 'missing-identifiers' || fallback.reason === 'not-found');
+
+  if (shouldAttemptNumberMappingFallback && providerNumberE164) {
     try {
       const numberMapping = await connectShyftNumberMappingServiceAsync.resolveRoutingMappingByNumber({
         tenantId: numberMappingTenantScope,

--- a/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
+++ b/apps/connectshyft-api/src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts
@@ -608,6 +608,98 @@ describe('connectshyft inbound sms webhook route characterization', () => {
     }
   });
 
+  it('continues first-contact inbound SMS when only the mapped provider number is available', async () => {
+    const app = buildApp();
+    const { canonicalEventSpy, ensureThreadSpy, restore } = mockInboundSmsPersistence({
+      ensuredThreadId: 'thread-sms-characterization-first-contact-2016',
+      ensuredNeighborId: 'neighbor-connectshyft-f1-2016',
+      ensuredPersonId: 'person-connectshyft-f1-2016',
+    });
+    const createNeighborSpy = jest.spyOn(neighborsModule, 'createNeighborFromInbound')
+      .mockResolvedValue({
+        ok: true,
+        code: 'CONNECTSHYFT_NEIGHBOR_CREATED',
+        httpStatus: 201,
+        data: {
+          neighbor: {
+            neighborId: 'neighbor-connectshyft-f1-2016',
+          },
+        },
+      } as any);
+    resolveInboundIdentitySpy.mockResolvedValueOnce(buildIdentityAttachment({
+      personId: 'person-connectshyft-f1-2016',
+      selectedCandidatePersonId: 'person-connectshyft-f1-2016',
+      contactPointId: 'contact-point-connectshyft-f1-2016',
+      contactPointEventId: 'contact-point-event-connectshyft-f1-2016',
+    }) as any);
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/connectshyft/webhooks/sms')
+        .set(buildSmsHeaders())
+        .send(buildInboundSmsBody({
+          tenantId: undefined,
+          orgUnitId: undefined,
+          threadId: undefined,
+          sid: undefined,
+          providerEventId: undefined,
+          providerMessageId: undefined,
+          from: '+12605552016',
+        }));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        ok: true,
+        code: 'CONNECTSHYFT_WEBHOOK_ACCEPTED',
+        data: {
+          eventType: 'sms.inbound',
+          providerResolution: {
+            requestedProvider: 'telnyx',
+            resolvedProvider: 'telnyx',
+            deterministic: true,
+            adapterInvoked: true,
+          },
+          correlation: {
+            source: 'number_mapping',
+            deterministic: true,
+            threadId: 'thread-sms-characterization-first-contact-2016',
+            tenantId: TEST_TENANT_ID,
+            orgUnitId: TEST_ORG_UNIT_ID,
+            neighborId: 'neighbor-connectshyft-f1-2016',
+            providerLegId: null,
+            providerMessageId: null,
+            providerEventId: null,
+            providerNumberE164: TEST_PROVIDER_NUMBER,
+          },
+          replaySafe: {
+            duplicate: false,
+            suppressedDomainWrites: false,
+            dedupeKey: expect.stringMatching(/^payload:[a-f0-9]{64}\|event:sms\.inbound$/),
+          },
+          threadId: 'thread-sms-characterization-first-contact-2016',
+          thread: buildEnsuredThread({
+            threadId: 'thread-sms-characterization-first-contact-2016',
+            neighborId: 'neighbor-connectshyft-f1-2016',
+            personId: 'person-connectshyft-f1-2016',
+          }),
+        },
+      });
+      expect(createNeighborSpy).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId: TEST_TENANT_ID,
+        orgUnitId: TEST_ORG_UNIT_ID,
+        phone: '+12605552016',
+      }));
+      expect(ensureThreadSpy).toHaveBeenCalledWith(expect.objectContaining({
+        neighborId: 'neighbor-connectshyft-f1-2016',
+        personId: 'person-connectshyft-f1-2016',
+      }));
+      expect(canonicalEventSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      createNeighborSpy.mockRestore();
+      restore();
+    }
+  });
+
   it.each([
     {
       name: 'required',


### PR DESCRIPTION
## Summary
- tighten inbound webhook correlation so mapped-number fallback only applies when provider-id correlation is missing or not found
- add helper tests covering first-contact mapped-number success and ambiguity precedence
- add route characterization coverage for first-contact inbound SMS with only a mapped provider number

## Testing
- npm test -- --runTestsByPath src/modules/connectshyft/__tests__/handlers.inboundWebhookContext.test.ts src/routes/api/v1/__tests__/connectshyft.webhook-sms.characterization.test.ts